### PR TITLE
Use XDG_RUNTIME_DIR for control socket when not root

### DIFF
--- a/src/cli/socket_client.zig
+++ b/src/cli/socket_client.zig
@@ -4,6 +4,16 @@ const linux = std.os.linux;
 
 pub const DEFAULT_SOCKET_PATH = "/run/padctl/padctl.sock";
 
+/// Resolve the socket path at runtime. Non-root: $XDG_RUNTIME_DIR/padctl/padctl.sock.
+/// Returns a slice into `buf` or a static string.
+pub fn resolveSocketPath(buf: []u8) []const u8 {
+    if (std.os.linux.getuid() == 0) return DEFAULT_SOCKET_PATH;
+    if (std.posix.getenv("XDG_RUNTIME_DIR")) |xdg| {
+        return std.fmt.bufPrint(buf, "{s}/padctl/padctl.sock", .{xdg}) catch DEFAULT_SOCKET_PATH;
+    }
+    return DEFAULT_SOCKET_PATH;
+}
+
 pub const ConnectError = posix.SocketError || posix.ConnectError || error{ PathTooLong, InvalidPath };
 
 pub fn connectToSocket(path: []const u8) ConnectError!posix.fd_t {

--- a/src/main.zig
+++ b/src/main.zig
@@ -144,6 +144,7 @@ const Cli = struct {
     status_cmd: bool = false,
     devices_cmd: bool = false,
     socket_path: []const u8 = cli.socket_client.DEFAULT_SOCKET_PATH,
+    socket_explicit: bool = false,
 
     fn deinit(self: *Cli) void {
         self.validate_files.deinit(self.allocator);
@@ -295,6 +296,7 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                     device_id = args.next() orelse return error.MissingArgValue;
                 } else if (std.mem.eql(u8, sub_arg, "--socket")) {
                     parsed_cli.socket_path = args.next() orelse return error.MissingArgValue;
+                    parsed_cli.socket_explicit = true;
                 } else {
                     std.log.err("unknown switch argument: {s}", .{sub_arg});
                     return error.UnknownArgument;
@@ -306,6 +308,7 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
             while (args.next()) |sub_arg| {
                 if (std.mem.eql(u8, sub_arg, "--socket")) {
                     parsed_cli.socket_path = args.next() orelse return error.MissingArgValue;
+                    parsed_cli.socket_explicit = true;
                 } else {
                     std.log.err("unknown status argument: {s}", .{sub_arg});
                     return error.UnknownArgument;
@@ -316,6 +319,7 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
             while (args.next()) |sub_arg| {
                 if (std.mem.eql(u8, sub_arg, "--socket")) {
                     parsed_cli.socket_path = args.next() orelse return error.MissingArgValue;
+                    parsed_cli.socket_explicit = true;
                 } else {
                     std.log.err("unknown devices argument: {s}", .{sub_arg});
                     return error.UnknownArgument;
@@ -429,6 +433,11 @@ pub fn main() !void {
         std.process.exit(1);
     };
     defer parsed.deinit();
+
+    var sock_path_buf: [256]u8 = undefined;
+    if (!parsed.socket_explicit) {
+        parsed.socket_path = cli.socket_client.resolveSocketPath(&sock_path_buf);
+    }
 
     // install subcommand
     if (parsed.install_opts) |opts| {

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -19,7 +19,7 @@ const mapping_discovery = @import("config/mapping_discovery.zig");
 const ControlSocket = @import("io/control_socket.zig").ControlSocket;
 const control_socket = @import("io/control_socket.zig");
 
-pub const DEFAULT_SOCKET_PATH = "/run/padctl/padctl.sock";
+const socket_client = @import("cli/socket_client.zig");
 
 /// One running device under Supervisor management.
 pub const ManagedInstance = struct {
@@ -166,7 +166,9 @@ pub const Supervisor = struct {
 
         const inotify_result = initInotify(allocator);
 
-        const sock = ControlSocket.init(allocator, DEFAULT_SOCKET_PATH) catch |err| blk: {
+        var sock_path_buf: [256]u8 = undefined;
+        const sock_path = socket_client.resolveSocketPath(&sock_path_buf);
+        const sock = ControlSocket.init(allocator, sock_path) catch |err| blk: {
             std.log.warn("control socket unavailable: {}", .{err});
             break :blk null;
         };


### PR DESCRIPTION
## Summary
- Non-root: socket at `$XDG_RUNTIME_DIR/padctl/padctl.sock` (typically `/run/user/1000/padctl/`)
- Root: socket at `/run/padctl/padctl.sock` (unchanged)
- Single `resolveSocketPath()` in socket_client.zig shared by daemon and CLI
- `--socket` flag overrides the resolved path

Fixes the `control socket unavailable: error.AccessDenied` when running without root.

## Test plan
- [x] `zig build test` passes