### PR TITLE
Fix L3 DRT: BTN_TOUCH production bug + packet transform inversion + button clear

### DIFF
--- a/src/config/input_codes.zig
+++ b/src/config/input_codes.zig
@@ -152,6 +152,20 @@ const btn_table = [_]CodeEntry{
     .{ .name = "BTN_TRIGGER_HAPPY38", .code = c.BTN_TRIGGER_HAPPY38 },
     .{ .name = "BTN_TRIGGER_HAPPY39", .code = c.BTN_TRIGGER_HAPPY39 },
     .{ .name = "BTN_TRIGGER_HAPPY40", .code = c.BTN_TRIGGER_HAPPY40 },
+    // Touch/stylus
+    .{ .name = "BTN_TOOL_PEN", .code = c.BTN_TOOL_PEN },
+    .{ .name = "BTN_TOOL_RUBBER", .code = c.BTN_TOOL_RUBBER },
+    .{ .name = "BTN_TOOL_BRUSH", .code = c.BTN_TOOL_BRUSH },
+    .{ .name = "BTN_TOOL_PENCIL", .code = c.BTN_TOOL_PENCIL },
+    .{ .name = "BTN_TOOL_AIRBRUSH", .code = c.BTN_TOOL_AIRBRUSH },
+    .{ .name = "BTN_TOOL_FINGER", .code = c.BTN_TOOL_FINGER },
+    .{ .name = "BTN_TOOL_MOUSE", .code = c.BTN_TOOL_MOUSE },
+    .{ .name = "BTN_TOOL_LENS", .code = c.BTN_TOOL_LENS },
+    .{ .name = "BTN_TOOL_QUINTTAP", .code = c.BTN_TOOL_QUINTTAP },
+    .{ .name = "BTN_TOUCH", .code = c.BTN_TOUCH },
+    .{ .name = "BTN_TOOL_DOUBLETAP", .code = c.BTN_TOOL_DOUBLETAP },
+    .{ .name = "BTN_TOOL_TRIPLETAP", .code = c.BTN_TOOL_TRIPLETAP },
+    .{ .name = "BTN_TOOL_QUADTAP", .code = c.BTN_TOOL_QUADTAP },
 };
 
 const key_table = [_]CodeEntry{

--- a/src/test/full_e2e_generative_test.zig
+++ b/src/test/full_e2e_generative_test.zig
@@ -331,6 +331,39 @@ fn writeFieldValue(buf: []u8, offset: usize, t: FieldType, value: i64) void {
 }
 
 const FieldTag = interp_mod.FieldTag;
+const CompiledTransformChain = interp_mod.CompiledTransformChain;
+const TransformOp = interp_mod.TransformOp;
+
+// Apply inverse of the transform chain so that production forward-transform yields val.
+// Processes transforms in reverse order; skips abs/clamp/deadzone (not invertible).
+fn applyInverseTransforms(val: i64, chain: *const CompiledTransformChain) i64 {
+    var v = val;
+    var i: usize = chain.len;
+    while (i > 0) {
+        i -= 1;
+        const tr = chain.items[i];
+        v = switch (tr.op) {
+            .negate => if (v == std.math.minInt(i64)) std.math.maxInt(i64) else -v,
+            .scale => blk: {
+                const span = tr.b - tr.a;
+                if (span == 0) break :blk v;
+                const t_max: i128 = switch (chain.type_tag) {
+                    .u8 => 255,
+                    .i8 => 127,
+                    .u16le, .u16be => 65535,
+                    .i16le, .i16be => 32767,
+                    .u32le, .u32be => 4294967295,
+                    .i32le, .i32be => 2147483647,
+                };
+                const shifted: i128 = @as(i128, v) - tr.a;
+                break :blk @intCast(@divTrunc(shifted * t_max, span));
+            },
+            // abs, clamp, deadzone: not cleanly invertible — pass through
+            .abs, .clamp, .deadzone => v,
+        };
+    }
+    return v;
+}
 
 fn buildPacketFromDelta(cr: *const CompiledReport, delta: GamepadStateDelta, buf: []u8) void {
     // Overlay non-null delta fields onto buf (caller must provide persistent state).
@@ -338,7 +371,9 @@ fn buildPacketFromDelta(cr: *const CompiledReport, delta: GamepadStateDelta, buf
     for (cr.fields[0..cr.field_count]) |*cf| {
         const val = getDeltaFieldForTag(delta, cf.tag) orelse continue;
         if (cf.mode == .standard) {
-            writeFieldValue(buf, cf.offset, cf.type_tag, val);
+            // Apply inverse transforms so production forward-transform yields val.
+            const raw_val = if (cf.has_transform) applyInverseTransforms(val, &cf.transforms) else val;
+            writeFieldValue(buf, cf.offset, cf.type_tag, raw_val);
         } else {
             // bits mode
             const raw: u32 = @intCast(@as(u64, @bitCast(@as(i64, val))) & ((@as(u64, 1) << @intCast(cf.bit_count)) - 1));
@@ -353,6 +388,10 @@ fn buildPacketFromDelta(cr: *const CompiledReport, delta: GamepadStateDelta, buf
     // Write button_group bits
     if (cr.button_group) |*cbg| {
         if (delta.buttons) |buttons| {
+            // Clear source bytes first so released buttons don't persist.
+            for (0..cbg.src_size) |i| {
+                buf[cbg.src_off + i] = 0;
+            }
             for (cbg.entries[0..cbg.count]) |entry| {
                 const mask: u64 = @as(u64, 1) << @as(u6, @intCast(@intFromEnum(entry.btn_id)));
                 if (buttons & mask != 0) {


### PR DESCRIPTION
## Summary
- **Production bug**: Add `BTN_TOUCH` + 13 `BTN_TOOL_*` codes to `input_codes.zig` — Sony DualSense/DualShock4 uinput creation was failing
- **Test fix**: `buildPacketFromDelta` now applies inverse transforms (negate/scale) before writing to raw packet
- **Test fix**: Button group bytes cleared each frame before writing — buttons can now be released

Found by L3 generative DRT.

## Test plan
- [x] `zig build test` passes
- [x] `zig fmt --check` passes
- [ ] `zig build test-e2e` — needs privilege verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for touch and stylus input devices, including pen, brush, pencil, airbrush, and gesture recognition tools.

* **Tests**
  * Enhanced test coverage for input transformations and button state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->