### PR TITLE
Fix critical test audit findings: DRT correctness + crash-only assertions (C1/C2/I3/I4)

### DIFF
--- a/src/test/properties/drt_props.zig
+++ b/src/test/properties/drt_props.zig
@@ -3,6 +3,12 @@
 // For every device TOML: generate 1000 random HID packets, run both the
 // production interpreter and the reference interpreter, and verify that each
 // scalar field extracted by production matches the reference oracle.
+//
+// DRT SCOPE: catches runtime extraction bugs (wrong read logic, bad transform
+// math) but NOT config compilation bugs, because both oracle and production
+// share CompiledField/CompiledReport from production.  A wrong offset or
+// type_tag in compileReport would affect both sides equally and go undetected.
+// See reference_interp.zig for the canonical note on this compromise.
 
 const std = @import("std");
 const testing = std.testing;
@@ -15,11 +21,43 @@ const helpers = @import("../helpers.zig");
 const Interpreter = interp_mod.Interpreter;
 const MAX_FIELDS = interp_mod.MAX_FIELDS;
 
+// Dpad hat-switch decode: 0=N,1=NE,2=E,3=SE,4=S,5=SW,6=W,7=NW, 8+=neutral
+const HAT_X = [8]i8{ 0, 1, 1, 1, 0, -1, -1, -1 };
+const HAT_Y = [8]i8{ -1, -1, 0, 1, 1, 1, 0, -1 };
+
 // saturate mirrors production's saturateCast.
 fn saturate(comptime T: type, v: i64) T {
     if (v > std.math.maxInt(T)) return std.math.maxInt(T);
     if (v < std.math.minInt(T)) return std.math.minInt(T);
     return @intCast(v);
+}
+
+// Inject a valid checksum into pkt so verifyChecksumCompiled passes.
+fn injectChecksum(cr: *const interp_mod.CompiledReport, pkt: []u8) void {
+    const cs = cr.checksum orelse return;
+    const data = pkt[cs.range_start..cs.range_end];
+    switch (cs.algo) {
+        .sum8 => {
+            var sum: u8 = 0;
+            for (data) |b| sum +%= b;
+            pkt[cs.expect_off] = sum;
+        },
+        .xor => {
+            var xv: u8 = 0;
+            for (data) |b| xv ^= b;
+            pkt[cs.expect_off] = xv;
+        },
+        .crc32 => {
+            var crc = std.hash.crc.Crc32IsoHdlc.init();
+            if (cs.seed) |seed| {
+                const seed_byte: u8 = @intCast(seed & 0xff);
+                crc.update(&[_]u8{seed_byte});
+            }
+            crc.update(data);
+            const computed = crc.final();
+            std.mem.writeInt(u32, pkt[cs.expect_off..][0..4], computed, .little);
+        },
+    }
 }
 
 test "DRT: production interpreter matches reference oracle on random packets" {
@@ -44,6 +82,7 @@ test "DRT: production interpreter matches reference oracle on random packets" {
             const pkt = buf[0..@min(size, buf.len)];
 
             const iface: u8 = @intCast(cr.src.interface);
+            var tested_count: usize = 0;
 
             for (0..1000) |_| {
                 random.bytes(pkt);
@@ -54,10 +93,13 @@ test "DRT: production interpreter matches reference oracle on random packets" {
                         if (off + i < pkt.len) pkt[off + i] = @intCast(byte);
                     }
                 }
+                // For checksum devices, inject a valid checksum so extraction
+                // logic is actually exercised (not silently skipped every time).
+                if (cr.checksum != null) injectChecksum(cr, pkt);
 
-                // Production result — skip on checksum mismatch (expected).
                 const prod_delta = interp.processReport(iface, pkt) catch continue;
                 const delta = prod_delta orelse continue;
+                tested_count += 1;
 
                 // Reference oracle
                 var ref_buf: [MAX_FIELDS]ref.FieldResult = undefined;
@@ -141,10 +183,57 @@ test "DRT: production interpreter matches reference oracle on random packets" {
                             try testing.expect(delta.battery_level != null);
                             try testing.expectEqual(@as(u8, @intCast(fr.val & 0xff)), delta.battery_level.?);
                         },
-                        .dpad, .unknown => {}, // multi-output tags
+                        .dpad => {
+                            // Compare hat-switch decode: raw val → dpad_x/dpad_y
+                            const hat = fr.val;
+                            const exp_x: i8 = if (hat >= 0 and hat < 8) HAT_X[@intCast(hat)] else 0;
+                            const exp_y: i8 = if (hat >= 0 and hat < 8) HAT_Y[@intCast(hat)] else 0;
+                            try testing.expectEqual(exp_x, delta.dpad_x orelse 0);
+                            try testing.expectEqual(exp_y, delta.dpad_y orelse 0);
+                        },
+                        .unknown => {},
                     }
                 }
             }
