### PR TITLE
fix: retry hotplug open() on transient errors beyond EACCES (#64)

### DIFF
--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -617,7 +617,7 @@ pub const Supervisor = struct {
     fn netlinkCallback(self: *Supervisor, action: netlink.UeventAction, devname: []const u8) void {
         switch (action) {
             .add => self.attach(devname) catch |err| {
-                if (err == error.AccessDenied) {
+                if (err == error.HotplugTransient) {
                     self.enqueueHotplugRetry(devname);
                 } else {
                     std.log.warn("hotplug attach {s}: {}", .{ devname, err });
@@ -666,7 +666,7 @@ pub const Supervisor = struct {
             const p = &self.hotplug_pending.items[i];
             const name = p.devname[0..p.len];
             self.attach(name) catch |err| {
-                if (err != error.AccessDenied) {
+                if (err != error.HotplugTransient) {
                     std.log.warn("hotplug retry {s}: {}, dropping", .{ name, err });
                     _ = self.hotplug_pending.swapRemove(i);
                     continue;
@@ -1512,16 +1512,29 @@ pub const Supervisor = struct {
         return self.attachWithRoot(devname, "/dev");
     }
 
+    /// Transient open() errors that should trigger hotplug retry.
+    pub fn isTransientOpenError(err: anyerror) bool {
+        return switch (err) {
+            error.AccessDenied,
+            error.PermissionDenied,
+            error.DeviceBusy,
+            error.FileNotFound,
+            error.NoDevice,
+            => true,
+            else => false,
+        };
+    }
+
     pub fn attachWithRoot(self: *Supervisor, devname: []const u8, dev_root: []const u8) !void {
         var path_buf: [128]u8 = undefined;
         const path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ dev_root, devname });
 
         const fd = posix.open(path, .{ .ACCMODE = .RDWR, .NONBLOCK = true }, 0) catch |err| {
-            if (err == error.AccessDenied) {
-                std.log.warn("hotplug: {s} not ready (EACCES)", .{path});
-                return error.AccessDenied;
+            if (isTransientOpenError(err)) {
+                std.log.warn("hotplug: {s} not ready ({s}), will retry", .{ path, @errorName(err) });
+                return error.HotplugTransient;
             }
-            return;
+            return err;
         };
         defer posix.close(fd);
 
@@ -1543,7 +1556,7 @@ pub const Supervisor = struct {
 
         const iface_id = readInterfaceId(path) orelse {
             std.log.debug("hotplug: {s} sysfs not ready, will retry", .{path});
-            return error.AccessDenied;
+            return error.HotplugTransient;
         };
         const declared = for (cfg.?.device.interface) |ci| {
             if (iface_id == @as(u8, @intCast(ci.id))) break true;

--- a/src/test/bugfix_regression_test.zig
+++ b/src/test/bugfix_regression_test.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const testing = std.testing;
 const render = @import("../debug/render.zig");
 const hidraw = @import("../io/hidraw.zig");
+const Supervisor = @import("../supervisor.zig").Supervisor;
 
 // -- Test 1: renderFrame with empty raw slice --
 
@@ -38,7 +39,39 @@ test "stripInputSuffix: same base path deduplicates" {
     try testing.expectEqualStrings(a, b);
 }
 
-// -- Test 3: directory walker finds .toml in subdirectories --
+// -- Test 3 (issue #64): isTransientOpenError classifies errors correctly --
+// Regression: previously only error.AccessDenied was retried; EPERM/ENODEV/ENOENT
+// caused a silent drop (bare `return`), losing the hotplug attach forever.
+
+test "isTransientOpenError: transient errors are retried" {
+    try testing.expect(Supervisor.isTransientOpenError(error.AccessDenied));
+    try testing.expect(Supervisor.isTransientOpenError(error.PermissionDenied));
+    try testing.expect(Supervisor.isTransientOpenError(error.DeviceBusy));
+    try testing.expect(Supervisor.isTransientOpenError(error.FileNotFound));
+    try testing.expect(Supervisor.isTransientOpenError(error.NoDevice));
+}
+
+test "isTransientOpenError: fatal errors are not retried" {
+    try testing.expect(!Supervisor.isTransientOpenError(error.OutOfMemory));
+    try testing.expect(!Supervisor.isTransientOpenError(error.SystemResources));
+    try testing.expect(!Supervisor.isTransientOpenError(error.Unexpected));
+}
+
+// -- Test 4 (issue #64): attachWithRoot maps any transient open error to HotplugTransient --
+// Regression: previously EPERM/ENODEV/ENOENT were normalized to error.AccessDenied,
+// making it impossible for callers to distinguish the retry sentinel from a real EACCES.
+
+test "attachWithRoot: missing device returns HotplugTransient, not AccessDenied" {
+    var sup = try Supervisor.initForTest(testing.allocator);
+    defer sup.deinit();
+
+    // Use a nonexistent path under a real-looking dev root.
+    // open() will fail with FileNotFound — a transient error — which must surface as HotplugTransient.
+    const result = sup.attachWithRoot("hidraw99", "/dev/nonexistent_root_for_test");
+    try testing.expectError(error.HotplugTransient, result);
+}
+
+// -- Test 5: directory walker finds .toml in subdirectories --
 
 test "walker: finds toml files in subdirectories" {
     var tmp = testing.tmpDir(.{});


### PR DESCRIPTION
## Summary

- `attachWithRoot` only treated `error.AccessDenied` as retryable; all other open failures silently returned, dropping the hotplug attach with no log and no retry.
- When systemd's cgroup `DeviceAllow` ACL hasn't yet propagated to a freshly-created hidraw node, `open()` can return `EPERM`, `ENODEV`, or `ENOENT` — all of which were silently swallowed.
- The retry mechanism (`enqueueHotplugRetry`, commit 3b6a669) was already wired up; only the error classification was too narrow.

## Root Cause

```zig
// before — EPERM/ENODEV/ENOENT hit bare return, lost forever
const fd = posix.open(path, ...) catch |err| {
    if (err == error.AccessDenied) { ...; return error.AccessDenied; }
    return; // silent drop
};
```

## Fix

Extracted `isTransientOpenError(err)` — a small pure function covering all plausibly-transient errors (`AccessDenied`, `PermissionDenied`, `DeviceBusy`, `FileNotFound`, `NoDevice`). Any transient error now logs a warning with the error name and path, then returns `error.AccessDenied` to enter the existing retry path. Fatal errors (OOM, etc.) propagate as before.

## Test Plan

- [ ] `zig build test` passes (includes two new regression tests)
- [ ] `zig build` succeeds
- New tests in `src/test/bugfix_regression_test.zig`:
  - `isTransientOpenError: transient errors are retried`
  - `isTransientOpenError: fatal errors are not retried`

Fixes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of device attachment and hotplug event handling through enhanced error classification.
  * Transient device failures now trigger appropriate retry behavior instead of propagating as permanent failures.
  * Enhanced error handling better distinguishes between recoverable and unrecoverable device access issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->