### PR TITLE
fix: I/O layer safety — hidraw dangling pointer, usbraw resource leak

### DIFF
--- a/src/io/hidraw.zig
+++ b/src/io/hidraw.zig
@@ -234,7 +234,8 @@ pub const HidrawDevice = struct {
 
 /// Read the HID physical path from sysfs uevent; caller owns the returned slice.
 pub fn readPhysicalPath(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {
-    const phys = readPhysFromSysfs(path) orelse return allocator.dupe(u8, path);
+    var buf: [1024]u8 = undefined;
+    const phys = readPhysFromSysfs(path, &buf) orelse return allocator.dupe(u8, path);
     const stripped = stripInputSuffix(phys);
     if (stripped.len == 0) return allocator.dupe(u8, path);
     return allocator.dupe(u8, stripped);
@@ -261,14 +262,13 @@ pub fn readInterfaceId(path: []const u8) ?u8 {
 
 /// Read HID_PHYS value from sysfs uevent file for a hidraw node.
 /// Returned slice points into an internal read buffer; caller must copy if needed.
-fn readPhysFromSysfs(path: []const u8) ?[]const u8 {
+fn readPhysFromSysfs(path: []const u8, buf: *[1024]u8) ?[]const u8 {
     const basename = std.fs.path.basename(path);
     var path_buf: [256]u8 = undefined;
     const sysfs_path = std.fmt.bufPrint(&path_buf, "/sys/class/hidraw/{s}/device/uevent", .{basename}) catch return null;
     const fd = std.fs.openFileAbsolute(sysfs_path, .{}) catch return null;
     defer fd.close();
-    var buf: [1024]u8 = undefined;
-    const n = fd.read(&buf) catch return null;
+    const n = fd.read(buf) catch return null;
     if (n == 0) return null;
     const content = buf[0..n];
     var lines = std.mem.splitScalar(u8, content, '\n');

--- a/src/io/usbraw.zig
+++ b/src/io/usbraw.zig
@@ -112,8 +112,11 @@ pub const UsbrawDevice = struct {
         }
 
         const pipe_fds = try std.posix.pipe2(.{ .NONBLOCK = true, .CLOEXEC = true });
+        errdefer std.posix.close(pipe_fds[0]);
+        errdefer std.posix.close(pipe_fds[1]);
 
         const self = try alloc.create(UsbrawDevice);
+        errdefer alloc.destroy(self);
         self.* = .{
             .handle = handle,
             .ctx = ctx.?,
@@ -128,6 +131,11 @@ pub const UsbrawDevice = struct {
             .thread = undefined,
             .allocator = alloc,
         };
+        errdefer {
+            _ = c.libusb_release_interface(handle, interface_id);
+            c.libusb_close(handle);
+            c.libusb_exit(ctx.?);
+        }
         self.thread = try std.Thread.spawn(.{}, readLoop, .{self});
         return self;
     }
@@ -174,8 +182,8 @@ pub const UsbrawDevice = struct {
     fn read(ptr: *anyopaque, buf: []u8) DeviceIO.ReadError!usize {
         const self: *UsbrawDevice = @ptrCast(@alignCast(ptr));
         if (self.disconnected.load(.acquire)) return DeviceIO.ReadError.Disconnected;
-        var dummy: [1]u8 = undefined;
-        _ = std.posix.read(self.pipe_r, &dummy) catch {};
+        var drain: [64]u8 = undefined;
+        _ = std.posix.read(self.pipe_r, &drain) catch {};
         const n = self.ring.pop(buf);
         if (n == 0) return DeviceIO.ReadError.Again;
         return n;


### PR DESCRIPTION
## Summary
- **hidraw.zig**: Fix use-after-stack in `readPhysFromSysfs` — returned slice pointed into local stack buffer. Now accepts caller-provided buffer.
- **usbraw.zig**: Add `errdefer` guards for pipe fds, libusb handle/ctx, and self allocation in `open()`. Previously leaked all resources if `alloc.create` or `Thread.spawn` failed.
- **usbraw.zig**: Increase pipe drain buffer from 1 to 64 bytes to prevent notification starvation under high input rates.

## Test plan
- [x] `zig build test` passes
- [x] `zig build test-tsan` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened error handling in USB device operations to ensure proper resource cleanup during initialization failures, enhancing stability.

* **Refactor**
  * Optimized buffer and memory allocation in hardware I/O operations for improved performance and resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->