+            // Every report must have been tested at least once.  Without this,
+            // checksum devices silently skip all 1000 iterations (I4).
+            try testing.expect(tested_count > 0);
         }
+    }
+}
+
+// I3: exhaustive dpad test — all 9 hat values (0-8) against hardcoded expected.
+test "DRT: dpad hat-switch exhaustive — all 9 values decode correctly" {
+    const allocator = testing.allocator;
+    const toml =
+        \\[device]
+        \\name = "DpadTest"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0xAA]
+        \\[report.fields]
+        \\dpad = { offset = 1, type = "u8" }
+    ;
+    const parsed = try device_mod.parseString(allocator, toml);
+    defer parsed.deinit();
+    const interp = interp_mod.Interpreter.init(&parsed.value);
+
+    const expected_x = [9]i8{ 0, 1, 1, 1, 0, -1, -1, -1, 0 };
+    const expected_y = [9]i8{ -1, -1, 0, 1, 1, 1, 0, -1, 0 };
+
+    for (0..9) |hat| {
+        var raw = [_]u8{ 0xAA, @intCast(hat), 0, 0 };
+        const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+        try testing.expectEqual(expected_x[hat], delta.dpad_x orelse 0);
+        try testing.expectEqual(expected_y[hat], delta.dpad_y orelse 0);
     }
 }

--- a/src/test/properties/e2e_pipeline_props.zig
+++ b/src/test/properties/e2e_pipeline_props.zig
@@ -475,7 +475,15 @@ test "e2e pipeline: random packets through full pipeline — no crash" {
         raw[2] = 0xef;
 
         const delta = (interp.processReport(1, &raw) catch continue) orelse continue;
-        _ = try m.apply(delta, 16);
+        const ev = try m.apply(delta, 16);
+        // Invariant: aux key/mouse codes must be non-zero.
+        for (ev.aux.slice()) |aux| {
+            switch (aux) {
+                .key => |k| try testing.expect(k.code > 0),
+                .mouse_button => |mb| try testing.expect(mb.code > 0),
+                .rel => {},
+            }
+        }
     }
 }
 

--- a/src/test/properties/interpreter_props.zig
+++ b/src/test/properties/interpreter_props.zig
@@ -34,10 +34,22 @@ test "property: interpreter robustness — random packets never crash" {
             for (0..1000) |_| {
                 random.bytes(pkt);
                 const iface: u8 = @intCast(report.interface);
-                _ = interp.processReport(iface, pkt) catch |err| switch (err) {
-                    error.ChecksumMismatch => {},
-                    error.MalformedConfig => {},
+                const result = interp.processReport(iface, pkt) catch |err| switch (err) {
+                    error.ChecksumMismatch => continue,
+                    error.MalformedConfig => continue,
                 };
+                const delta = result orelse continue;
+                // Invariant: axis values within i16 range.
+                if (delta.ax) |v| try testing.expect(v >= std.math.minInt(i16) and v <= std.math.maxInt(i16));
+                if (delta.ay) |v| try testing.expect(v >= std.math.minInt(i16) and v <= std.math.maxInt(i16));
+                if (delta.rx) |v| try testing.expect(v >= std.math.minInt(i16) and v <= std.math.maxInt(i16));
+                if (delta.ry) |v| try testing.expect(v >= std.math.minInt(i16) and v <= std.math.maxInt(i16));
+                if (delta.gyro_x) |v| try testing.expect(v >= std.math.minInt(i16) and v <= std.math.maxInt(i16));
+                if (delta.gyro_y) |v| try testing.expect(v >= std.math.minInt(i16) and v <= std.math.maxInt(i16));
+                if (delta.gyro_z) |v| try testing.expect(v >= std.math.minInt(i16) and v <= std.math.maxInt(i16));
+                // Invariant: trigger values within u8 range.
+                if (delta.lt) |v| try testing.expect(v <= std.math.maxInt(u8));
+                if (delta.rt) |v| try testing.expect(v <= std.math.maxInt(u8));
             }
         }
     }

