### PR TITLE
Add failure shrinking and regression corpus (G4)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -96,6 +96,7 @@ pub const testing_support = struct {
     pub const supervisor_sm_props = @import("test/properties/supervisor_sm_props.zig");
     pub const negative_corpus_props = @import("test/properties/negative_corpus_props.zig");
     pub const generative_mapper_props = @import("test/properties/generative_mapper_props.zig");
+    pub const regression_corpus_props = @import("test/properties/regression_corpus_props.zig");
     pub const reference_interp = @import("test/reference_interp.zig");
     pub const gen = @import("test/gen/gen.zig");
 };

--- a/src/test/gen/gen.zig
+++ b/src/test/gen/gen.zig
@@ -2,3 +2,4 @@ pub const config_gen = @import("config_gen.zig");
 pub const sequence_gen = @import("sequence_gen.zig");
 pub const mapper_oracle = @import("mapper_oracle.zig");
 pub const transition_id = @import("transition_id.zig");
+pub const shrink = @import("shrink.zig");

--- a/src/test/gen/shrink.zig
+++ b/src/test/gen/shrink.zig
@@ -1,0 +1,124 @@
+// shrink.zig — failure minimization for generative test cases.
+//
+// When the harness detects a production-oracle divergence, shrink the
+// failing frame sequence to the smallest reproducing case.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const sequence_gen = @import("sequence_gen.zig");
+const mapping = @import("../../config/mapping.zig");
+
+pub const Frame = sequence_gen.Frame;
+pub const MappingConfig = mapping.MappingConfig;
+
+/// Callback type: returns true if the failure still reproduces on `frames`.
+/// `ctx` is an opaque pointer to caller-provided state (e.g. TOML + allocator).
+pub const CheckFn = *const fn (ctx: *anyopaque, frames: []const Frame) bool;
+
+/// Shrink `frames` to the minimal sub-sequence that still triggers a failure.
+/// `checkFn(ctx, frames)` must return true iff the failure reproduces.
+/// Caller owns the returned slice (allocated with `allocator`).
+pub fn shrinkSequence(
+    allocator: Allocator,
+    frames: []const Frame,
+    ctx: *anyopaque,
+    checkFn: CheckFn,
+) Allocator.Error![]Frame {
+    if (frames.len == 0) return allocator.dupe(Frame, frames);
+
+    var current = try allocator.dupe(Frame, frames);
+
+    // Pass 1: binary search on length
+    current = try binaryTrimLength(allocator, current, ctx, checkFn);
+
+    // Pass 2: remove individual frames
+    current = try removeIndividualFrames(allocator, current, ctx, checkFn);
+
+    // Pass 3: simplify delta fields
+    simplifyDeltas(current, ctx, checkFn);
+
+    return current;
+}
+
+fn binaryTrimLength(
+    allocator: Allocator,
+    frames: []Frame,
+    ctx: *anyopaque,
+    checkFn: CheckFn,
+) Allocator.Error![]Frame {
+    var cur = frames;
+    while (cur.len > 1) {
+        const half = cur.len / 2;
+        if (checkFn(ctx, cur[0..half])) {
+            const smaller = try allocator.dupe(Frame, cur[0..half]);
+            allocator.free(cur);
+            cur = smaller;
+        } else if (checkFn(ctx, cur[half..])) {
+            const smaller = try allocator.dupe(Frame, cur[half..]);
+            allocator.free(cur);
+            cur = smaller;
+        } else {
+            break;
+        }
+    }
+    return cur;
+}
+
+fn removeIndividualFrames(
+    allocator: Allocator,
+    frames: []Frame,
+    ctx: *anyopaque,
+    checkFn: CheckFn,
+) Allocator.Error![]Frame {
+    var cur = frames;
+    var i: usize = 0;
+    while (i < cur.len) {
+        const candidate = try allocator.alloc(Frame, cur.len - 1);
+        @memcpy(candidate[0..i], cur[0..i]);
+        @memcpy(candidate[i..], cur[i + 1 ..]);
+
+        if (checkFn(ctx, candidate)) {
+            allocator.free(cur);
+            cur = candidate;
+        } else {
+            allocator.free(candidate);
+            i += 1;
+        }
+    }
+    return cur;
+}
+
+fn simplifyDeltas(frames: []Frame, ctx: *anyopaque, checkFn: CheckFn) void {
+    for (frames) |*f| {
+        const saved = f.delta;
+
+        if (f.delta.ax != null) {
+            f.delta.ax = null;
+            if (!checkFn(ctx, frames)) f.delta.ax = saved.ax;
+        }
+        if (f.delta.ay != null) {
+            f.delta.ay = null;
+            if (!checkFn(ctx, frames)) f.delta.ay = saved.ay;
+        }
+        if (f.delta.cx != null) {
+            f.delta.cx = null;
+            if (!checkFn(ctx, frames)) f.delta.cx = saved.cx;
+        }
+        if (f.delta.cy != null) {
+            f.delta.cy = null;
+            if (!checkFn(ctx, frames)) f.delta.cy = saved.cy;
+        }
+        if (f.delta.gx != null) {
+            f.delta.gx = null;
+            if (!checkFn(ctx, frames)) f.delta.gx = saved.gx;
+        }
+        if (f.delta.gy != null) {
+            f.delta.gy = null;
+            if (!checkFn(ctx, frames)) f.delta.gy = saved.gy;
+        }
+        if (f.delta.gz != null) {
+            f.delta.gz = null;
+            if (!checkFn(ctx, frames)) f.delta.gz = saved.gz;
+        }
+    }
+}

