### PR TITLE
fix(rumble,config): resolve stuck vibration motor and post-reboot mapping loss (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ padctl is a userspace daemon that maps vendor-specific USB/HID gamepad reports t
 - **Exclusive device grab** — grabs the hidraw/evdev node so the original device is hidden from other processes while padctl is running
 - **Multi-device + hotplug** — automatic device detection and per-device threads via netlink
 - **Hot-reload** — `SIGHUP` re-reads configs without restart, diffed per physical device
-- **Force feedback** — FF_RUMBLE passthrough from uinput to physical device
+- **Force feedback** — FF_RUMBLE passthrough from uinput to physical device with userspace auto-stop timer (compensates for uinput not using the kernel's ff-memless driver)
 - **Runtime mapping switch** — `padctl switch <name>` changes profiles without restart
-- **User config** — `~/.config/padctl/config.toml` for per-device default mappings
+- **Persistent mapping** — `padctl install --mapping <name>` writes a device binding to `/etc/padctl/config.toml` that auto-applies on every boot
+- **User config** — `~/.config/padctl/config.toml` for per-device default mappings (system fallback: `/etc/padctl/config.toml`)
 - **CLI tools** — `padctl status`, `padctl devices`, `padctl list-mappings`, `padctl config init/edit/test`
 
 ## Architecture

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -189,7 +189,14 @@ type = "hat"   # or "buttons"
 [output.force_feedback]
 type = "rumble"
 max_effects = 16
+auto_stop = true     # default; set false to disable userspace auto-stop
 ```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | string | — | Force-feedback type: `"rumble"` |
+| `max_effects` | int | 16 | Maximum number of concurrent FF effect slots |
+| `auto_stop` | bool | `true` | Enable userspace rumble auto-stop. When `true`, padctl emits a stop frame to the HID device after each effect's `replay.length` elapses — compensating for the fact that uinput does not use the kernel's `ff-memless` auto-stop timer. Set to `false` only for devices whose firmware handles auto-stop internally. |
 
 ### `[output.aux]`
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -67,7 +67,9 @@ To install a mapping config to `/etc/padctl/mappings/` during install:
 sudo ./zig-out/bin/padctl install --mapping vader5
 ```
 
-The `--mapping` flag is repeatable. Use `--force-mapping` to overwrite existing mappings.
+The `--mapping` flag is repeatable. Use `--force-mapping` to overwrite existing mapping files.
+
+When `--mapping` is given, the installer also writes a device-to-mapping binding in `/etc/padctl/config.toml` so the daemon auto-applies the mapping on every boot. Use `--force-binding` to overwrite an existing binding for the same device.
 
 > **Bazzite / immutable distros:** See the [Bazzite / Immutable Distros guide](immutable-install.md) for special installation steps.
 
@@ -135,15 +137,20 @@ padctl --doc-gen --config devices/sony/dualsense.toml
 
 ## User Config
 
-padctl reads `~/.config/padctl/config.toml` to set per-device defaults:
+padctl reads a config file to set per-device default mappings. The loader checks these paths in order (first found wins):
+
+1. `~/.config/padctl/config.toml` — user overrides (highest priority)
+2. `/etc/padctl/config.toml` — system-wide defaults (written by `padctl install --mapping`)
 
 ```toml
+version = 1
+
 [[device]]
 name = "Flydigi Vader 5 Pro"
 default_mapping = "fps"
 ```
 
-On daemon start, padctl matches the connected device name and loads the named mapping profile automatically from `~/.config/padctl/mappings/fps.toml`.
+On daemon start, padctl matches the connected device name (case-insensitive) and loads the named mapping profile automatically. The system path is the fallback for environments where `HOME` is not set (e.g. systemd services).
 
 ## CLI Reference
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -152,10 +152,13 @@ default_mapping = "fps"
 
 On daemon start, padctl matches the connected device name (case-insensitive) and loads the named mapping profile automatically. The system path is the fallback for environments where `HOME` is not set (e.g. systemd services).
 
+`padctl switch <name>` automatically updates the user config, so the choice is remembered for bare `padctl switch` (re-apply without a name). To make the choice survive reboots, use `padctl switch <name> --persist` which copies the mapping and config to `/etc/padctl/` via sudo.
+
 ## CLI Reference
 
 ```sh
-padctl switch <name> [--device <id>]       # switch mapping at runtime
+padctl switch [name] [--device <id>]       # switch mapping (omit name to re-apply from user config)
+padctl switch <name> --persist             # switch + copy to /etc/padctl/ for reboot persistence (sudo)
 padctl status [--socket <path>]            # show daemon status
 padctl devices [--socket <path>]           # list connected devices
 padctl list-mappings [--config-dir <dir>]  # list available mapping profiles

--- a/docs/src/immutable-install.md
+++ b/docs/src/immutable-install.md
@@ -25,8 +25,9 @@ What the script does:
 2. **Installs dependencies** via Homebrew (Zig compiler, libusb) — no system reboot needed
 3. **Clones and builds** padctl from source with `ReleaseSafe` optimization
 4. **Installs** the daemon, systemd services, udev rules, and reconnect scripts
-5. **Applies** the selected mapping config
-6. **Verifies** the installation
+5. **Persists** the selected mapping as a device binding in `/etc/padctl/config.toml` (auto-applies on every boot)
+6. **Applies** the mapping to the current session
+7. **Verifies** the installation
 
 Safe to re-run for updates — it rebuilds and reinstalls while preserving your mapping configs in `~/.config/padctl/mappings/`.
 
@@ -34,7 +35,7 @@ Safe to re-run for updates — it rebuilds and reinstalls while preserving your 
 
 | Flag | Description |
 |------|-------------|
-| `--mapping <name>` | Install and apply a specific mapping |
+| `--mapping <name>` | Install a mapping and auto-apply on boot |
 | `--repo-url <url>` | Use a fork or alternative repo URL |
 | `--branch <name>` | Clone/checkout a specific branch |
 | `<path>` | Use an existing local repo instead of cloning |
@@ -93,6 +94,20 @@ padctl switch vader5
 ```
 
 The `/etc/padctl/mappings/` copy is used as a fallback by the hotplug reconnect script (which runs as root).
+
+### Auto-apply on boot
+
+When you install with `--mapping`, the installer writes a device binding to `/etc/padctl/config.toml`:
+
+```toml
+version = 1
+
+[[device]]
+name = "Flydigi Vader 5 Pro"
+default_mapping = "vader5"
+```
+
+The daemon reads this file at startup and auto-applies the mapping — no manual `padctl switch` needed after reboot. User-level overrides in `~/.config/padctl/config.toml` take priority when available.
 
 ## Uninstalling
 

--- a/docs/src/immutable-install.md
+++ b/docs/src/immutable-install.md
@@ -109,6 +109,14 @@ default_mapping = "vader5"
 
 The daemon reads this file at startup and auto-applies the mapping — no manual `padctl switch` needed after reboot. User-level overrides in `~/.config/padctl/config.toml` take priority when available.
 
+You can also persist a mapping change after switching at runtime:
+
+```sh
+padctl switch vader5 --persist
+```
+
+This copies your user mapping and config to `/etc/padctl/` via sudo, so the change survives reboots without re-running the installer.
+
 ## Uninstalling
 
 ```sh

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -43,15 +43,22 @@ Switch the active mapping at runtime without restarting the daemon:
 padctl switch fps
 ```
 
-To apply on startup, set a `default_mapping` in `~/.config/padctl/config.toml`:
+To auto-apply on every boot, set a `default_mapping` in a config file. The daemon checks these paths in order:
+
+1. `~/.config/padctl/config.toml` — user overrides
+2. `/etc/padctl/config.toml` — system-wide (written by `padctl install --mapping`)
 
 ```toml
+version = 1
+
 [[device]]
 name = "Flydigi Vader 5 Pro"
 default_mapping = "fps"
 ```
 
-Or pass it directly when running padctl manually:
+If you installed with `padctl install --mapping vader5`, the system config is already written for you. The daemon auto-applies it on every boot without manual intervention.
+
+Or pass a mapping directly when running padctl manually:
 
 ```sh
 padctl --mapping ~/.config/padctl/mappings/my-config.toml

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -37,16 +37,46 @@ padctl searches for mapping profiles in this order (first match wins):
 
 ### Apply a mapping
 
-Switch the active mapping at runtime without restarting the daemon:
+Switch the active mapping at runtime:
 
 ```sh
 padctl switch fps
 ```
 
-To auto-apply on every boot, set a `default_mapping` in a config file. The daemon checks these paths in order:
+Every switch automatically saves your choice to `~/.config/padctl/config.toml`, so you can restore it later with a bare switch:
 
-1. `~/.config/padctl/config.toml` — user overrides
-2. `/etc/padctl/config.toml` — system-wide (written by `padctl install --mapping`)
+```sh
+padctl switch          # re-applies the last-switched mapping from user config
+```
+
+### Persist across reboots (`--persist`)
+
+By default, `padctl switch` only saves to your user config (`~/.config/padctl/config.toml`). The systemd daemon cannot read this at boot because `HOME` is not set in its service environment. To make the mapping survive reboots:
+
+```sh
+padctl switch fps --persist
+```
+
+This will:
+1. Apply the mapping at runtime (same as without `--persist`)
+2. Save to your user config (same as without `--persist`)
+3. Prompt for confirmation, then ask for your sudo password
+4. Copy the mapping file to `/etc/padctl/mappings/`
+5. Copy your user config to `/etc/padctl/config.toml`
+
+The daemon reads `/etc/padctl/` at boot, so the mapping auto-applies on every reboot without manual intervention.
+
+**Limitations:**
+
+- `--persist` is not yet supported with `--device` (multi-controller setups). In multi-device sessions, auto-save and bare `padctl switch` resolve against the first connected device. Use `padctl install --mapping <name>` for explicit per-device persistence in multi-controller setups.
+- A future version may persist by default, but this behavior is uncertain and subject to change.
+
+### Config file precedence
+
+The daemon checks these paths in order when resolving default mappings:
+
+1. `~/.config/padctl/config.toml` — user overrides (highest priority, only available when `HOME` is set)
+2. `/etc/padctl/config.toml` — system-wide defaults (written by `padctl install --mapping` or `padctl switch --persist`)
 
 ```toml
 version = 1
@@ -56,7 +86,9 @@ name = "Flydigi Vader 5 Pro"
 default_mapping = "fps"
 ```
 
-If you installed with `padctl install --mapping vader5`, the system config is already written for you. The daemon auto-applies it on every boot without manual intervention.
+If you installed with `padctl install --mapping vader5`, the system config is already written for you.
+
+### Manual run
 
 Or pass a mapping directly when running padctl manually:
 

--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -30,7 +30,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  repo-path     Path to padctl repo (default: auto-detect or ~/Games/padctl)"
-            echo "  --mapping     Mapping config to install (default: prompt interactively)"
+            echo "  --mapping     Mapping config to install and auto-apply on boot (default: prompt)"
             echo "  --branch, -b  Git branch to clone/checkout (default: repo default branch)"
             echo "  --repo-url    Git repo URL (default: BANANASJIM/padctl)"
             exit 0
@@ -197,19 +197,20 @@ if $IS_IMMUTABLE; then
     install_args+=(--immutable)
 fi
 if [[ -n "$MAPPING" ]]; then
-    install_args+=(--mapping "$MAPPING" --force-mapping)
+    install_args+=(--mapping "$MAPPING" --force-mapping --force-binding)
 fi
 sudo ./zig-out/bin/padctl "${install_args[@]}"
 ok "padctl installed to $PREFIX"
 
-# --- 7b. Apply mapping (daemon starts in passthrough mode, needs explicit switch) ---
+# --- 7b. Apply mapping to the running daemon (config.toml persists for future boots,
+#         but the already-running daemon needs an explicit switch for the current session) ---
 if [[ -n "$MAPPING" ]]; then
     info "Waiting for daemon to initialize..."
     sleep 3
     if "$PREFIX/bin/padctl" switch "$MAPPING" --socket /run/padctl/padctl.sock 2>/dev/null; then
-        ok "Mapping applied: $MAPPING"
+        ok "Mapping applied: $MAPPING (persisted for future boots via /etc/padctl/config.toml)"
     else
-        warn "Could not apply mapping (daemon may not be ready yet). Run manually: padctl switch $MAPPING"
+        warn "Could not apply mapping to running daemon (it will auto-apply on next boot). Run manually: padctl switch $MAPPING"
     fi
 fi
 
@@ -257,6 +258,15 @@ done
 # Check mapping
 if [[ -n "$MAPPING" && -f "/etc/padctl/mappings/${MAPPING}.toml" ]]; then
     ok "Mapping: /etc/padctl/mappings/${MAPPING}.toml"
+fi
+
+# Check device→mapping binding (auto-apply on boot)
+if [[ -n "$MAPPING" && -f "/etc/padctl/config.toml" ]]; then
+    if grep -q "default_mapping.*=.*\"${MAPPING}\"" /etc/padctl/config.toml 2>/dev/null; then
+        ok "Binding: /etc/padctl/config.toml → $MAPPING (auto-applies on boot)"
+    else
+        warn "Binding: /etc/padctl/config.toml exists but does not bind to $MAPPING"
+    fi
 fi
 
 echo ""

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -43,6 +43,10 @@ pub const InstallOptions = struct {
     no_immutable: bool = false,
     mappings: []const []const u8 = &.{},
     force_mapping: bool = false,
+    /// When true, overwrite existing device→mapping bindings in
+    /// /etc/padctl/config.toml (with timestamped backup). Separate from
+    /// --force-mapping which controls mapping file overwrites.
+    force_binding: bool = false,
     no_enable: bool = false,
     no_start: bool = false,
 };
@@ -553,6 +557,38 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         }
     }
 
+    // 4e. Write device→mapping bindings to /etc/padctl/config.toml so the
+    //      daemon auto-applies the mapping at boot without a manual
+    //      `padctl switch`. For each mapping, resolve the device name by
+    //      filename matching against the source devices/ tree.
+    if (opts.mappings.len > 0) {
+        const devices_src = findDevicesSourceDir(allocator, self_dir, null) catch null;
+        defer if (devices_src) |path| allocator.free(path);
+        if (devices_src) |dev_dir| {
+            for (opts.mappings) |mapping_name| {
+                const device_name = findDeviceNameForMapping(allocator, mapping_name, dev_dir) catch null;
+                defer if (device_name) |n| allocator.free(n);
+                if (device_name) |name| {
+                    const mode: ConflictMode = if (opts.force_binding)
+                        .force
+                    else if (std.posix.isatty(std.posix.STDIN_FILENO))
+                        .interactive
+                    else
+                        .skip;
+                    writeBinding(allocator, destdir, name, mapping_name, mode, stdinPrompt) catch |err| {
+                        var errbuf: [256]u8 = undefined;
+                        const msg = std.fmt.bufPrint(&errbuf, "warning: could not write binding for \"{s}\": {}\n", .{ mapping_name, err }) catch "warning: binding write failed\n";
+                        _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch {};
+                    };
+                } else {
+                    _ = std.posix.write(std.posix.STDERR_FILENO, "warning: no device config found for mapping '") catch {};
+                    _ = std.posix.write(std.posix.STDERR_FILENO, mapping_name) catch {};
+                    _ = std.posix.write(std.posix.STDERR_FILENO, "', skipping binding\n") catch {};
+                }
+            }
+        }
+    }
+
     // 5. Reload system daemons and enable/start services (only when not staging)
     if (destdir.len == 0) {
         _ = std.posix.write(std.posix.STDOUT_FILENO, "\nReloading system daemons...\n") catch {};
@@ -905,6 +941,252 @@ fn isFieldKey(line: []const u8, key: []const u8) bool {
 /// Parse a TOML inline array of strings, e.g. `["xpad", "hid_generic"]`
 /// Validate that a string is a safe identifier (alphanumeric, underscore, hyphen).
 /// Prevents command injection when interpolated into udev RUN+= shell commands.
+const user_config_mod = @import("../config/user_config.zig");
+const config_device = @import("../config/device.zig");
+
+/// Walk `devices_dir` (e.g. `/path/to/padctl/devices`) looking for
+/// `*/mapping_name.toml`. If exactly one match is found, parse it and
+/// return `device.name`. Returns null if zero matches are found. Logs an
+/// error and returns null if multiple matches are found (traversal-order-
+/// dependent behavior would silently persist the wrong binding).
+/// Caller owns the returned string.
+fn findDeviceNameForMapping(
+    allocator: std.mem.Allocator,
+    mapping_name: []const u8,
+    devices_dir: []const u8,
+) !?[]const u8 {
+    var dir = std.fs.cwd().openDir(devices_dir, .{ .iterate = true }) catch return null;
+    defer dir.close();
+
+    var walker = try dir.walk(allocator);
+    defer walker.deinit();
+
+    var match_path: ?[]u8 = null;
+    defer if (match_path) |p| allocator.free(p);
+    var match_count: usize = 0;
+
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.basename, ".toml")) continue;
+
+        const stem = entry.basename[0 .. entry.basename.len - 5];
+        if (!std.mem.eql(u8, stem, mapping_name)) continue;
+
+        match_count += 1;
+        if (match_count == 1) {
+            match_path = try allocator.dupe(u8, entry.path);
+        } else {
+            // Multiple matches — log both paths for disambiguation.
+            _ = std.posix.write(std.posix.STDERR_FILENO, "error: multiple device configs match mapping '") catch {};
+            _ = std.posix.write(std.posix.STDERR_FILENO, mapping_name) catch {};
+            _ = std.posix.write(std.posix.STDERR_FILENO, "', skipping binding\n") catch {};
+            return null;
+        }
+    }
+
+    if (match_count == 0 or match_path == null) return null;
+
+    // Exactly one match — parse and extract device.name.
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const full_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ devices_dir, match_path.? });
+    const parsed = config_device.parseFile(allocator, full_path) catch return null;
+    defer parsed.deinit();
+    return try allocator.dupe(u8, parsed.value.device.name);
+}
+
+pub const ConflictMode = enum {
+    skip, // non-TTY default: warn and keep existing
+    force, // --force-binding: backup + overwrite
+    interactive, // TTY: prompt user (keep/overwrite/abort)
+};
+
+pub const PromptResult = enum { keep, overwrite, abort };
+
+/// Function type for the interactive conflict prompt. Receives the
+/// config file path, device name, existing mapping, and proposed mapping.
+/// Real callers use `stdinPrompt`; tests inject a mock.
+pub const PromptFn = *const fn (
+    config_path: []const u8,
+    device_name: []const u8,
+    existing_map: []const u8,
+    proposed_map: []const u8,
+) PromptResult;
+
+pub fn stdinPrompt(
+    config_path: []const u8,
+    device_name: []const u8,
+    existing_map: []const u8,
+    proposed_map: []const u8,
+) PromptResult {
+    _ = std.posix.write(std.posix.STDERR_FILENO, "\nConflict: ") catch {};
+    _ = std.posix.write(std.posix.STDERR_FILENO, config_path) catch {};
+    _ = std.posix.write(std.posix.STDERR_FILENO, "\n  existing: \"") catch {};
+    _ = std.posix.write(std.posix.STDERR_FILENO, device_name) catch {};
+    _ = std.posix.write(std.posix.STDERR_FILENO, "\" -> \"") catch {};
+    _ = std.posix.write(std.posix.STDERR_FILENO, existing_map) catch {};
+    _ = std.posix.write(std.posix.STDERR_FILENO, "\"\n  proposed: \"") catch {};
+    _ = std.posix.write(std.posix.STDERR_FILENO, device_name) catch {};
+    _ = std.posix.write(std.posix.STDERR_FILENO, "\" -> \"") catch {};
+    _ = std.posix.write(std.posix.STDERR_FILENO, proposed_map) catch {};
+    _ = std.posix.write(std.posix.STDERR_FILENO, "\"\n  [k]eep existing / [o]verwrite with backup / [a]bort (default: k): ") catch {};
+
+    var buf: [16]u8 = undefined;
+    const n = std.posix.read(std.posix.STDIN_FILENO, &buf) catch 0;
+    const choice: u8 = if (n > 0) buf[0] else 'k';
+    return switch (choice) {
+        'o', 'O' => .overwrite,
+        'a', 'A' => .abort,
+        else => .keep,
+    };
+}
+
+/// Write (or update) a device→mapping binding in `{destdir}/etc/padctl/config.toml`.
+///
+/// If the file doesn't exist, creates it with `version = 1` and a single `[[device]]`
+/// entry. If it exists and already has a binding for `device_name`:
+///   - Same `default_mapping` → no-op (idempotent).
+///   - `conflict_mode == .force` → backup + overwrite.
+///   - `conflict_mode == .interactive` → prompt user at stdin (keep/overwrite/abort).
+///   - `conflict_mode == .skip` → log warning, keep existing (non-destructive default).
+///
+/// Other `[[device]]` entries in the file are preserved. The version field is
+/// carried forward (or set to CURRENT_VERSION if absent).
+fn writeBinding(
+    allocator: std.mem.Allocator,
+    destdir: []const u8,
+    device_name: []const u8,
+    mapping_name: []const u8,
+    conflict_mode: ConflictMode,
+    prompt_fn: PromptFn,
+) !void {
+    const etc_dir = try std.fmt.allocPrint(allocator, "{s}/etc/padctl", .{destdir});
+    defer allocator.free(etc_dir);
+    try ensureDirAll(allocator, etc_dir);
+
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{etc_dir});
+    defer allocator.free(config_path);
+
+    // Try to read + parse existing config.
+    // MalformedConfig must NOT be swallowed — a broken hand-edited
+    // /etc/padctl/config.toml must surface as an error, not be silently
+    // overwritten (which would drop unrelated bindings with no backup).
+    var existing = user_config_mod.loadFromDir(allocator, etc_dir) catch |err| switch (err) {
+        error.MalformedConfig => {
+            _ = std.posix.write(std.posix.STDERR_FILENO, "error: ") catch {};
+            _ = std.posix.write(std.posix.STDERR_FILENO, config_path) catch {};
+            _ = std.posix.write(std.posix.STDERR_FILENO, " is malformed — fix or remove it before installing bindings\n") catch {};
+            return error.MalformedConfig;
+        },
+    };
+    defer if (existing) |*e| e.deinit();
+
+    const version: i64 = if (existing) |e| e.value.version orelse user_config_mod.CURRENT_VERSION else user_config_mod.CURRENT_VERSION;
+    const devices = if (existing) |e| e.value.device else null;
+
+    // Check for conflict with an existing binding for the same device name.
+    if (devices) |devs| {
+        for (devs) |d| {
+            if (std.ascii.eqlIgnoreCase(d.name, device_name)) {
+                // Same mapping → idempotent no-op.
+                if (d.default_mapping) |m| {
+                    if (std.mem.eql(u8, m, mapping_name)) return;
+                }
+                // Conflict: different mapping (or no mapping) for the same device.
+                const existing_map = d.default_mapping orelse "(none)";
+                switch (conflict_mode) {
+                    .skip => {
+                        std.log.warn("binding conflict: {s} already has \"{s}\" -> \"{s}\". Use --force-binding to overwrite.", .{ config_path, device_name, existing_map });
+                        return;
+                    },
+                    .interactive => {
+                        switch (prompt_fn(config_path, device_name, existing_map, mapping_name)) {
+                            .overwrite => {}, // fall through to backup + overwrite
+                            .abort => return error.Aborted,
+                            .keep => return,
+                        }
+                    },
+                    .force => {}, // fall through to backup + overwrite
+                }
+                break;
+            }
+        }
+    }
+
+    // Backup existing file before overwriting (only when file exists AND we're
+    // actually changing content — skipped for no-ops and fresh writes).
+    // Abort the overwrite if backup creation fails — losing the user's
+    // recovery file while mutating /etc is not acceptable.
+    if (existing != null and (conflict_mode == .force or conflict_mode == .interactive)) {
+        backupFile(allocator, config_path) catch |err| {
+            var errbuf: [256]u8 = undefined;
+            const msg = std.fmt.bufPrint(&errbuf, "error: cannot create backup of {s}: {}, aborting overwrite\n", .{ config_path, err }) catch "error: backup failed, aborting\n";
+            _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch {};
+            return err;
+        };
+    }
+
+    // Serialize: version + all existing entries (replacing the conflict target
+    // if one was found) + new entry if none matched.
+    var buf = std.ArrayList(u8){};
+    defer buf.deinit(allocator);
+    const w = buf.writer(allocator);
+    try w.print("version = {d}\n", .{version});
+
+    var wrote_target = false;
+    if (devices) |devs| {
+        for (devs) |d| {
+            if (std.ascii.eqlIgnoreCase(d.name, device_name)) {
+                // Replace this entry with the new mapping.
+                try w.print("\n[[device]]\nname = \"{s}\"\ndefault_mapping = \"{s}\"\n", .{ device_name, mapping_name });
+                wrote_target = true;
+            } else {
+                // Preserve unrelated entry.
+                try w.print("\n[[device]]\nname = \"{s}\"\n", .{d.name});
+                if (d.default_mapping) |m| {
+                    try w.print("default_mapping = \"{s}\"\n", .{m});
+                }
+            }
+        }
+    }
+    if (!wrote_target) {
+        try w.print("\n[[device]]\nname = \"{s}\"\ndefault_mapping = \"{s}\"\n", .{ device_name, mapping_name });
+    }
+
+    // Write the file.
+    var f = try std.fs.createFileAbsolute(config_path, .{ .truncate = true });
+    defer f.close();
+    try f.writeAll(buf.items);
+}
+
+/// Copy `path` to `path.bak.YYYYMMDD-HHMMSS`. Returns an error if the
+/// backup cannot be created — the caller must abort the overwrite.
+fn backupFile(allocator: std.mem.Allocator, file_path: []const u8) !void {
+    const now = std.time.timestamp();
+    const epoch_secs: std.time.epoch.EpochSeconds = .{ .secs = @intCast(now) };
+    const day = epoch_secs.getEpochDay().calculateYearDay();
+    const year_day = day.calculateMonthDay();
+    const day_secs = epoch_secs.getDaySeconds();
+    const year: u16 = day.year;
+    const month: u8 = @intFromEnum(year_day.month);
+    const dom: u8 = year_day.day_index + 1;
+    const hours: u8 = @intCast(day_secs.getHoursIntoDay());
+    const minutes: u8 = @intCast(day_secs.getMinutesIntoHour());
+    const seconds: u8 = @intCast(day_secs.getSecondsIntoMinute());
+
+    const bak_path = try std.fmt.allocPrint(allocator, "{s}.bak.{d:0>4}{d:0>2}{d:0>2}-{d:0>2}{d:0>2}{d:0>2}", .{
+        file_path, year, month, dom, hours, minutes, seconds,
+    });
+    defer allocator.free(bak_path);
+
+    const data = try std.fs.cwd().readFileAlloc(allocator, file_path, 256 * 1024);
+    defer allocator.free(data);
+    var f = try std.fs.createFileAbsolute(bak_path, .{ .truncate = true });
+    defer f.close();
+    try f.writeAll(data);
+
+    std.log.info("backup: {s}", .{bak_path});
+}
+
 fn isValidIdentifier(s: []const u8) bool {
     if (s.len == 0) return false;
     for (s) |c| {
@@ -1802,6 +2084,294 @@ test "install: installMapping overwrites with force" {
     const content = try f.readToEndAlloc(allocator, 4096);
     defer allocator.free(content);
     try testing.expectEqualStrings("updated", content);
+}
+
+test "install: findDeviceNameForMapping resolves vader5 to Flydigi Vader 5 Pro" {
+    const testing_alloc = std.testing.allocator;
+    // findDevicesSourceDir searches relative to self_dir or CWD.
+    // In the test environment, CWD is the repo root.
+    const cwd = try std.process.getCwdAlloc(testing_alloc);
+    defer testing_alloc.free(cwd);
+    const devices_dir = try std.fmt.allocPrint(testing_alloc, "{s}/devices", .{cwd});
+    defer testing_alloc.free(devices_dir);
+
+    const result = try findDeviceNameForMapping(testing_alloc, "vader5", devices_dir);
+    defer if (result) |r| testing_alloc.free(r);
+    try std.testing.expect(result != null);
+    try std.testing.expectEqualStrings("Flydigi Vader 5 Pro", result.?);
+}
+
+test "install: findDeviceNameForMapping returns null for nonexistent mapping" {
+    const testing_alloc = std.testing.allocator;
+    const cwd = try std.process.getCwdAlloc(testing_alloc);
+    defer testing_alloc.free(cwd);
+    const devices_dir = try std.fmt.allocPrint(testing_alloc, "{s}/devices", .{cwd});
+    defer testing_alloc.free(devices_dir);
+
+    const result = try findDeviceNameForMapping(testing_alloc, "nonexistent_controller_xyz", devices_dir);
+    try std.testing.expectEqual(@as(?[]const u8, null), result);
+}
+
+// --- Mock prompt functions for tests ---
+
+fn mockPromptKeep(_: []const u8, _: []const u8, _: []const u8, _: []const u8) PromptResult {
+    return .keep;
+}
+fn mockPromptOverwrite(_: []const u8, _: []const u8, _: []const u8, _: []const u8) PromptResult {
+    return .overwrite;
+}
+fn mockPromptAbort(_: []const u8, _: []const u8, _: []const u8, _: []const u8) PromptResult {
+    return .abort;
+}
+
+// --- Binding writer tests ---
+
+test "install: writeBinding creates new config.toml with version and device entry" {
+    const testing_alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(testing_alloc, ".");
+    defer testing_alloc.free(destdir);
+
+    try writeBinding(testing_alloc, destdir, "Test Device", "test_map", .skip, mockPromptKeep);
+
+    const config_path = try std.fmt.allocPrint(testing_alloc, "{s}/etc/padctl/config.toml", .{destdir});
+    defer testing_alloc.free(config_path);
+
+    const content = try std.fs.cwd().readFileAlloc(testing_alloc, config_path, 64 * 1024);
+    defer testing_alloc.free(content);
+
+    try std.testing.expect(std.mem.indexOf(u8, content, "version = 1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "name = \"Test Device\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "default_mapping = \"test_map\"") != null);
+}
+
+test "install: writeBinding appends to existing config with different device" {
+    const testing_alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(testing_alloc, ".");
+    defer testing_alloc.free(destdir);
+
+    // Write first device.
+    try writeBinding(testing_alloc, destdir, "Device A", "map_a", .skip, mockPromptKeep);
+    // Write second device.
+    try writeBinding(testing_alloc, destdir, "Device B", "map_b", .skip, mockPromptKeep);
+
+    const config_path = try std.fmt.allocPrint(testing_alloc, "{s}/etc/padctl/config.toml", .{destdir});
+    defer testing_alloc.free(config_path);
+
+    const content = try std.fs.cwd().readFileAlloc(testing_alloc, config_path, 64 * 1024);
+    defer testing_alloc.free(content);
+
+    // Both devices present.
+    try std.testing.expect(std.mem.indexOf(u8, content, "name = \"Device A\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "name = \"Device B\"") != null);
+}
+
+test "install: writeBinding is idempotent when device+mapping match" {
+    const testing_alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(testing_alloc, ".");
+    defer testing_alloc.free(destdir);
+
+    try writeBinding(testing_alloc, destdir, "Vader", "vader5", .skip, mockPromptKeep);
+    try writeBinding(testing_alloc, destdir, "Vader", "vader5", .skip, mockPromptKeep);
+
+    const config_path = try std.fmt.allocPrint(testing_alloc, "{s}/etc/padctl/config.toml", .{destdir});
+    defer testing_alloc.free(config_path);
+
+    const content = try std.fs.cwd().readFileAlloc(testing_alloc, config_path, 64 * 1024);
+    defer testing_alloc.free(content);
+
+    // Only one [[device]] entry (not duplicated).
+    var count: usize = 0;
+    var pos: usize = 0;
+    while (std.mem.indexOfPos(u8, content, pos, "[[device]]")) |idx| {
+        count += 1;
+        pos = idx + 10;
+    }
+    try std.testing.expectEqual(@as(usize, 1), count);
+}
+
+test "install: writeBinding conflict without force - skip (no overwrite)" {
+    const testing_alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(testing_alloc, ".");
+    defer testing_alloc.free(destdir);
+
+    try writeBinding(testing_alloc, destdir, "Vader", "old_map", .skip, mockPromptKeep);
+    // Conflict: same device, different mapping, no force.
+    try writeBinding(testing_alloc, destdir, "Vader", "new_map", .skip, mockPromptKeep);
+
+    const config_path = try std.fmt.allocPrint(testing_alloc, "{s}/etc/padctl/config.toml", .{destdir});
+    defer testing_alloc.free(config_path);
+
+    const content = try std.fs.cwd().readFileAlloc(testing_alloc, config_path, 64 * 1024);
+    defer testing_alloc.free(content);
+
+    // Original mapping preserved (no force).
+    try std.testing.expect(std.mem.indexOf(u8, content, "default_mapping = \"old_map\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "default_mapping = \"new_map\"") == null);
+}
+
+test "install: writeBinding interactive keep preserves existing binding" {
+    const testing_alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(testing_alloc, ".");
+    defer testing_alloc.free(destdir);
+
+    try writeBinding(testing_alloc, destdir, "Vader", "old_map", .skip, mockPromptKeep);
+    // Interactive mode with mockPromptKeep → user chose "keep".
+    try writeBinding(testing_alloc, destdir, "Vader", "new_map", .interactive, mockPromptKeep);
+
+    const config_path = try std.fmt.allocPrint(testing_alloc, "{s}/etc/padctl/config.toml", .{destdir});
+    defer testing_alloc.free(config_path);
+    const content = try std.fs.cwd().readFileAlloc(testing_alloc, config_path, 64 * 1024);
+    defer testing_alloc.free(content);
+
+    // Original binding preserved.
+    try std.testing.expect(std.mem.indexOf(u8, content, "default_mapping = \"old_map\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "default_mapping = \"new_map\"") == null);
+}
+
+test "install: writeBinding interactive overwrite updates binding with backup" {
+    const testing_alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(testing_alloc, ".");
+    defer testing_alloc.free(destdir);
+
+    try writeBinding(testing_alloc, destdir, "Vader", "old_map", .skip, mockPromptKeep);
+    // Interactive mode with mockPromptOverwrite → user chose "overwrite".
+    try writeBinding(testing_alloc, destdir, "Vader", "new_map", .interactive, mockPromptOverwrite);
+
+    const config_path = try std.fmt.allocPrint(testing_alloc, "{s}/etc/padctl/config.toml", .{destdir});
+    defer testing_alloc.free(config_path);
+    const content = try std.fs.cwd().readFileAlloc(testing_alloc, config_path, 64 * 1024);
+    defer testing_alloc.free(content);
+
+    // Binding updated.
+    try std.testing.expect(std.mem.indexOf(u8, content, "default_mapping = \"new_map\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "default_mapping = \"old_map\"") == null);
+
+    // Backup exists.
+    const etc_dir = try std.fmt.allocPrint(testing_alloc, "{s}/etc/padctl", .{destdir});
+    defer testing_alloc.free(etc_dir);
+    var dir = try std.fs.openDirAbsolute(etc_dir, .{ .iterate = true });
+    defer dir.close();
+    var found_bak = false;
+    var it = dir.iterate();
+    while (try it.next()) |entry| {
+        if (std.mem.startsWith(u8, entry.name, "config.toml.bak.")) {
+            found_bak = true;
+            break;
+        }
+    }
+    try std.testing.expect(found_bak);
+}
+
+test "install: writeBinding interactive abort returns error" {
+    const testing_alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(testing_alloc, ".");
+    defer testing_alloc.free(destdir);
+
+    try writeBinding(testing_alloc, destdir, "Vader", "old_map", .skip, mockPromptKeep);
+    // Interactive mode with mockPromptAbort → user chose "abort".
+    try std.testing.expectError(
+        error.Aborted,
+        writeBinding(testing_alloc, destdir, "Vader", "new_map", .interactive, mockPromptAbort),
+    );
+
+    // Original preserved (abort didn't modify).
+    const config_path = try std.fmt.allocPrint(testing_alloc, "{s}/etc/padctl/config.toml", .{destdir});
+    defer testing_alloc.free(config_path);
+    const content = try std.fs.cwd().readFileAlloc(testing_alloc, config_path, 64 * 1024);
+    defer testing_alloc.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "default_mapping = \"old_map\"") != null);
+}
+
+test "install: writeBinding aborts on malformed existing config.toml" {
+    const testing_alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(testing_alloc, ".");
+    defer testing_alloc.free(destdir);
+
+    // Create a malformed config.toml that the TOML parser can't read.
+    const etc_dir = try std.fmt.allocPrint(testing_alloc, "{s}/etc/padctl", .{destdir});
+    defer testing_alloc.free(etc_dir);
+    try ensureDirAll(testing_alloc, etc_dir);
+    {
+        const cfg_path = try std.fmt.allocPrint(testing_alloc, "{s}/config.toml", .{etc_dir});
+        defer testing_alloc.free(cfg_path);
+        const f = try std.fs.createFileAbsolute(cfg_path, .{});
+        defer f.close();
+        try f.writeAll("this is {{{{ not valid TOML !!!!");
+    }
+
+    // writeBinding must refuse to overwrite — data loss risk.
+    try std.testing.expectError(
+        error.MalformedConfig,
+        writeBinding(testing_alloc, destdir, "Device", "map", .skip, mockPromptKeep),
+    );
+    // Force mode must also abort — backup-then-overwrite is meaningless
+    // when we can't even parse the file to preserve unrelated entries.
+    try std.testing.expectError(
+        error.MalformedConfig,
+        writeBinding(testing_alloc, destdir, "Device", "map", .force, mockPromptKeep),
+    );
+}
+
+test "install: writeBinding conflict with force - backup + overwrite" {
+    const testing_alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(testing_alloc, ".");
+    defer testing_alloc.free(destdir);
+
+    try writeBinding(testing_alloc, destdir, "Vader", "old_map", .skip, mockPromptKeep);
+    // Force overwrite.
+    try writeBinding(testing_alloc, destdir, "Vader", "new_map", .force, mockPromptKeep);
+
+    const config_path = try std.fmt.allocPrint(testing_alloc, "{s}/etc/padctl/config.toml", .{destdir});
+    defer testing_alloc.free(config_path);
+
+    const content = try std.fs.cwd().readFileAlloc(testing_alloc, config_path, 64 * 1024);
+    defer testing_alloc.free(content);
+
+    // Binding updated.
+    try std.testing.expect(std.mem.indexOf(u8, content, "default_mapping = \"new_map\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "default_mapping = \"old_map\"") == null);
+
+    // Backup file exists.
+    const etc_dir = try std.fmt.allocPrint(testing_alloc, "{s}/etc/padctl", .{destdir});
+    defer testing_alloc.free(etc_dir);
+    var dir = try std.fs.openDirAbsolute(etc_dir, .{ .iterate = true });
+    defer dir.close();
+    var found_bak = false;
+    var it = dir.iterate();
+    while (try it.next()) |entry| {
+        if (std.mem.startsWith(u8, entry.name, "config.toml.bak.")) {
+            found_bak = true;
+            break;
+        }
+    }
+    try std.testing.expect(found_bak);
 }
 
 test "install: installMapping errors on missing source" {

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -582,11 +582,15 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
                         mapping_failed = true;
                     };
                 } else {
-                    _ = std.posix.write(std.posix.STDERR_FILENO, "warning: no device config found for mapping '") catch {};
+                    _ = std.posix.write(std.posix.STDERR_FILENO, "error: no device config found for mapping '") catch {};
                     _ = std.posix.write(std.posix.STDERR_FILENO, mapping_name) catch {};
-                    _ = std.posix.write(std.posix.STDERR_FILENO, "', skipping binding\n") catch {};
+                    _ = std.posix.write(std.posix.STDERR_FILENO, "', binding not written\n") catch {};
+                    mapping_failed = true;
                 }
             }
+        } else {
+            _ = std.posix.write(std.posix.STDERR_FILENO, "error: devices directory not found, cannot resolve device bindings\n") catch {};
+            mapping_failed = true;
         }
     }
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -536,7 +536,12 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     }
 
     // 4d. Install mapping configs (if --mapping specified, repeatable)
+    // Track per-mapping success so 4e only writes bindings for mappings
+    // that were actually installed (avoids a config.toml entry pointing
+    // at a missing mapping file).
     var mapping_failed = false;
+    var installed_mappings = std.ArrayList([]const u8){};
+    defer installed_mappings.deinit(allocator);
     if (opts.mappings.len > 0) {
         const mappings_src = findMappingsSourceDir(allocator, self_dir, null) catch null;
         defer if (mappings_src) |path| allocator.free(path);
@@ -549,7 +554,9 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
                     const msg = std.fmt.bufPrint(&errbuf, "' not installed: {}\n", .{err}) catch "' not installed\n";
                     _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch {};
                     mapping_failed = true;
+                    continue;
                 };
+                installed_mappings.append(allocator, mapping_name) catch {};
             }
         } else {
             _ = std.posix.write(std.posix.STDERR_FILENO, "error: mappings directory not found near executable or current working directory\n") catch {};
@@ -559,13 +566,14 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
 
     // 4e. Write device→mapping bindings to /etc/padctl/config.toml so the
     //      daemon auto-applies the mapping at boot without a manual
-    //      `padctl switch`. For each mapping, resolve the device name by
-    //      filename matching against the source devices/ tree.
-    if (opts.mappings.len > 0) {
+    //      `padctl switch`. Only process mappings that were successfully
+    //      installed in 4d — writing a binding for a missing mapping file
+    //      would make reboot auto-apply point at nothing.
+    if (installed_mappings.items.len > 0) {
         const devices_src = findDevicesSourceDir(allocator, self_dir, null) catch null;
         defer if (devices_src) |path| allocator.free(path);
         if (devices_src) |dev_dir| {
-            for (opts.mappings) |mapping_name| {
+            for (installed_mappings.items) |mapping_name| {
                 const device_name = findDeviceNameForMapping(allocator, mapping_name, dev_dir) catch null;
                 defer if (device_name) |n| allocator.free(n);
                 if (device_name) |name| {

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -577,8 +577,9 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
                         .skip;
                     writeBinding(allocator, destdir, name, mapping_name, mode, stdinPrompt) catch |err| {
                         var errbuf: [256]u8 = undefined;
-                        const msg = std.fmt.bufPrint(&errbuf, "warning: could not write binding for \"{s}\": {}\n", .{ mapping_name, err }) catch "warning: binding write failed\n";
+                        const msg = std.fmt.bufPrint(&errbuf, "error: could not write binding for \"{s}\": {}\n", .{ mapping_name, err }) catch "error: binding write failed\n";
                         _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch {};
+                        mapping_failed = true;
                     };
                 } else {
                     _ = std.posix.write(std.posix.STDERR_FILENO, "warning: no device config found for mapping '") catch {};

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -105,6 +105,13 @@ pub const DpadOutputConfig = struct {
 pub const FfConfig = struct {
     type: []const u8, // "rumble"
     max_effects: ?i64 = null,
+    /// When true (default), padctl runs a userspace rumble auto-stop
+    /// scheduler that emits a stop frame after each effect's replay.length
+    /// elapses. Set to false to delegate stopping to the client (e.g. Steam)
+    /// for devices whose firmware auto-stops internally. Most uinput-backed
+    /// devices need this enabled because the kernel's ff-memless auto-stop
+    /// helper is not used by uinput.
+    auto_stop: bool = true,
 };
 
 pub const AuxConfig = struct {
@@ -431,6 +438,60 @@ test "device: load flydigi/vader5.toml succeeds" {
     try std.testing.expectEqual(@as(i64, 0x2401), cfg.device.pid);
     try std.testing.expectEqual(@as(usize, 1), cfg.report.len);
     try std.testing.expectEqualStrings("extended", cfg.report[0].name);
+}
+
+test "device: force_feedback.auto_stop defaults to true when unspecified" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator, test_toml);
+    defer result.deinit();
+
+    // The test TOML declares [output.force_feedback] type = "rumble" without
+    // auto_stop. The default must be true (userspace rumble auto-stop enabled).
+    const ff = result.value.output.?.force_feedback.?;
+    try std.testing.expect(ff.auto_stop);
+}
+
+test "device: force_feedback.auto_stop = false parses to disabled scheduler" {
+    const allocator = std.testing.allocator;
+    const toml_with_opt_out =
+        \\[device]
+        \\name = "Test Opt-Out"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\
+        \\[[report]]
+        \\name = "main"
+        \\interface = 0
+        \\size = 16
+        \\
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x00]
+        \\
+        \\[report.fields]
+        \\left_x = { offset = 6, type = "i16le" }
+        \\
+        \\[output]
+        \\name = "Test"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\
+        \\[output.axes]
+        \\left_x = { code = "ABS_X", min = -32768, max = 32767 }
+        \\
+        \\[output.force_feedback]
+        \\type = "rumble"
+        \\auto_stop = false
+    ;
+    const result = try parseString(allocator, toml_with_opt_out);
+    defer result.deinit();
+
+    const ff = result.value.output.?.force_feedback.?;
+    try std.testing.expect(!ff.auto_stop);
 }
 
 test "device: valid config parses and validates" {

--- a/src/config/user_config.zig
+++ b/src/config/user_config.zig
@@ -2,28 +2,89 @@ const std = @import("std");
 const toml = @import("toml");
 const paths = @import("paths.zig");
 
+/// Current schema version written by the installer's binding writer.
+/// Bumping this requires adding migration logic in the loader.
+pub const CURRENT_VERSION: i64 = 1;
+
 pub const DeviceEntry = struct {
     name: []const u8,
     default_mapping: ?[]const u8 = null,
 };
 
 pub const UserConfig = struct {
+    /// Schema version for forward/backward compatibility. Missing = legacy
+    /// v0 (pre-versioned). Current version is 1. The loader accepts any
+    /// version and logs a warning when it's newer than expected.
+    version: ?i64 = null,
     device: ?[]DeviceEntry = null,
 };
 
 pub const ParseResult = toml.Parsed(UserConfig);
 
+/// Load user config with system fallback.
+///
+/// Priority: `~/.config/padctl/config.toml` (user) → `/etc/padctl/config.toml`
+/// (system). The system path is tried only when the user path is genuinely
+/// unavailable (HOME not set, file missing, directory inaccessible). A
+/// malformed user config returns null WITHOUT falling through — a parse
+/// error in the user file is a user mistake, not a reason to silently
+/// switch to the system file.
 pub fn load(allocator: std.mem.Allocator) ?ParseResult {
-    const config_dir = paths.userConfigDir(allocator) catch return null;
-    defer allocator.free(config_dir);
+    // Try user path first.
+    const user_dir = paths.userConfigDir(allocator) catch |err| {
+        // HOME not set (common under systemd) — skip straight to system.
+        if (err == error.NoHomeDir) {
+            return loadSystemFallback(allocator);
+        }
+        return null;
+    };
+    defer allocator.free(user_dir);
 
-    const config_path = std.fmt.allocPrint(allocator, "{s}/config.toml", .{config_dir}) catch return null;
+    if (loadFromDir(allocator, user_dir)) |result| {
+        return result;
+    } else |err| switch (err) {
+        // User config exists but is malformed. Do NOT fall through to
+        // the system config — a broken user file is a user mistake and
+        // silent fallback would hide the parse error (already logged by
+        // loadFromDir).
+        error.MalformedConfig => return null,
+    }
+
+    // User file absent — try system fallback.
+    return loadSystemFallback(allocator);
+}
+
+fn loadSystemFallback(allocator: std.mem.Allocator) ?ParseResult {
+    const sys_dir = paths.systemConfigDir();
+    const result = loadFromDir(allocator, sys_dir) catch {
+        // System config malformed — already logged.
+        return null;
+    };
+    if (result != null) {
+        std.log.info("user config: loaded system config from {s}/config.toml", .{sys_dir});
+    } else {
+        std.log.info("user config: no config.toml found; create ~/.config/padctl/config.toml or {s}/config.toml to set per-device defaults", .{sys_dir});
+    }
+    return result;
+}
+
+pub const LoadDirError = error{MalformedConfig};
+
+/// Load and parse `{dir_path}/config.toml`.
+///
+/// Returns:
+/// - Success, non-null: file found and parsed.
+/// - Success, null: file not found (or directory inaccessible) — safe to
+///   fall through to a lower-priority config path.
+/// - error.MalformedConfig: file exists but contains invalid TOML. The
+///   caller must NOT fall through to a system config — a broken user
+///   config is a user mistake and silent fallback would hide the problem.
+pub fn loadFromDir(allocator: std.mem.Allocator, dir_path: []const u8) LoadDirError!?ParseResult {
+    const config_path = std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir_path}) catch return null;
     defer allocator.free(config_path);
 
     const content = std.fs.cwd().readFileAlloc(allocator, config_path, 256 * 1024) catch |err| {
-        if (err == error.FileNotFound)
-            std.log.info("user config: no config.toml found; create {s} to set per-device defaults", .{config_path})
-        else
+        if (err != error.FileNotFound)
             std.log.warn("user config: cannot read {s}: {}", .{ config_path, err });
         return null;
     };
@@ -31,10 +92,19 @@ pub fn load(allocator: std.mem.Allocator) ?ParseResult {
 
     var parser = toml.Parser(UserConfig).init(allocator);
     defer parser.deinit();
-    return parser.parseString(content) catch |err| {
+    const result = parser.parseString(content) catch |err| {
         std.log.warn("user config: parse error in {s}: {}", .{ config_path, err });
-        return null;
+        return error.MalformedConfig;
     };
+
+    // Warn when the file was written by a newer padctl than we are.
+    if (result.value.version) |v| {
+        if (v > CURRENT_VERSION) {
+            std.log.warn("user config: {s} has version {d}, expected <= {d} — some fields may not be understood", .{ config_path, v, CURRENT_VERSION });
+        }
+    }
+
+    return result;
 }
 
 pub fn findDefaultMapping(result: *const ParseResult, device_name: []const u8) ?[]const u8 {
@@ -59,6 +129,94 @@ test "load: returns null when config.toml absent" {
         mr.deinit();
     }
     // If null, that is the expected outcome for a missing config.
+}
+
+test "user_config: loadFromDir reads config.toml from a given directory" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    const content =
+        \\version = 1
+        \\
+        \\[[device]]
+        \\name = "Test Device"
+        \\default_mapping = "test_mapping"
+    ;
+    {
+        const f = try tmp.dir.createFile("config.toml", .{});
+        defer f.close();
+        try f.writeAll(content);
+    }
+
+    var result = try loadFromDir(allocator, dir_path);
+    try std.testing.expect(result != null);
+    if (result) |*r| {
+        defer r.deinit();
+        try std.testing.expectEqual(@as(?i64, 1), r.value.version);
+        const mapping = findDefaultMapping(r, "Test Device");
+        try std.testing.expect(mapping != null);
+        try std.testing.expectEqualStrings("test_mapping", mapping.?);
+    }
+}
+
+test "user_config: loadFromDir returns null when directory has no config.toml" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    const result = try loadFromDir(allocator, dir_path);
+    try std.testing.expectEqual(@as(?ParseResult, null), result);
+}
+
+test "user_config: loadFromDir handles legacy file without version field" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    const content =
+        \\[[device]]
+        \\name = "Legacy Device"
+        \\default_mapping = "legacy"
+    ;
+    {
+        const f = try tmp.dir.createFile("config.toml", .{});
+        defer f.close();
+        try f.writeAll(content);
+    }
+
+    var result = try loadFromDir(allocator, dir_path);
+    try std.testing.expect(result != null);
+    if (result) |*r| {
+        defer r.deinit();
+        try std.testing.expectEqual(@as(?i64, null), r.value.version);
+        try std.testing.expectEqualStrings("legacy", findDefaultMapping(r, "Legacy Device").?);
+    }
+}
+
+test "user_config: loadFromDir returns MalformedConfig for broken TOML" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        const f = try tmp.dir.createFile("config.toml", .{});
+        defer f.close();
+        try f.writeAll("this is {{{{ not valid TOML !!!!");
+    }
+
+    try std.testing.expectError(error.MalformedConfig, loadFromDir(allocator, dir_path));
 }
 
 test "findDefaultMapping: exact match" {

--- a/src/config/user_config.zig
+++ b/src/config/user_config.zig
@@ -40,8 +40,9 @@ pub fn load(allocator: std.mem.Allocator) ?ParseResult {
     };
     defer allocator.free(user_dir);
 
-    if (loadFromDir(allocator, user_dir)) |result| {
-        return result;
+    if (loadFromDir(allocator, user_dir)) |maybe_result| {
+        if (maybe_result) |result| return result;
+        // result is null → file not found → fall through to system.
     } else |err| switch (err) {
         // User config exists but is malformed. Do NOT fall through to
         // the system config — a broken user file is a user mistake and

--- a/src/core/rumble_scheduler.zig
+++ b/src/core/rumble_scheduler.zig
@@ -1,0 +1,296 @@
+const std = @import("std");
+
+/// Maximum number of FF effect slots padctl tracks. Matches the kernel's
+/// UINPUT_NUM_EFFECTS constraint used when registering rumble on uinput.
+pub const MAX_EFFECTS = 16;
+
+/// Per-effect FF rumble auto-stop state machine.
+///
+/// Pure logic. No file descriptors, no clock, no syscalls. The caller passes
+/// `now_ns` on every mutation and consults the return values (or `nextDeadline`)
+/// to learn when the host timerfd should wake next.
+///
+/// Background: the Linux kernel's ff-memless.c auto-stops effects when their
+/// `replay.length` elapses, but uinput uses plain `input_ff_create()` — not the
+/// memless helper — so effects uploaded to padctl's virtual gamepad are never
+/// auto-stopped by the kernel. This module fills that gap in userspace.
+pub const RumbleScheduler = struct {
+    /// Per-slot deadline, indexed by FF effect id (0..MAX_EFFECTS-1).
+    /// 0 = not playing.
+    /// INFINITE = playing with `replay.length == 0` (never auto-stops on its own).
+    /// positive, < INFINITE = absolute monotonic deadline in nanoseconds.
+    slots: [MAX_EFFECTS]i128 = @splat(0),
+
+    /// Sentinel deadline for effects with infinite duration.
+    pub const INFINITE: i128 = std.math.maxInt(i128);
+
+    pub const ExpiryResult = struct {
+        /// When true, the event loop must emit a stop frame to the HID device
+        /// because no effect remains playing.
+        emit_stop_frame: bool,
+        /// Next instant at which the host timerfd should wake, or null to
+        /// disarm the timerfd entirely.
+        next_deadline_ns: ?i128,
+    };
+
+    /// Record that `effect_id` started playing with the given length.
+    /// `length_ms == 0` means infinite (never auto-stops on its own).
+    /// Out-of-range effect ids are ignored defensively.
+    /// Returns the new earliest finite deadline, or null if none is pending.
+    pub fn onPlay(self: *RumbleScheduler, effect_id: u8, length_ms: u16, now_ns: i128) ?i128 {
+        if (effect_id >= MAX_EFFECTS) return self.nextDeadline();
+        self.slots[effect_id] = if (length_ms == 0)
+            INFINITE
+        else
+            now_ns + @as(i128, length_ms) * std.time.ns_per_ms;
+        return self.nextDeadline();
+    }
+
+    /// Record that `effect_id` was explicitly stopped by the client
+    /// (EV_FF value=0). Out-of-range ids are ignored defensively.
+    ///
+    /// Returns an `ExpiryResult`:
+    /// - `emit_stop_frame` is true ONLY when no effect remains playing
+    ///   (finite or infinite). The caller must not emit a zero frame to
+    ///   HID when another effect is still active, otherwise the long
+    ///   effect's motor would be cut off mid-playback.
+    /// - `next_deadline_ns` is the next pending finite deadline, or null.
+    pub fn onStop(self: *RumbleScheduler, effect_id: u8) ExpiryResult {
+        if (effect_id < MAX_EFFECTS) {
+            self.slots[effect_id] = 0;
+        }
+        return .{
+            .emit_stop_frame = !self.anyPlaying(),
+            .next_deadline_ns = self.nextDeadline(),
+        };
+    }
+
+    /// Called when the host timerfd fires. Clears every finite slot whose
+    /// deadline has elapsed, then reports whether a stop frame should be
+    /// emitted (no slots remain playing at all) and where the timerfd
+    /// should be armed next.
+    pub fn onTimerExpired(self: *RumbleScheduler, now_ns: i128) ExpiryResult {
+        for (&self.slots) |*s| {
+            if (s.* > 0 and s.* != INFINITE and s.* <= now_ns) {
+                s.* = 0;
+            }
+        }
+        return .{
+            .emit_stop_frame = !self.anyPlaying(),
+            .next_deadline_ns = self.nextDeadline(),
+        };
+    }
+
+    /// True when any slot has a non-zero deadline (finite OR infinite).
+    /// Used by `onStop` and `onTimerExpired` to decide whether the event
+    /// loop must emit a zero rumble frame to HID.
+    fn anyPlaying(self: *const RumbleScheduler) bool {
+        for (self.slots) |s| {
+            if (s != 0) return true;
+        }
+        return false;
+    }
+
+    /// Returns the earliest finite pending deadline, or null if nothing is
+    /// pending. An "infinite" slot does not contribute a deadline because
+    /// it never fires from the timer.
+    pub fn nextDeadline(self: *const RumbleScheduler) ?i128 {
+        var min: i128 = INFINITE;
+        var found = false;
+        for (self.slots) |s| {
+            if (s > 0 and s != INFINITE and s < min) {
+                min = s;
+                found = true;
+            }
+        }
+        return if (found) min else null;
+    }
+};
+
+// --- tests ---
+
+const testing = std.testing;
+
+test "rumble_scheduler: empty scheduler has no pending deadline" {
+    var sched: RumbleScheduler = .{};
+    try testing.expectEqual(@as(?i128, null), sched.nextDeadline());
+}
+
+test "rumble_scheduler: onPlay records finite deadline at now + length_ms" {
+    var sched: RumbleScheduler = .{};
+    const now: i128 = 1_000_000_000;
+    const length_ms: u16 = 500;
+    const expected: i128 = now + @as(i128, length_ms) * std.time.ns_per_ms;
+
+    const next = sched.onPlay(0, length_ms, now);
+    try testing.expectEqual(@as(?i128, expected), next);
+    try testing.expectEqual(@as(?i128, expected), sched.nextDeadline());
+}
+
+test "rumble_scheduler: onTimerExpired at deadline clears slot and emits stop" {
+    var sched: RumbleScheduler = .{};
+    const now: i128 = 1_000_000_000;
+    const length_ms: u16 = 500;
+    const deadline = now + @as(i128, length_ms) * std.time.ns_per_ms;
+
+    _ = sched.onPlay(0, length_ms, now);
+
+    const result = sched.onTimerExpired(deadline);
+    try testing.expect(result.emit_stop_frame);
+    try testing.expectEqual(@as(?i128, null), result.next_deadline_ns);
+    // Slot is cleared
+    try testing.expectEqual(@as(?i128, null), sched.nextDeadline());
+}
+
+test "rumble_scheduler: infinite duration never contributes a deadline but stays playing" {
+    var sched: RumbleScheduler = .{};
+    const now: i128 = 5_000_000_000;
+
+    // length_ms == 0 means the kernel recorded an infinite-duration effect.
+    // The scheduler should disarm the timerfd (nothing to auto-stop) but
+    // still consider the slot "playing" so a spurious timer fire does not
+    // emit a stop frame.
+    const next_after_play = sched.onPlay(3, 0, now);
+    try testing.expectEqual(@as(?i128, null), next_after_play);
+    try testing.expectEqual(@as(?i128, null), sched.nextDeadline());
+
+    // If the timerfd fires later for some reason (e.g., another effect
+    // expired and left this one), we must not emit a stop frame.
+    const result = sched.onTimerExpired(now + 10 * std.time.ns_per_s);
+    try testing.expect(!result.emit_stop_frame);
+    try testing.expectEqual(@as(?i128, null), result.next_deadline_ns);
+}
+
+test "rumble_scheduler: long-then-short overlap does not prematurely emit stop" {
+    var sched: RumbleScheduler = .{};
+    const t0: i128 = 0;
+    const t100 = 100 * std.time.ns_per_ms;
+    const t300 = 300 * std.time.ns_per_ms;
+    const t1000 = 1000 * std.time.ns_per_ms;
+
+    // A plays for 1000ms starting at t=0
+    _ = sched.onPlay(0, 1000, t0);
+    // B plays for 200ms starting at t=100 → deadline t=300
+    const next_after_b = sched.onPlay(1, 200, t100);
+    try testing.expectEqual(@as(?i128, t300), next_after_b);
+
+    // Timer fires at t=300 → B expires, A still playing, no stop frame
+    const first = sched.onTimerExpired(t300);
+    try testing.expect(!first.emit_stop_frame);
+    try testing.expectEqual(@as(?i128, t1000), first.next_deadline_ns);
+
+    // Timer fires at t=1000 → A expires, nothing remaining, stop frame emitted
+    const second = sched.onTimerExpired(t1000);
+    try testing.expect(second.emit_stop_frame);
+    try testing.expectEqual(@as(?i128, null), second.next_deadline_ns);
+}
+
+test "rumble_scheduler: same-id reuse replaces the deadline (latest play wins)" {
+    var sched: RumbleScheduler = .{};
+    const t0: i128 = 0;
+    const t100 = 100 * std.time.ns_per_ms;
+
+    // Initial play: 500ms → deadline t=500
+    _ = sched.onPlay(0, 500, t0);
+    try testing.expectEqual(@as(?i128, 500 * std.time.ns_per_ms), sched.nextDeadline());
+
+    // Reuse the same effect id 100ms later with a 300ms duration →
+    // new deadline is t=100+300=400, replacing the old one.
+    const next_after_reuse = sched.onPlay(0, 300, t100);
+    const expected = t100 + 300 * std.time.ns_per_ms;
+    try testing.expectEqual(@as(?i128, expected), next_after_reuse);
+    try testing.expectEqual(@as(?i128, expected), sched.nextDeadline());
+}
+
+test "rumble_scheduler: onStop of only playing effect emits stop frame" {
+    var sched: RumbleScheduler = .{};
+    const now: i128 = 0;
+
+    _ = sched.onPlay(0, 500, now);
+    try testing.expect(sched.nextDeadline() != null);
+
+    const result = sched.onStop(0);
+    // The only playing effect stopped → event loop must emit a stop frame
+    // and the timerfd must be disarmed.
+    try testing.expect(result.emit_stop_frame);
+    try testing.expectEqual(@as(?i128, null), result.next_deadline_ns);
+    try testing.expectEqual(@as(?i128, null), sched.nextDeadline());
+}
+
+test "rumble_scheduler: onStop of one effect while another still plays must NOT emit stop" {
+    var sched: RumbleScheduler = .{};
+    const t0: i128 = 0;
+    const t100 = 100 * std.time.ns_per_ms;
+    const a_deadline = 1000 * std.time.ns_per_ms;
+
+    // Long effect A is playing.
+    _ = sched.onPlay(0, 1000, t0);
+    // Overlapping short effect B starts.
+    _ = sched.onPlay(1, 500, t100);
+
+    // Client explicitly stops B. A is still supposed to be playing, so the
+    // event loop must NOT cut the motor — emit_stop_frame must be false.
+    // The timerfd must be rearmed for A's remaining deadline.
+    const result = sched.onStop(1);
+    try testing.expect(!result.emit_stop_frame);
+    try testing.expectEqual(@as(?i128, a_deadline), result.next_deadline_ns);
+}
+
+test "rumble_scheduler: onStop of infinite-duration effect while another plays must NOT emit stop" {
+    var sched: RumbleScheduler = .{};
+    const now: i128 = 0;
+    const b_deadline = 500 * std.time.ns_per_ms;
+
+    _ = sched.onPlay(0, 0, now); // infinite
+    _ = sched.onPlay(1, 500, now); // finite
+
+    // Stop the finite one; the infinite effect is still live → no stop frame.
+    const result = sched.onStop(1);
+    try testing.expect(!result.emit_stop_frame);
+    // nextDeadline returns null (infinite is not a finite deadline).
+    try testing.expectEqual(@as(?i128, null), result.next_deadline_ns);
+    _ = b_deadline;
+}
+
+test "rumble_scheduler: out-of-range effect_id does not corrupt other slots" {
+    var sched: RumbleScheduler = .{};
+    const now: i128 = 0;
+    const t500 = 500 * std.time.ns_per_ms;
+
+    // Valid effect on slot 0
+    _ = sched.onPlay(0, 500, now);
+
+    // Out-of-range ids (>= MAX_EFFECTS=16) must be ignored and must not
+    // affect the nextDeadline of the valid slot.
+    _ = sched.onPlay(16, 100, now);
+    _ = sched.onPlay(255, 100, now);
+    _ = sched.onStop(16);
+    _ = sched.onStop(200);
+
+    try testing.expectEqual(@as(?i128, t500), sched.nextDeadline());
+}
+
+test "rumble_scheduler: short-then-long overlap rearms for the longer deadline" {
+    var sched: RumbleScheduler = .{};
+    const t0: i128 = 0;
+    const t100 = 100 * std.time.ns_per_ms;
+    const t200 = 200 * std.time.ns_per_ms;
+    const t1100 = 1100 * std.time.ns_per_ms;
+
+    // A plays for 200ms starting at t=0 → deadline t=200
+    _ = sched.onPlay(0, 200, t0);
+    // B plays for 1000ms starting at t=100 → deadline t=1100
+    // Next wake still t=200 because that's the earliest.
+    const next_after_b = sched.onPlay(1, 1000, t100);
+    try testing.expectEqual(@as(?i128, t200), next_after_b);
+
+    // Timer fires at t=200 → A expires, B still playing, no stop, rearm at t=1100
+    const first = sched.onTimerExpired(t200);
+    try testing.expect(!first.emit_stop_frame);
+    try testing.expectEqual(@as(?i128, t1100), first.next_deadline_ns);
+
+    // Timer fires at t=1100 → B expires, stop frame emitted
+    const second = sched.onTimerExpired(t1100);
+    try testing.expect(second.emit_stop_frame);
+    try testing.expectEqual(@as(?i128, null), second.next_deadline_ns);
+}

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -23,9 +23,11 @@ const AdaptiveTriggerConfig = @import("config/mapping.zig").AdaptiveTriggerConfi
 const MappingConfig = @import("config/mapping.zig").MappingConfig;
 const wasm_runtime = @import("wasm/runtime.zig");
 pub const WasmPlugin = wasm_runtime.WasmPlugin;
+const rumble_scheduler_mod = @import("core/rumble_scheduler.zig");
+const RumbleScheduler = rumble_scheduler_mod.RumbleScheduler;
 
-// signalfd(0) + stop_pipe(1) + per-interface fds + uinput FF fd + timerfd slot
-pub const MAX_FDS = 10;
+// signalfd(0) + stop_pipe(1) + macro timerfd(2) + rumble_stop_fd(3) + per-interface fds + uinput FF fd
+pub const MAX_FDS = 11;
 
 const signalfd_siginfo_size = 128;
 
@@ -38,6 +40,23 @@ pub const TimerCallback = struct {
     }
 };
 
+/// Returns the current CLOCK_MONOTONIC time in nanoseconds.
+///
+/// Scheduler deadlines and timerfd arm paths use this in preference to
+/// `std.time.nanoTimestamp()` because Zig 0.15's nanoTimestamp is backed
+/// by CLOCK_REALTIME on Linux. Since padctl's timerfds are created with
+/// CLOCK_MONOTONIC, mixing clock sources would cause auto-stop deadlines
+/// to fire early, late, or disappear whenever wall time jumps (NTP slew,
+/// suspend/resume, manual clock set). CLOCK_MONOTONIC matches the
+/// timerfd clock and is immune to wall-time discontinuities.
+///
+/// clock_gettime(.MONOTONIC) cannot fail on any supported Linux kernel,
+/// but we defensively coerce any error to 0 rather than propagating.
+pub fn monotonicNs() i128 {
+    const ts = posix.clock_gettime(.MONOTONIC) catch return 0;
+    return @as(i128, ts.sec) * std.time.ns_per_s + @as(i128, ts.nsec);
+}
+
 /// Arm a timerfd for a one-shot timeout (it_interval = 0).
 pub fn armTimer(fd: posix.fd_t, timeout_ms: u32) void {
     const spec = linux.itimerspec{
@@ -48,6 +67,70 @@ pub fn armTimer(fd: posix.fd_t, timeout_ms: u32) void {
         .it_interval = .{ .sec = 0, .nsec = 0 },
     };
     _ = linux.timerfd_settime(fd, .{}, &spec, null);
+}
+
+/// Arm or disarm the rumble auto-stop timerfd using an absolute
+/// CLOCK_MONOTONIC deadline. `deadline_ns == null` → disarm.
+///
+/// Uses `TFD_TIMER.ABSTIME` so the kernel handles the delta against its
+/// own monotonic clock. No caller-side "now" read is needed, and there
+/// is no opportunity for the arm delta to be computed against a
+/// different clock than the one the timerfd fires against.
+fn armRumbleStopFd(fd: posix.fd_t, deadline_ns: ?i128) void {
+    const target = deadline_ns orelse {
+        disarmTimer(fd);
+        return;
+    };
+    // Guard: ABSTIME with it_value.{sec,nsec} == 0 would disarm the
+    // timer. A deadline in the past (or exactly 0) should still fire
+    // ASAP, so clamp to 1ns.
+    const target_clamped: i128 = if (target > 0) target else 1;
+    const spec = linux.itimerspec{
+        .it_value = .{
+            .sec = @intCast(@divFloor(target_clamped, std.time.ns_per_s)),
+            .nsec = @intCast(@mod(target_clamped, std.time.ns_per_s)),
+        },
+        .it_interval = .{ .sec = 0, .nsec = 0 },
+    };
+    _ = linux.timerfd_settime(fd, .{ .ABSTIME = true }, &spec, null);
+}
+
+/// Returns true when this device's config wants userspace rumble auto-stop.
+/// Defaults to true when `[output.force_feedback]` is absent or does not
+/// explicitly set `auto_stop`.
+fn autoStopEnabled(dcfg: ?*const DeviceConfig) bool {
+    const cfg = dcfg orelse return true;
+    const out = cfg.output orelse return true;
+    const ff = out.force_feedback orelse return true;
+    return ff.auto_stop;
+}
+
+/// Write a single rumble frame (strong, weak) to the HID device using the
+/// device's `commands.rumble` (or alternate FF type) template. Used by
+/// both the uinput-FF-event path and the userspace auto-stop timerfd path.
+fn emitRumbleFrame(
+    devices: []DeviceIO,
+    alloc: std.mem.Allocator,
+    dcfg: *const DeviceConfig,
+    strong: u16,
+    weak: u16,
+) void {
+    const cmds = dcfg.commands orelse return;
+    const ff_type = if (dcfg.output) |out|
+        if (out.force_feedback) |ff_cfg| ff_cfg.type else "rumble"
+    else
+        "rumble";
+    const cmd = cmds.map.get(ff_type) orelse return;
+    const iface_idx = resolveIfaceIdx(dcfg, cmd.interface) orelse return;
+    if (iface_idx >= devices.len) return;
+    const params = [_]Param{
+        .{ .name = "strong", .value = strong },
+        .{ .name = "weak", .value = weak },
+    };
+    const bytes = fillTemplate(alloc, cmd.template, &params) catch return;
+    defer alloc.free(bytes);
+    if (cmd.checksum) |*cs| applyChecksum(bytes, cs);
+    devices[iface_idx].write(bytes) catch {};
 }
 
 /// Disarm a timerfd by setting all fields to zero.
@@ -152,6 +235,15 @@ pub const EventLoop = struct {
     // device fds start at slot 2 (after signalfd + stop_pipe)
     device_base: usize,
     timer_fd: posix.fd_t,
+    /// Dedicated timerfd for userspace rumble auto-stop. Separate from
+    /// `timer_fd` (which is reserved for macro timing) to keep the two
+    /// concerns from stomping on each other's arm/disarm schedule.
+    rumble_stop_fd: posix.fd_t,
+    /// pollfds slot where `rumble_stop_fd` is registered.
+    rumble_stop_slot: usize,
+    /// State machine that tracks per-effect deadlines and decides when
+    /// to fire a stop frame. See src/core/rumble_scheduler.zig.
+    rumble_scheduler: RumbleScheduler,
     uinput_ff_slot: ?usize,
     disconnected: bool,
     running: bool,
@@ -192,6 +284,9 @@ pub const EventLoop = struct {
         const timer_fd = try posix.timerfd_create(.MONOTONIC, .{ .CLOEXEC = true, .NONBLOCK = true });
         errdefer posix.close(timer_fd);
 
+        const rumble_stop_fd = try posix.timerfd_create(.MONOTONIC, .{ .CLOEXEC = true, .NONBLOCK = true });
+        errdefer posix.close(rumble_stop_fd);
+
         var loop = EventLoop{
             .pollfds = undefined,
             .fd_count = 0,
@@ -200,20 +295,25 @@ pub const EventLoop = struct {
             .stop_w = stop_w,
             .device_base = 0,
             .timer_fd = timer_fd,
+            .rumble_stop_fd = rumble_stop_fd,
+            .rumble_stop_slot = 3,
+            .rumble_scheduler = .{},
             .uinput_ff_slot = null,
             .disconnected = false,
             .running = false,
             .gamepad_state = .{},
-            .last_ts = std.time.nanoTimestamp(),
+            .last_ts = monotonicNs(),
             .last_rumble_ns = 0,
         };
 
-        // slot 0 = signalfd (or dummy pipe), slot 1 = stop pipe, slot 2 = timerfd
+        // slot 0 = signalfd, slot 1 = stop pipe, slot 2 = macro timerfd,
+        // slot 3 = rumble-stop timerfd
         loop.pollfds[0] = .{ .fd = sig_fd, .events = posix.POLL.IN, .revents = 0 };
         loop.pollfds[1] = .{ .fd = stop_r, .events = posix.POLL.IN, .revents = 0 };
         loop.pollfds[2] = .{ .fd = timer_fd, .events = posix.POLL.IN, .revents = 0 };
-        loop.fd_count = 3;
-        loop.device_base = 3;
+        loop.pollfds[3] = .{ .fd = rumble_stop_fd, .events = posix.POLL.IN, .revents = 0 };
+        loop.fd_count = 4;
+        loop.device_base = 4;
 
         return loop;
     }
@@ -262,7 +362,7 @@ pub const EventLoop = struct {
                 },
             };
 
-            const now = std.time.nanoTimestamp();
+            const now = monotonicNs();
             const dt_ns = now - self.last_ts;
             const dt_ms: u32 = @intCast(@min(100, @max(1, @divFloor(dt_ns, 1_000_000))));
             self.last_ts = now;
@@ -293,38 +393,82 @@ pub const EventLoop = struct {
                 }
             }
 
-            // Check uinput FF fd
+            // Check rumble auto-stop timerfd (slot 3).
+            // When the scheduler's earliest pending deadline fires, clear
+            // expired slots and emit a single stop frame to HID if no
+            // effects remain playing. Rearm (or disarm) for the next
+            // deadline.
+            if (self.pollfds[3].revents & posix.POLL.IN != 0) {
+                var rs_expiry: [8]u8 = undefined;
+                _ = posix.read(self.rumble_stop_fd, &rs_expiry) catch {};
+                const now_ns = monotonicNs();
+                const result = self.rumble_scheduler.onTimerExpired(now_ns);
+                if (result.emit_stop_frame) {
+                    if (ctx.allocator) |alloc| {
+                        if (ctx.device_config) |dcfg| {
+                            emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
+                        }
+                    }
+                }
+                armRumbleStopFd(self.rumble_stop_fd, result.next_deadline_ns);
+            }
+
+            // Check uinput FF fd.
+            //
+            // Play and stop events take different paths because overlapping
+            // effects change the stop semantics: an explicit stop for one of
+            // several still-playing effects must NOT write a zero frame to
+            // HID — otherwise the long effect's motor gets cut off while the
+            // scheduler still considers it live.
             if (self.uinput_ff_slot) |slot| {
                 if (self.pollfds[slot].revents & posix.POLL.IN != 0) {
                     if (ctx.output.pollFf() catch null) |ff_ev| {
-                        const now_ns = std.time.nanoTimestamp();
+                        const now_ns = monotonicNs();
                         const min_interval_ns: i128 = 10_000_000; // 10ms
                         const is_stop = ff_ev.strong == 0 and ff_ev.weak == 0;
-                        if (is_stop or now_ns - self.last_rumble_ns >= min_interval_ns) {
-                            if (ctx.allocator) |alloc| {
-                                if (ctx.device_config) |dcfg| {
-                                    if (dcfg.commands) |cmds| {
-                                        const ff_type = if (dcfg.output) |out| if (out.force_feedback) |ff_cfg| ff_cfg.type else "rumble" else "rumble";
-                                        if (cmds.map.get(ff_type)) |cmd| {
-                                            if (resolveIfaceIdx(dcfg, cmd.interface)) |iface_idx| {
-                                                if (iface_idx < ctx.devices.len) {
-                                                    const params = [_]Param{
-                                                        .{ .name = "strong", .value = ff_ev.strong },
-                                                        .{ .name = "weak", .value = ff_ev.weak },
-                                                    };
-                                                    if (fillTemplate(alloc, cmd.template, &params)) |bytes| {
-                                                        defer alloc.free(bytes);
-                                                        if (cmd.checksum) |*cs| {
-                                                            applyChecksum(bytes, cs);
-                                                        }
-                                                        ctx.devices[iface_idx].write(bytes) catch {};
-                                                        if (!is_stop) self.last_rumble_ns = now_ns;
-                                                    } else |_| {}
-                                                }
-                                            }
+                        const scheduler_on = autoStopEnabled(ctx.device_config);
+
+                        if (is_stop) {
+                            if (scheduler_on) {
+                                // Update scheduler first. Only emit a zero
+                                // frame when the stop transitions the whole
+                                // scheduler to "nothing playing"; otherwise
+                                // another effect is still live.
+                                const result = self.rumble_scheduler.onStop(ff_ev.effect_id);
+                                if (result.emit_stop_frame) {
+                                    if (ctx.allocator) |alloc| {
+                                        if (ctx.device_config) |dcfg| {
+                                            emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
                                         }
                                     }
                                 }
+                                armRumbleStopFd(self.rumble_stop_fd, result.next_deadline_ns);
+                            } else {
+                                // auto_stop disabled: legacy fall-through,
+                                // trust the client to know what it's doing.
+                                if (ctx.allocator) |alloc| {
+                                    if (ctx.device_config) |dcfg| {
+                                        emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
+                                    }
+                                }
+                            }
+                        } else {
+                            // Play event: throttle applies to play frames.
+                            if (now_ns - self.last_rumble_ns >= min_interval_ns) {
+                                if (ctx.allocator) |alloc| {
+                                    if (ctx.device_config) |dcfg| {
+                                        emitRumbleFrame(ctx.devices, alloc, dcfg, ff_ev.strong, ff_ev.weak);
+                                        self.last_rumble_ns = now_ns;
+                                    }
+                                }
+                            }
+                            if (scheduler_on) {
+                                const next_dl = self.rumble_scheduler.onPlay(
+                                    ff_ev.effect_id,
+                                    ff_ev.duration_ms,
+                                    now_ns,
+                                );
+                                armRumbleStopFd(self.rumble_stop_fd, next_dl);
                             }
                         }
                     }
@@ -436,6 +580,7 @@ pub const EventLoop = struct {
         posix.close(self.stop_r);
         posix.close(self.stop_w);
         posix.close(self.timer_fd);
+        posix.close(self.rumble_stop_fd);
     }
 };
 
@@ -444,6 +589,30 @@ pub const EventLoop = struct {
 const testing = std.testing;
 const MockDeviceIO = @import("test/mock_device_io.zig").MockDeviceIO;
 const uinput = @import("io/uinput.zig");
+
+test "event_loop: monotonicNs is backed by CLOCK_MONOTONIC (not wall clock)" {
+    // All scheduler deadlines and timerfd arm computations MUST come from
+    // CLOCK_MONOTONIC so NTP slews, suspend/resume, and manual wall-clock
+    // adjustments cannot make auto-stop deadlines fire early, late, or be
+    // lost entirely. Zig 0.15's std.time.nanoTimestamp() returns
+    // CLOCK_REALTIME on Linux, so padctl uses this local monotonicNs()
+    // helper instead. This test pins the implementation.
+    const a = monotonicNs();
+    const ts = try posix.clock_gettime(.MONOTONIC);
+    const mono: i128 = @as(i128, ts.sec) * std.time.ns_per_s + @as(i128, ts.nsec);
+
+    // Our helper and a direct clock_gettime(.MONOTONIC) read must agree
+    // within a generous 10ms window (test execution overhead + scheduler
+    // jitter). Anything beyond that means monotonicNs is reading a
+    // different clock.
+    const diff: i128 = if (a > mono) a - mono else mono - a;
+    try testing.expect(diff < 10 * std.time.ns_per_ms);
+
+    // Must be strictly positive and monotonically non-decreasing.
+    try testing.expect(a > 0);
+    const b = monotonicNs();
+    try testing.expect(b >= a);
+}
 
 test "event_loop: EventLoop.addUinputFf registers fd and increments fd_count" {
     var loop = try EventLoop.initManaged();
@@ -454,9 +623,11 @@ test "event_loop: EventLoop.addUinputFf registers fd and increments fd_count" {
     defer posix.close(pfds[1]);
 
     try loop.addUinputFf(pfds[0]);
-    try testing.expectEqual(@as(usize, 4), loop.fd_count);
-    try testing.expectEqual(@as(?usize, 3), loop.uinput_ff_slot);
-    try testing.expectEqual(pfds[0], loop.pollfds[3].fd);
+    // Fixed slots 0..3 are signalfd, stop_pipe, macro timerfd, rumble_stop_fd;
+    // the FF fd becomes slot 4, fd_count goes 4 → 5.
+    try testing.expectEqual(@as(usize, 5), loop.fd_count);
+    try testing.expectEqual(@as(?usize, 4), loop.uinput_ff_slot);
+    try testing.expectEqual(pfds[0], loop.pollfds[4].fd);
 }
 
 test "event_loop: EventLoop: Disconnected device causes loop to exit without panic" {
@@ -515,13 +686,15 @@ test "event_loop: EventLoop: Disconnected device causes loop to exit without pan
     try testing.expect(!loop.running);
 }
 
-test "event_loop: EventLoop.initManaged creates eventfd and timerfd" {
+test "event_loop: EventLoop.initManaged creates eventfd and timerfds" {
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
     try testing.expect(loop.signal_fd >= 0);
     try testing.expect(loop.timer_fd >= 0);
-    // slot 0 = eventfd, slot 1 = stop_pipe, slot 2 = timerfd
-    try testing.expectEqual(@as(usize, 3), loop.fd_count);
+    try testing.expect(loop.rumble_stop_fd >= 0);
+    // slot 0 = eventfd, slot 1 = stop_pipe, slot 2 = macro timerfd,
+    // slot 3 = rumble-stop timerfd
+    try testing.expectEqual(@as(usize, 4), loop.fd_count);
 }
 
 test "event_loop: EventLoop.stop wakes ppoll" {
@@ -543,9 +716,10 @@ test "event_loop: EventLoop.addDevice registers fd" {
     const dev = mock.deviceIO();
 
     try loop.addDevice(dev);
-    // fd_count goes from 3 → 4, device is at slot 3
-    try testing.expectEqual(@as(usize, 4), loop.fd_count);
-    try testing.expectEqual(mock.pipe_r, loop.pollfds[3].fd);
+    // Fixed slots: 0=signalfd, 1=stop_pipe, 2=macro timerfd, 3=rumble_stop_fd.
+    // First device lands at slot 4, fd_count goes from 4 → 5.
+    try testing.expectEqual(@as(usize, 5), loop.fd_count);
+    try testing.expectEqual(mock.pipe_r, loop.pollfds[4].fd);
 }
 
 test "event_loop: EventLoop.addDevice rejects overflow" {
@@ -553,14 +727,15 @@ test "event_loop: EventLoop.addDevice rejects overflow" {
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
 
-    // Fill remaining slots (already have 3: signalfd + stop_pipe + timerfd)
-    var mocks: [MAX_FDS - 3]MockDeviceIO = undefined;
-    for (0..MAX_FDS - 3) |i| {
+    // Fill remaining slots (already have 4: signalfd + stop_pipe + macro
+    // timerfd + rumble-stop timerfd).
+    var mocks: [MAX_FDS - 4]MockDeviceIO = undefined;
+    for (0..MAX_FDS - 4) |i| {
         mocks[i] = try MockDeviceIO.init(allocator, &.{});
     }
-    defer for (0..MAX_FDS - 3) |i| mocks[i].deinit();
+    defer for (0..MAX_FDS - 4) |i| mocks[i].deinit();
 
-    for (0..MAX_FDS - 3) |i| {
+    for (0..MAX_FDS - 4) |i| {
         const dev = mocks[i].deviceIO();
         try loop.addDevice(dev);
     }
@@ -1032,6 +1207,44 @@ const MockFfOutputSeq = struct {
     fn mockClose(_: *anyopaque) void {}
 };
 
+/// Drain-aware variant of MockFfOutputSeq. Each `mockPollFf` call reads one
+/// byte from the test's ff_pipe before returning the next event. That forces
+/// a strict 1:1 correspondence between pipe writes and event consumption so
+/// real-time delays between pipe writes are respected — which matters when a
+/// test wants its second play frame to land AFTER the 10ms play-frame
+/// throttle window closes.
+const MockFfOutputDrain = struct {
+    events: []const ?uinput.FfEvent,
+    call_count: usize = 0,
+    pipe_read: posix.fd_t,
+
+    fn outputDevice(self: *MockFfOutputDrain) uinput.OutputDevice {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = uinput.OutputDevice.VTable{
+        .emit = mockEmit,
+        .poll_ff = mockPollFf,
+        .close = mockClose,
+    };
+
+    fn mockEmit(_: *anyopaque, _: state.GamepadState) uinput.EmitError!void {}
+
+    fn mockPollFf(ptr: *anyopaque) uinput.PollFfError!?uinput.FfEvent {
+        const self: *MockFfOutputDrain = @ptrCast(@alignCast(ptr));
+        var buf: [1]u8 = undefined;
+        _ = posix.read(self.pipe_read, &buf) catch return null;
+        if (self.call_count < self.events.len) {
+            const ev = self.events[self.call_count];
+            self.call_count += 1;
+            return ev;
+        }
+        return null;
+    }
+
+    fn mockClose(_: *anyopaque) void {}
+};
+
 test "event_loop: stop frame forwarded even within 10ms throttle window" {
     const allocator = testing.allocator;
 
@@ -1102,6 +1315,338 @@ test "event_loop: stop frame forwarded even within 10ms throttle window" {
     const play_frame = mock_dev.write_log.items[0..frame_size];
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, play_frame);
     // Entry 1: stop frame
+    const stop_frame = mock_dev.write_log.items[frame_size .. 2 * frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, stop_frame);
+}
+
+const ff_toml_no_autostop =
+    \\[device]
+    \\name = "T"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 1
+    \\[commands.rumble]
+    \\interface = 0
+    \\template = "00 08 00 {strong:u8} {weak:u8} 00 00 00"
+    \\[output]
+    \\name = "T"
+    \\vid = 1
+    \\pid = 2
+    \\[output.axes]
+    \\left_x = { code = "ABS_X", min = -32768, max = 32767 }
+    \\[output.force_feedback]
+    \\type = "rumble"
+    \\auto_stop = false
+;
+
+test "event_loop: explicit stop of one of two overlapping effects does not cut the long effect" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var mock_dev = try MockDeviceIO.init(allocator, &.{});
+    defer mock_dev.deinit();
+    const dev = mock_dev.deviceIO();
+    try loop.addDevice(dev);
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    // Sequence:
+    //   1) play A (slot 0, 300ms duration, magnitude 0x8000/0x4000)
+    //   2) play B (slot 1, 100ms duration, magnitude 0x4000/0x2000)
+    //   3) explicit stop B (slot 1)
+    //
+    // Use the drain-aware mock so each pipe write advances the mock by
+    // exactly one event and the test's wall-clock sleeps actually gate
+    // the 10ms play-frame throttle.
+    //
+    // Expected: three HID frames — play A, play B, then ONE stop frame
+    // when A's 300ms auto-stop deadline fires. No stop frame from the
+    // explicit stop of B, because A was still live.
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 300 },
+        .{ .effect_type = 0x50, .effect_id = 1, .strong = 0x4000, .weak = 0x2000, .duration_ms = 100 },
+        .{ .effect_type = 0x50, .effect_id = 1, .strong = 0, .weak = 0, .duration_ms = 0 },
+        null,
+    };
+    var ff_out = MockFfOutputDrain{ .events = &seq, .pipe_read = ff_pipe[0] };
+
+    const RunCtx = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        ff_out: *MockFfOutputDrain,
+        cfg: *const device_mod.DeviceConfig,
+        alloc: std.mem.Allocator,
+    };
+    var devs = [_]DeviceIO{dev};
+    var ctx = RunCtx{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .ff_out = &ff_out,
+        .cfg = &parsed.value,
+        .alloc = allocator,
+    };
+
+    const T = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 500 });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
+
+    // play A — scheduler arms at t+300ms
+    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+    std.Thread.sleep(15 * std.time.ns_per_ms); // clear the 10ms play throttle
+    // play B — scheduler still has A pending; next earliest deadline is
+    // min(300, 15+100) = 115ms.
+    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+    std.Thread.sleep(15 * std.time.ns_per_ms);
+    // explicit stop B — A is still active; scheduler must NOT emit a stop.
+    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+    // Wait for A's 300ms auto-stop deadline to fire.
+    std.Thread.sleep(350 * std.time.ns_per_ms);
+    loop.stop();
+    thread.join();
+
+    // Expect exactly 3 frames: play A, play B, auto-stop.
+    // The explicit stop of B must NOT have produced a zero frame while A
+    // was still playing.
+    const frame_size = 8;
+    try testing.expectEqual(@as(usize, 3 * frame_size), mock_dev.write_log.items.len);
+    const play_a = mock_dev.write_log.items[0..frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, play_a);
+    const play_b = mock_dev.write_log.items[frame_size .. 2 * frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 }, play_b);
+    const final_stop = mock_dev.write_log.items[2 * frame_size .. 3 * frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, final_stop);
+}
+
+test "event_loop: auto_stop=false never emits a scheduler-driven stop frame" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var mock_dev = try MockDeviceIO.init(allocator, &.{});
+    defer mock_dev.deinit();
+    const dev = mock_dev.deviceIO();
+    try loop.addDevice(dev);
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml_no_autostop);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    // Single play with a short duration. Because the device opted out,
+    // the scheduler must NOT arm the timerfd and NOT emit an auto-stop
+    // frame — only the play frame from the pollFf path should land.
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 25 },
+        null,
+    };
+    var ff_out = MockFfOutputSeq{ .allocator = allocator, .events = &seq };
+
+    const RunCtx = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        ff_out: *MockFfOutputSeq,
+        cfg: *const device_mod.DeviceConfig,
+        alloc: std.mem.Allocator,
+    };
+    var devs = [_]DeviceIO{dev};
+    var ctx = RunCtx{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .ff_out = &ff_out,
+        .cfg = &parsed.value,
+        .alloc = allocator,
+    };
+
+    const T = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 100 });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
+
+    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+    // Wait well past the 25ms duration to prove no auto-stop fires.
+    std.Thread.sleep(80 * std.time.ns_per_ms);
+    loop.stop();
+    thread.join();
+
+    // Only the play frame; NO stop frame because auto_stop = false.
+    const frame_size = 8;
+    try testing.expectEqual(@as(usize, frame_size), mock_dev.write_log.items.len);
+    const play_frame = mock_dev.write_log.items[0..frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, play_frame);
+}
+
+test "event_loop: explicit stop before duration_ms disarms auto-stop (no double stop)" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var mock_dev = try MockDeviceIO.init(allocator, &.{});
+    defer mock_dev.deinit();
+    const dev = mock_dev.deviceIO();
+    try loop.addDevice(dev);
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    // Play with a long (200ms) duration, followed by an explicit stop a few
+    // ms later. The scheduler must cancel the 200ms auto-stop deadline so
+    // that only one stop frame (the explicit one) hits HID — not a second
+    // redundant stop from the timer firing later.
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 200 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0, .weak = 0, .duration_ms = 0 },
+        null,
+    };
+    var ff_out = MockFfOutputSeq{ .allocator = allocator, .events = &seq };
+
+    const RunCtx = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        ff_out: *MockFfOutputSeq,
+        cfg: *const device_mod.DeviceConfig,
+        alloc: std.mem.Allocator,
+    };
+    var devs = [_]DeviceIO{dev};
+    var ctx = RunCtx{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .ff_out = &ff_out,
+        .cfg = &parsed.value,
+        .alloc = allocator,
+    };
+
+    const T = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 300 });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
+
+    // First wake: play event → scheduler arms at t+200ms.
+    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+    std.Thread.sleep(5 * std.time.ns_per_ms);
+    // Second wake: explicit stop → scheduler disarms.
+    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+    // Wait well past the original 200ms to prove the timer never fires.
+    std.Thread.sleep(260 * std.time.ns_per_ms);
+    loop.stop();
+    thread.join();
+
+    // Exactly 2 frames: play + stop. No third stop from the (disarmed) timer.
+    const frame_size = 8;
+    try testing.expectEqual(@as(usize, 2 * frame_size), mock_dev.write_log.items.len);
+    const play_frame = mock_dev.write_log.items[0..frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, play_frame);
+    const stop_frame = mock_dev.write_log.items[frame_size .. 2 * frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, stop_frame);
+}
+
+test "event_loop: rumble auto-stop emits stop frame after duration_ms elapses" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var mock_dev = try MockDeviceIO.init(allocator, &.{});
+    defer mock_dev.deinit();
+    const dev = mock_dev.deviceIO();
+    try loop.addDevice(dev);
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    // Single play event with a short finite duration (25ms).
+    // The client deliberately does NOT send an explicit stop — matching
+    // what Steam/SDL does when relying on the kernel's ff-memless auto-stop
+    // for real controllers. padctl must emit its own stop frame.
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 25 },
+        null,
+    };
+    var ff_out = MockFfOutputSeq{ .allocator = allocator, .events = &seq };
+
+    const RunCtx = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        ff_out: *MockFfOutputSeq,
+        cfg: *const device_mod.DeviceConfig,
+        alloc: std.mem.Allocator,
+    };
+    var devs = [_]DeviceIO{dev};
+    var ctx = RunCtx{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .ff_out = &ff_out,
+        .cfg = &parsed.value,
+        .alloc = allocator,
+    };
+
+    const T = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 100 });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
+
+    // Wake the loop so pollFf delivers the play event. The scheduler should
+    // then arm rumble_stop_fd at t+25ms. No more FF events are sent.
+    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+    // Wait long enough for the 25ms deadline to fire plus scheduling slack.
+    std.Thread.sleep(80 * std.time.ns_per_ms);
+    loop.stop();
+    thread.join();
+
+    // Template: "00 08 00 {strong:u8} {weak:u8} 00 00 00" → 8-byte frame
+    const frame_size = 8;
+    try testing.expectEqual(@as(usize, 2 * frame_size), mock_dev.write_log.items.len);
+    const play_frame = mock_dev.write_log.items[0..frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, play_frame);
     const stop_frame = mock_dev.write_log.items[frame_size .. 2 * frame_size];
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, stop_frame);
 }

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -108,29 +108,32 @@ fn autoStopEnabled(dcfg: ?*const DeviceConfig) bool {
 /// Write a single rumble frame (strong, weak) to the HID device using the
 /// device's `commands.rumble` (or alternate FF type) template. Used by
 /// both the uinput-FF-event path and the userspace auto-stop timerfd path.
+/// Returns true if the frame was successfully written to HID. Callers
+/// must only advance scheduler/throttle state when this returns true.
 fn emitRumbleFrame(
     devices: []DeviceIO,
     alloc: std.mem.Allocator,
     dcfg: *const DeviceConfig,
     strong: u16,
     weak: u16,
-) void {
-    const cmds = dcfg.commands orelse return;
+) bool {
+    const cmds = dcfg.commands orelse return false;
     const ff_type = if (dcfg.output) |out|
         if (out.force_feedback) |ff_cfg| ff_cfg.type else "rumble"
     else
         "rumble";
-    const cmd = cmds.map.get(ff_type) orelse return;
-    const iface_idx = resolveIfaceIdx(dcfg, cmd.interface) orelse return;
-    if (iface_idx >= devices.len) return;
+    const cmd = cmds.map.get(ff_type) orelse return false;
+    const iface_idx = resolveIfaceIdx(dcfg, cmd.interface) orelse return false;
+    if (iface_idx >= devices.len) return false;
     const params = [_]Param{
         .{ .name = "strong", .value = strong },
         .{ .name = "weak", .value = weak },
     };
-    const bytes = fillTemplate(alloc, cmd.template, &params) catch return;
+    const bytes = fillTemplate(alloc, cmd.template, &params) catch return false;
     defer alloc.free(bytes);
     if (cmd.checksum) |*cs| applyChecksum(bytes, cs);
-    devices[iface_idx].write(bytes) catch {};
+    devices[iface_idx].write(bytes) catch return false;
+    return true;
 }
 
 /// Disarm a timerfd by setting all fields to zero.
@@ -406,7 +409,7 @@ pub const EventLoop = struct {
                 if (result.emit_stop_frame) {
                     if (ctx.allocator) |alloc| {
                         if (ctx.device_config) |dcfg| {
-                            emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
+                            _ = emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
                         }
                     }
                 }
@@ -438,7 +441,7 @@ pub const EventLoop = struct {
                                 if (result.emit_stop_frame) {
                                     if (ctx.allocator) |alloc| {
                                         if (ctx.device_config) |dcfg| {
-                                            emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
+                                            _ = emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
                                         }
                                     }
                                 }
@@ -448,7 +451,7 @@ pub const EventLoop = struct {
                                 // trust the client to know what it's doing.
                                 if (ctx.allocator) |alloc| {
                                     if (ctx.device_config) |dcfg| {
-                                        emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
+                                        _ = emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
                                     }
                                 }
                             }
@@ -463,9 +466,10 @@ pub const EventLoop = struct {
                             if (now_ns - self.last_rumble_ns >= min_interval_ns) {
                                 if (ctx.allocator) |alloc| {
                                     if (ctx.device_config) |dcfg| {
-                                        emitRumbleFrame(ctx.devices, alloc, dcfg, ff_ev.strong, ff_ev.weak);
-                                        self.last_rumble_ns = now_ns;
-                                        forwarded = true;
+                                        if (emitRumbleFrame(ctx.devices, alloc, dcfg, ff_ev.strong, ff_ev.weak)) {
+                                            self.last_rumble_ns = now_ns;
+                                            forwarded = true;
+                                        }
                                     }
                                 }
                             }

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -454,15 +454,22 @@ pub const EventLoop = struct {
                             }
                         } else {
                             // Play event: throttle applies to play frames.
+                            // The scheduler must only record the deadline when
+                            // the frame is actually forwarded to HID — otherwise
+                            // a throttled (dropped) frame could replace an
+                            // active deadline and later emit a stop for an
+                            // effect the device never received.
+                            var forwarded = false;
                             if (now_ns - self.last_rumble_ns >= min_interval_ns) {
                                 if (ctx.allocator) |alloc| {
                                     if (ctx.device_config) |dcfg| {
                                         emitRumbleFrame(ctx.devices, alloc, dcfg, ff_ev.strong, ff_ev.weak);
                                         self.last_rumble_ns = now_ns;
+                                        forwarded = true;
                                     }
                                 }
                             }
-                            if (scheduler_on) {
+                            if (scheduler_on and forwarded) {
                                 const next_dl = self.rumble_scheduler.onPlay(
                                     ff_ev.effect_id,
                                     ff_ev.duration_ms,

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -45,12 +45,26 @@ fn ioctlPtr(fd: std.posix.fd_t, request: u32, ptr: usize) !void {
     };
 }
 
-pub const FfEffect = struct { strong: u16 = 0, weak: u16 = 0 };
+pub const FfEffect = struct {
+    strong: u16 = 0,
+    weak: u16 = 0,
+    /// Effect replay length in milliseconds. 0 means infinite (no auto-stop).
+    /// Populated from `ff_effect.replay.length` during UI_FF_UPLOAD so the
+    /// event loop can drive the userspace rumble auto-stop scheduler.
+    length_ms: u16 = 0,
+};
 
 pub const FfEvent = struct {
     effect_type: u16,
     strong: u16,
     weak: u16,
+    /// FF effect id (slot, 0..15) the event refers to. Defaults to 0 for
+    /// legacy call sites that do not set it explicitly.
+    effect_id: u8 = 0,
+    /// Effect duration in milliseconds from `ff_effect.replay.length`.
+    /// 0 means infinite (or unknown) — the rumble auto-stop scheduler
+    /// treats it as "no auto-stop, wait for explicit stop".
+    duration_ms: u16 = 0,
 };
 
 pub const EmitError = error{ WriteFailed, DeviceGone };
@@ -367,6 +381,7 @@ pub const UinputDevice = struct {
                         self.ff_effects[@intCast(upload.effect.id)] = .{
                             .strong = upload.effect.u.rumble.strong_magnitude,
                             .weak = upload.effect.u.rumble.weak_magnitude,
+                            .length_ms = @intCast(upload.effect.replay.length),
                         };
                     }
                     upload.retval = 0;
@@ -383,11 +398,28 @@ pub const UinputDevice = struct {
                 }
             } else if (ev.type == c.EV_FF) {
                 const id: usize = @intCast(ev.code);
-                if (ev.value == 0 or id >= 16) {
-                    result = FfEvent{ .effect_type = c.FF_RUMBLE, .strong = 0, .weak = 0 };
+                // Out-of-range FF effect ids must be silently dropped.
+                // Collapsing them into a zero FfEvent would look like
+                // an explicit stop for slot 0 downstream, which would
+                // spuriously cancel the real rumble auto-stop deadline.
+                if (id >= 16) continue;
+                if (ev.value == 0) {
+                    result = FfEvent{
+                        .effect_type = c.FF_RUMBLE,
+                        .effect_id = @intCast(id),
+                        .strong = 0,
+                        .weak = 0,
+                        .duration_ms = 0,
+                    };
                 } else {
                     const eff = self.ff_effects[id];
-                    result = FfEvent{ .effect_type = c.FF_RUMBLE, .strong = eff.strong, .weak = eff.weak };
+                    result = FfEvent{
+                        .effect_type = c.FF_RUMBLE,
+                        .effect_id = @intCast(id),
+                        .strong = eff.strong,
+                        .weak = eff.weak,
+                        .duration_ms = eff.length_ms,
+                    };
                 }
             }
         }
@@ -1078,6 +1110,27 @@ test "uinput: pollFf play: returns stored ff_effects values" {
     try std.testing.expectEqual(@as(u16, 0x8000), result.?.weak);
 }
 
+test "uinput: pollFf play: carries effect_id and duration_ms for scheduler" {
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    // Simulate an upload with a 500ms finite duration on slot 3.
+    dev.ff_effects[3] = .{ .strong = 0x4000, .weak = 0x2000, .length_ms = 500 };
+
+    const ev = c.input_event{ .type = c.EV_FF, .code = 3, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
+
+    const result = try dev.pollFf();
+    try std.testing.expect(result != null);
+    try std.testing.expectEqual(@as(u8, 3), result.?.effect_id);
+    try std.testing.expectEqual(@as(u16, 500), result.?.duration_ms);
+}
+
 test "uinput: pollFf play stop (value=0): returns zeros" {
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
@@ -1098,7 +1151,36 @@ test "uinput: pollFf play stop (value=0): returns zeros" {
     try std.testing.expectEqual(@as(u16, 0), result.?.weak);
 }
 
-test "uinput: pollFf play: id >= 16 returns zeros (no panic)" {
+test "uinput: pollFf stop: carries effect_id from EV_FF code, duration_ms=0" {
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    // Slot had a finite duration; explicit stop must NOT report that duration
+    // (it's a stop, not a play) but MUST report the right effect_id so the
+    // event loop can clear the matching scheduler slot.
+    dev.ff_effects[4] = .{ .strong = 0x1111, .weak = 0x2222, .length_ms = 750 };
+
+    const ev = c.input_event{ .type = c.EV_FF, .code = 4, .value = 0, .time = std.mem.zeroes(c.timeval) };
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
+
+    const result = try dev.pollFf();
+    try std.testing.expect(result != null);
+    try std.testing.expectEqual(@as(u8, 4), result.?.effect_id);
+    try std.testing.expectEqual(@as(u16, 0), result.?.duration_ms);
+    try std.testing.expectEqual(@as(u16, 0), result.?.strong);
+    try std.testing.expectEqual(@as(u16, 0), result.?.weak);
+}
+
+test "uinput: pollFf: out-of-range EV_FF code is dropped (returns null)" {
+    // A malformed or unexpected EV_FF event with code >= MAX_EFFECTS (16)
+    // must be silently dropped rather than collapsed into a bogus
+    // FfEvent{effect_id=0, strong=0, weak=0}. The latter would trigger
+    // the downstream scheduler to spuriously stop the real slot 0 effect.
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1112,9 +1194,34 @@ test "uinput: pollFf play: id >= 16 returns zeros (no panic)" {
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
 
     const result = try dev.pollFf();
+    try std.testing.expectEqual(@as(?FfEvent, null), result);
+}
+
+test "uinput: pollFf: out-of-range id does not shadow a preceding valid play event" {
+    // If a valid play event for a real slot arrives in the same drain batch
+    // as an out-of-range id, the valid event must be the one returned —
+    // previously the out-of-range event overwrote `result` with zeros.
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    dev.ff_effects[2] = .{ .strong = 0xaaaa, .weak = 0x5555, .length_ms = 200 };
+
+    const valid = c.input_event{ .type = c.EV_FF, .code = 2, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    const garbage = c.input_event{ .type = c.EV_FF, .code = 42, .value = 0, .time = std.mem.zeroes(c.timeval) };
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&valid));
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&garbage));
+
+    const result = try dev.pollFf();
     try std.testing.expect(result != null);
-    try std.testing.expectEqual(@as(u16, 0), result.?.strong);
-    try std.testing.expectEqual(@as(u16, 0), result.?.weak);
+    try std.testing.expectEqual(@as(u8, 2), result.?.effect_id);
+    try std.testing.expectEqual(@as(u16, 0xaaaa), result.?.strong);
+    try std.testing.expectEqual(@as(u16, 0x5555), result.?.weak);
+    try std.testing.expectEqual(@as(u16, 200), result.?.duration_ms);
 }
 
 test "uinput: ff_effects: erase clears slot" {
@@ -1148,6 +1255,23 @@ test "uinput: ff_effects: upload stores strong and weak" {
     try std.testing.expectEqual(@as(u16, 0x5678), dev.ff_effects[5].weak);
     // Other slots unaffected
     try std.testing.expectEqual(@as(u16, 0), dev.ff_effects[0].strong);
+}
+
+test "uinput: ff_effects: slot carries length_ms for auto-stop scheduling" {
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    // Default initialization must leave length_ms at zero (infinite / unknown).
+    try std.testing.expectEqual(@as(u16, 0), dev.ff_effects[7].length_ms);
+
+    // An upload writing a finite duration must populate length_ms verbatim.
+    dev.ff_effects[7] = .{ .strong = 0, .weak = 0, .length_ms = 500 };
+    try std.testing.expectEqual(@as(u16, 500), dev.ff_effects[7].length_ms);
 }
 
 test "uinput: stateFieldForAxis: known axes return correct fields" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -337,6 +337,10 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                     std.log.err("unknown switch argument: {s}", .{sub_arg});
                     return error.UnknownArgument;
                 } else {
+                    if (name != null) {
+                        std.log.err("switch accepts at most one mapping name", .{});
+                        return error.UnknownArgument;
+                    }
                     name = sub_arg;
                 }
             }
@@ -941,7 +945,13 @@ fn runSudoCopy(src: []const u8, dst: []const u8, err_writer: anytype) bool {
         err_writer.writeAll("error: sudo cp failed\n") catch {};
         return false;
     };
-    if (result.Exited != 0) {
+    // child.wait() returns a tagged union — accessing .Exited directly
+    // panics in safe builds if the process was killed by a signal.
+    const ok = switch (result) {
+        .Exited => |code| code == 0,
+        else => false,
+    };
+    if (!ok) {
         err_writer.writeAll("error: sudo cp returned non-zero\n") catch {};
         return false;
     }
@@ -959,7 +969,10 @@ fn runSudoMkdir(dir: []const u8, err_writer: anytype) bool {
         err_writer.writeAll("error: sudo mkdir failed\n") catch {};
         return false;
     };
-    return result.Exited == 0;
+    return switch (result) {
+        .Exited => |code| code == 0,
+        else => false,
+    };
 }
 
 /// Write a config.toml with a single device binding. Reads existing file

--- a/src/main.zig
+++ b/src/main.zig
@@ -202,6 +202,8 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                     try mapping_list.append(allocator, args.next() orelse return error.MissingArgValue);
                 } else if (std.mem.eql(u8, iarg, "--force-mapping")) {
                     opts.force_mapping = true;
+                } else if (std.mem.eql(u8, iarg, "--force-binding")) {
+                    opts.force_binding = true;
                 } else if (std.mem.eql(u8, iarg, "--no-enable")) {
                     opts.no_enable = true;
                 } else if (std.mem.eql(u8, iarg, "--no-start")) {
@@ -387,6 +389,7 @@ fn printHelp() void {
         \\    --no-immutable      Force standard install even on detected immutable OS
         \\    --mapping <name>    Install a mapping config to /etc/padctl/mappings/ (repeatable)
         \\    --force-mapping     Overwrite existing mapping files
+        \\    --force-binding     Overwrite device bindings in /etc/padctl/config.toml
         \\    --no-enable         Skip systemctl enable
         \\    --no-start          Skip systemctl start
         \\  uninstall             Remove installed files, stop and disable service

--- a/src/main.zig
+++ b/src/main.zig
@@ -54,6 +54,7 @@ pub const core = struct {
     pub const macro = @import("core/macro.zig");
     pub const timer_queue = @import("core/timer_queue.zig");
     pub const macro_player = @import("core/macro_player.zig");
+    pub const rumble_scheduler = @import("core/rumble_scheduler.zig");
 };
 
 pub const io = struct {
@@ -744,6 +745,7 @@ pub fn main() !void {
 
 test {
     std.testing.refAllDecls(@This());
+    _ = @import("core/rumble_scheduler.zig");
     _ = @import("test/bugfix_regression_test.zig");
     _ = @import("test/properties/config_props.zig");
     _ = @import("test/properties/contract_props.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -608,9 +608,12 @@ pub fn main() !void {
 
             if (sw.persist) {
                 if (sw.device_id != null) {
-                    stderr_writer.writeAll("warning: --persist with --device is not yet supported (multi-device ambiguity)\n") catch {};
+                    stderr_writer.writeAll("error: --persist with --device is not yet supported (multi-device ambiguity)\n") catch {};
+                    std.process.exit(1);
                 } else {
-                    persistToSystemConfig(allocator, mapping_name, parsed.socket_path, stderr_writer);
+                    if (!persistToSystemConfig(allocator, mapping_name, parsed.socket_path, stderr_writer)) {
+                        std.process.exit(1);
+                    }
                 }
             }
         }
@@ -815,7 +818,6 @@ test {
 fn resolveDefaultMapping(allocator: std.mem.Allocator, socket_path: []const u8) ?[]const u8 {
     const socket_client = @import("cli/socket_client.zig");
     const user_config_mod = @import("config/user_config.zig");
-    const paths = @import("config/paths.zig");
 
     // Get the device name from the daemon.
     const fd = socket_client.connectToSocket(socket_path) catch return null;
@@ -824,17 +826,12 @@ fn resolveDefaultMapping(allocator: std.mem.Allocator, socket_path: []const u8) 
     const resp = socket_client.sendCommand(fd, "STATUS\n", &resp_buf) catch return null;
     const device_name = parseDeviceFromStatus(resp) orelse return null;
 
-    // Read user config.
-    const user_dir = paths.userConfigDir(allocator) catch return null;
-    defer allocator.free(user_dir);
-    var result = user_config_mod.loadFromDir(allocator, user_dir) catch return null;
-    if (result) |*r| {
-        // Don't deinit — the returned string points into parsed memory.
-        // Caller must use the name before r goes out of scope.
-        // For a CLI that exits immediately, this is fine.
-        return user_config_mod.findDefaultMapping(r, device_name);
-    }
-    return null;
+    // Use the shared loader which respects the user → system fallback.
+    // Don't deinit — the returned string points into parsed memory.
+    // Caller must use the name before the process exits, which is fine
+    // for a CLI that exits immediately after switch.
+    var result = user_config_mod.load(allocator) orelse return null;
+    return user_config_mod.findDefaultMapping(&result, device_name);
 }
 
 /// Save the current mapping choice to ~/.config/padctl/config.toml so that
@@ -866,7 +863,7 @@ fn saveToUserConfig(allocator: std.mem.Allocator, mapping_name: []const u8, sock
 
 /// Interactive --persist: confirm with user, elevate via sudo, copy mapping
 /// file + config.toml to /etc/padctl/ so the binding survives reboot.
-fn persistToSystemConfig(allocator: std.mem.Allocator, mapping_name: []const u8, socket_path: []const u8, err_writer: anytype) void {
+fn persistToSystemConfig(allocator: std.mem.Allocator, mapping_name: []const u8, socket_path: []const u8, err_writer: anytype) bool {
     const paths = @import("config/paths.zig");
     const mapping_discovery = @import("config/mapping_discovery.zig");
 
@@ -882,7 +879,7 @@ fn persistToSystemConfig(allocator: std.mem.Allocator, mapping_name: []const u8,
     const choice: u8 = if (n > 0) input_buf[0] else 'n';
     if (choice != 'y' and choice != 'Y') {
         err_writer.writeAll("Aborted.\n") catch {};
-        return;
+        return false;
     }
 
     var ok = true;
@@ -927,6 +924,7 @@ fn persistToSystemConfig(allocator: std.mem.Allocator, mapping_name: []const u8,
     } else {
         err_writer.writeAll("Persistence incomplete — check the errors above.\n") catch {};
     }
+    return ok;
 }
 
 fn runSudoCopy(src: []const u8, dst: []const u8, err_writer: anytype) bool {

--- a/src/main.zig
+++ b/src/main.zig
@@ -148,7 +148,7 @@ const Cli = struct {
     reload_pid: ?[]const u8 = null,
     pid_file: ?[]const u8 = null,
     config_cmd: ?ConfigCmd = null,
-    switch_cmd: ?struct { name: []const u8, device_id: ?[]const u8 = null } = null,
+    switch_cmd: ?struct { name: ?[]const u8 = null, device_id: ?[]const u8 = null, persist: bool = false } = null,
     status_cmd: bool = false,
     devices_cmd: bool = false,
     socket_path: []const u8 = cli.socket_client.DEFAULT_SOCKET_PATH,
@@ -322,23 +322,25 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                 return error.UnknownArgument;
             }
         } else if (std.mem.eql(u8, arg, "switch")) {
-            const name = args.next() orelse {
-                std.log.err("switch: missing mapping name", .{});
-                return error.MissingArgValue;
-            };
+            var name: ?[]const u8 = null;
             var device_id: ?[]const u8 = null;
+            var persist = false;
             while (args.next()) |sub_arg| {
                 if (std.mem.eql(u8, sub_arg, "--device")) {
                     device_id = args.next() orelse return error.MissingArgValue;
                 } else if (std.mem.eql(u8, sub_arg, "--socket")) {
                     parsed_cli.socket_path = args.next() orelse return error.MissingArgValue;
                     parsed_cli.socket_explicit = true;
-                } else {
+                } else if (std.mem.eql(u8, sub_arg, "--persist")) {
+                    persist = true;
+                } else if (sub_arg[0] == '-') {
                     std.log.err("unknown switch argument: {s}", .{sub_arg});
                     return error.UnknownArgument;
+                } else {
+                    name = sub_arg;
                 }
             }
-            parsed_cli.switch_cmd = .{ .name = name, .device_id = device_id };
+            parsed_cli.switch_cmd = .{ .name = name, .device_id = device_id, .persist = persist };
         } else if (std.mem.eql(u8, arg, "status")) {
             parsed_cli.status_cmd = true;
             while (args.next()) |sub_arg| {
@@ -403,7 +405,8 @@ fn printHelp() void {
         \\  list-mappings         List discovered mapping profiles from XDG paths
         \\    --config-dir <dir>  Also show device-specific mappings from this directory
         \\  reload [--pid <pid>]  Send SIGHUP to running padctl daemon
-        \\  switch <name>         Switch active mapping profile (name must come before options)
+        \\  switch [name]         Switch mapping (omit name to re-apply from user config)
+        \\    --persist           Copy mapping + config to /etc/padctl/ (survives reboot, uses sudo)
         \\    --device <id>       Apply only to specific device
         \\    --socket <path>     Socket path (default: /run/padctl/padctl.sock)
         \\  status                Show daemon status (current mapping, devices)
@@ -578,7 +581,39 @@ pub fn main() !void {
 
     // switch subcommand
     if (parsed.switch_cmd) |sw| {
-        const rc = cli.switch_mapping.run(sw.name, sw.device_id, parsed.socket_path, stdout_writer, stderr_writer);
+        // Resolve the mapping name: either explicit or from user config.
+        const mapping_name: []const u8 = sw.name orelse blk: {
+            // Bare `padctl switch` — read default_mapping from user config.
+            // NOTE: with multiple connected controllers, this resolves
+            // against the first device in the STATUS response. A future
+            // version should require --device in multi-device setups or
+            // add a device-keyed daemon API.
+            const resolved = resolveDefaultMapping(allocator, parsed.socket_path) orelse {
+                stderr_writer.writeAll("error: no mapping name given and no default_mapping in ~/.config/padctl/config.toml\n") catch {};
+                stderr_writer.writeAll("  usage: padctl switch <name>\n") catch {};
+                std.process.exit(1);
+            };
+            break :blk resolved;
+        };
+
+        const rc = cli.switch_mapping.run(mapping_name, sw.device_id, parsed.socket_path, stdout_writer, stderr_writer);
+        if (rc == 0) {
+            // Auto-save to user config so `padctl switch` (no args) can
+            // restore the choice. Skipped when --device targets a specific
+            // controller because we can't reliably map a hidraw id to a
+            // device name without a device-keyed daemon API.
+            if (sw.device_id == null) {
+                saveToUserConfig(allocator, mapping_name, parsed.socket_path, stderr_writer);
+            }
+
+            if (sw.persist) {
+                if (sw.device_id != null) {
+                    stderr_writer.writeAll("warning: --persist with --device is not yet supported (multi-device ambiguity)\n") catch {};
+                } else {
+                    persistToSystemConfig(allocator, mapping_name, parsed.socket_path, stderr_writer);
+                }
+            }
+        }
         std.process.exit(rc);
     }
 
@@ -774,9 +809,242 @@ test {
     _ = @import("test/gen/transition_id.zig");
 }
 
+/// Resolve the default mapping name from the user's config.toml for the
+/// currently connected device (queried from daemon STATUS). Used by bare
+/// `padctl switch` (no mapping name given).
+fn resolveDefaultMapping(allocator: std.mem.Allocator, socket_path: []const u8) ?[]const u8 {
+    const socket_client = @import("cli/socket_client.zig");
+    const user_config_mod = @import("config/user_config.zig");
+    const paths = @import("config/paths.zig");
+
+    // Get the device name from the daemon.
+    const fd = socket_client.connectToSocket(socket_path) catch return null;
+    defer std.posix.close(fd);
+    var resp_buf: [4096]u8 = undefined;
+    const resp = socket_client.sendCommand(fd, "STATUS\n", &resp_buf) catch return null;
+    const device_name = parseDeviceFromStatus(resp) orelse return null;
+
+    // Read user config.
+    const user_dir = paths.userConfigDir(allocator) catch return null;
+    defer allocator.free(user_dir);
+    var result = user_config_mod.loadFromDir(allocator, user_dir) catch return null;
+    if (result) |*r| {
+        // Don't deinit — the returned string points into parsed memory.
+        // Caller must use the name before r goes out of scope.
+        // For a CLI that exits immediately, this is fine.
+        return user_config_mod.findDefaultMapping(r, device_name);
+    }
+    return null;
+}
+
+/// Save the current mapping choice to ~/.config/padctl/config.toml so that
+/// bare `padctl switch` can restore it next time.
+fn saveToUserConfig(allocator: std.mem.Allocator, mapping_name: []const u8, socket_path: []const u8, _: anytype) void {
+    const socket_client = @import("cli/socket_client.zig");
+    const paths = @import("config/paths.zig");
+
+    const fd = socket_client.connectToSocket(socket_path) catch return;
+    defer std.posix.close(fd);
+    var resp_buf: [4096]u8 = undefined;
+    const resp = socket_client.sendCommand(fd, "STATUS\n", &resp_buf) catch return;
+    const device_name = parseDeviceFromStatus(resp) orelse return;
+
+    const user_dir = paths.userConfigDir(allocator) catch return;
+    defer allocator.free(user_dir);
+
+    // Ensure dir exists.
+    std.fs.makeDirAbsolute(user_dir) catch |e| switch (e) {
+        error.PathAlreadyExists => {},
+        else => return,
+    };
+
+    writeConfigToml(allocator, user_dir, device_name, mapping_name) catch {
+        std.log.warn("could not save to ~/.config/padctl/config.toml (file may be malformed)", .{});
+        return;
+    };
+}
+
+/// Interactive --persist: confirm with user, elevate via sudo, copy mapping
+/// file + config.toml to /etc/padctl/ so the binding survives reboot.
+fn persistToSystemConfig(allocator: std.mem.Allocator, mapping_name: []const u8, socket_path: []const u8, err_writer: anytype) void {
+    const paths = @import("config/paths.zig");
+    const mapping_discovery = @import("config/mapping_discovery.zig");
+
+    _ = socket_path;
+
+    // Interactive confirmation.
+    err_writer.writeAll("\n--persist will copy your mapping and config to /etc/padctl/\n") catch {};
+    err_writer.writeAll("so the daemon auto-applies it on every boot (requires sudo).\n") catch {};
+    err_writer.writeAll("Continue? [y/N]: ") catch {};
+
+    var input_buf: [16]u8 = undefined;
+    const n = std.posix.read(std.posix.STDIN_FILENO, &input_buf) catch 0;
+    const choice: u8 = if (n > 0) input_buf[0] else 'n';
+    if (choice != 'y' and choice != 'Y') {
+        err_writer.writeAll("Aborted.\n") catch {};
+        return;
+    }
+
+    var ok = true;
+
+    // Ensure destination directories exist.
+    if (!runSudoMkdir("/etc/padctl/mappings", err_writer)) ok = false;
+
+    // Copy mapping file to /etc/padctl/mappings/
+    const mapping_path = mapping_discovery.findMapping(allocator, mapping_name) catch null;
+    defer if (mapping_path) |p| allocator.free(p);
+    if (mapping_path) |src| {
+        const dst = std.fmt.allocPrint(allocator, "/etc/padctl/mappings/{s}.toml", .{mapping_name}) catch null;
+        if (dst) |d| {
+            defer allocator.free(d);
+            if (!runSudoCopy(src, d, err_writer)) ok = false;
+        } else ok = false;
+    } else {
+        err_writer.writeAll("warning: mapping file for '") catch {};
+        err_writer.writeAll(mapping_name) catch {};
+        err_writer.writeAll("' not found, skipping mapping copy\n") catch {};
+        ok = false;
+    }
+
+    // Copy user config.toml to /etc/padctl/config.toml
+    const user_dir = paths.userConfigDir(allocator) catch null;
+    defer if (user_dir) |d| allocator.free(d);
+    if (user_dir) |d| {
+        const user_config = std.fmt.allocPrint(allocator, "{s}/config.toml", .{d}) catch null;
+        defer if (user_config) |p| allocator.free(p);
+        if (user_config) |src| {
+            if (std.fs.accessAbsolute(src, .{})) |_| {
+                if (!runSudoCopy(src, "/etc/padctl/config.toml", err_writer)) ok = false;
+            } else |_| {
+                err_writer.writeAll("warning: no user config.toml to copy\n") catch {};
+                ok = false;
+            }
+        }
+    }
+
+    if (ok) {
+        err_writer.writeAll("Mapping persisted to /etc/padctl/ (survives reboot).\n") catch {};
+    } else {
+        err_writer.writeAll("Persistence incomplete — check the errors above.\n") catch {};
+    }
+}
+
+fn runSudoCopy(src: []const u8, dst: []const u8, err_writer: anytype) bool {
+    const argv = [_][]const u8{ "sudo", "cp", src, dst };
+    var child = std.process.Child.init(&argv, std.heap.page_allocator);
+    child.stdin_behavior = .Inherit;
+    child.stdout_behavior = .Inherit;
+    child.stderr_behavior = .Inherit;
+    child.spawn() catch {
+        err_writer.writeAll("error: failed to run sudo cp\n") catch {};
+        return false;
+    };
+    const result = child.wait() catch {
+        err_writer.writeAll("error: sudo cp failed\n") catch {};
+        return false;
+    };
+    if (result.Exited != 0) {
+        err_writer.writeAll("error: sudo cp returned non-zero\n") catch {};
+        return false;
+    }
+    return true;
+}
+
+fn runSudoMkdir(dir: []const u8, err_writer: anytype) bool {
+    const argv = [_][]const u8{ "sudo", "mkdir", "-p", dir };
+    var child = std.process.Child.init(&argv, std.heap.page_allocator);
+    child.stdin_behavior = .Inherit;
+    child.stdout_behavior = .Inherit;
+    child.stderr_behavior = .Inherit;
+    child.spawn() catch return false;
+    const result = child.wait() catch {
+        err_writer.writeAll("error: sudo mkdir failed\n") catch {};
+        return false;
+    };
+    return result.Exited == 0;
+}
+
+/// Write a config.toml with a single device binding. Reads existing file
+/// to preserve other device entries.
+fn writeConfigToml(
+    allocator: std.mem.Allocator,
+    dir: []const u8,
+    device_name: []const u8,
+    mapping_name: []const u8,
+) !void {
+    const user_config_mod = @import("config/user_config.zig");
+
+    // MalformedConfig must NOT be swallowed — a broken hand-edited
+    // config.toml would lose unrelated bindings if we overwrite it.
+    var existing = user_config_mod.loadFromDir(allocator, dir) catch |err| switch (err) {
+        error.MalformedConfig => return error.MalformedConfig,
+    };
+    defer if (existing) |*e| e.deinit();
+
+    const version: i64 = if (existing) |e| e.value.version orelse user_config_mod.CURRENT_VERSION else user_config_mod.CURRENT_VERSION;
+    const devices = if (existing) |e| e.value.device else null;
+
+    var buf = std.ArrayList(u8){};
+    defer buf.deinit(allocator);
+    const w = buf.writer(allocator);
+    try w.print("version = {d}\n", .{version});
+
+    var wrote_target = false;
+    if (devices) |devs| {
+        for (devs) |d| {
+            if (std.ascii.eqlIgnoreCase(d.name, device_name)) {
+                try w.print("\n[[device]]\nname = \"{s}\"\ndefault_mapping = \"{s}\"\n", .{ device_name, mapping_name });
+                wrote_target = true;
+            } else {
+                try w.print("\n[[device]]\nname = \"{s}\"\n", .{d.name});
+                if (d.default_mapping) |m| {
+                    try w.print("default_mapping = \"{s}\"\n", .{m});
+                }
+            }
+        }
+    }
+    if (!wrote_target) {
+        try w.print("\n[[device]]\nname = \"{s}\"\ndefault_mapping = \"{s}\"\n", .{ device_name, mapping_name });
+    }
+
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir});
+    defer allocator.free(config_path);
+    var f = try std.fs.createFileAbsolute(config_path, .{ .truncate = true });
+    defer f.close();
+    try f.writeAll(buf.items);
+}
+
+fn parseDeviceFromStatus(resp: []const u8) ?[]const u8 {
+    // Format: "STATUS device=NAME active=BOOL\n"
+    const prefix = "STATUS device=";
+    var it = std.mem.splitScalar(u8, resp, '\n');
+    while (it.next()) |line| {
+        if (std.mem.startsWith(u8, line, prefix)) {
+            const rest = line[prefix.len..];
+            // Find " active=" delimiter
+            if (std.mem.indexOf(u8, rest, " active=")) |end| {
+                return rest[0..end];
+            }
+        }
+    }
+    return null;
+}
+
 // --- CLI tests ---
 
 const testing = std.testing;
+
+test "main: parseDeviceFromStatus extracts device name" {
+    const resp = "STATUS device=Flydigi Vader 5 Pro active=true\n";
+    const name = parseDeviceFromStatus(resp);
+    try testing.expect(name != null);
+    try testing.expectEqualStrings("Flydigi Vader 5 Pro", name.?);
+}
+
+test "main: parseDeviceFromStatus returns null for empty response" {
+    try testing.expectEqual(@as(?[]const u8, null), parseDeviceFromStatus(""));
+    try testing.expectEqual(@as(?[]const u8, null), parseDeviceFromStatus("OK\n"));
+}
 
 test "main: parseHexBytes via init_seq" {
     // Smoke-test that init_seq is reachable from main

--- a/src/main.zig
+++ b/src/main.zig
@@ -587,13 +587,20 @@ pub fn main() !void {
     if (parsed.switch_cmd) |sw| {
         // Resolve the mapping name: either explicit or from user config.
         const mapping_name: []const u8 = sw.name orelse blk: {
+            // Bare `padctl switch --device` is ambiguous: resolveDefaultMapping
+            // can't target a specific device. Require an explicit mapping name.
+            if (sw.device_id != null) {
+                stderr_writer.writeAll("error: provide a mapping name when using --device\n") catch {};
+                stderr_writer.writeAll("  usage: padctl switch <name> --device <id>\n") catch {};
+                std.process.exit(1);
+            }
             // Bare `padctl switch` — read default_mapping from user config.
             // NOTE: with multiple connected controllers, this resolves
             // against the first device in the STATUS response. A future
             // version should require --device in multi-device setups or
             // add a device-keyed daemon API.
             const resolved = resolveDefaultMapping(allocator, parsed.socket_path) orelse {
-                stderr_writer.writeAll("error: no mapping name given and no default_mapping in ~/.config/padctl/config.toml\n") catch {};
+                stderr_writer.writeAll("error: no mapping name given and no default_mapping in config.toml\n") catch {};
                 stderr_writer.writeAll("  usage: padctl switch <name>\n") catch {};
                 std.process.exit(1);
             };


### PR DESCRIPTION
## Summary

Fixes both bugs reported in #65: the vibration motor getting stuck on (eventually crashing the Vader 5 firmware), and the mapping not being applied automatically after reboot. Also overhauls `padctl switch` with auto-save, bare re-apply, and a `--persist` flag for reboot persistence.

### Motivation

@nextproblemreporter on Bazzite reported two issues after installing padctl via `bazzite-setup.sh --mapping vader5`:

1. **Rumble stuck on**: clicking Steam's ping-test button causes the motor to get stuck every 10-30 clicks. After ~10 minutes of rumble-heavy gameplay, the Vader 5 Pro firmware crashes. Previous fix attempts in #67 (throttle bypass) and #68 (pending_play removal) did not resolve this.

2. **Mapping lost on reboot**: after every reboot, the user had to manually run `padctl switch vader5` to get layers and gyro working. The previous fix in #67 (case-insensitive name lookup) did not resolve this.

Both bugs were traced to architectural gaps rather than surface-level logic errors — the root causes required reading kernel source code and inspecting the live systemd service environment.

### What's new

**Rumble auto-stop (fixes Bug A):**
- New `src/core/rumble_scheduler.zig` — pure state machine with per-effect deadline tracking (16 slots). Implements userspace equivalent of the kernel's `ff-memless` auto-stop timer, which uinput does not use (`input_ff_create()` vs `input_ff_create_memless()`).
- Dedicated `rumble_stop_fd` timerfd in the event loop, armed via `TFD_TIMER_ABSTIME` against `CLOCK_MONOTONIC` deadlines. All clock reads use a new `monotonicNs()` helper instead of `std.time.nanoTimestamp()` (which is `CLOCK_REALTIME` in Zig 0.15).
- `FfEvent` extended with `effect_id` and `duration_ms` from `ff_effect.replay.length`.
- `pollFf` drops out-of-range EV_FF codes (id >= 16) instead of collapsing them to a bogus slot-0 stop event.
- Explicit stop events consult the scheduler BEFORE emitting a zero frame — overlapping effects don't prematurely cut each other.
- Device TOML opt-out: `[output.force_feedback] auto_stop = false` for devices with firmware-level auto-stop.

**Mapping persistence (fixes Bug B):**
- `user_config.load()` falls back to `/etc/padctl/config.toml` when `HOME` is not set (the systemd service runs as root with no HOME). `loadFromDir()` returns `error.MalformedConfig` for broken files to prevent silent fallback.
- `padctl install --mapping NAME` writes a `[[device]]` binding to `/etc/padctl/config.toml` with `version = 1` schema field. Device name resolved by filename matching (`--mapping vader5` → `devices/*/vader5.toml`).
- New `--force-binding` flag (separate from `--force-mapping`) with TTY-aware conflict handling: interactive prompt (keep/overwrite/abort) via injectable `PromptFn`, non-TTY warn+skip, force mode with timestamped backup.
- Malformed existing config.toml aborts the write with a clear error instead of silently overwriting.
- Backup errors propagate and abort the overwrite.

**`padctl switch` overhaul:**
- `padctl switch vader5` now auto-saves the binding to `~/.config/padctl/config.toml`.
- `padctl switch` (no name) reads the default mapping from user config and re-applies it.
- `padctl switch vader5 --persist` interactively confirms, then copies the mapping file and config to `/etc/padctl/` via `sudo cp` so the change survives reboot.
- `--device` flag skips auto-save and --persist (multi-device ambiguity not yet resolved).

**Documentation:**
- `device-config.md`: `auto_stop` field table.
- `getting-started.md`: `--force-binding`, `--persist`, config load order, CLI reference updated.
- `immutable-install.md`: auto-apply on boot section, `--persist` as alternative to re-running installer.
- `mapping-guide.md`: full rewrite of "Apply a mapping" with auto-save, bare switch, --persist flow, limitations, config precedence.
- `README.md`: persistent mapping feature line, auto-stop in FF description.
- `bazzite-setup.sh`: passes `--force-binding`, verify step checks config.toml binding, help text updated.

### Non-breaking changes

- All new `InstallOptions` fields default to `false`/empty — existing `padctl install` behavior unchanged.
- `auto_stop` defaults to `true` — all existing device TOMLs parse without modification.
- `FfEvent.effect_id` and `duration_ms` default to 0 — existing mock FF outputs in tests work unchanged.
- `UserConfig.version` defaults to `null` — legacy config files without a version field parse correctly.
- `padctl switch <name>` still works exactly as before, with the addition of auto-saving to user config.
- `MAX_FDS` bumped from 10 to 11 to accommodate `rumble_stop_fd`.

### Changed files

| File | Changes |
|------|---------|
| `src/core/rumble_scheduler.zig` | New: pure state machine for per-effect auto-stop deadlines (12 unit tests) |
| `src/event_loop.zig` | Rumble stop timerfd, `monotonicNs()`, restructured FF handler with scheduler integration, `MockFfOutputDrain` for throttle-aware tests (+635/-18) |
| `src/io/uinput.zig` | `FfEffect.length_ms`, `FfEvent.{effect_id, duration_ms}`, drop out-of-range EV_FF codes (+136/-8) |
| `src/config/device.zig` | `FfConfig.auto_stop` opt-out field (+61) |
| `src/config/user_config.zig` | `loadFromDir()` with `MalformedConfig` error, system fallback, version field (+174/-4) |
| `src/cli/install.zig` | Binding writer, `ConflictMode`, `PromptFn`, `findDeviceNameForMapping`, `--force-binding` (+570) |
| `src/main.zig` | `--force-binding` + `--persist` CLI parsing, switch overhaul (auto-save, bare re-apply, persist-to-system), `parseDeviceFromStatus` (+291/-7) |
| `scripts/bazzite-setup.sh` | `--force-binding`, verify binding, updated messages (+20/-13) |
| `docs/src/device-config.md` | `auto_stop` field documentation (+7) |
| `docs/src/getting-started.md` | Config load order, `--persist`, CLI reference (+18/-3) |
| `docs/src/immutable-install.md` | Auto-apply on boot, `--persist` section (+29/-3) |
| `docs/src/mapping-guide.md` | Full rewrite: auto-save, bare switch, --persist, limitations (+45/-7) |
| `README.md` | Persistent mapping + auto-stop feature lines (+5/-2) |

## Test plan

- [x] `zig build test` — 746 tests passing (44 new)
- [x] `zig build test-safe` — ReleaseSafe, 746 passing
- [x] `zig build test-tsan` — ThreadSanitizer, 746 passing
- [x] `zig build check-fmt` — clean
- [x] Steam ping stress test: 30 consecutive pings at varied cadence, zero stuck-motor events
- [x] 10-minute rumble-heavy game session, no firmware crash
- [x] Cold boot reboot test (2 boots): `journalctl -u padctl.service` shows `loaded system config from /etc/padctl/config.toml` and `mapping loaded` on both boots, no `passthrough (no mapping)`
- [x] `padctl switch vader5` auto-saves to `~/.config/padctl/config.toml`
- [x] Bare `padctl switch` re-applies from user config
- [x] Interactive conflict prompt verified manually in terminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Userspace rumble auto-stop with a new auto_stop option (defaults on) to avoid stuck effects.
  * Persistent device→mapping bindings: install/persist commands write system bindings so mappings auto-apply on boot.
  * CLI: run `padctl switch` with no name to re-apply last mapping; `--persist` saves mapping/config system-wide.

* **Configuration**
  * User config (~/.config/padctl/config.toml) takes precedence; /etc/padctl/config.toml is a system fallback.

* **Documentation**
  * Docs updated to cover auto-stop, persistence, precedence, and the new CLI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->