--- a/src/test/properties/mapper_props.zig
+++ b/src/test/properties/mapper_props.zig
@@ -40,7 +40,16 @@ test "property: random input deltas never crash mapper" {
 
     for (0..1000) |_| {
         const delta = state_mod.generateRandomDelta(rng);
-        _ = try m.apply(delta, 16);
+        const ev = try m.apply(delta, 16);
+        // Invariant: aux key/mouse codes must be non-zero (no code 0 in Linux input).
+        for (ev.aux.slice()) |aux| {
+            switch (aux) {
+                .key => |k| try testing.expect(k.code > 0),
+                .mouse_button => |mb| try testing.expect(mb.code > 0),
+                .rel => {},
+            }
+        }
+        _ = ev.gamepad.buttons;
     }
 }
 
@@ -149,7 +158,15 @@ test "property: random button remap pairs — no crash" {
         var m = &ctx.mapper;
 
         const delta = state_mod.generateRandomDelta(rng);
-        _ = try m.apply(delta, 16);
+        const ev = try m.apply(delta, 16);
+        for (ev.aux.slice()) |aux| {
+            switch (aux) {
+                .key => |k| try testing.expect(k.code > 0),
+                .mouse_button => |mb| try testing.expect(mb.code > 0),
+                .rel => {},
+            }
+        }
+        _ = ev.gamepad.buttons;
     }
 }
 
@@ -220,9 +237,13 @@ test "property: empty config — passthrough no crash" {
     for (0..1000) |_| {
         const delta = state_mod.generateRandomDelta(rng);
         const ev = try m.apply(delta, 16);
-        // no remaps → no aux events from button remapping
-        // (gyro/stick may still produce none since mode=off by default)
-        _ = ev;
+        // No remaps → gamepad output equals input (passthrough).
+        if (delta.buttons) |b| try testing.expectEqual(b, ev.gamepad.buttons);
+        if (delta.ax) |v| try testing.expectEqual(v, ev.gamepad.ax);
+        if (delta.ay) |v| try testing.expectEqual(v, ev.gamepad.ay);
+        if (delta.lt) |v| try testing.expectEqual(v, ev.gamepad.lt);
+        if (delta.rt) |v| try testing.expectEqual(v, ev.gamepad.rt);
+        try testing.expectEqual(@as(usize, 0), ev.aux.len);
     }
 }
 
@@ -241,7 +262,15 @@ test "property: empty layer array — no crash" {
 
     for (0..1000) |_| {
         const delta = state_mod.generateRandomDelta(rng);
-        _ = try m.apply(delta, 16);
+        const ev = try m.apply(delta, 16);
+        for (ev.aux.slice()) |aux| {
+            switch (aux) {
+                .key => |k| try testing.expect(k.code > 0),
+                .mouse_button => |mb| try testing.expect(mb.code > 0),
+                .rel => {},
+            }
+        }
+        _ = ev.gamepad.buttons;
     }
 }
 

--- a/src/test/reference_interp.zig
+++ b/src/test/reference_interp.zig
@@ -3,6 +3,14 @@
 // This reimplements field extraction and transform chain independently of the
 // production interpreter.  Bugs in production code will not be present here
 // because the implementations share no code paths.
+//
+// CONSCIOUS COMPROMISE: CompiledField/CompiledReport/CompiledButtonGroup are
+// imported from production.  This means DRT catches runtime extraction bugs
+// (wrong read logic, wrong transform math) but NOT config compilation bugs
+// (e.g., wrong offset or type_tag assigned during compileReport).  A bug that
+// produces a wrong CompiledField would go undetected here because both oracle
+// and production operate on the same compiled representation.
+// See drt_props.zig for the corresponding note.
 
 const std = @import("std");
 const interp_mod = @import("../core/interpreter.zig");


### PR DESCRIPTION
## Summary
- **C1**: Document conscious compromise in reference_interp.zig (shared CompiledField)
- **C2**: Upgrade 6 crash-only property tests with invariant assertions (TP1 compliance)
- **I3**: DRT now compares dpad hat-switch values + exhaustive 9-value test
- **I4**: DRT injects valid checksums into random packets; asserts tested_count > 0 per device

## Test plan
- [x] `zig build test` passes
- [x] TSAN passes