--- a/src/test/properties/generative_mapper_props.zig
+++ b/src/test/properties/generative_mapper_props.zig
@@ -6,6 +6,7 @@ const config_gen = @import("../gen/config_gen.zig");
 const sequence_gen = @import("../gen/sequence_gen.zig");
 const mapper_oracle = @import("../gen/mapper_oracle.zig");
 const transition_id = @import("../gen/transition_id.zig");
+const shrink_mod = @import("../gen/shrink.zig");
 const mapping = @import("../../config/mapping.zig");
 const state_mod = @import("../../core/state.zig");
 
@@ -14,6 +15,52 @@ const GamepadStateDelta = state_mod.GamepadStateDelta;
 const Frame = sequence_gen.Frame;
 const OracleState = mapper_oracle.OracleState;
 const CoverageTracker = transition_id.CoverageTracker;
+
+// --- Shrink support ---
+
+// Context for the shrink check callback.
+const ShrinkCtx = struct {
+    allocator: std.mem.Allocator,
+    /// TOML string (owned by the context, fixed buffer — length stored here).
+    toml_buf: [4096]u8,
+    toml_len: usize,
+};
+
+// Check whether frames still diverge when replayed from a fresh mapper + oracle.
+fn shrinkCheck(raw_ctx: *anyopaque, frames: []const Frame) bool {
+    const ctx: *ShrinkCtx = @alignCast(@ptrCast(raw_ctx));
+    const toml = ctx.toml_buf[0..ctx.toml_len];
+
+    const parsed = mapping.parseString(ctx.allocator, toml) catch return false;
+    defer parsed.deinit();
+
+    var mc = helpers.makeMapper(toml, ctx.allocator) catch return false;
+    defer mc.deinit();
+
+    var oracle = OracleState{};
+
+    for (frames) |frame| {
+        const prod = mc.mapper.apply(frame.delta, @as(u32, frame.dt_ms)) catch return false;
+        const oout = mapper_oracle.apply(&oracle, frame.delta, &parsed.value, @as(u64, frame.dt_ms));
+
+        if (oout.gamepad.buttons != prod.gamepad.buttons) return true;
+        if (oout.gamepad.dpad_x != prod.gamepad.dpad_x) return true;
+        if (oout.gamepad.dpad_y != prod.gamepad.dpad_y) return true;
+    }
+    return false;
+}
+
+fn logMinimalCase(toml: []const u8, min_frames: []const Frame) void {
+    std.log.err("=== MINIMAL REPRODUCING CASE ===", .{});
+    std.log.err("mapping_toml:\n{s}", .{toml});
+    std.log.err("frames ({d}):", .{min_frames.len});
+    for (min_frames, 0..) |f, i| {
+        std.log.err("  [{d}] dt={d} buttons={?} ax={?} ay={?}", .{
+            i, f.dt_ms, f.delta.buttons, f.delta.ax, f.delta.ay,
+        });
+    }
+    std.log.err("================================", .{});
+}
 
 fn btnMaskByName(name: []const u8) u64 {
     const id = std.meta.stringToEnum(state_mod.ButtonId, name) orelse return 0;
@@ -64,6 +111,10 @@ fn runHarness(
         const frames = frames_buf[0..@min(n_frames, frames_buf.len)];
         sequence_gen.randomSequence(rng, frames, parsed.value);
 
+        // Build shrink context once per config (contains TOML copy + allocator).
+        var sctx = ShrinkCtx{ .allocator = allocator, .toml_buf = undefined, .toml_len = map_toml.len };
+        @memcpy(sctx.toml_buf[0..map_toml.len], map_toml);
+
         for (frames) |frame| {
             const prev_oracle = oracle;
 
@@ -88,6 +139,22 @@ fn runHarness(
 
             const prod_out = try ctx.mapper.apply(frame.delta, @as(u32, frame.dt_ms));
             const oracle_out = mapper_oracle.apply(&oracle, frame.delta, &parsed.value, @as(u64, frame.dt_ms));
+
+            // On divergence: shrink the full sequence, log the minimal case, then assert.
+            const btn_ok = oracle_out.gamepad.buttons == prod_out.gamepad.buttons;
+            const dx_ok = oracle_out.gamepad.dpad_x == prod_out.gamepad.dpad_x;
+            const dy_ok = oracle_out.gamepad.dpad_y == prod_out.gamepad.dpad_y;
+
+            if (!btn_ok or !dx_ok or !dy_ok) {
+                const min_frames = shrink_mod.shrinkSequence(
+                    allocator,
+                    frames,
+                    &sctx,
+                    shrinkCheck,
+                ) catch frames; // on OOM fall back to original
+                defer if (min_frames.ptr != frames.ptr) allocator.free(min_frames);
+                logMinimalCase(map_toml, min_frames);
+            }
 
             // Deterministic: button output (suppress + inject)
             try testing.expectEqual(oracle_out.gamepad.buttons, prod_out.gamepad.buttons);

--- a/src/test/properties/regression_corpus_props.zig
+++ b/src/test/properties/regression_corpus_props.zig
@@ -1,0 +1,64 @@
+// regression_corpus_props.zig — deterministic regression tests for mapper bugs
+// discovered by the generative harness.
+//
+// Each RegressionCase encodes the minimal reproducing sequence found by shrink.zig.
+// Add new cases here as bugs are confirmed.
+
+const std = @import("std");
+const testing = std.testing;
+
+const helpers = @import("../helpers.zig");
+const mapper_oracle = @import("../gen/mapper_oracle.zig");
+const sequence_gen = @import("../gen/sequence_gen.zig");
+const mapping = @import("../../config/mapping.zig");
+
+const OracleState = mapper_oracle.OracleState;
+const Frame = sequence_gen.Frame;
+
+const RegressionCase = struct {
+    name: []const u8,
+    mapping_toml: []const u8,
+    frames: []const Frame,
+    /// Expected button state after each frame (parallel to frames[]).
+    expected_buttons: []const u64,
+};
+
+// Corpus is empty until the generative harness discovers a reproducible bug
+// and its minimal case is committed here.
+const cases = [_]RegressionCase{
+    // Cases will be added here as bugs are found
+};
+
+test "regression: all corpus cases pass" {
+    const allocator = testing.allocator;
+
+    for (cases) |case| {
+        var ctx = try helpers.makeMapper(case.mapping_toml, allocator);
+        defer ctx.deinit();
+
+        const parsed = try mapping.parseString(allocator, case.mapping_toml);
+        defer parsed.deinit();
+
+        var oracle = OracleState{};
+
+        std.debug.assert(case.frames.len == case.expected_buttons.len);
+
+        for (case.frames, case.expected_buttons, 0..) |frame, expected, idx| {
+            const prod = try ctx.mapper.apply(frame.delta, @as(u32, frame.dt_ms));
+            const oout = mapper_oracle.apply(&oracle, frame.delta, &parsed.value, @as(u64, frame.dt_ms));
+
+            testing.expectEqual(expected, prod.gamepad.buttons) catch |err| {
+                std.log.err("regression '{s}' frame {d}: production={d} expected={d}", .{
+                    case.name, idx, prod.gamepad.buttons, expected,
+                });
+                return err;
+            };
+            testing.expectEqual(expected, oout.gamepad.buttons) catch |err| {
+                std.log.err("regression '{s}' frame {d}: oracle={d} expected={d}", .{
+                    case.name, idx, oout.gamepad.buttons, expected,
+                });
+                return err;
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `src/test/gen/shrink.zig` (~95 lines): 3-pass minimization (binary trim, frame removal, field simplification)
- `src/test/properties/regression_corpus_props.zig` (~60 lines): fixed regression case corpus structure
- Integrated shrinking into G3 harness: on divergence, shrink + log minimal case before asserting

## Test plan
- [x] `zig build test` passes