### PR TITLE
Standardize test naming convention across 339 tests (I1/I5)

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -398,14 +398,14 @@ fn parseHexOrDec(comptime T: type, s: []const u8) !T {
 
 // --- tests ---
 
-test "parseHexOrDec" {
+test "install: parseHexOrDec" {
     const testing = std.testing;
     try testing.expectEqual(@as(u16, 0x37d7), try parseHexOrDec(u16, "0x37d7"));
     try testing.expectEqual(@as(u16, 1234), try parseHexOrDec(u16, "1234"));
     try testing.expectEqual(@as(u16, 0x054c), try parseHexOrDec(u16, "0x054c"));
 }
 
-test "extractVidPid from vader5 content" {
+test "install: extractVidPid from vader5 content" {
     const testing = std.testing;
     const allocator = testing.allocator;
 
@@ -442,7 +442,7 @@ test "extractVidPid from vader5 content" {
     try testing.expectEqualStrings("Flydigi Vader 5 Pro", entries.items[0].name);
 }
 
-test "isFieldKey exact and prefix-safe" {
+test "install: isFieldKey exact and prefix-safe" {
     const testing = std.testing;
     try testing.expect(isFieldKey("pid = 0x2401", "pid"));
     try testing.expect(isFieldKey("pid=0x2401", "pid"));
@@ -453,7 +453,7 @@ test "isFieldKey exact and prefix-safe" {
     try testing.expect(!isFieldKey("namespace = \"x\"", "name"));
 }
 
-test "extractVidPid ignores pid_controller field" {
+test "install: extractVidPid ignores pid_controller field" {
     const testing = std.testing;
     const allocator = testing.allocator;
 
@@ -490,7 +490,7 @@ test "extractVidPid ignores pid_controller field" {
     try testing.expectEqual(@as(u16, 0x5678), entries.items[0].pid);
 }
 
-test "generateServiceContent uses prefix" {
+test "install: generateServiceContent uses prefix" {
     const testing = std.testing;
     const allocator = testing.allocator;
     const content = try generateServiceContent(allocator, "/usr/local");
@@ -500,7 +500,7 @@ test "generateServiceContent uses prefix" {
     try testing.expect(std.mem.indexOf(u8, content, "/usr/bin/padctl") == null);
 }
 
-test "generateUdevRules produces valid output" {
+test "install: generateUdevRules produces valid output" {
     const testing = std.testing;
     const allocator = testing.allocator;
 
@@ -542,7 +542,7 @@ test "generateUdevRules produces valid output" {
     try testing.expect(std.mem.indexOf(u8, content, "KERNEL==\"uinput\"") != null);
 }
 
-test "findDevicesSourceDir discovers repo-root devices from zig-out/bin" {
+test "install: findDevicesSourceDir discovers repo-root devices from zig-out/bin" {
     const testing = std.testing;
     const allocator = testing.allocator;
 
@@ -566,7 +566,7 @@ test "findDevicesSourceDir discovers repo-root devices from zig-out/bin" {
     try testing.expectEqualStrings(repo_devices, found.?);
 }
 
-test "findDevicesSourceDir falls back to cwd devices" {
+test "install: findDevicesSourceDir falls back to cwd devices" {
     const testing = std.testing;
     const allocator = testing.allocator;
 

--- a/src/cli/scan.zig
+++ b/src/cli/scan.zig
@@ -385,36 +385,36 @@ pub fn run(allocator: std.mem.Allocator, config_dirs: []const []const u8, writer
 
 // --- tests ---
 
-test "extractHexField: hex value" {
+test "scan: extractHexField: hex value" {
     const toml_str = "vid = 0x37d7\npid = 0x2401\n";
     try std.testing.expectEqual(@as(?u16, 0x37d7), extractHexField(toml_str, "vid"));
     try std.testing.expectEqual(@as(?u16, 0x2401), extractHexField(toml_str, "pid"));
 }
 
-test "extractHexField: decimal value" {
+test "scan: extractHexField: decimal value" {
     const toml_str = "vid = 1000\npid = 512\n";
     try std.testing.expectEqual(@as(?u16, 1000), extractHexField(toml_str, "vid"));
     try std.testing.expectEqual(@as(?u16, 512), extractHexField(toml_str, "pid"));
 }
 
-test "extractHexField: missing key" {
+test "scan: extractHexField: missing key" {
     try std.testing.expectEqual(@as(?u16, null), extractHexField("name = \"foo\"\n", "vid"));
 }
 
-test "extractHexField: quoted value not parsed" {
+test "scan: extractHexField: quoted value not parsed" {
     try std.testing.expectEqual(@as(?u16, null), extractHexField("vid = \"0x1234\"\n", "vid"));
 }
 
-test "extractHexField: uppercase hex" {
+test "scan: extractHexField: uppercase hex" {
     try std.testing.expectEqual(@as(?u16, 0x1a86), extractHexField("vid = 0x1A86\n", "vid"));
 }
 
-test "extractHexField: ignores commented-out lines" {
+test "scan: extractHexField: ignores commented-out lines" {
     try std.testing.expectEqual(@as(?u16, null), extractHexField("# vid = 0x1234\n", "vid"));
     try std.testing.expectEqual(@as(?u16, 0x5678), extractHexField("# vid = 0x1234\nvid = 0x5678\n", "vid"));
 }
 
-test "findConfig: matches VID/PID with correct interface" {
+test "scan: findConfig: matches VID/PID with correct interface" {
     const allocator = std.testing.allocator;
     // vader5.toml: vid=0x37d7 pid=0x2401, interface=1
     const path = findConfig(allocator, "devices", 0x37d7, 0x2401, 1) catch null;
@@ -423,12 +423,12 @@ test "findConfig: matches VID/PID with correct interface" {
     try std.testing.expect(std.mem.endsWith(u8, path.?, ".toml"));
 }
 
-test "findConfig: no match returns error" {
+test "scan: findConfig: no match returns error" {
     const allocator = std.testing.allocator;
     try std.testing.expectError(error.NotFound, findConfig(allocator, "devices", 0xffff, 0xffff, null));
 }
 
-test "findConfig: vader4-pro matches with correct interface" {
+test "scan: findConfig: vader4-pro matches with correct interface" {
     const allocator = std.testing.allocator;
     // vader4-pro-04b4-2412.toml: vid=0x04b4 pid=0x2412, interface=2
     const path = findConfig(allocator, "devices", 0x04b4, 0x2412, 2) catch null;
@@ -436,48 +436,48 @@ test "findConfig: vader4-pro matches with correct interface" {
     try std.testing.expect(path != null);
 }
 
-test "findConfig: vader4-pro rejects wrong interface" {
+test "scan: findConfig: vader4-pro rejects wrong interface" {
     const allocator = std.testing.allocator;
     // vader4-pro config requires interface 2; interface 0 should not match
     try std.testing.expectError(error.NotFound, findConfig(allocator, "devices", 0x04b4, 0x2412, 0));
 }
 
-test "configHasInterfaceId: single section match" {
+test "scan: configHasInterfaceId: single section match" {
     const toml = "[[device.interface]]\nid = 2\nclass = \"hid\"\n";
     try std.testing.expectEqual(@as(?bool, true), configHasInterfaceId(toml, 2));
     try std.testing.expectEqual(@as(?bool, false), configHasInterfaceId(toml, 1));
 }
 
-test "configHasInterfaceId: no section returns null" {
+test "scan: configHasInterfaceId: no section returns null" {
     const toml = "[device]\nname = \"foo\"\nvid = 0x1234\n";
     try std.testing.expectEqual(@as(?bool, null), configHasInterfaceId(toml, 0));
 }
 
-test "configHasInterfaceId: multiple sections" {
+test "scan: configHasInterfaceId: multiple sections" {
     const toml = "[[device.interface]]\nid = 0\nclass = \"vendor\"\n\n[[device.interface]]\nid = 2\nclass = \"hid\"\n";
     try std.testing.expectEqual(@as(?bool, true), configHasInterfaceId(toml, 2));
     try std.testing.expectEqual(@as(?bool, true), configHasInterfaceId(toml, 0));
     try std.testing.expectEqual(@as(?bool, false), configHasInterfaceId(toml, 1));
 }
 
-test "matchInterfaceId: no constraint returns null" {
+test "scan: matchInterfaceId: no constraint returns null" {
     const toml = "[device]\nname = \"foo\"\n";
     try std.testing.expectEqual(@as(?bool, null), matchInterfaceId(toml, 1));
     try std.testing.expectEqual(@as(?bool, null), matchInterfaceId(toml, null));
 }
 
-test "matchInterfaceId: with constraint and known iface" {
+test "scan: matchInterfaceId: with constraint and known iface" {
     const toml = "[[device.interface]]\nid = 2\n";
     try std.testing.expectEqual(@as(?bool, true), matchInterfaceId(toml, 2));
     try std.testing.expectEqual(@as(?bool, false), matchInterfaceId(toml, 0));
 }
 
-test "matchInterfaceId: with constraint and null iface returns false" {
+test "scan: matchInterfaceId: with constraint and null iface returns false" {
     const toml = "[[device.interface]]\nid = 2\n";
     try std.testing.expectEqual(@as(?bool, false), matchInterfaceId(toml, null));
 }
 
-test "freeEntries: empty slice is a no-op" {
+test "scan: freeEntries: empty slice is a no-op" {
     const empty: []ScanEntry = &.{};
     freeEntries(std.testing.allocator, empty);
 }

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -411,7 +411,7 @@ const test_toml =
     \\max_effects = 16
 ;
 
-test "load flydigi/vader5.toml succeeds" {
+test "device: load flydigi/vader5.toml succeeds" {
     const allocator = std.testing.allocator;
     const result = try parseFile(allocator, "devices/flydigi/vader5.toml");
     defer result.deinit();
@@ -424,7 +424,7 @@ test "load flydigi/vader5.toml succeeds" {
     try std.testing.expectEqualStrings("extended", cfg.report[0].name);
 }
 
-test "valid config parses and validates" {
+test "device: valid config parses and validates" {
     const allocator = std.testing.allocator;
     const result = try parseString(allocator, test_toml);
     defer result.deinit();
@@ -435,7 +435,7 @@ test "valid config parses and validates" {
     try std.testing.expectEqual(@as(i64, 0x37d7), cfg.device.vid);
 }
 
-test "offset out of bounds returns error" {
+test "device: offset out of bounds returns error" {
     const allocator = std.testing.allocator;
     const bad =
         \\[device]
@@ -455,7 +455,7 @@ test "offset out of bounds returns error" {
     try std.testing.expectError(error.OffsetOutOfBounds, parseString(allocator, bad));
 }
 
-test "duplicate field name returns error" {
+test "device: duplicate field name returns error" {
     const cfg = DeviceConfig{
         .device = .{
             .name = "test",
@@ -468,7 +468,7 @@ test "duplicate field name returns error" {
     try validate(&cfg);
 }
 
-test "invalid transform returns error" {
+test "device: invalid transform returns error" {
     const allocator = std.testing.allocator;
     const bad =
         \\[device]
@@ -488,7 +488,7 @@ test "invalid transform returns error" {
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad));
 }
 
-test "transform chain exceeding max count returns error" {
+test "device: transform chain exceeding max count returns error" {
     const allocator = std.testing.allocator;
     const bad =
         \\[device]
@@ -508,7 +508,7 @@ test "transform chain exceeding max count returns error" {
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad));
 }
 
-test "transform chain at max count is accepted" {
+test "device: transform chain at max count is accepted" {
     const allocator = std.testing.allocator;
     const ok =
         \\[device]
@@ -529,7 +529,7 @@ test "transform chain at max count is accepted" {
     defer parsed.deinit();
 }
 
-test "unknown button name returns error" {
+test "device: unknown button name returns error" {
     const allocator = std.testing.allocator;
     const bad =
         \\[device]
@@ -550,7 +550,7 @@ test "unknown button name returns error" {
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad));
 }
 
-test "load devices/sony/dualsense.toml succeeds" {
+test "device: load devices/sony/dualsense.toml succeeds" {
     const allocator = std.testing.allocator;
     const result = try parseFile(allocator, "devices/sony/dualsense.toml");
     defer result.deinit();
@@ -564,7 +564,7 @@ test "load devices/sony/dualsense.toml succeeds" {
     try std.testing.expectEqualStrings("bt", cfg.report[1].name);
 }
 
-test "dualsense.toml report field count" {
+test "device: dualsense.toml report field count" {
     const allocator = std.testing.allocator;
     const result = try parseFile(allocator, "devices/sony/dualsense.toml");
     defer result.deinit();
@@ -577,7 +577,7 @@ test "dualsense.toml report field count" {
     try std.testing.expectEqual(@as(usize, 16), fields.map.count());
 }
 
-test "dualsense.toml commands count" {
+test "device: dualsense.toml commands count" {
     const allocator = std.testing.allocator;
     const result = try parseFile(allocator, "devices/sony/dualsense.toml");
     defer result.deinit();
@@ -588,7 +588,7 @@ test "dualsense.toml commands count" {
     try std.testing.expectEqual(@as(usize, 6), cmds.map.count());
 }
 
-test "dualsense.toml output axes and buttons count" {
+test "device: dualsense.toml output axes and buttons count" {
     const allocator = std.testing.allocator;
     const result = try parseFile(allocator, "devices/sony/dualsense.toml");
     defer result.deinit();
@@ -619,7 +619,7 @@ const emulate_toml =
     \\emulate = "xbox-360"
 ;
 
-test "emulate preset resolves vid/pid/name and axes/buttons" {
+test "device: emulate preset resolves vid/pid/name and axes/buttons" {
     const allocator = std.testing.allocator;
     const result = try parseString(allocator, emulate_toml);
     defer result.deinit();
@@ -632,7 +632,7 @@ test "emulate preset resolves vid/pid/name and axes/buttons" {
     try std.testing.expect(out.buttons != null);
 }
 
-test "emulate preset: explicit vid overrides preset" {
+test "device: emulate preset: explicit vid overrides preset" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[device]
@@ -658,7 +658,7 @@ test "emulate preset: explicit vid overrides preset" {
     try std.testing.expectEqual(@as(?i64, 0x0ce6), out.pid);
 }
 
-test "emulate preset: unknown preset returns error" {
+test "device: emulate preset: unknown preset returns error" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[device]
@@ -890,7 +890,7 @@ test "device: bits span > 4 bytes returns error" {
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, toml_str));
 }
 
-test "lookup transform is rejected" {
+test "device: lookup transform is rejected" {
     const allocator = std.testing.allocator;
     const bad =
         \\[device]
@@ -910,7 +910,7 @@ test "lookup transform is rejected" {
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad));
 }
 
-test "generic mode: valid config parses" {
+test "device: generic mode: valid config parses" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[device]
@@ -943,7 +943,7 @@ test "generic mode: valid config parses" {
     try std.testing.expectEqualStrings("generic", result.value.device.mode.?);
 }
 
-test "generic mode: missing output.mapping returns error" {
+test "device: generic mode: missing output.mapping returns error" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[device]
@@ -964,7 +964,7 @@ test "generic mode: missing output.mapping returns error" {
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, toml_str));
 }
 
-test "generic mode: unknown event code returns error" {
+test "device: generic mode: unknown event code returns error" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[device]
@@ -989,7 +989,7 @@ test "generic mode: unknown event code returns error" {
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, toml_str));
 }
 
-test "generic mode: ABS event missing range returns error" {
+test "device: generic mode: ABS event missing range returns error" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[device]
@@ -1014,7 +1014,7 @@ test "generic mode: ABS event missing range returns error" {
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, toml_str));
 }
 
-test "fuzz parseString: no panic on arbitrary input" {
+test "device: fuzz parseString: no panic on arbitrary input" {
     try std.testing.fuzz({}, struct {
         fn run(_: void, input: []const u8) !void {
             const result = parseString(std.testing.allocator, input);

--- a/src/config/input_codes.zig
+++ b/src/config/input_codes.zig
@@ -309,7 +309,7 @@ pub fn resolveBtnCode(name: []const u8) error{UnknownBtnCode}!u16 {
     return error.UnknownBtnCode;
 }
 
-test "resolveAbsCode: known codes" {
+test "input_codes: resolveAbsCode: known codes" {
     try std.testing.expectEqual(@as(u16, 0x00), try resolveAbsCode("ABS_X"));
     try std.testing.expectEqual(@as(u16, 0x01), try resolveAbsCode("ABS_Y"));
     try std.testing.expectEqual(@as(u16, 0x03), try resolveAbsCode("ABS_RX"));
@@ -317,13 +317,13 @@ test "resolveAbsCode: known codes" {
     try std.testing.expectEqual(@as(u16, 0x11), try resolveAbsCode("ABS_HAT0Y"));
 }
 
-test "resolveAbsCode: unknown returns error" {
+test "input_codes: resolveAbsCode: unknown returns error" {
     try std.testing.expectError(error.UnknownAbsCode, resolveAbsCode("INVALID"));
     try std.testing.expectError(error.UnknownAbsCode, resolveAbsCode(""));
     try std.testing.expectError(error.UnknownAbsCode, resolveAbsCode("BTN_SOUTH"));
 }
 
-test "resolveBtnCode: known codes" {
+test "input_codes: resolveBtnCode: known codes" {
     try std.testing.expectEqual(@as(u16, 0x130), try resolveBtnCode("BTN_SOUTH"));
     try std.testing.expectEqual(@as(u16, 0x131), try resolveBtnCode("BTN_EAST"));
     try std.testing.expectEqual(@as(u16, 0x133), try resolveBtnCode("BTN_NORTH"));
@@ -333,12 +333,12 @@ test "resolveBtnCode: known codes" {
     try std.testing.expectEqual(@as(u16, 0x2c2), try resolveBtnCode("BTN_TRIGGER_HAPPY3"));
 }
 
-test "resolveBtnCode: unknown returns error" {
+test "input_codes: resolveBtnCode: unknown returns error" {
     try std.testing.expectError(error.UnknownBtnCode, resolveBtnCode("INVALID"));
     try std.testing.expectError(error.UnknownBtnCode, resolveBtnCode("ABS_X"));
 }
 
-test "resolveKeyCode: known codes" {
+test "input_codes: resolveKeyCode: known codes" {
     try std.testing.expectEqual(@as(u16, 0x1e), try resolveKeyCode("KEY_A"));
     try std.testing.expectEqual(@as(u16, 0x3b), try resolveKeyCode("KEY_F1"));
     try std.testing.expectEqual(@as(u16, 0x58), try resolveKeyCode("KEY_F12"));
@@ -349,14 +349,14 @@ test "resolveKeyCode: known codes" {
     try std.testing.expectEqual(@as(u16, 0x6c), try resolveKeyCode("KEY_DOWN"));
 }
 
-test "resolveKeyCode: unknown returns error" {
+test "input_codes: resolveKeyCode: unknown returns error" {
     try std.testing.expectError(error.UnknownKeyCode, resolveKeyCode("INVALID"));
     try std.testing.expectError(error.UnknownKeyCode, resolveKeyCode(""));
     try std.testing.expectError(error.UnknownKeyCode, resolveKeyCode("BTN_SOUTH"));
     try std.testing.expectError(error.UnknownKeyCode, resolveKeyCode("ABS_X"));
 }
 
-test "resolveMouseCode: known codes" {
+test "input_codes: resolveMouseCode: known codes" {
     try std.testing.expectEqual(@as(u16, 0x110), try resolveMouseCode("mouse_left"));
     try std.testing.expectEqual(@as(u16, 0x111), try resolveMouseCode("mouse_right"));
     try std.testing.expectEqual(@as(u16, 0x112), try resolveMouseCode("mouse_middle"));
@@ -366,31 +366,31 @@ test "resolveMouseCode: known codes" {
     try std.testing.expectEqual(@as(u16, 0x116), try resolveMouseCode("mouse_back"));
 }
 
-test "resolveMouseCode: unknown returns error" {
+test "input_codes: resolveMouseCode: unknown returns error" {
     try std.testing.expectError(error.UnknownMouseCode, resolveMouseCode("INVALID"));
     try std.testing.expectError(error.UnknownMouseCode, resolveMouseCode(""));
     try std.testing.expectError(error.UnknownMouseCode, resolveMouseCode("BTN_LEFT"));
     try std.testing.expectError(error.UnknownMouseCode, resolveMouseCode("MOUSE_LEFT"));
 }
 
-test "resolveEventCode: ABS_WHEEL returns EV_ABS" {
+test "input_codes: resolveEventCode: ABS_WHEEL returns EV_ABS" {
     const r = try resolveEventCode("ABS_WHEEL");
     try std.testing.expectEqual(@as(u16, c.EV_ABS), r.event_type);
     try std.testing.expectEqual(@as(u16, c.ABS_WHEEL), r.event_code);
 }
 
-test "resolveEventCode: BTN_GEAR_UP returns EV_KEY" {
+test "input_codes: resolveEventCode: BTN_GEAR_UP returns EV_KEY" {
     const r = try resolveEventCode("BTN_GEAR_UP");
     try std.testing.expectEqual(@as(u16, c.EV_KEY), r.event_type);
     try std.testing.expectEqual(@as(u16, c.BTN_GEAR_UP), r.event_code);
 }
 
-test "resolveEventCode: KEY_A returns EV_KEY" {
+test "input_codes: resolveEventCode: KEY_A returns EV_KEY" {
     const r = try resolveEventCode("KEY_A");
     try std.testing.expectEqual(@as(u16, c.EV_KEY), r.event_type);
     try std.testing.expectEqual(@as(u16, c.KEY_A), r.event_code);
 }
 
-test "resolveEventCode: INVALID returns error" {
+test "input_codes: resolveEventCode: INVALID returns error" {
     try std.testing.expectError(error.UnknownEventCode, resolveEventCode("INVALID"));
 }

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -158,7 +158,7 @@ const test_toml_basic =
     \\A = "B"
 ;
 
-test "MappingConfig parses name and remap" {
+test "mapping: MappingConfig parses name and remap" {
     const allocator = std.testing.allocator;
     const result = try parseString(allocator, test_toml_basic);
     defer result.deinit();
@@ -171,7 +171,7 @@ test "MappingConfig parses name and remap" {
     try std.testing.expectEqualStrings("B", cfg.remap.?.map.get("A").?);
 }
 
-test "MappingConfig: empty config" {
+test "mapping: MappingConfig: empty config" {
     const allocator = std.testing.allocator;
     const result = try parseString(allocator, "");
     defer result.deinit();
@@ -249,7 +249,7 @@ const test_toml_full =
     \\B = "KEY_F2"
 ;
 
-test "MappingConfig: full config with layers, gyro, stick, dpad" {
+test "mapping: MappingConfig: full config with layers, gyro, stick, dpad" {
     const allocator = std.testing.allocator;
     const result = try parseString(allocator, test_toml_full);
     defer result.deinit();
@@ -313,14 +313,14 @@ test "MappingConfig: full config with layers, gyro, stick, dpad" {
     try validate(&cfg);
 }
 
-test "validate: missing [mapping] section returns default empty MappingConfig" {
+test "mapping: validate: missing [mapping] section returns default empty MappingConfig" {
     const allocator = std.testing.allocator;
     const result = try parseString(allocator, "");
     defer result.deinit();
     try validate(&result.value);
 }
 
-test "validate: [[layer]] preserved in declaration order" {
+test "mapping: validate: [[layer]] preserved in declaration order" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[[layer]]
@@ -345,7 +345,7 @@ test "validate: [[layer]] preserved in declaration order" {
     try validate(&result.value);
 }
 
-test "validate: invalid activation value returns error" {
+test "mapping: validate: invalid activation value returns error" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[[layer]]
@@ -358,7 +358,7 @@ test "validate: invalid activation value returns error" {
     try std.testing.expectError(error.InvalidConfig, validate(&result.value));
 }
 
-test "validate: duplicate layer name returns error" {
+test "mapping: validate: duplicate layer name returns error" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[[layer]]
@@ -374,7 +374,7 @@ test "validate: duplicate layer name returns error" {
     try std.testing.expectError(error.InvalidConfig, validate(&result.value));
 }
 
-test "validate: hold_timeout out of range returns error" {
+test "mapping: validate: hold_timeout out of range returns error" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[[layer]]
@@ -412,7 +412,7 @@ const test_toml_macro =
     \\M1 = "macro:dodge_roll"
 ;
 
-test "[[macro]] multi-entry parse: all step primitives correct" {
+test "mapping: [[macro]] multi-entry parse: all step primitives correct" {
     const allocator = std.testing.allocator;
     const result = try parseString(allocator, test_toml_macro);
     defer result.deinit();
@@ -444,7 +444,7 @@ test "[[macro]] multi-entry parse: all step primitives correct" {
     try validate(&cfg);
 }
 
-test "validate: macro:name remap target references unknown macro returns error" {
+test "mapping: validate: macro:name remap target references unknown macro returns error" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[remap]
@@ -455,7 +455,7 @@ test "validate: macro:name remap target references unknown macro returns error" 
     try std.testing.expectError(error.UnknownMacro, validate(&result.value));
 }
 
-test "validate: macro:name in layer remap references unknown macro returns error" {
+test "mapping: validate: macro:name in layer remap references unknown macro returns error" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[[layer]]
@@ -470,7 +470,7 @@ test "validate: macro:name in layer remap references unknown macro returns error
     try std.testing.expectError(error.UnknownMacro, validate(&result.value));
 }
 
-test "adaptive_trigger: valid mode parses and validates" {
+test "mapping: adaptive_trigger: valid mode parses and validates" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[adaptive_trigger]
@@ -496,7 +496,7 @@ test "adaptive_trigger: valid mode parses and validates" {
     try validate(&cfg);
 }
 
-test "adaptive_trigger: invalid mode returns error" {
+test "mapping: adaptive_trigger: invalid mode returns error" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[adaptive_trigger]
@@ -507,7 +507,7 @@ test "adaptive_trigger: invalid mode returns error" {
     try std.testing.expectError(error.InvalidConfig, validate(&result.value));
 }
 
-test "adaptive_trigger: invalid mode in layer returns error" {
+test "mapping: adaptive_trigger: invalid mode in layer returns error" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[[layer]]
@@ -522,7 +522,7 @@ test "adaptive_trigger: invalid mode in layer returns error" {
     try std.testing.expectError(error.InvalidConfig, validate(&result.value));
 }
 
-test "adaptive_trigger: per-layer valid mode validates" {
+test "mapping: adaptive_trigger: per-layer valid mode validates" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[[layer]]
@@ -545,7 +545,7 @@ test "adaptive_trigger: per-layer valid mode validates" {
     try std.testing.expectEqual(@as(?i64, 30), at.left.?.start);
 }
 
-test "fuzz parseString: no panic on arbitrary input" {
+test "mapping: fuzz parseString: no panic on arbitrary input" {
     try std.testing.fuzz({}, struct {
         fn run(_: void, input: []const u8) !void {
             const result = parseString(std.testing.allocator, input);

--- a/src/core/command.zig
+++ b/src/core/command.zig
@@ -62,7 +62,7 @@ fn findParam(params: []const Param, name: []const u8) ?u16 {
 
 const testing = std.testing;
 
-test "fillTemplate: hex literals + u8 placeholders" {
+test "command: fillTemplate: hex literals + u8 placeholders" {
     const allocator = testing.allocator;
     const result = try fillTemplate(allocator, "00 08 00 {strong:u8} {weak:u8} 00 00 00", &.{
         .{ .name = "strong", .value = 0x8000 },
@@ -72,7 +72,7 @@ test "fillTemplate: hex literals + u8 placeholders" {
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, result);
 }
 
-test "fillTemplate: u16le" {
+test "command: fillTemplate: u16le" {
     const allocator = testing.allocator;
     const result = try fillTemplate(allocator, "{weak:u16le}", &.{
         .{ .name = "weak", .value = 0x1234 },
@@ -81,7 +81,7 @@ test "fillTemplate: u16le" {
     try testing.expectEqualSlices(u8, &[_]u8{ 0x34, 0x12 }, result);
 }
 
-test "fillTemplate: u16be" {
+test "command: fillTemplate: u16be" {
     const allocator = testing.allocator;
     const result = try fillTemplate(allocator, "{strong:u16be}", &.{
         .{ .name = "strong", .value = 0x8000 },
@@ -90,7 +90,7 @@ test "fillTemplate: u16be" {
     try testing.expectEqualSlices(u8, &[_]u8{ 0x80, 0x00 }, result);
 }
 
-test "fillTemplate: no type defaults to u8" {
+test "command: fillTemplate: no type defaults to u8" {
     const allocator = testing.allocator;
     const result = try fillTemplate(allocator, "{strong}", &.{
         .{ .name = "strong", .value = 0x8000 },
@@ -99,35 +99,35 @@ test "fillTemplate: no type defaults to u8" {
     try testing.expectEqualSlices(u8, &[_]u8{0x80}, result);
 }
 
-test "fillTemplate: pure hex template" {
+test "command: fillTemplate: pure hex template" {
     const allocator = testing.allocator;
     const result = try fillTemplate(allocator, "de ad be ef", &.{});
     defer allocator.free(result);
     try testing.expectEqualSlices(u8, &[_]u8{ 0xde, 0xad, 0xbe, 0xef }, result);
 }
 
-test "fillTemplate: empty template" {
+test "command: fillTemplate: empty template" {
     const allocator = testing.allocator;
     const result = try fillTemplate(allocator, "", &.{});
     defer allocator.free(result);
     try testing.expectEqual(@as(usize, 0), result.len);
 }
 
-test "fillTemplate: unknown param name returns error" {
+test "command: fillTemplate: unknown param name returns error" {
     const allocator = testing.allocator;
     try testing.expectError(error.UnknownParam, fillTemplate(allocator, "{ghost:u8}", &.{
         .{ .name = "strong", .value = 0 },
     }));
 }
 
-test "fillTemplate: unsupported type returns error" {
+test "command: fillTemplate: unsupported type returns error" {
     const allocator = testing.allocator;
     try testing.expectError(error.UnsupportedParamType, fillTemplate(allocator, "{x:u32}", &.{
         .{ .name = "x", .value = 0 },
     }));
 }
 
-test "fillTemplate: hex byte out of range returns error" {
+test "command: fillTemplate: hex byte out of range returns error" {
     const allocator = testing.allocator;
     try testing.expectError(error.InvalidHexByte, fillTemplate(allocator, "1ff", &.{}));
 }

--- a/src/core/dpad.zig
+++ b/src/core/dpad.zig
@@ -73,7 +73,7 @@ fn makeCfg(mode: []const u8, suppress_gamepad: ?bool) DpadConfig {
     return .{ .mode = mode, .suppress_gamepad = suppress_gamepad };
 }
 
-test "gamepad mode: no aux events emitted" {
+test "dpad: gamepad mode: no aux events emitted" {
     const cfg = makeCfg("gamepad", null);
     var aux = AuxEventList{};
     var suppressed: u64 = 0;
@@ -84,7 +84,7 @@ test "gamepad mode: no aux events emitted" {
     try testing.expect(!suppress_hat);
 }
 
-test "arrows mode: dpad_y < 0 -> KEY_UP press" {
+test "dpad: arrows mode: dpad_y < 0 -> KEY_UP press" {
     const cfg = makeCfg("arrows", null);
     var aux = AuxEventList{};
     var suppressed: u64 = 0;
@@ -96,7 +96,7 @@ test "arrows mode: dpad_y < 0 -> KEY_UP press" {
     try testing.expect(ev.key.pressed);
 }
 
-test "arrows mode: dpad from up to none -> KEY_UP release" {
+test "dpad: arrows mode: dpad from up to none -> KEY_UP release" {
     const cfg = makeCfg("arrows", null);
     var aux = AuxEventList{};
     var suppressed: u64 = 0;
@@ -108,7 +108,7 @@ test "arrows mode: dpad from up to none -> KEY_UP release" {
     try testing.expect(!ev.key.pressed);
 }
 
-test "arrows mode: diagonal up+right -> two key presses" {
+test "dpad: arrows mode: diagonal up+right -> two key presses" {
     const cfg = makeCfg("arrows", null);
     var aux = AuxEventList{};
     var suppressed: u64 = 0;
@@ -126,7 +126,7 @@ test "arrows mode: diagonal up+right -> two key presses" {
     try testing.expect(got_right);
 }
 
-test "suppress_gamepad: DPad button bits suppressed" {
+test "dpad: suppress_gamepad: DPad button bits suppressed" {
     const cfg = makeCfg("arrows", true);
     var aux = AuxEventList{};
     var suppressed: u64 = 0;
@@ -137,7 +137,7 @@ test "suppress_gamepad: DPad button bits suppressed" {
     try testing.expect(suppress_hat);
 }
 
-test "suppress_gamepad=false: no button suppression" {
+test "dpad: suppress_gamepad=false: no button suppression" {
     const cfg = makeCfg("arrows", false);
     var aux = AuxEventList{};
     var suppressed: u64 = 0;
@@ -147,7 +147,7 @@ test "suppress_gamepad=false: no button suppression" {
     try testing.expect(!suppress_hat);
 }
 
-test "edge detection: same state produces no events" {
+test "dpad: edge detection: same state produces no events" {
     const cfg = makeCfg("arrows", null);
     var aux = AuxEventList{};
     var suppressed: u64 = 0;
@@ -157,7 +157,7 @@ test "edge detection: same state produces no events" {
     try testing.expectEqual(@as(usize, 0), aux.len);
 }
 
-test "arrows mode: all four directions" {
+test "dpad: arrows mode: all four directions" {
     const cfg = makeCfg("arrows", null);
 
     // down

--- a/src/core/gyro.zig
+++ b/src/core/gyro.zig
@@ -87,7 +87,7 @@ fn applyCurve(ema: f32, cfg: *const GyroConfig) f32 {
 
 const testing = std.testing;
 
-test "mode=off: zero output" {
+test "gyro: mode=off: zero output" {
     var g = GyroProcessor{};
     const cfg = GyroConfig{};
     const out = g.process(&cfg, 1000, 2000, 500);
@@ -97,7 +97,7 @@ test "mode=off: zero output" {
     try testing.expect(out.joy_y == null);
 }
 
-test "deadzone: input within deadzone returns zero" {
+test "gyro: deadzone: input within deadzone returns zero" {
     var g = GyroProcessor{};
     const cfg = GyroConfig{ .mode = "mouse", .deadzone = 100, .smoothing = 0.0 };
     const out = g.process(&cfg, 50, 80, 0);
@@ -105,7 +105,7 @@ test "deadzone: input within deadzone returns zero" {
     try testing.expectEqual(@as(i32, 0), out.rel_y);
 }
 
-test "deadzone: input outside deadzone returns nonzero (large value)" {
+test "gyro: deadzone: input outside deadzone returns nonzero (large value)" {
     var g = GyroProcessor{};
     const cfg = GyroConfig{ .mode = "mouse", .deadzone = 100, .smoothing = 0.0, .sensitivity_x = 10.0, .sensitivity_y = 10.0 };
     // normalized: (30000-100)/32667 ≈ 0.915, * 10 * range ≈ 9 pixels/frame
@@ -113,7 +113,7 @@ test "deadzone: input outside deadzone returns nonzero (large value)" {
     try testing.expect(out.rel_x != 0 or g.accum_x != 0);
 }
 
-test "smoothing=0: no EMA delay (direct pass-through)" {
+test "gyro: smoothing=0: no EMA delay (direct pass-through)" {
     var g = GyroProcessor{};
     // sensitivity=1.0, max input=32767 → output ≈ 1.0 unit/frame at full deflection
     // Use large input: normalized ≈ 1.0, sensitivity=32767 → scaled = 32767*32767/32767 = 32767
@@ -123,7 +123,7 @@ test "smoothing=0: no EMA delay (direct pass-through)" {
     try testing.expect(out.rel_y > 0);
 }
 
-test "sub-pixel accumulation: small values accumulate to integer delta" {
+test "gyro: sub-pixel accumulation: small values accumulate to integer delta" {
     var g = GyroProcessor{};
     // normalized: raw=16384 (half max), normalized=0.5, curve=1 → curved=0.5
     // applyCurve = 0.5 * 32767 = 16383.5; scaled = 16383.5 * sensitivity / 32767
@@ -138,7 +138,7 @@ test "sub-pixel accumulation: small values accumulate to integer delta" {
     try testing.expect(g.accum_x >= 0.0 and g.accum_x < 1.0);
 }
 
-test "invert_x/invert_y: negates output" {
+test "gyro: invert_x/invert_y: negates output" {
     var g1 = GyroProcessor{};
     var g2 = GyroProcessor{};
     // Use full-scale input with high sensitivity to get non-zero integer output
@@ -150,7 +150,7 @@ test "invert_x/invert_y: negates output" {
     try testing.expectEqual(-out_normal.rel_y, out_invert.rel_y);
 }
 
-test "curve=1.0 linear vs curve=2.0 exponential" {
+test "gyro: curve=1.0 linear vs curve=2.0 exponential" {
     // Normalized curve: at half-scale input, curve=2 gives 0.25, curve=1 gives 0.5.
     // Verify curve=2 produces less total motion than curve=1 at half-scale.
     var g1 = GyroProcessor{};
@@ -166,7 +166,7 @@ test "curve=1.0 linear vs curve=2.0 exponential" {
     try testing.expect(total_linear > total_exp);
 }
 
-test "EMA smoothing: consecutive frames converge" {
+test "gyro: EMA smoothing: consecutive frames converge" {
     var g = GyroProcessor{};
     const cfg = GyroConfig{ .mode = "mouse", .smoothing = 0.5, .sensitivity_x = 1000.0, .sensitivity_y = 1000.0 };
     // Feed constant input; EMA should converge towards steady state

--- a/src/core/interpreter.zig
+++ b/src/core/interpreter.zig
@@ -685,7 +685,7 @@ fn makeIf1Sample() [32]u8 {
     return raw;
 }
 
-test "IF1 sample: axes, buttons, IMU" {
+test "interpreter: IF1 sample: axes, buttons, IMU" {
     const allocator = testing.allocator;
     const parsed = try device.parseString(allocator, vader5_toml);
     defer parsed.deinit();
@@ -712,7 +712,7 @@ test "IF1 sample: axes, buttons, IMU" {
     try testing.expect(btns & (@as(u64, 1) << b_bit) != 0);
 }
 
-test "match miss: wrong magic returns null" {
+test "interpreter: match miss: wrong magic returns null" {
     const allocator = testing.allocator;
     const parsed = try device.parseString(allocator, vader5_toml);
     defer parsed.deinit();
@@ -723,7 +723,7 @@ test "match miss: wrong magic returns null" {
     try testing.expectEqual(@as(?GamepadStateDelta, null), result);
 }
 
-test "short raw returns null" {
+test "interpreter: short raw returns null" {
     const allocator = testing.allocator;
     const parsed = try device.parseString(allocator, vader5_toml);
     defer parsed.deinit();
@@ -733,7 +733,7 @@ test "short raw returns null" {
     try testing.expectEqual(@as(?GamepadStateDelta, null), result);
 }
 
-test "wrong interface_id returns null" {
+test "interpreter: wrong interface_id returns null" {
     const allocator = testing.allocator;
     const parsed = try device.parseString(allocator, vader5_toml);
     defer parsed.deinit();
@@ -743,7 +743,7 @@ test "wrong interface_id returns null" {
     try testing.expectEqual(@as(?GamepadStateDelta, null), result);
 }
 
-test "different interface_id matches different report" {
+test "interpreter: different interface_id matches different report" {
     const allocator = testing.allocator;
     const parsed = try device.parseString(allocator, vader5_if0_toml);
     defer parsed.deinit();
@@ -763,7 +763,7 @@ test "different interface_id matches different report" {
     try testing.expectEqual(@as(?i16, null), d2.ax); // not in IF0 report
 }
 
-test "checksum sum8 mismatch returns error" {
+test "interpreter: checksum sum8 mismatch returns error" {
     const allocator = testing.allocator;
     const toml_str =
         \\[device]
@@ -793,7 +793,7 @@ test "checksum sum8 mismatch returns error" {
     try testing.expectError(ProcessError.ChecksumMismatch, interp.processReport(0, &raw));
 }
 
-test "checksum sum8 correct passes" {
+test "interpreter: checksum sum8 correct passes" {
     const allocator = testing.allocator;
     const toml_str =
         \\[device]
@@ -827,7 +827,7 @@ test "checksum sum8 correct passes" {
     try testing.expectEqual(@as(?u8, null), delta.lt);
 }
 
-test "checksum xor" {
+test "interpreter: checksum xor" {
     const allocator = testing.allocator;
     const toml_str =
         \\[device]
@@ -859,7 +859,7 @@ test "checksum xor" {
     try testing.expectEqual(@as(?u64, null), delta.buttons);
 }
 
-test "checksum xor mismatch returns error" {
+test "interpreter: checksum xor mismatch returns error" {
     const allocator = testing.allocator;
     const toml_str =
         \\[device]
@@ -889,7 +889,7 @@ test "checksum xor mismatch returns error" {
     try testing.expectError(ProcessError.ChecksumMismatch, interp.processReport(0, &raw));
 }
 
-test "checksum range out of bounds returns null" {
+test "interpreter: checksum range out of bounds returns null" {
     const allocator = testing.allocator;
     const toml_str =
         \\[device]
@@ -920,7 +920,7 @@ test "checksum range out of bounds returns null" {
     try testing.expectEqual(@as(?GamepadStateDelta, null), result);
 }
 
-test "transform negate" {
+test "interpreter: transform negate" {
     const allocator = testing.allocator;
     const toml_str =
         \\[device]
@@ -950,7 +950,7 @@ test "transform negate" {
     try testing.expectEqual(@as(?i16, -300), delta.ax);
 }
 
-test "transform scale" {
+test "interpreter: transform scale" {
     const allocator = testing.allocator;
     const toml_str =
         \\[device]
@@ -981,7 +981,7 @@ test "transform scale" {
     try testing.expectEqual(@as(?i16, 32767), delta.ax);
 }
 
-test "transform clamp" {
+test "interpreter: transform clamp" {
     const allocator = testing.allocator;
     const toml_str =
         \\[device]
@@ -1011,7 +1011,7 @@ test "transform clamp" {
     try testing.expectEqual(@as(?u8, 200), delta.lt);
 }
 
-test "transform chain scale+negate" {
+test "interpreter: transform chain scale+negate" {
     const allocator = testing.allocator;
     const toml_str =
         \\[device]
@@ -1064,7 +1064,7 @@ fn makeDualSenseSample() [64]u8 {
     return raw;
 }
 
-test "DualSense USB report: axes, triggers, IMU, buttons" {
+test "interpreter: DualSense USB report: axes, triggers, IMU, buttons" {
     const allocator = testing.allocator;
     const parsed = try @import("../config/device.zig").parseFile(allocator, "devices/sony/dualsense.toml");
     defer parsed.deinit();
@@ -1097,7 +1097,7 @@ test "DualSense USB report: axes, triggers, IMU, buttons" {
     try testing.expect(btns & (@as(u64, 1) << @as(u6, @intCast(@intFromEnum(ButtonId.B)))) == 0); // Circle not pressed
 }
 
-test "DualSense right_y=0x00 saturates to 32767" {
+test "interpreter: DualSense right_y=0x00 saturates to 32767" {
     const allocator = testing.allocator;
     const parsed = try @import("../config/device.zig").parseFile(allocator, "devices/sony/dualsense.toml");
     defer parsed.deinit();
@@ -1109,7 +1109,7 @@ test "DualSense right_y=0x00 saturates to 32767" {
     try testing.expectEqual(@as(?i16, 32767), delta.ry);
 }
 
-test "DualSense joystick boundary values" {
+test "interpreter: DualSense joystick boundary values" {
     const allocator = testing.allocator;
     const parsed = try @import("../config/device.zig").parseFile(allocator, "devices/sony/dualsense.toml");
     defer parsed.deinit();
@@ -1133,7 +1133,7 @@ test "DualSense joystick boundary values" {
     try testing.expectEqual(@as(?i16, -32768), d3.ax);
 }
 
-test "DualSense L1+R1 simultaneously pressed" {
+test "interpreter: DualSense L1+R1 simultaneously pressed" {
     const allocator = testing.allocator;
     const parsed = try @import("../config/device.zig").parseFile(allocator, "devices/sony/dualsense.toml");
     defer parsed.deinit();
@@ -1150,7 +1150,7 @@ test "DualSense L1+R1 simultaneously pressed" {
     try testing.expect(btns & (@as(u64, 1) << rb_bit) != 0);
 }
 
-test "DualSense all buttons released" {
+test "interpreter: DualSense all buttons released" {
     const allocator = testing.allocator;
     const parsed = try @import("../config/device.zig").parseFile(allocator, "devices/sony/dualsense.toml");
     defer parsed.deinit();
@@ -1163,7 +1163,7 @@ test "DualSense all buttons released" {
     try testing.expectEqual(@as(u32, 0), btns);
 }
 
-test "DualSense battery_level: bits DSL extracts 4-bit nibble" {
+test "interpreter: DualSense battery_level: bits DSL extracts 4-bit nibble" {
     const allocator = testing.allocator;
     const parsed = try @import("../config/device.zig").parseFile(allocator, "devices/sony/dualsense.toml");
     defer parsed.deinit();
@@ -1178,7 +1178,7 @@ test "DualSense battery_level: bits DSL extracts 4-bit nibble" {
     try testing.expectEqual(@as(?u8, 8), delta.battery_level);
 }
 
-test "battery_level FieldTag: parseFieldTag and applyFieldTag" {
+test "interpreter: battery_level FieldTag: parseFieldTag and applyFieldTag" {
     try testing.expectEqual(FieldTag.battery_level, parseFieldTag("battery_level"));
     try testing.expectEqual(FieldTag.unknown, parseFieldTag("battery_raw"));
 
@@ -1219,7 +1219,7 @@ fn makeDualSenseBtSample() [78]u8 {
     return raw;
 }
 
-test "DualSense BT report: axes, triggers, IMU, buttons, CRC32" {
+test "interpreter: DualSense BT report: axes, triggers, IMU, buttons, CRC32" {
     const allocator = testing.allocator;
     const parsed = try @import("../config/device.zig").parseFile(allocator, "devices/sony/dualsense.toml");
     defer parsed.deinit();
@@ -1246,7 +1246,7 @@ test "DualSense BT report: axes, triggers, IMU, buttons, CRC32" {
     try testing.expect(btns & (@as(u64, 1) << a_bit) != 0);
 }
 
-test "DualSense BT report: CRC32 mismatch returns error" {
+test "interpreter: DualSense BT report: CRC32 mismatch returns error" {
     const allocator = testing.allocator;
     const parsed = try @import("../config/device.zig").parseFile(allocator, "devices/sony/dualsense.toml");
     defer parsed.deinit();
@@ -1257,7 +1257,7 @@ test "DualSense BT report: CRC32 mismatch returns error" {
     try testing.expectError(ProcessError.ChecksumMismatch, interp.processReport(3, &raw));
 }
 
-test "button_group batch extraction" {
+test "interpreter: button_group batch extraction" {
     const allocator = testing.allocator;
     const toml_str =
         \\[device]
@@ -1316,7 +1316,7 @@ const crc32_base_toml =
     \\expect = { offset = 4, type = "u32le" }
 ;
 
-test "checksum crc32 correct passes" {
+test "interpreter: checksum crc32 correct passes" {
     const allocator = testing.allocator;
     const parsed = try device.parseString(allocator, crc32_base_toml);
     defer parsed.deinit();
@@ -1328,7 +1328,7 @@ test "checksum crc32 correct passes" {
     try testing.expectEqual(@as(?i16, null), delta.ax);
 }
 
-test "checksum crc32 mismatch returns error" {
+test "interpreter: checksum crc32 mismatch returns error" {
     const allocator = testing.allocator;
     const parsed = try device.parseString(allocator, crc32_base_toml);
     defer parsed.deinit();
@@ -1338,7 +1338,7 @@ test "checksum crc32 mismatch returns error" {
     try testing.expectError(ProcessError.ChecksumMismatch, interp.processReport(0, &raw));
 }
 
-test "checksum crc32 with seed" {
+test "interpreter: checksum crc32 with seed" {
     const allocator = testing.allocator;
     const toml_str =
         \\[device]
@@ -1409,7 +1409,7 @@ test "interpreter: all-0xFF report does not panic" {
     try testing.expectEqual(@as(?GamepadStateDelta, null), result);
 }
 
-test "fuzz processReport: no panic on arbitrary input" {
+test "interpreter: fuzz processReport: no panic on arbitrary input" {
     const allocator = testing.allocator;
     const parsed = try device.parseString(allocator, vader5_toml);
     defer parsed.deinit();
@@ -1589,7 +1589,7 @@ test "interpreter: bits field unsigned default" {
     try testing.expectEqual(@as(?u8, 255), delta.lt);
 }
 
-test "extractBits: start_bit=7 single bit" {
+test "interpreter: extractBits: start_bit=7 single bit" {
     try testing.expectEqual(@as(u32, 1), extractBits(&[_]u8{0x80}, 0, 7, 1));
     try testing.expectEqual(@as(u32, 0), extractBits(&[_]u8{0x7F}, 0, 7, 1));
 }
@@ -1631,7 +1631,7 @@ test "interpreter: touch0_active bits round-trip" {
     try testing.expectEqual(@as(?bool, false), d2.touch0_active);
 }
 
-test "FieldTag.dpad: hat switch values 0-7 decode correctly" {
+test "interpreter: FieldTag.dpad: hat switch values 0-7 decode correctly" {
     // HID hat: 0=N, 1=NE, 2=E, 3=SE, 4=S, 5=SW, 6=W, 7=NW
     const HAT_X = [8]i8{ 0, 1, 1, 1, 0, -1, -1, -1 };
     const HAT_Y = [8]i8{ -1, -1, 0, 1, 1, 1, 0, -1 };
@@ -1685,7 +1685,7 @@ test "mutation audit: scale boundary correctness" {
 
 // Scale asymmetry: for signed types, val = minInt (e.g. -32768 for i16le) produces an
 // out-of-range intermediate that saturateCast clamps to minInt.  Document current behavior.
-test "scale signed type minInt edge case" {
+test "interpreter: scale signed type minInt edge case" {
     // scale(-32768, 32767) on i16le type_max=32767
     var chain = compileTransformChain("scale(-32768, 32767)", .i16le);
     // val = -32768: (-32768 * 65535) / 32767 + (-32768) = out-of-range, saturated by caller
@@ -1821,7 +1821,7 @@ test "mutation audit: processReport match polarity" {
     try testing.expectEqual(@as(?GamepadStateDelta, null), d_zero);
 }
 
-test "FieldTag.dpad: value 8 (released) and >8 treated as neutral" {
+test "interpreter: FieldTag.dpad: value 8 (released) and >8 treated as neutral" {
     var delta = GamepadStateDelta{};
     applyFieldTag(&delta, .dpad, 8);
     try std.testing.expectEqual(@as(i8, 0), delta.dpad_x.?);

--- a/src/core/layer.zig
+++ b/src/core/layer.zig
@@ -166,7 +166,7 @@ const testing = std.testing;
 const aim_cfg = LayerConfig{ .name = "aim", .trigger = "LT" };
 const fn_cfg = LayerConfig{ .name = "fn", .trigger = "Select" };
 
-test "getActive: no active layer returns null" {
+test "layer: getActive: no active layer returns null" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
 
@@ -174,7 +174,7 @@ test "getActive: no active layer returns null" {
     try testing.expect(ls.getActive(&configs) == null);
 }
 
-test "getActive: hold ACTIVE returns matching layer" {
+test "layer: getActive: hold ACTIVE returns matching layer" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     ls.tap_hold = .{ .layer_name = "aim", .layer_activated = true, .phase = .active };
@@ -185,7 +185,7 @@ test "getActive: hold ACTIVE returns matching layer" {
     try testing.expectEqualStrings("aim", active.?.name);
 }
 
-test "getActive: hold PENDING (not activated) does not activate layer" {
+test "layer: getActive: hold PENDING (not activated) does not activate layer" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     ls.tap_hold = .{ .layer_name = "aim", .layer_activated = false, .phase = .pending };
@@ -194,7 +194,7 @@ test "getActive: hold PENDING (not activated) does not activate layer" {
     try testing.expect(ls.getActive(&configs) == null);
 }
 
-test "getActive: toggle on returns matching layer" {
+test "layer: getActive: toggle on returns matching layer" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     try ls.toggled.put("fn", {});
@@ -205,7 +205,7 @@ test "getActive: toggle on returns matching layer" {
     try testing.expectEqualStrings("fn", active.?.name);
 }
 
-test "getActive: hold ACTIVE takes priority over toggled" {
+test "layer: getActive: hold ACTIVE takes priority over toggled" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     ls.tap_hold = .{ .layer_name = "aim", .layer_activated = true, .phase = .active };
@@ -217,7 +217,7 @@ test "getActive: hold ACTIVE takes priority over toggled" {
     try testing.expectEqualStrings("aim", active.?.name);
 }
 
-test "getActive: multiple toggled layers — declaration order wins (ADR-004)" {
+test "layer: getActive: multiple toggled layers — declaration order wins (ADR-004)" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     try ls.toggled.put("aim", {});
@@ -229,7 +229,7 @@ test "getActive: multiple toggled layers — declaration order wins (ADR-004)" {
     try testing.expectEqualStrings("aim", active.?.name);
 }
 
-test "getActive: multiple toggled layers — fn declared first wins when aim is absent" {
+test "layer: getActive: multiple toggled layers — fn declared first wins when aim is absent" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     try ls.toggled.put("fn", {});
@@ -240,7 +240,7 @@ test "getActive: multiple toggled layers — fn declared first wins when aim is 
     try testing.expectEqualStrings("fn", active.?.name);
 }
 
-test "getActive: configs length boundary — toggled name not in configs returns null" {
+test "layer: getActive: configs length boundary — toggled name not in configs returns null" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     try ls.toggled.put("unknown", {});
@@ -249,7 +249,7 @@ test "getActive: configs length boundary — toggled name not in configs returns
     try testing.expect(ls.getActive(&configs) == null);
 }
 
-test "getActive: empty configs always returns null" {
+test "layer: getActive: empty configs always returns null" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     ls.tap_hold = .{ .layer_name = "aim", .layer_activated = true, .phase = .active };
@@ -260,7 +260,7 @@ test "getActive: empty configs always returns null" {
 
 // --- T4: tap-hold state machine tests ---
 
-test "tap-hold: press → PENDING, arm_timer_ms set" {
+test "layer: tap-hold: press → PENDING, arm_timer_ms set" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
 
@@ -274,7 +274,7 @@ test "tap-hold: press → PENDING, arm_timer_ms set" {
     try testing.expectEqual(TapHoldPhase.pending, ls.tap_hold.?.phase);
 }
 
-test "tap-hold: PENDING + timer expired → ACTIVE, layer_activated = true" {
+test "layer: tap-hold: PENDING + timer expired → ACTIVE, layer_activated = true" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     _ = ls.onTriggerPress("aim", 200);
@@ -289,7 +289,7 @@ test "tap-hold: PENDING + timer expired → ACTIVE, layer_activated = true" {
     try testing.expect(ls.tap_hold.?.layer_activated);
 }
 
-test "tap-hold: PENDING + release → IDLE, tap_event has value" {
+test "layer: tap-hold: PENDING + release → IDLE, tap_event has value" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     _ = ls.onTriggerPress("aim", 200);
@@ -302,7 +302,7 @@ test "tap-hold: PENDING + release → IDLE, tap_event has value" {
     try testing.expect(ls.tap_hold == null);
 }
 
-test "tap-hold: PENDING + release with no tap target → IDLE, no tap_event" {
+test "layer: tap-hold: PENDING + release with no tap target → IDLE, no tap_event" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     _ = ls.onTriggerPress("aim", 200);
@@ -313,7 +313,7 @@ test "tap-hold: PENDING + release with no tap target → IDLE, no tap_event" {
     try testing.expect(ls.tap_hold == null);
 }
 
-test "tap-hold: ACTIVE + release → IDLE, layer_deactivated = true" {
+test "layer: tap-hold: ACTIVE + release → IDLE, layer_deactivated = true" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     _ = ls.onTriggerPress("aim", 200);
@@ -327,7 +327,7 @@ test "tap-hold: ACTIVE + release → IDLE, layer_deactivated = true" {
     try testing.expect(ls.tap_hold == null);
 }
 
-test "tap-hold: IDLE + release → no-op" {
+test "layer: tap-hold: IDLE + release → no-op" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
 
@@ -338,7 +338,7 @@ test "tap-hold: IDLE + release → no-op" {
     try testing.expect(!res.layer_deactivated);
 }
 
-test "tap-hold: IDLE + timer expired → no-op (stale timer)" {
+test "layer: tap-hold: IDLE + timer expired → no-op (stale timer)" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
 
@@ -347,7 +347,7 @@ test "tap-hold: IDLE + timer expired → no-op (stale timer)" {
     try testing.expect(res.arm_timer_ms == null);
 }
 
-test "tap-hold: ACTIVE re-press same trigger → ignored" {
+test "layer: tap-hold: ACTIVE re-press same trigger → ignored" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     _ = ls.onTriggerPress("aim", 200);
@@ -374,7 +374,7 @@ fn selMask() u64 {
     return @as(u64, 1) << @as(u6, @intCast(@intFromEnum(@import("state.zig").ButtonId.Select)));
 }
 
-test "processLayerTriggers: Hold press → PENDING, arm timer" {
+test "layer: processLayerTriggers: Hold press → PENDING, arm timer" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     const configs = [_]LayerConfig{hold_aim};
@@ -388,7 +388,7 @@ test "processLayerTriggers: Hold press → PENDING, arm timer" {
     try testing.expectEqual(TapHoldPhase.pending, ls.tap_hold.?.phase);
 }
 
-test "processLayerTriggers: Hold PENDING + timer → ACTIVE, getActive returns layer" {
+test "layer: processLayerTriggers: Hold PENDING + timer → ACTIVE, getActive returns layer" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     const configs = [_]LayerConfig{hold_aim};
@@ -401,7 +401,7 @@ test "processLayerTriggers: Hold PENDING + timer → ACTIVE, getActive returns l
     try testing.expectEqualStrings("aim", ls.getActive(&configs).?.name);
 }
 
-test "processLayerTriggers: Hold ACTIVE + release → IDLE" {
+test "layer: processLayerTriggers: Hold ACTIVE + release → IDLE" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     const configs = [_]LayerConfig{hold_aim};
@@ -416,7 +416,7 @@ test "processLayerTriggers: Hold ACTIVE + release → IDLE" {
     try testing.expect(ls.getActive(&configs) == null);
 }
 
-test "processLayerTriggers: Hold PENDING release → tap event + disarm" {
+test "layer: processLayerTriggers: Hold PENDING release → tap event + disarm" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     const tap_cfg = LayerConfig{ .name = "aim", .trigger = "LT", .activation = "hold", .tap = "KEY_F13" };
@@ -431,7 +431,7 @@ test "processLayerTriggers: Hold PENDING release → tap event + disarm" {
     try testing.expect(ls.tap_hold == null);
 }
 
-test "processLayerTriggers: ADR-004 mutual exclusion — second Hold press ignored while PENDING" {
+test "layer: processLayerTriggers: ADR-004 mutual exclusion — second Hold press ignored while PENDING" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     const configs = [_]LayerConfig{ hold_aim, hold_fn };
@@ -447,7 +447,7 @@ test "processLayerTriggers: ADR-004 mutual exclusion — second Hold press ignor
     try testing.expectEqualStrings("aim", ls.tap_hold.?.layer_name);
 }
 
-test "processLayerTriggers: ADR-004 mutual exclusion — second Hold press ignored while ACTIVE" {
+test "layer: processLayerTriggers: ADR-004 mutual exclusion — second Hold press ignored while ACTIVE" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     const configs = [_]LayerConfig{ hold_aim, hold_fn };
@@ -462,7 +462,7 @@ test "processLayerTriggers: ADR-004 mutual exclusion — second Hold press ignor
     try testing.expectEqualStrings("aim", ls.tap_hold.?.layer_name);
 }
 
-test "processLayerTriggers: Toggle release → layer on" {
+test "layer: processLayerTriggers: Toggle release → layer on" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     const configs = [_]LayerConfig{toggle_sel};
@@ -474,7 +474,7 @@ test "processLayerTriggers: Toggle release → layer on" {
     try testing.expect(ls.getActive(&configs) != null);
 }
 
-test "processLayerTriggers: Toggle second release → layer off" {
+test "layer: processLayerTriggers: Toggle second release → layer off" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     const configs = [_]LayerConfig{toggle_sel};
@@ -487,7 +487,7 @@ test "processLayerTriggers: Toggle second release → layer off" {
     try testing.expect(ls.getActive(&configs) == null);
 }
 
-test "processLayerTriggers: Toggle on blocked while Hold ACTIVE" {
+test "layer: processLayerTriggers: Toggle on blocked while Hold ACTIVE" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     const configs = [_]LayerConfig{ hold_aim, toggle_sel };
@@ -503,7 +503,7 @@ test "processLayerTriggers: Toggle on blocked while Hold ACTIVE" {
     try testing.expectEqualStrings("aim", ls.getActive(&configs).?.name);
 }
 
-test "processLayerTriggers: Toggle + Hold coexist, Hold takes priority in getActive" {
+test "layer: processLayerTriggers: Toggle + Hold coexist, Hold takes priority in getActive" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     const configs = [_]LayerConfig{ hold_aim, toggle_sel };
@@ -522,7 +522,7 @@ test "processLayerTriggers: Toggle + Hold coexist, Hold takes priority in getAct
     try testing.expectEqualStrings("aim", ls.getActive(&configs).?.name);
 }
 
-test "processLayerTriggers: multiple Toggles on — declaration order wins (ADR-004)" {
+test "layer: processLayerTriggers: multiple Toggles on — declaration order wins (ADR-004)" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
     const tog_a = LayerConfig{ .name = "a", .trigger = "LB", .activation = "toggle" };

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -444,7 +444,7 @@ fn makeMapper(cfg: *const MappingConfig, allocator: std.mem.Allocator) !Mapper {
     return Mapper.init(cfg, std.posix.STDIN_FILENO, allocator);
 }
 
-test "no layer no remap: apply passes through unchanged" {
+test "mapper: no layer no remap: apply passes through unchanged" {
     const allocator = testing.allocator;
     const parsed = try makeMapping("", allocator);
     defer parsed.deinit();
@@ -458,7 +458,7 @@ test "no layer no remap: apply passes through unchanged" {
     try testing.expectEqual(@as(usize, 0), events.aux.len);
 }
 
-test "base remap disabled: source button suppressed" {
+test "mapper: base remap disabled: source button suppressed" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[remap]
@@ -475,7 +475,7 @@ test "base remap disabled: source button suppressed" {
     try testing.expectEqual(@as(usize, 0), events.aux.len);
 }
 
-test "base remap key: source -> KEY_F13 aux event" {
+test "mapper: base remap key: source -> KEY_F13 aux event" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[remap]
@@ -500,7 +500,7 @@ test "base remap key: source -> KEY_F13 aux event" {
     }
 }
 
-test "base remap gamepad_button: A -> B" {
+test "mapper: base remap gamepad_button: A -> B" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[remap]
@@ -520,7 +520,7 @@ test "base remap gamepad_button: A -> B" {
     try testing.expectEqual(@as(usize, 0), events.aux.len);
 }
 
-test "layer remap overrides base: base A->B, layer A->C" {
+test "mapper: layer remap overrides base: base A->B, layer A->C" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[remap]
@@ -558,7 +558,7 @@ test "layer remap overrides base: base A->B, layer A->C" {
     try testing.expect((events.gamepad.buttons & (@as(u64, 1) << x_idx)) != 0);
 }
 
-test "suppress accumulates: base suppress A + layer suppress B" {
+test "mapper: suppress accumulates: base suppress A + layer suppress B" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[remap]
@@ -590,7 +590,7 @@ test "suppress accumulates: base suppress A + layer suppress B" {
     try testing.expectEqual(@as(u64, 0), events.gamepad.buttons & (@as(u64, 1) << b_idx));
 }
 
-test "inject last-write wins: layer inject overrides base inject for same button" {
+test "mapper: inject last-write wins: layer inject overrides base inject for same button" {
     const allocator = testing.allocator;
     // base: A->X, layer: A->Y — layer's inject for A's target wins
     const parsed = try makeMapping(
@@ -624,7 +624,7 @@ test "inject last-write wins: layer inject overrides base inject for same button
     try testing.expect((events.gamepad.buttons & (@as(u64, 1) << y_idx)) != 0);
 }
 
-test "prev frame masking: suppress produces correct diff" {
+test "mapper: prev frame masking: suppress produces correct diff" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[remap]
@@ -650,7 +650,7 @@ test "prev frame masking: suppress produces correct diff" {
     try testing.expectEqual(@as(u64, 0), ev2.prev.buttons & a_mask);
 }
 
-test "onTimerExpired: PENDING -> ACTIVE activates layer" {
+test "mapper: onTimerExpired: PENDING -> ACTIVE activates layer" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[[layer]]
@@ -683,7 +683,7 @@ test "onTimerExpired: PENDING -> ACTIVE activates layer" {
     try testing.expect((events.gamepad.buttons & (@as(u64, 1) << b_idx)) != 0);
 }
 
-test "layer gyro override: active layer gyro config used" {
+test "mapper: layer gyro override: active layer gyro config used" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[gyro]
@@ -714,7 +714,7 @@ test "layer gyro override: active layer gyro config used" {
     try testing.expectApproxEqAbs(@as(f32, 100.0), gcfg.sensitivity_x, 1e-4);
 }
 
-test "layer dpad override: active layer dpad config used" {
+test "mapper: layer dpad override: active layer dpad config used" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[dpad]
@@ -743,7 +743,7 @@ test "layer dpad override: active layer dpad config used" {
     try testing.expectEqual(@as(?bool, true), dcfg.suppress_gamepad);
 }
 
-test "gamepad_button tap: injected this frame, released next frame" {
+test "mapper: gamepad_button tap: injected this frame, released next frame" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[[layer]]
@@ -776,7 +776,7 @@ test "gamepad_button tap: injected this frame, released next frame" {
     try testing.expect(m.pending_tap_release == null);
 }
 
-test "dt_ms propagation: stick mouse output scales with dt" {
+test "mapper: dt_ms propagation: stick mouse output scales with dt" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[stick.right]
@@ -819,7 +819,7 @@ test "dt_ms propagation: stick mouse output scales with dt" {
     try testing.expect(diff <= 2);
 }
 
-test "dpad prev mask: suppress_dpad_hat applied to masked_prev" {
+test "mapper: dpad prev mask: suppress_dpad_hat applied to masked_prev" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[dpad]
@@ -840,26 +840,26 @@ test "dpad prev mask: suppress_dpad_hat applied to masked_prev" {
     try testing.expectEqual(@as(i8, 0), ev2.prev.dpad_y);
 }
 
-test "checkGyroActivate: null always true" {
+test "mapper: checkGyroActivate: null always true" {
     try testing.expect(checkGyroActivate(null, 0));
     try testing.expect(checkGyroActivate(null, 0xFFFFFFFF));
 }
 
-test "checkGyroActivate: always always true" {
+test "mapper: checkGyroActivate: always always true" {
     try testing.expect(checkGyroActivate("always", 0));
 }
 
-test "checkGyroActivate: hold_RB pressed" {
+test "mapper: checkGyroActivate: hold_RB pressed" {
     const rb_idx: u6 = @intCast(@intFromEnum(ButtonId.RB));
     const rb_mask: u64 = @as(u64, 1) << rb_idx;
     try testing.expect(checkGyroActivate("hold_RB", rb_mask));
 }
 
-test "checkGyroActivate: hold_RB not pressed" {
+test "mapper: checkGyroActivate: hold_RB not pressed" {
     try testing.expect(!checkGyroActivate("hold_RB", 0));
 }
 
-test "checkGyroActivate: unknown button name returns false" {
+test "mapper: checkGyroActivate: unknown button name returns false" {
     try testing.expect(!checkGyroActivate("hold_UNKNOWN", 0xFFFFFFFF));
 }
 
@@ -934,7 +934,7 @@ test "mapper: AuxEventList empty slice returns zero length" {
     try testing.expectEqual(@as(usize, 0), list.slice().len);
 }
 
-test "gyro activate: inactive frame no REL events and processor reset" {
+test "mapper: gyro activate: inactive frame no REL events and processor reset" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[gyro]
@@ -961,7 +961,7 @@ test "gyro activate: inactive frame no REL events and processor reset" {
     try testing.expectApproxEqAbs(@as(f32, 0.0), m.gyro_proc.ema_y, 1e-5);
 }
 
-test "gyro activate: active when RB held, inactive when released" {
+test "mapper: gyro activate: active when RB held, inactive when released" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[gyro]
@@ -993,7 +993,7 @@ test "gyro activate: active when RB held, inactive when released" {
     try testing.expectEqual(@as(usize, 0), ev_inactive.aux.len);
 }
 
-test "gyro joystick mode: overrides emit_state.rx/ry, suppresses original axes" {
+test "mapper: gyro joystick mode: overrides emit_state.rx/ry, suppresses original axes" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[gyro]
@@ -1024,7 +1024,7 @@ test "gyro joystick mode: overrides emit_state.rx/ry, suppresses original axes" 
     }
 }
 
-test "gyro joystick mode: null joy_x does not touch rx" {
+test "mapper: gyro joystick mode: null joy_x does not touch rx" {
     const allocator = testing.allocator;
     // mode=off → process() returns joy_x=null, joy_y=null
     const parsed = try makeMapping(
@@ -1042,7 +1042,7 @@ test "gyro joystick mode: null joy_x does not touch rx" {
     try testing.expectEqual(@as(i16, -1234), ev.gamepad.ry);
 }
 
-test "gyro mouse mode: joy_x/y do not affect emit_state axes" {
+test "mapper: gyro mouse mode: joy_x/y do not affect emit_state axes" {
     const allocator = testing.allocator;
     const parsed = try makeMapping(
         \\[gyro]

--- a/src/core/remap.zig
+++ b/src/core/remap.zig
@@ -47,41 +47,41 @@ pub fn resolveTarget(raw: []const u8) !RemapTargetResolved {
 
 // --- tests ---
 
-test "resolveTarget: macro:dodge_roll -> RemapTargetResolved.macro" {
+test "remap: resolveTarget: macro:dodge_roll -> RemapTargetResolved.macro" {
     const target = try resolveTarget("macro:dodge_roll");
     try std.testing.expectEqualStrings("dodge_roll", target.macro);
 }
 
-test "resolveTarget: KEY_F13 -> key 183" {
+test "remap: resolveTarget: KEY_F13 -> key 183" {
     const target = try resolveTarget("KEY_F13");
     try std.testing.expectEqual(@as(u16, 183), target.key);
 }
 
-test "resolveTarget: BTN_LEFT -> mouse_button 0x110" {
+test "remap: resolveTarget: BTN_LEFT -> mouse_button 0x110" {
     const target = try resolveTarget("BTN_LEFT");
     try std.testing.expectEqual(@as(u16, 0x110), target.mouse_button);
 }
 
-test "resolveTarget: mouse_left -> mouse_button 0x110" {
+test "remap: resolveTarget: mouse_left -> mouse_button 0x110" {
     const target = try resolveTarget("mouse_left");
     try std.testing.expectEqual(@as(u16, 0x110), target.mouse_button);
 }
 
-test "resolveTarget: A -> gamepad_button .A" {
+test "remap: resolveTarget: A -> gamepad_button .A" {
     const target = try resolveTarget("A");
     try std.testing.expectEqual(ButtonId.A, target.gamepad_button);
 }
 
-test "resolveTarget: B -> gamepad_button .B" {
+test "remap: resolveTarget: B -> gamepad_button .B" {
     const target = try resolveTarget("B");
     try std.testing.expectEqual(ButtonId.B, target.gamepad_button);
 }
 
-test "resolveTarget: disabled -> .disabled" {
+test "remap: resolveTarget: disabled -> .disabled" {
     const target = try resolveTarget("disabled");
     try std.testing.expectEqual(RemapTargetResolved.disabled, target);
 }
 
-test "resolveTarget: unknown string -> error.UnknownRemapTarget" {
+test "remap: resolveTarget: unknown string -> error.UnknownRemapTarget" {
     try std.testing.expectError(error.UnknownRemapTarget, resolveTarget("unknown_garbage"));
 }

--- a/src/core/state.zig
+++ b/src/core/state.zig
@@ -170,7 +170,7 @@ pub fn generateRandomDelta(rng: std.Random) GamepadStateDelta {
 
 // --- tests ---
 
-test "applyDelta: null fields leave state unchanged" {
+test "state: applyDelta: null fields leave state unchanged" {
     var s = GamepadState{ .ax = 10, .ay = 20, .buttons = 0xFF };
     s.applyDelta(.{});
     try std.testing.expectEqual(@as(i16, 10), s.ax);
@@ -178,7 +178,7 @@ test "applyDelta: null fields leave state unchanged" {
     try std.testing.expectEqual(@as(u64, 0xFF), s.buttons);
 }
 
-test "applyDelta: full overwrite" {
+test "state: applyDelta: full overwrite" {
     var s = GamepadState{};
     s.applyDelta(.{
         .ax = 100,
@@ -210,7 +210,7 @@ test "applyDelta: full overwrite" {
     try std.testing.expectEqual(@as(i16, -30), s.accel_z);
 }
 
-test "applyDelta: partial overwrite leaves other fields unchanged" {
+test "state: applyDelta: partial overwrite leaves other fields unchanged" {
     var s = GamepadState{ .ax = 5, .ay = 6, .rx = 7, .buttons = 0xF0 };
     s.applyDelta(.{ .ax = 99, .buttons = 0x0F });
     try std.testing.expectEqual(@as(i16, 99), s.ax);
@@ -219,14 +219,14 @@ test "applyDelta: partial overwrite leaves other fields unchanged" {
     try std.testing.expectEqual(@as(u64, 0x0F), s.buttons);
 }
 
-test "diff: identical states produce empty delta" {
+test "state: diff: identical states produce empty delta" {
     const s = GamepadState{ .ax = 10, .buttons = 0xFF };
     const d = s.diff(s);
     try std.testing.expectEqual(@as(?i16, null), d.ax);
     try std.testing.expectEqual(@as(?u64, null), d.buttons);
 }
 
-test "diff: changed fields appear in delta" {
+test "state: diff: changed fields appear in delta" {
     const prev = GamepadState{ .ax = 10, .ay = 20 };
     const curr = GamepadState{ .ax = 50, .ay = 20, .lt = 128 };
     const d = curr.diff(prev);
@@ -235,7 +235,7 @@ test "diff: changed fields appear in delta" {
     try std.testing.expectEqual(@as(?u8, 128), d.lt);
 }
 
-test "applyDelta: touchpad fields" {
+test "state: applyDelta: touchpad fields" {
     var s = GamepadState{};
     s.applyDelta(.{ .touch0_x = 1000, .touch0_y = -500, .touch0_active = true });
     try std.testing.expectEqual(@as(i16, 1000), s.touch0_x);
@@ -245,7 +245,7 @@ test "applyDelta: touchpad fields" {
     try std.testing.expectEqual(false, s.touch1_active);
 }
 
-test "diff: touchpad fields appear in delta" {
+test "state: diff: touchpad fields appear in delta" {
     const prev = GamepadState{};
     const curr = GamepadState{ .touch0_x = 100, .touch1_active = true };
     const d = curr.diff(prev);
@@ -255,7 +255,7 @@ test "diff: touchpad fields appear in delta" {
     try std.testing.expectEqual(@as(?bool, null), d.touch0_active);
 }
 
-test "applyDelta: battery_level field" {
+test "state: applyDelta: battery_level field" {
     var s = GamepadState{};
     try std.testing.expectEqual(@as(u8, 0), s.battery_level);
     s.applyDelta(.{ .battery_level = 7 });
@@ -264,7 +264,7 @@ test "applyDelta: battery_level field" {
     try std.testing.expectEqual(@as(u8, 7), s.battery_level);
 }
 
-test "diff: battery_level appears in delta when changed" {
+test "state: diff: battery_level appears in delta when changed" {
     const prev = GamepadState{};
     const curr = GamepadState{ .battery_level = 10 };
     const d = curr.diff(prev);
@@ -274,7 +274,7 @@ test "diff: battery_level appears in delta when changed" {
     try std.testing.expectEqual(@as(?u8, null), same.battery_level);
 }
 
-test "property: applyDelta(a, diff(b, a)) == b" {
+test "state: property: applyDelta(a, diff(b, a)) == b" {
     var prng = std.Random.DefaultPrng.init(42);
     const rng = prng.random();
     for (0..1000) |_| {
@@ -291,7 +291,7 @@ test "property: applyDelta(a, diff(b, a)) == b" {
     }
 }
 
-test "property: diff(s, s) produces all-null delta" {
+test "state: property: diff(s, s) produces all-null delta" {
     var prng = std.Random.DefaultPrng.init(99);
     const rng = prng.random();
     for (0..1000) |_| {
@@ -304,14 +304,14 @@ test "property: diff(s, s) produces all-null delta" {
     }
 }
 
-test "synthesizeDpadAxes: no buttons → 0,0" {
+test "state: synthesizeDpadAxes: no buttons → 0,0" {
     var gs = GamepadState{};
     gs.synthesizeDpadAxes();
     try std.testing.expectEqual(@as(i8, 0), gs.dpad_x);
     try std.testing.expectEqual(@as(i8, 0), gs.dpad_y);
 }
 
-test "synthesizeDpadAxes: cardinal directions" {
+test "state: synthesizeDpadAxes: cardinal directions" {
     const T = std.testing;
     const cases = [_]struct { btn: ButtonId, dx: i8, dy: i8 }{
         .{ .btn = .DPadUp, .dx = 0, .dy = -1 },
@@ -328,7 +328,7 @@ test "synthesizeDpadAxes: cardinal directions" {
     }
 }
 
-test "synthesizeDpadAxes: diagonal combinations" {
+test "state: synthesizeDpadAxes: diagonal combinations" {
     const T = std.testing;
     const cases = [_]struct { btns: []const ButtonId, dx: i8, dy: i8 }{
         .{ .btns = &.{ .DPadUp, .DPadRight }, .dx = 1, .dy = -1 },

--- a/src/core/stick.zig
+++ b/src/core/stick.zig
@@ -85,7 +85,7 @@ fn applyDeadzone(val: i16, deadzone: i16) f32 {
 
 const testing = std.testing;
 
-test "gamepad mode: process returns zero StickOutput" {
+test "stick: gamepad mode: process returns zero StickOutput" {
     var sp = StickProcessor{};
     const cfg = StickConfig{ .mode = "gamepad" };
     const out = sp.process(&cfg, 10000, -5000, 16);
@@ -95,7 +95,7 @@ test "gamepad mode: process returns zero StickOutput" {
     try testing.expectEqual(@as(i32, 0), out.hwheel);
 }
 
-test "mouse mode: deadzone suppresses output" {
+test "stick: mouse mode: deadzone suppresses output" {
     var sp = StickProcessor{};
     const cfg = StickConfig{ .mode = "mouse", .deadzone = 1000, .sensitivity = 1.0 };
     // axis values within deadzone → no movement
@@ -104,14 +104,14 @@ test "mouse mode: deadzone suppresses output" {
     try testing.expectEqual(@as(i32, 0), out.rel_y);
 }
 
-test "mouse mode: outside deadzone produces nonzero output" {
+test "stick: mouse mode: outside deadzone produces nonzero output" {
     var sp = StickProcessor{};
     const cfg = StickConfig{ .mode = "mouse", .deadzone = 100, .sensitivity = 10.0 };
     const out = sp.process(&cfg, 32000, 0, 16);
     try testing.expect(out.rel_x != 0);
 }
 
-test "mouse mode: dt normalization scales proportionally" {
+test "stick: mouse mode: dt normalization scales proportionally" {
     var sp8 = StickProcessor{};
     var sp16 = StickProcessor{};
     const cfg = StickConfig{ .mode = "mouse", .deadzone = 0, .sensitivity = 100.0 };
@@ -132,7 +132,7 @@ test "mouse mode: dt normalization scales proportionally" {
     try testing.expect(diff <= 2);
 }
 
-test "mouse mode: sub-pixel accumulation precision" {
+test "stick: mouse mode: sub-pixel accumulation precision" {
     var sp = StickProcessor{};
     const cfg = StickConfig{ .mode = "mouse", .deadzone = 0, .sensitivity = 1.0 };
     // Small input that accumulates across frames
@@ -147,7 +147,7 @@ test "mouse mode: sub-pixel accumulation precision" {
     try testing.expect(sp.mouse_accum_x >= 0 and sp.mouse_accum_x < 1.0);
 }
 
-test "scroll mode: accumulates to step" {
+test "stick: scroll mode: accumulates to step" {
     var sp = StickProcessor{};
     const cfg = StickConfig{ .mode = "scroll", .deadzone = 0, .sensitivity = 10.0 };
     var steps: i32 = 0;
@@ -158,7 +158,7 @@ test "scroll mode: accumulates to step" {
     try testing.expect(steps > 0);
 }
 
-test "scroll mode: small input accumulates across frames" {
+test "stick: scroll mode: small input accumulates across frames" {
     var sp = StickProcessor{};
     const cfg = StickConfig{ .mode = "scroll", .deadzone = 0, .sensitivity = 1.0 };
     // Single small-value frame should not immediately produce a step
@@ -168,7 +168,7 @@ test "scroll mode: small input accumulates across frames" {
     try testing.expect(sp.scroll_accum != 0);
 }
 
-test "dt=0: mouse delta is zero" {
+test "stick: dt=0: mouse delta is zero" {
     var sp = StickProcessor{};
     const cfg = StickConfig{ .mode = "mouse", .deadzone = 0, .sensitivity = 100.0 };
     const out = sp.process(&cfg, 32000, 32000, 0);

--- a/src/debug/render.zig
+++ b/src/debug/render.zig
@@ -973,7 +973,7 @@ fn makeTestState() GamepadState {
 
 const default_config = RenderConfig{ .has_gyro = true };
 
-test "renderFrame: contains axis values" {
+test "render: renderFrame: contains axis values" {
     var buf: [8192]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     const gs = makeTestState();
@@ -986,7 +986,7 @@ test "renderFrame: contains axis values" {
     try testing.expect(std.mem.indexOf(u8, out, "999") != null);
 }
 
-test "renderFrame: contains trigger values" {
+test "render: renderFrame: contains trigger values" {
     var buf: [8192]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     const gs = makeTestState();
@@ -997,7 +997,7 @@ test "renderFrame: contains trigger values" {
     try testing.expect(std.mem.indexOf(u8, out, "64") != null);
 }
 
-test "renderFrame: contains gyro values" {
+test "render: renderFrame: contains gyro values" {
     var buf: [8192]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     const gs = makeTestState();
@@ -1009,7 +1009,7 @@ test "renderFrame: contains gyro values" {
     try testing.expect(std.mem.indexOf(u8, out, "300") != null);
 }
 
-test "renderFrame: no gyro section when disabled" {
+test "render: renderFrame: no gyro section when disabled" {
     var buf: [8192]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     const gs = makeTestState();
@@ -1020,7 +1020,7 @@ test "renderFrame: no gyro section when disabled" {
     try testing.expect(std.mem.indexOf(u8, out, "GX") == null);
 }
 
-test "renderFrame: touchpad section when enabled" {
+test "render: renderFrame: touchpad section when enabled" {
     var buf: [8192]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     var gs = GamepadState{};
@@ -1033,7 +1033,7 @@ test "renderFrame: touchpad section when enabled" {
     try testing.expect(std.mem.indexOf(u8, out, "500") != null);
 }
 
-test "renderFrame: contains raw hex bytes" {
+test "render: renderFrame: contains raw hex bytes" {
     var buf: [8192]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     const gs = GamepadState{};
@@ -1046,7 +1046,7 @@ test "renderFrame: contains raw hex bytes" {
     try testing.expect(std.mem.indexOf(u8, out, "ef") != null);
 }
 
-test "renderFrame: rumble_on shows rumble indicator" {
+test "render: renderFrame: rumble_on shows rumble indicator" {
     var buf: [8192]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     const gs = GamepadState{};
@@ -1056,7 +1056,7 @@ test "renderFrame: rumble_on shows rumble indicator" {
     try testing.expect(std.mem.indexOf(u8, out, "ON") != null);
 }
 
-test "renderFrame: contains ANSI escape sequences" {
+test "render: renderFrame: contains ANSI escape sequences" {
     var buf: [8192]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     const gs = GamepadState{};
@@ -1066,7 +1066,7 @@ test "renderFrame: contains ANSI escape sequences" {
     try testing.expect(std.mem.indexOf(u8, out, "\x1b[") != null);
 }
 
-test "renderFrame: pressed button highlighted differently" {
+test "render: renderFrame: pressed button highlighted differently" {
     var buf_pressed: [8192]u8 = undefined;
     var buf_released: [8192]u8 = undefined;
     var fbs1 = std.io.fixedBufferStream(&buf_pressed);
@@ -1084,7 +1084,7 @@ test "renderFrame: pressed button highlighted differently" {
     try testing.expect(!std.mem.eql(u8, fbs1.getWritten(), fbs2.getWritten()));
 }
 
-test "renderFrame: extended buttons shown when configured" {
+test "render: renderFrame: extended buttons shown when configured" {
     var buf: [8192]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     var gs = GamepadState{};
@@ -1096,7 +1096,7 @@ test "renderFrame: extended buttons shown when configured" {
     try testing.expect(std.mem.indexOf(u8, out, "[Z]") != null);
 }
 
-test "renderFrame: mapped mode shows grouped outputs" {
+test "render: renderFrame: mapped mode shows grouped outputs" {
     var buf: [8192]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     const gs = makeTestState();
@@ -1123,7 +1123,7 @@ test "renderFrame: mapped mode shows grouped outputs" {
     try testing.expect(std.mem.indexOf(u8, out, "Test Pad") != null);
 }
 
-test "shortenEventCode: known codes" {
+test "render: shortenEventCode: known codes" {
     try testing.expectEqualStrings("S", shortenEventCode("BTN_SOUTH"));
     try testing.expectEqualStrings("HM", shortenEventCode("BTN_MODE"));
     try testing.expectEqualStrings("H1", shortenEventCode("BTN_TRIGGER_HAPPY1"));
@@ -1133,7 +1133,7 @@ test "shortenEventCode: known codes" {
     try testing.expectEqualStrings("MM", shortenEventCode("BTN_MIDDLE"));
 }
 
-test "categorizeEventCode: categories" {
+test "render: categorizeEventCode: categories" {
     try testing.expectEqual(OutputCategory.gamepad, categorizeEventCode("BTN_SOUTH"));
     try testing.expectEqual(OutputCategory.keyboard, categorizeEventCode("KEY_F13"));
     try testing.expectEqual(OutputCategory.mouse, categorizeEventCode("BTN_LEFT"));
@@ -1141,7 +1141,7 @@ test "categorizeEventCode: categories" {
     try testing.expectEqual(OutputCategory.gamepad, categorizeEventCode("BTN_TRIGGER_HAPPY1"));
 }
 
-test "Stats: packet counting and per-second rate" {
+test "render: Stats: packet counting and per-second rate" {
     var st = Stats.init(1000);
     st.recordPacket(1000);
     st.recordPacket(1100);
@@ -1155,7 +1155,7 @@ test "Stats: packet counting and per-second rate" {
     try testing.expect(st.packets_per_sec > 0);
 }
 
-test "Stats: button change tracking and ring buffer" {
+test "render: Stats: button change tracking and ring buffer" {
     var st = Stats.init(0);
     st.recordButtonChange(.A, true, 100);
     try testing.expectEqual(@as(u64, 1), st.key_press_count);
@@ -1175,7 +1175,7 @@ test "Stats: button change tracking and ring buffer" {
     try testing.expectEqual(true, ev1.pressed);
 }
 
-test "Stats: ring buffer wraps at 8" {
+test "render: Stats: ring buffer wraps at 8" {
     var st = Stats.init(0);
     // Fill 10 events, ring buffer holds last 8
     for (0..10) |i| {
@@ -1196,7 +1196,7 @@ test "Stats: ring buffer wraps at 8" {
     try testing.expectEqual(@as(?KeyEvent, null), st.eventAt(8));
 }
 
-test "renderStats: produces Stats section with data" {
+test "render: renderStats: produces Stats section with data" {
     var buf: [8192]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     const gs = GamepadState{};

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -425,7 +425,7 @@ const testing = std.testing;
 const MockDeviceIO = @import("test/mock_device_io.zig").MockDeviceIO;
 const uinput = @import("io/uinput.zig");
 
-test "EventLoop.addUinputFf registers fd and increments fd_count" {
+test "event_loop: EventLoop.addUinputFf registers fd and increments fd_count" {
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
 
@@ -439,7 +439,7 @@ test "EventLoop.addUinputFf registers fd and increments fd_count" {
     try testing.expectEqual(pfds[0], loop.pollfds[3].fd);
 }
 
-test "EventLoop: Disconnected device causes loop to exit without panic" {
+test "event_loop: EventLoop: Disconnected device causes loop to exit without panic" {
     const allocator = testing.allocator;
     var mock = try MockDeviceIO.init(allocator, &.{});
     defer mock.deinit();
@@ -495,7 +495,7 @@ test "EventLoop: Disconnected device causes loop to exit without panic" {
     try testing.expect(!loop.running);
 }
 
-test "EventLoop.initManaged creates eventfd and timerfd" {
+test "event_loop: EventLoop.initManaged creates eventfd and timerfd" {
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
     try testing.expect(loop.signal_fd >= 0);
@@ -504,7 +504,7 @@ test "EventLoop.initManaged creates eventfd and timerfd" {
     try testing.expectEqual(@as(usize, 3), loop.fd_count);
 }
 
-test "EventLoop.stop wakes ppoll" {
+test "event_loop: EventLoop.stop wakes ppoll" {
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
     loop.stop();
@@ -513,7 +513,7 @@ test "EventLoop.stop wakes ppoll" {
     try testing.expectEqual(@as(usize, 1), ready);
 }
 
-test "EventLoop.addDevice registers fd" {
+test "event_loop: EventLoop.addDevice registers fd" {
     const allocator = testing.allocator;
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
@@ -528,7 +528,7 @@ test "EventLoop.addDevice registers fd" {
     try testing.expectEqual(mock.pipe_r, loop.pollfds[3].fd);
 }
 
-test "EventLoop.addDevice rejects overflow" {
+test "event_loop: EventLoop.addDevice rejects overflow" {
     const allocator = testing.allocator;
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
@@ -550,7 +550,7 @@ test "EventLoop.addDevice rejects overflow" {
     try testing.expectError(error.TooManyFds, loop.addDevice(extra_dev));
 }
 
-test "armTimer / disarmTimer: arm then disarm does not leave fd readable" {
+test "event_loop: armTimer / disarmTimer: arm then disarm does not leave fd readable" {
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
 
@@ -563,7 +563,7 @@ test "armTimer / disarmTimer: arm then disarm does not leave fd readable" {
     try testing.expectEqual(@as(usize, 0), ready);
 }
 
-test "armTimer: fires after timeout" {
+test "event_loop: armTimer: fires after timeout" {
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
 
@@ -580,7 +580,7 @@ test "armTimer: fires after timeout" {
     try testing.expectEqual(@as(usize, 8), n);
 }
 
-test "EventLoop timerfd: mapper.onTimerExpired invoked on timer expiry" {
+test "event_loop: EventLoop timerfd: mapper.onTimerExpired invoked on timer expiry" {
     const allocator = testing.allocator;
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
@@ -676,7 +676,7 @@ const minimal_toml =
     \\left_x = { offset = 1, type = "i16le" }
 ;
 
-test "EventLoop mini: device frame dispatched to interpreter and output" {
+test "event_loop: EventLoop mini: device frame dispatched to interpreter and output" {
     const allocator = testing.allocator;
 
     var loop = try EventLoop.initManaged();
@@ -986,7 +986,7 @@ test "event_loop: config-driven FF command key — output.force_feedback.type ov
 const command = @import("core/command.zig");
 const mapping_mod = @import("config/mapping.zig");
 
-test "buildAdaptiveTriggerParams: maps left/right values with shift" {
+test "event_loop: buildAdaptiveTriggerParams: maps left/right values with shift" {
     const at = mapping_mod.AdaptiveTriggerConfig{
         .mode = "feedback",
         .right = .{ .position = 40, .strength = 180 },
@@ -1009,7 +1009,7 @@ test "buildAdaptiveTriggerParams: maps left/right values with shift" {
     try testing.expectEqual(@as(u16, 200 << 8), params[7].value);
 }
 
-test "buildAdaptiveTriggerParams: null params default to 0" {
+test "event_loop: buildAdaptiveTriggerParams: null params default to 0" {
     const at = mapping_mod.AdaptiveTriggerConfig{ .mode = "off" };
     var buf: [12]Param = undefined;
     const params = buildAdaptiveTriggerParams(&buf, &at);
@@ -1018,7 +1018,7 @@ test "buildAdaptiveTriggerParams: null params default to 0" {
     }
 }
 
-test "fillTemplate: adaptive trigger feedback template produces correct bytes" {
+test "event_loop: fillTemplate: adaptive trigger feedback template produces correct bytes" {
     const allocator = testing.allocator;
     const template = "02 0c 00 00 00 00 00 00 00 00 00 01 {r_position:u8} {r_strength:u8} 00 00 00 00 00 00 00 00 01 {l_position:u8} {l_strength:u8} 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00";
     const at = mapping_mod.AdaptiveTriggerConfig{
@@ -1050,7 +1050,7 @@ test "fillTemplate: adaptive trigger feedback template produces correct bytes" {
     try testing.expectEqual(@as(u8, 200), result[24]);
 }
 
-test "fillTemplate: adaptive trigger off template is all zeros except report ID and flags" {
+test "event_loop: fillTemplate: adaptive trigger off template is all zeros except report ID and flags" {
     const allocator = testing.allocator;
     const template = "02 0c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00";
     const result = try command.fillTemplate(allocator, template, &.{});
@@ -1064,7 +1064,7 @@ test "fillTemplate: adaptive trigger off template is all zeros except report ID 
     }
 }
 
-test "applyAdaptiveTrigger: round-trip mapping config to device write" {
+test "event_loop: applyAdaptiveTrigger: round-trip mapping config to device write" {
     const allocator = testing.allocator;
 
     const at_toml =
@@ -1109,7 +1109,7 @@ test "applyAdaptiveTrigger: round-trip mapping config to device write" {
     try testing.expectEqual(@as(u8, 255), mock_dev.write_log.items[24]); // l_strength
 }
 
-test "applyAdaptiveTrigger: unknown mode silently skips" {
+test "event_loop: applyAdaptiveTrigger: unknown mode silently skips" {
     const allocator = testing.allocator;
 
     const parsed = try device_mod.parseString(allocator, minimal_toml);
@@ -1125,7 +1125,7 @@ test "applyAdaptiveTrigger: unknown mode silently skips" {
     try testing.expectEqual(@as(usize, 0), mock_dev.write_log.items.len);
 }
 
-test "applyAdaptiveTrigger: custom command_prefix routes correctly" {
+test "event_loop: applyAdaptiveTrigger: custom command_prefix routes correctly" {
     const allocator = testing.allocator;
 
     const toml_str =

--- a/src/init.zig
+++ b/src/init.zig
@@ -99,40 +99,40 @@ pub fn runInitSequence(
 
 // --- tests ---
 
-test "parseHexBytes basic" {
+test "init: parseHexBytes basic" {
     const allocator = std.testing.allocator;
     const bytes = try parseHexBytes(allocator, "5aa5 0102 03");
     defer allocator.free(bytes);
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x5a, 0xa5, 0x01, 0x02, 0x03 }, bytes);
 }
 
-test "parseHexBytes no spaces" {
+test "init: parseHexBytes no spaces" {
     const allocator = std.testing.allocator;
     const bytes = try parseHexBytes(allocator, "deadbeef");
     defer allocator.free(bytes);
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0xde, 0xad, 0xbe, 0xef }, bytes);
 }
 
-test "parseHexBytes empty" {
+test "init: parseHexBytes empty" {
     const allocator = std.testing.allocator;
     const bytes = try parseHexBytes(allocator, "");
     defer allocator.free(bytes);
     try std.testing.expectEqual(@as(usize, 0), bytes.len);
 }
 
-test "parseHexBytes invalid char returns error" {
+test "init: parseHexBytes invalid char returns error" {
     const allocator = std.testing.allocator;
     try std.testing.expectError(error.InvalidHex, parseHexBytes(allocator, "5xaa"));
 }
 
-test "parseHexBytes odd length returns error" {
+test "init: parseHexBytes odd length returns error" {
     const allocator = std.testing.allocator;
     try std.testing.expectError(error.InvalidHex, parseHexBytes(allocator, "5a0"));
 }
 
 const MockDeviceIO = @import("test/mock_device_io.zig").MockDeviceIO;
 
-test "runInitSequence: sends command and matches response_prefix" {
+test "init: runInitSequence: sends command and matches response_prefix" {
     const allocator = std.testing.allocator;
 
     // response: 0x5a, 0xa5, 0x00 — prefix matches [0x5a, 0xa5]
@@ -152,7 +152,7 @@ test "runInitSequence: sends command and matches response_prefix" {
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x5a, 0xa5, 0x01, 0x01 }, mock.write_log.items);
 }
 
-test "runInitSequence: exhausted retries logs warning and continues" {
+test "init: runInitSequence: exhausted retries logs warning and continues" {
     const allocator = std.testing.allocator;
 
     // No frames — every read returns Again → warns but does not fail
@@ -168,7 +168,7 @@ test "runInitSequence: exhausted retries logs warning and continues" {
     try runInitSequence(allocator, dev, init_cfg);
 }
 
-test "runInitSequence: enable command sent after commands" {
+test "init: runInitSequence: enable command sent after commands" {
     const allocator = std.testing.allocator;
 
     // Two reads: one for the main command, one for enable
@@ -188,7 +188,7 @@ test "runInitSequence: enable command sent after commands" {
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x01, 0x01, 0x02, 0x02 }, mock.write_log.items);
 }
 
-test "runInitSequence: wrong prefix after retries logs warning and continues" {
+test "init: runInitSequence: wrong prefix after retries logs warning and continues" {
     const allocator = std.testing.allocator;
 
     // Response has wrong prefix — warns but does not fail

--- a/src/io/control_socket.zig
+++ b/src/io/control_socket.zig
@@ -184,61 +184,61 @@ fn containsPathTraversal(s: []const u8) bool {
 
 const testing = std.testing;
 
-test "parseCommand: SWITCH global" {
+test "control_socket: parseCommand: SWITCH global" {
     const cmd = parseCommand("SWITCH fps\n");
     try testing.expectEqual(CommandTag.switch_mapping, cmd.tag);
     try testing.expectEqualStrings("fps", cmd.name);
 }
 
-test "parseCommand: SWITCH per-device" {
+test "control_socket: parseCommand: SWITCH per-device" {
     const cmd = parseCommand("SWITCH racing --device hidraw0\n");
     try testing.expectEqual(CommandTag.switch_device, cmd.tag);
     try testing.expectEqualStrings("racing", cmd.name);
     try testing.expectEqualStrings("hidraw0", cmd.device_id);
 }
 
-test "parseCommand: STATUS" {
+test "control_socket: parseCommand: STATUS" {
     const cmd = parseCommand("STATUS\n");
     try testing.expectEqual(CommandTag.status, cmd.tag);
 }
 
-test "parseCommand: LIST" {
+test "control_socket: parseCommand: LIST" {
     const cmd = parseCommand("LIST\n");
     try testing.expectEqual(CommandTag.list, cmd.tag);
 }
 
-test "parseCommand: DEVICES" {
+test "control_socket: parseCommand: DEVICES" {
     const cmd = parseCommand("DEVICES\n");
     try testing.expectEqual(CommandTag.devices, cmd.tag);
 }
 
-test "parseCommand: unknown" {
+test "control_socket: parseCommand: unknown" {
     const cmd = parseCommand("FOOBAR\n");
     try testing.expectEqual(CommandTag.unknown, cmd.tag);
 }
 
-test "parseCommand: empty" {
+test "control_socket: parseCommand: empty" {
     const cmd = parseCommand("\n");
     try testing.expectEqual(CommandTag.unknown, cmd.tag);
 }
 
-test "parseCommand: case insensitive" {
+test "control_socket: parseCommand: case insensitive" {
     const cmd = parseCommand("switch FPS\n");
     try testing.expectEqual(CommandTag.switch_mapping, cmd.tag);
     try testing.expectEqualStrings("FPS", cmd.name);
 }
 
-test "parseCommand: SWITCH missing name" {
+test "control_socket: parseCommand: SWITCH missing name" {
     const cmd = parseCommand("SWITCH\n");
     try testing.expectEqual(CommandTag.unknown, cmd.tag);
 }
 
-test "parseCommand: SWITCH --device missing id" {
+test "control_socket: parseCommand: SWITCH --device missing id" {
     const cmd = parseCommand("SWITCH fps --device\n");
     try testing.expectEqual(CommandTag.unknown, cmd.tag);
 }
 
-test "parseCommand: path traversal rejected" {
+test "control_socket: parseCommand: path traversal rejected" {
     try testing.expectEqual(CommandTag.unknown, parseCommand("SWITCH ../etc/passwd\n").tag);
     try testing.expectEqual(CommandTag.unknown, parseCommand("SWITCH foo/bar\n").tag);
     try testing.expectEqual(CommandTag.unknown, parseCommand("SWITCH a\\b\n").tag);
@@ -252,7 +252,7 @@ fn testSocketpair() ![2]posix.fd_t {
     return fds;
 }
 
-test "ControlSocket: socketpair read/write" {
+test "control_socket: ControlSocket: socketpair read/write" {
     const fds = try testSocketpair();
     defer posix.close(fds[0]);
     defer posix.close(fds[1]);
@@ -268,7 +268,7 @@ test "ControlSocket: socketpair read/write" {
     try testing.expectEqualStrings("fps", cmd.name);
 }
 
-test "ControlSocket: init rejects overly long unix socket path" {
+test "control_socket: ControlSocket: init rejects overly long unix socket path" {
     const allocator = testing.allocator;
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/io/hidraw.zig
+++ b/src/io/hidraw.zig
@@ -320,7 +320,7 @@ pub fn parseInterfaceId(phys: []const u8) ?u8 {
 
 // --- tests ---
 
-test "parseInterfaceId basic" {
+test "hidraw: parseInterfaceId basic" {
     try std.testing.expectEqual(@as(?u8, 1), parseInterfaceId("usb-0000:00:14.0-1.2/input1"));
     try std.testing.expectEqual(@as(?u8, 0), parseInterfaceId("usb-0000:00:14.0-1/input0"));
     try std.testing.expectEqual(@as(?u8, 2), parseInterfaceId("input2"));
@@ -328,13 +328,13 @@ test "parseInterfaceId basic" {
     try std.testing.expectEqual(@as(?u8, null), parseInterfaceId(""));
 }
 
-test "parseInterfaceId Vader5 format" {
+test "hidraw: parseInterfaceId Vader5 format" {
     // Typical USB phys string: "usb-xhci_hcd.0.auto-1/input1"
     try std.testing.expectEqual(@as(?u8, 1), parseInterfaceId("usb-xhci_hcd.0.auto-1/input1"));
     try std.testing.expectEqual(@as(?u8, 0), parseInterfaceId("usb-xhci_hcd.0.auto-1/input0"));
 }
 
-test "discoverAllWithRoot: nonexistent dev_root returns empty" {
+test "hidraw: discoverAllWithRoot: nonexistent dev_root returns empty" {
     const allocator = std.testing.allocator;
     const paths: [][]const u8 = try HidrawDevice.discoverAllWithRoot(allocator, 0x1234, 0x5678, "/nonexistent_hidraw_root_xyz");
     defer {
@@ -344,24 +344,24 @@ test "discoverAllWithRoot: nonexistent dev_root returns empty" {
     try std.testing.expectEqual(@as(usize, 0), paths.len);
 }
 
-test "parseInterfaceId: deep multi-segment path" {
+test "hidraw: parseInterfaceId: deep multi-segment path" {
     try std.testing.expectEqual(@as(?u8, 3), parseInterfaceId("usb-0000:00:14.0-2.4/input3"));
     try std.testing.expectEqual(@as(?u8, 0), parseInterfaceId("platform/soc/usb/input0"));
 }
 
-test "parseInterfaceId: bare 'input' without number returns null" {
+test "hidraw: parseInterfaceId: bare 'input' without number returns null" {
     try std.testing.expectEqual(@as(?u8, null), parseInterfaceId("usb/input"));
     try std.testing.expectEqual(@as(?u8, null), parseInterfaceId("input"));
 }
 
-test "parseInterfaceId: finds last 'inputN' even when trailing segment is non-input" {
+test "hidraw: parseInterfaceId: finds last 'inputN' even when trailing segment is non-input" {
     // "event0" is not an input* segment; walk finds "input5" → 5
     try std.testing.expectEqual(@as(?u8, 5), parseInterfaceId("usb/input5/event0"));
     // no inputN anywhere → null
     try std.testing.expectEqual(@as(?u8, null), parseInterfaceId("usb/event0/dev"));
 }
 
-test "grabAssociatedEvdev sysfs path parsing" {
+test "hidraw: grabAssociatedEvdev sysfs path parsing" {
     // Build a temp sysfs-like tree and verify grab logic finds eventK entries.
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -812,7 +812,7 @@ const MockOutputDevice = struct {
     fn mockClose(_: *anyopaque) void {}
 };
 
-test "ioctl constants match Linux kernel values" {
+test "uinput: ioctl constants match Linux kernel values" {
     // Linux: #define UI_SET_EVBIT _IOW('U', 100, int)  → type=0x55,nr=100,size=4 → 0x40045564
     // _IOW encodes: dir=1(write),type='U',nr,size
     // dir=1 << 30, type << 8, nr, size << 16
@@ -826,7 +826,7 @@ test "ioctl constants match Linux kernel values" {
     try std.testing.expectEqual(expected_create, UI_DEV_CREATE);
 }
 
-test "emit: same state produces no events (via mock)" {
+test "uinput: emit: same state produces no events (via mock)" {
     const allocator = std.testing.allocator;
     var mock = MockOutputDevice.init(allocator);
     defer mock.deinit();
@@ -840,7 +840,7 @@ test "emit: same state produces no events (via mock)" {
     try std.testing.expectEqual(@as(usize, 0), mock.emitted.items.len);
 }
 
-test "emit: state change recorded once" {
+test "uinput: emit: state change recorded once" {
     const allocator = std.testing.allocator;
     var mock = MockOutputDevice.init(allocator);
     defer mock.deinit();
@@ -858,7 +858,7 @@ test "emit: state change recorded once" {
     try std.testing.expectEqual(@as(i16, 100), mock.emitted.items[0].ax);
 }
 
-test "emit: button change recorded" {
+test "uinput: emit: button change recorded" {
     const allocator = std.testing.allocator;
     var mock = MockOutputDevice.init(allocator);
     defer mock.deinit();
@@ -902,13 +902,13 @@ const MockAuxDevice = struct {
     fn mockAuxClose(_: *anyopaque) void {}
 };
 
-test "AuxEvent.rel: construct and match" {
+test "uinput: AuxEvent.rel: construct and match" {
     const ev = AuxEvent{ .rel = .{ .code = c.REL_X, .value = 5 } };
     try std.testing.expectEqual(@as(u16, c.REL_X), ev.rel.code);
     try std.testing.expectEqual(@as(i32, 5), ev.rel.value);
 }
 
-test "emitAux: rel event recorded by mock" {
+test "uinput: emitAux: rel event recorded by mock" {
     const allocator = std.testing.allocator;
     var mock = MockAuxDevice.init(allocator);
     defer mock.deinit();
@@ -922,7 +922,7 @@ test "emitAux: rel event recorded by mock" {
     try std.testing.expectEqual(@as(i32, 5), mock.emitted.items[0].rel.value);
 }
 
-test "emitAux: rel value=0 not recorded" {
+test "uinput: emitAux: rel value=0 not recorded" {
     const allocator = std.testing.allocator;
     var mock = MockAuxDevice.init(allocator);
     defer mock.deinit();
@@ -944,7 +944,7 @@ test "emitAux: rel value=0 not recorded" {
     try std.testing.expectEqual(@as(i32, 0), mock.emitted.items[0].rel.value);
 }
 
-test "emitAux: REL_X and REL_Y same batch recorded in order" {
+test "uinput: emitAux: REL_X and REL_Y same batch recorded in order" {
     const allocator = std.testing.allocator;
     var mock = MockAuxDevice.init(allocator);
     defer mock.deinit();
@@ -959,7 +959,7 @@ test "emitAux: REL_X and REL_Y same batch recorded in order" {
     try std.testing.expectEqual(@as(u16, c.REL_Y), mock.emitted.items[1].rel.code);
 }
 
-test "emitAux: REL_WHEEL positive and negative values" {
+test "uinput: emitAux: REL_WHEEL positive and negative values" {
     const allocator = std.testing.allocator;
     var mock = MockAuxDevice.init(allocator);
     defer mock.deinit();
@@ -976,7 +976,7 @@ test "emitAux: REL_WHEEL positive and negative values" {
     try std.testing.expectEqual(@as(i32, -1), mock.emitted.items[1].rel.value);
 }
 
-test "emitAux: existing key event unaffected by rel addition" {
+test "uinput: emitAux: existing key event unaffected by rel addition" {
     const allocator = std.testing.allocator;
     var mock = MockAuxDevice.init(allocator);
     defer mock.deinit();
@@ -990,12 +990,12 @@ test "emitAux: existing key event unaffected by rel addition" {
     try std.testing.expect(mock.emitted.items[0].key.pressed);
 }
 
-test "ioctl constant: UI_SET_RELBIT matches kernel value" {
+test "uinput: ioctl constant: UI_SET_RELBIT matches kernel value" {
     const expected: u32 = (1 << 30) | (@as(u32, 'U') << 8) | 102 | (@as(u32, @sizeOf(c_int)) << 16);
     try std.testing.expectEqual(expected, UI_SET_RELBIT);
 }
 
-test "pollFf drain loop: empty pipe returns null without blocking" {
+test "uinput: pollFf drain loop: empty pipe returns null without blocking" {
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1008,7 +1008,7 @@ test "pollFf drain loop: empty pipe returns null without blocking" {
     try std.testing.expectEqual(@as(?FfEvent, null), result);
 }
 
-test "pollFf drain loop: drains multiple events and returns last EV_FF" {
+test "uinput: pollFf drain loop: drains multiple events and returns last EV_FF" {
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1029,7 +1029,7 @@ test "pollFf drain loop: drains multiple events and returns last EV_FF" {
     try std.testing.expectEqual(@as(u16, c.FF_RUMBLE), result.?.effect_type);
 }
 
-test "pollFfFd returns the fd" {
+test "uinput: pollFfFd returns the fd" {
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1041,7 +1041,7 @@ test "pollFfFd returns the fd" {
     try std.testing.expectEqual(pfds[0], dev.pollFfFd());
 }
 
-test "ff_effects: initial state all zeros" {
+test "uinput: ff_effects: initial state all zeros" {
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1056,7 +1056,7 @@ test "ff_effects: initial state all zeros" {
     }
 }
 
-test "pollFf play: returns stored ff_effects values" {
+test "uinput: pollFf play: returns stored ff_effects values" {
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1078,7 +1078,7 @@ test "pollFf play: returns stored ff_effects values" {
     try std.testing.expectEqual(@as(u16, 0x8000), result.?.weak);
 }
 
-test "pollFf play stop (value=0): returns zeros" {
+test "uinput: pollFf play stop (value=0): returns zeros" {
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1098,7 +1098,7 @@ test "pollFf play stop (value=0): returns zeros" {
     try std.testing.expectEqual(@as(u16, 0), result.?.weak);
 }
 
-test "pollFf play: id >= 16 returns zeros (no panic)" {
+test "uinput: pollFf play: id >= 16 returns zeros (no panic)" {
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1117,7 +1117,7 @@ test "pollFf play: id >= 16 returns zeros (no panic)" {
     try std.testing.expectEqual(@as(u16, 0), result.?.weak);
 }
 
-test "ff_effects: erase clears slot" {
+test "uinput: ff_effects: erase clears slot" {
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1133,7 +1133,7 @@ test "ff_effects: erase clears slot" {
     try std.testing.expectEqual(@as(u16, 0), dev.ff_effects[2].weak);
 }
 
-test "ff_effects: upload stores strong and weak" {
+test "uinput: ff_effects: upload stores strong and weak" {
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1150,7 +1150,7 @@ test "ff_effects: upload stores strong and weak" {
     try std.testing.expectEqual(@as(u16, 0), dev.ff_effects[0].strong);
 }
 
-test "stateFieldForAxis: known axes return correct fields" {
+test "uinput: stateFieldForAxis: known axes return correct fields" {
     try std.testing.expectEqual(UinputDevice.AxisStateField.ax, try UinputDevice.stateFieldForAxis("left_x"));
     try std.testing.expectEqual(UinputDevice.AxisStateField.ay, try UinputDevice.stateFieldForAxis("left_y"));
     try std.testing.expectEqual(UinputDevice.AxisStateField.rx, try UinputDevice.stateFieldForAxis("right_x"));
@@ -1161,7 +1161,7 @@ test "stateFieldForAxis: known axes return correct fields" {
     try std.testing.expectEqual(UinputDevice.AxisStateField.dpad_y, try UinputDevice.stateFieldForAxis("dpad_y"));
 }
 
-test "stateFieldForAxis: unknown axis returns error" {
+test "uinput: stateFieldForAxis: unknown axis returns error" {
     try std.testing.expectError(error.UnknownAxis, UinputDevice.stateFieldForAxis("nonexistent"));
     try std.testing.expectError(error.UnknownAxis, UinputDevice.stateFieldForAxis(""));
     try std.testing.expectError(error.UnknownAxis, UinputDevice.stateFieldForAxis("LEFT_X"));
@@ -1172,7 +1172,7 @@ fn readEvents(read_fd: std.posix.fd_t, out: []c.input_event) usize {
     return bytes / @sizeOf(c.input_event);
 }
 
-test "UinputDevice.emit: axis diff writes correct input_events via pipe" {
+test "uinput: UinputDevice.emit: axis diff writes correct input_events via pipe" {
     const pfds = try std.posix.pipe2(.{});
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1206,7 +1206,7 @@ test "UinputDevice.emit: axis diff writes correct input_events via pipe" {
     try std.testing.expectEqual(@as(u16, c.SYN_REPORT), events[2].code);
 }
 
-test "UinputDevice.emit: no change produces no write" {
+test "uinput: UinputDevice.emit: no change produces no write" {
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1227,7 +1227,7 @@ test "UinputDevice.emit: no change produces no write" {
     try std.testing.expectEqual(@as(usize, 0), n);
 }
 
-test "UinputDevice.emit: button press/release generates EV_KEY events" {
+test "uinput: UinputDevice.emit: button press/release generates EV_KEY events" {
     const pfds = try std.posix.pipe2(.{});
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1262,7 +1262,7 @@ test "UinputDevice.emit: button press/release generates EV_KEY events" {
     try std.testing.expectEqual(@as(i32, 0), events[0].value);
 }
 
-test "UinputDevice.emit: dpad hat generates ABS_HAT0X/Y events" {
+test "uinput: UinputDevice.emit: dpad hat generates ABS_HAT0X/Y events" {
     const pfds = try std.posix.pipe2(.{});
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1287,7 +1287,7 @@ test "UinputDevice.emit: dpad hat generates ABS_HAT0X/Y events" {
     try std.testing.expectEqual(@as(i32, -1), events[1].value);
 }
 
-test "TouchpadDevice.emit: finger down generates MT protocol events" {
+test "uinput: TouchpadDevice.emit: finger down generates MT protocol events" {
     const pfds = try std.posix.pipe2(.{});
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1320,7 +1320,7 @@ test "TouchpadDevice.emit: finger down generates MT protocol events" {
     try std.testing.expectEqual(@as(i32, 200), events[3].value);
 }
 
-test "TouchpadDevice.emit: finger lift sends tracking_id=-1" {
+test "uinput: TouchpadDevice.emit: finger lift sends tracking_id=-1" {
     const pfds = try std.posix.pipe2(.{});
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1354,7 +1354,7 @@ test "TouchpadDevice.emit: finger lift sends tracking_id=-1" {
     try std.testing.expectEqual(@as(i32, -1), events[1].value);
 }
 
-test "TouchpadDevice.emit: dual finger produces events for both slots" {
+test "uinput: TouchpadDevice.emit: dual finger produces events for both slots" {
     const pfds = try std.posix.pipe2(.{});
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1388,7 +1388,7 @@ test "TouchpadDevice.emit: dual finger produces events for both slots" {
     try std.testing.expect(saw_slot1);
 }
 
-test "GenericUinputDevice.emitGeneric: differential events via pipe" {
+test "uinput: GenericUinputDevice.emitGeneric: differential events via pipe" {
     const pfds = try std.posix.pipe2(.{});
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1423,7 +1423,7 @@ test "GenericUinputDevice.emitGeneric: differential events via pipe" {
     try std.testing.expectEqual(@as(i32, 1), gs.prev_values[1]);
 }
 
-test "GenericUinputDevice.emitGeneric: no change produces no write" {
+test "uinput: GenericUinputDevice.emitGeneric: no change produces no write" {
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -1248,7 +1248,7 @@ fn makeControlSocket(allocator: std.mem.Allocator, tmp_path: []const u8) !Contro
     return ControlSocket.init(allocator, sock_path);
 }
 
-test "Supervisor: global SWITCH rolls back all devices on failure" {
+test "supervisor: Supervisor: global SWITCH rolls back all devices on failure" {
     const allocator = testing.allocator;
 
     const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
@@ -1317,7 +1317,7 @@ test "Supervisor: global SWITCH rolls back all devices on failure" {
     try testing.expectEqual(false, @atomicLoad(bool, &sup.managed.items[1].instance.stopped, .acquire));
 }
 
-test "Supervisor: SWITCH with no devices returns no-devices" {
+test "supervisor: Supervisor: SWITCH with no devices returns no-devices" {
     const allocator = testing.allocator;
 
     const base_dir = "/tmp/padctl_supervisor_test_no_devices";
@@ -1349,7 +1349,7 @@ test "Supervisor: SWITCH with no devices returns no-devices" {
     try testing.expectEqualStrings("ERR no-devices\n", resp_buf[0..n]);
 }
 
-test "Supervisor: SIGHUP updates mapping without restarting instance" {
+test "supervisor: Supervisor: SIGHUP updates mapping without restarting instance" {
     const allocator = testing.allocator;
 
     const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
@@ -1385,7 +1385,7 @@ test "Supervisor: SIGHUP updates mapping without restarting instance" {
     try testing.expect(sup.managed.items[0].instance.mapper != null);
 }
 
-test "Supervisor: SIGHUP with new phys_key spawns new instance" {
+test "supervisor: Supervisor: SIGHUP with new phys_key spawns new instance" {
     const allocator = testing.allocator;
 
     const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
@@ -1414,7 +1414,7 @@ test "Supervisor: SIGHUP with new phys_key spawns new instance" {
     try testing.expectEqual(@as(usize, 2), sup.managed.items.len);
 }
 
-test "Supervisor: SIGHUP with removed phys_key stops instance" {
+test "supervisor: Supervisor: SIGHUP with removed phys_key stops instance" {
     const allocator = testing.allocator;
 
     const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
@@ -1444,7 +1444,7 @@ test "Supervisor: SIGHUP with removed phys_key stops instance" {
     try testing.expectEqualStrings("usb-1-1", sup.managed.items[0].phys_key);
 }
 
-test "Supervisor: two rapid reloads serialize — no race condition" {
+test "supervisor: Supervisor: two rapid reloads serialize — no race condition" {
     const allocator = testing.allocator;
 
     const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
@@ -1481,7 +1481,7 @@ test "Supervisor: two rapid reloads serialize — no race condition" {
     try testing.expectEqual(@as(u32, 1), sup.managed.items[0].instance.mapper.?.next_token);
 }
 
-test "Supervisor: reload null mapping clears existing mapper" {
+test "supervisor: Supervisor: reload null mapping clears existing mapper" {
     const allocator = testing.allocator;
 
     const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
@@ -1514,7 +1514,7 @@ test "Supervisor: reload null mapping clears existing mapper" {
     try testing.expect(sup.managed.items[0].instance.mapper == null);
 }
 
-test "Supervisor: empty config dir → zero instances" {
+test "supervisor: Supervisor: empty config dir → zero instances" {
     const allocator = testing.allocator;
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1529,7 +1529,7 @@ test "Supervisor: empty config dir → zero instances" {
     try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
 }
 
-test "Supervisor: dir with no toml files → zero instances" {
+test "supervisor: Supervisor: dir with no toml files → zero instances" {
     const allocator = testing.allocator;
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1546,7 +1546,7 @@ test "Supervisor: dir with no toml files → zero instances" {
     try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
 }
 
-test "Supervisor: two toml files, no matching hidraw → zero instances" {
+test "supervisor: Supervisor: two toml files, no matching hidraw → zero instances" {
     const allocator = testing.allocator;
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1564,7 +1564,7 @@ test "Supervisor: two toml files, no matching hidraw → zero instances" {
     try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
 }
 
-test "Supervisor: duplicate attach devname — only one instance created" {
+test "supervisor: Supervisor: duplicate attach devname — only one instance created" {
     const allocator = testing.allocator;
 
     const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
@@ -1594,7 +1594,7 @@ test "Supervisor: duplicate attach devname — only one instance created" {
     try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
 }
 
-test "Supervisor: detach unknown devname — no panic" {
+test "supervisor: Supervisor: detach unknown devname — no panic" {
     const allocator = testing.allocator;
 
     var sup = try Supervisor.initForTest(allocator);
@@ -1604,7 +1604,7 @@ test "Supervisor: detach unknown devname — no panic" {
     try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
 }
 
-test "Supervisor: attach-detach-attach same devname — new instance after re-attach" {
+test "supervisor: Supervisor: attach-detach-attach same devname — new instance after re-attach" {
     const allocator = testing.allocator;
 
     const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
@@ -1632,7 +1632,7 @@ test "Supervisor: attach-detach-attach same devname — new instance after re-at
     try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
 }
 
-test "Supervisor: two devnames attached simultaneously — independent threads" {
+test "supervisor: Supervisor: two devnames attached simultaneously — independent threads" {
     const allocator = testing.allocator;
 
     const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
@@ -1657,7 +1657,7 @@ test "Supervisor: two devnames attached simultaneously — independent threads" 
     try testing.expect(sup.managed.items[0].instance != sup.managed.items[1].instance);
 }
 
-test "Supervisor: initForTest sets inotify_fd and debounce_fd to -1" {
+test "supervisor: Supervisor: initForTest sets inotify_fd and debounce_fd to -1" {
     const allocator = testing.allocator;
     var sup = try Supervisor.initForTest(allocator);
     defer sup.deinit();
@@ -1667,7 +1667,7 @@ test "Supervisor: initForTest sets inotify_fd and debounce_fd to -1" {
     try testing.expectEqual(@as(?[]const u8, null), sup.config_dir);
 }
 
-test "Supervisor: inotify debounce coalescing with real timerfd" {
+test "supervisor: Supervisor: inotify debounce coalescing with real timerfd" {
     const allocator = testing.allocator;
     var sup = try Supervisor.initForTest(allocator);
 
@@ -1689,7 +1689,7 @@ test "Supervisor: inotify debounce coalescing with real timerfd" {
     try testing.expectError(error.WouldBlock, result);
 }
 
-test "Supervisor: armDebounce with invalid fd is no-op" {
+test "supervisor: Supervisor: armDebounce with invalid fd is no-op" {
     const allocator = testing.allocator;
     var sup = try Supervisor.initForTest(allocator);
     defer sup.deinit();
@@ -1698,7 +1698,7 @@ test "Supervisor: armDebounce with invalid fd is no-op" {
     sup.armDebounce();
 }
 
-test "initInotify: non-existent config dir returns disabled" {
+test "supervisor: initInotify: non-existent config dir returns disabled" {
     const allocator = testing.allocator;
 
     // Use testing allocator — if a real config dir exists, this test still
@@ -1715,7 +1715,7 @@ test "initInotify: non-existent config dir returns disabled" {
     }
 }
 
-test "initInotify: watches temp directory successfully" {
+test "supervisor: initInotify: watches temp directory successfully" {
     const allocator = testing.allocator;
 
     // Create a temp dir to use as config dir, then manually set up inotify on it
@@ -1746,7 +1746,7 @@ test "initInotify: watches temp directory successfully" {
     try testing.expect(n > 0);
 }
 
-test "Supervisor.serve: control socket accepts client and responds to STATUS" {
+test "supervisor: Supervisor.serve: control socket accepts client and responds to STATUS" {
     const allocator = testing.allocator;
     var sup = try Supervisor.initForTest(allocator);
 

--- a/src/tools/validate.zig
+++ b/src/tools/validate.zig
@@ -175,14 +175,14 @@ fn validateString(allocator: std.mem.Allocator, content: []const u8) ![]Validati
     return validateFile(path, allocator);
 }
 
-test "valid config: 0 errors" {
+test "validate: valid config: 0 errors" {
     const allocator = testing.allocator;
     const errors = try validateString(allocator, valid_toml);
     defer freeErrors(errors, allocator);
     try testing.expectEqual(@as(usize, 0), errors.len);
 }
 
-test "bit_index out of range: error reported" {
+test "validate: bit_index out of range: error reported" {
     const allocator = testing.allocator;
     const bad =
         \\[device]
@@ -207,7 +207,7 @@ test "bit_index out of range: error reported" {
     try testing.expect(errors.len > 0);
 }
 
-test "match overlap: error reported" {
+test "validate: match overlap: error reported" {
     const allocator = testing.allocator;
     const bad =
         \\[device]
@@ -239,7 +239,7 @@ test "match overlap: error reported" {
     try testing.expect(errors.len > 0);
 }
 
-test "unknown checksum algo: error reported" {
+test "validate: unknown checksum algo: error reported" {
     const allocator = testing.allocator;
     const bad =
         \\[device]
@@ -270,7 +270,7 @@ test "unknown checksum algo: error reported" {
     try testing.expect(found);
 }
 
-test "offset boundary exact: 60 + u32le in 64-byte report is valid" {
+test "validate: offset boundary exact: 60 + u32le in 64-byte report is valid" {
     const allocator = testing.allocator;
     const good =
         \\[device]
@@ -294,7 +294,7 @@ test "offset boundary exact: 60 + u32le in 64-byte report is valid" {
     try testing.expectEqual(@as(usize, 0), errors.len);
 }
 
-test "offset out of bounds: 61 + u32le in 64-byte report is error" {
+test "validate: offset out of bounds: 61 + u32le in 64-byte report is error" {
     const allocator = testing.allocator;
     const bad =
         \\[device]
@@ -318,7 +318,7 @@ test "offset out of bounds: 61 + u32le in 64-byte report is error" {
     try testing.expect(errors.len > 0);
 }
 
-test "validate devices/sony/dualsense.toml: 0 errors" {
+test "validate: validate devices/sony/dualsense.toml: 0 errors" {
     const allocator = testing.allocator;
     const errors = try validateFile("devices/sony/dualsense.toml", allocator);
     defer freeErrors(errors, allocator);
@@ -328,7 +328,7 @@ test "validate devices/sony/dualsense.toml: 0 errors" {
     try testing.expectEqual(@as(usize, 0), errors.len);
 }
 
-test "validate devices/nintendo/switch-pro.toml: 0 errors" {
+test "validate: validate devices/nintendo/switch-pro.toml: 0 errors" {
     const allocator = testing.allocator;
     const errors = try validateFile("devices/nintendo/switch-pro.toml", allocator);
     defer freeErrors(errors, allocator);
@@ -338,7 +338,7 @@ test "validate devices/nintendo/switch-pro.toml: 0 errors" {
     try testing.expectEqual(@as(usize, 0), errors.len);
 }
 
-test "validate devices/8bitdo/ultimate.toml: 0 errors" {
+test "validate: validate devices/8bitdo/ultimate.toml: 0 errors" {
     const allocator = testing.allocator;
     const errors = try validateFile("devices/8bitdo/ultimate.toml", allocator);
     defer freeErrors(errors, allocator);
@@ -348,7 +348,7 @@ test "validate devices/8bitdo/ultimate.toml: 0 errors" {
     try testing.expectEqual(@as(usize, 0), errors.len);
 }
 
-test "validate devices/microsoft/xbox-elite.toml: 0 errors" {
+test "validate: validate devices/microsoft/xbox-elite.toml: 0 errors" {
     const allocator = testing.allocator;
     const errors = try validateFile("devices/microsoft/xbox-elite.toml", allocator);
     defer freeErrors(errors, allocator);
@@ -358,7 +358,7 @@ test "validate devices/microsoft/xbox-elite.toml: 0 errors" {
     try testing.expectEqual(@as(usize, 0), errors.len);
 }
 
-test "undeclared interface in report: error reported" {
+test "validate: undeclared interface in report: error reported" {
     const allocator = testing.allocator;
     const bad =
         \\[device]
@@ -385,7 +385,7 @@ test "undeclared interface in report: error reported" {
     try testing.expect(found);
 }
 
-test "validate devices/flydigi/vader5.toml: 0 errors" {
+test "validate: validate devices/flydigi/vader5.toml: 0 errors" {
     const allocator = testing.allocator;
     const errors = try validateFile("devices/flydigi/vader5.toml", allocator);
     defer freeErrors(errors, allocator);


### PR DESCRIPTION
## Summary
- Rename 339 inline tests across 22 source files to follow TP6 `module: description` format
- Preserved existing `mutation audit:` and `fuzz:` prefixes
- Updated TP7 file tree in design/testing.md (docs repo)

## Test plan
- [x] `zig build test` passes
- [x] TSAN passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized test naming conventions across the test suite for improved organization and consistency.

* **Chores**
  * Updated test identifiers throughout the codebase to follow a structured naming pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->