### PR TITLE
fix: case-insensitive device name lookup + diagnostics for missing mapping (#65)

### DIFF
--- a/src/config/user_config.zig
+++ b/src/config/user_config.zig
@@ -21,7 +21,10 @@ pub fn load(allocator: std.mem.Allocator) ?ParseResult {
     defer allocator.free(config_path);
 
     const content = std.fs.cwd().readFileAlloc(allocator, config_path, 256 * 1024) catch |err| {
-        if (err != error.FileNotFound) std.log.warn("user config: cannot read {s}: {}", .{ config_path, err });
+        if (err == error.FileNotFound)
+            std.log.info("user config: no config.toml found; create {s} to set per-device defaults", .{config_path})
+        else
+            std.log.warn("user config: cannot read {s}: {}", .{ config_path, err });
         return null;
     };
     defer allocator.free(content);
@@ -34,12 +37,13 @@ pub fn load(allocator: std.mem.Allocator) ?ParseResult {
     };
 }
 
-/// Find the default_mapping for a device by name. Returns a slice into the parsed data.
 pub fn findDefaultMapping(result: *const ParseResult, device_name: []const u8) ?[]const u8 {
     const entries = result.value.device orelse return null;
     for (entries) |e| {
-        if (std.mem.eql(u8, e.name, device_name)) return e.default_mapping;
+        if (std.ascii.eqlIgnoreCase(e.name, device_name)) return e.default_mapping;
     }
+    if (entries.len > 0)
+        std.log.warn("user config: no entry for detected device \"{s}\" — add [[device]] name = \"{s}\" to config.toml", .{ device_name, device_name });
     return null;
 }
 
@@ -57,7 +61,7 @@ test "load: returns null when config.toml absent" {
     // If null, that is the expected outcome for a missing config.
 }
 
-test "findDefaultMapping: matches by name" {
+test "findDefaultMapping: exact match" {
     const allocator = std.testing.allocator;
 
     const toml_str =
@@ -77,6 +81,41 @@ test "findDefaultMapping: matches by name" {
 
     try std.testing.expectEqualStrings("fps", findDefaultMapping(&result, "Flydigi Vader 5 Pro").?);
     try std.testing.expectEqualStrings("default", findDefaultMapping(&result, "Sony DualSense").?);
+}
+
+test "findDefaultMapping: case-insensitive match" {
+    const allocator = std.testing.allocator;
+
+    const toml_str =
+        \\[[device]]
+        \\name = "Flydigi Vader 5 Pro"
+        \\default_mapping = "fps"
+    ;
+
+    var parser = toml.Parser(UserConfig).init(allocator);
+    defer parser.deinit();
+    var result = try parser.parseString(toml_str);
+    defer result.deinit();
+
+    // Different casing must still match.
+    try std.testing.expectEqualStrings("fps", findDefaultMapping(&result, "flydigi vader 5 pro").?);
+    try std.testing.expectEqualStrings("fps", findDefaultMapping(&result, "FLYDIGI VADER 5 PRO").?);
+}
+
+test "findDefaultMapping: no match returns null" {
+    const allocator = std.testing.allocator;
+
+    const toml_str =
+        \\[[device]]
+        \\name = "Flydigi Vader 5 Pro"
+        \\default_mapping = "fps"
+    ;
+
+    var parser = toml.Parser(UserConfig).init(allocator);
+    defer parser.deinit();
+    var result = try parser.parseString(toml_str);
+    defer result.deinit();
+
     try std.testing.expectEqual(@as(?[]const u8, null), findDefaultMapping(&result, "Unknown Device"));
 }
 


### PR DESCRIPTION
## Summary

- `findDefaultMapping` now matches device names case-insensitively (`std.ascii.eqlIgnoreCase`) so a config.toml entry like `"Flydigi Vader 5 Pro"` matches even when the HID string reports a different capitalisation
- When config.toml exists but has no `[[device]]` entry for the detected device, a `warn` is emitted with the verbatim device name so users can copy-paste it into their config
- When config.toml does not exist at all, an `info` log is emitted once at startup showing the expected path (`~/.config/padctl/config.toml`) so users discover the feature

## Root cause

`findDefaultMapping` used `std.mem.eql` (exact byte comparison). Any capitalisation mismatch between the HID-reported device name and the user's config.toml `name` field caused a silent null return, leaving the mapper uninitialised and the device running in passthrough (gyro and layers non-functional after reboot). Additionally, a missing config.toml produced no diagnostic output.

## Fix

Changed in `src/config/user_config.zig`:
- Line 45: `std.mem.eql` → `std.ascii.eqlIgnoreCase`
- Line 47: `warn` when entries exist but none matches (shows device name verbatim)
- Lines 24-27: `info` when config.toml is absent (shows expected file path)

No changes to supervisor.zig — the existing warn at line 1061 for missing mapping file is already adequate.

## Test plan

- [x] `zig build test` passes (all existing tests + new regression tests green)
- [x] `zig build` succeeds
- [x] `pre-push` tsan test passed
- New unit tests added in `src/config/user_config.zig`:
  - `findDefaultMapping: exact match` — existing behaviour preserved
  - `findDefaultMapping: case-insensitive match` — lowercase and UPPER variants both match
  - `findDefaultMapping: no match returns null` — non-matching device returns null

Fixes #65 (Part B — mapping not applied after reboot). Part A (rumble) is handled in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Device configuration now matches names case-insensitively and logs guidance if the config file is missing
  * Force-feedback stop commands are delivered immediately, bypassing throttle for more responsive feedback
  * Hotplug retry messages are clearer when devices aren’t ready and now handle more transient open errors

* **Tests**
  * Added regression tests for force-feedback throttling and transient error classification
<!-- end of auto-generated comment: release notes by coderabbit.ai -->