### PR TITLE
fix(mapper): wire pause_for_release + scan macro KEY_ targets for aux caps

### DIFF
--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -31,7 +31,7 @@ pub fn deriveAuxFromMapping(cfg: *const MappingConfig) DerivedAuxCaps {
         if (std.mem.eql(u8, d.mode, "arrows")) caps.needs_keyboard = true;
     }
 
-    if (cfg.remap) |*remap| scanRemapTargets(&caps, remap);
+    if (cfg.remap) |*remap| scanRemapTargets(&caps, cfg, remap);
 
     if (cfg.layer) |layers| {
         for (layers) |*layer| {
@@ -43,7 +43,7 @@ pub fn deriveAuxFromMapping(cfg: *const MappingConfig) DerivedAuxCaps {
             if (layer.dpad) |d| {
                 if (std.mem.eql(u8, d.mode, "arrows")) caps.needs_keyboard = true;
             }
-            if (layer.remap) |*remap| scanRemapTargets(&caps, remap);
+            if (layer.remap) |*remap| scanRemapTargets(&caps, cfg, remap);
         }
     }
 
@@ -56,26 +56,47 @@ fn scanStick(caps: *DerivedAuxCaps, stick: ?StickConfig) void {
         caps.needs_rel = true;
 }
 
-fn scanRemapTargets(caps: *DerivedAuxCaps, remap: *const toml.HashMap([]const u8)) void {
+fn scanTarget(caps: *DerivedAuxCaps, target: []const u8) void {
+    if (std.mem.startsWith(u8, target, "KEY_")) {
+        caps.needs_keyboard = true;
+    } else if (std.mem.eql(u8, target, "mouse_left") or std.mem.eql(u8, target, "BTN_LEFT")) {
+        caps.mouse_buttons |= 1;
+    } else if (std.mem.eql(u8, target, "mouse_right") or std.mem.eql(u8, target, "BTN_RIGHT")) {
+        caps.mouse_buttons |= 2;
+    } else if (std.mem.eql(u8, target, "mouse_middle") or std.mem.eql(u8, target, "BTN_MIDDLE")) {
+        caps.mouse_buttons |= 4;
+    } else if (std.mem.eql(u8, target, "mouse_side") or std.mem.eql(u8, target, "BTN_SIDE")) {
+        caps.mouse_buttons |= 8;
+    } else if (std.mem.eql(u8, target, "mouse_extra") or std.mem.eql(u8, target, "BTN_EXTRA")) {
+        caps.mouse_buttons |= 16;
+    } else if (std.mem.eql(u8, target, "mouse_forward") or std.mem.eql(u8, target, "BTN_FORWARD")) {
+        caps.mouse_buttons |= 32;
+    } else if (std.mem.eql(u8, target, "mouse_back") or std.mem.eql(u8, target, "BTN_BACK")) {
+        caps.mouse_buttons |= 64;
+    }
+}
+
+fn scanRemapTargets(caps: *DerivedAuxCaps, cfg: *const MappingConfig, remap: *const toml.HashMap([]const u8)) void {
     var it = remap.map.iterator();
     while (it.next()) |entry| {
         const target = entry.value_ptr.*;
-        if (std.mem.startsWith(u8, target, "KEY_")) {
-            caps.needs_keyboard = true;
-        } else if (std.mem.eql(u8, target, "mouse_left") or std.mem.eql(u8, target, "BTN_LEFT")) {
-            caps.mouse_buttons |= 1;
-        } else if (std.mem.eql(u8, target, "mouse_right") or std.mem.eql(u8, target, "BTN_RIGHT")) {
-            caps.mouse_buttons |= 2;
-        } else if (std.mem.eql(u8, target, "mouse_middle") or std.mem.eql(u8, target, "BTN_MIDDLE")) {
-            caps.mouse_buttons |= 4;
-        } else if (std.mem.eql(u8, target, "mouse_side") or std.mem.eql(u8, target, "BTN_SIDE")) {
-            caps.mouse_buttons |= 8;
-        } else if (std.mem.eql(u8, target, "mouse_extra") or std.mem.eql(u8, target, "BTN_EXTRA")) {
-            caps.mouse_buttons |= 16;
-        } else if (std.mem.eql(u8, target, "mouse_forward") or std.mem.eql(u8, target, "BTN_FORWARD")) {
-            caps.mouse_buttons |= 32;
-        } else if (std.mem.eql(u8, target, "mouse_back") or std.mem.eql(u8, target, "BTN_BACK")) {
-            caps.mouse_buttons |= 64;
+        if (std.mem.startsWith(u8, target, "macro:")) {
+            const macro_name = target["macro:".len..];
+            const macros = cfg.macro orelse continue;
+            for (macros) |*m| {
+                if (!std.mem.eql(u8, m.name, macro_name)) continue;
+                for (m.steps) |s| {
+                    switch (s) {
+                        .tap => |name| scanTarget(caps, name),
+                        .down => |name| scanTarget(caps, name),
+                        .up => |name| scanTarget(caps, name),
+                        .delay, .pause_for_release => {},
+                    }
+                }
+                break;
+            }
+        } else {
+            scanTarget(caps, target);
         }
     }
 }
@@ -760,6 +781,22 @@ test "deriveAuxFromMapping: BTN_BACK alias sets bit 64" {
     defer result.deinit();
     const caps = deriveAuxFromMapping(&result.value);
     try std.testing.expect(caps.mouse_buttons & 64 != 0);
+}
+
+test "deriveAuxFromMapping: macro:dodge_roll emitting KEY_B sets needs_keyboard" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[[macro]]
+        \\name = "dodge_roll"
+        \\steps = [{ tap = "KEY_B" }]
+        \\
+        \\[remap]
+        \\M1 = "macro:dodge_roll"
+    );
+    defer result.deinit();
+    const caps = deriveAuxFromMapping(&result.value);
+    try std.testing.expect(caps.needs_keyboard);
+    try std.testing.expect(caps.needsAux());
 }
 
 test "mapping: fuzz parseString: no panic on arbitrary input" {

--- a/src/core/macro_player.zig
+++ b/src/core/macro_player.zig
@@ -14,15 +14,16 @@ pub const MacroPlayer = struct {
     macro: *const Macro,
     step_index: usize,
     waiting_for_release: bool,
-    /// Token used when a delay deadline is armed in the TimerQueue.
     timer_token: u32,
+    trigger_src_idx: u6,
 
-    pub fn init(m: *const Macro, token: u32) MacroPlayer {
+    pub fn init(m: *const Macro, token: u32, src_idx: u6) MacroPlayer {
         return .{
             .macro = m,
             .step_index = 0,
             .waiting_for_release = false,
             .timer_token = token,
+            .trigger_src_idx = src_idx,
         };
     }
 
@@ -122,7 +123,7 @@ const testing = std.testing;
 const mapping = @import("../config/mapping.zig");
 
 fn makePlayer(m: *const Macro) MacroPlayer {
-    return MacroPlayer.init(m, 1);
+    return MacroPlayer.init(m, 1, 0);
 }
 
 fn dummyQueue(allocator: std.mem.Allocator) TimerQueue {
@@ -236,14 +237,44 @@ test "macro_player: emitPendingReleases down without up emits release" {
     }
 }
 
+test "macro_player: shift_hold — down pause_for_release up" {
+    const allocator = testing.allocator;
+    const steps = [_]MacroStep{ .{ .down = "KEY_LEFTSHIFT" }, .pause_for_release, .{ .up = "KEY_LEFTSHIFT" } };
+    const m = Macro{ .name = "shift_hold", .steps = &steps };
+    var player = makePlayer(&m);
+    var aux = AuxEventList{};
+    var q = dummyQueue(allocator);
+    defer q.deinit();
+
+    // press: down emitted, then pauses for release
+    const done1 = try player.step(&aux, &q);
+    try testing.expect(!done1);
+    try testing.expectEqual(@as(usize, 1), aux.len);
+    switch (aux.get(0)) {
+        .key => |k| try testing.expect(k.pressed),
+        else => return error.WrongType,
+    }
+
+    // release: notifyTriggerReleased + step -> up emitted, macro done
+    player.notifyTriggerReleased();
+    var aux2 = AuxEventList{};
+    const done2 = try player.step(&aux2, &q);
+    try testing.expect(done2);
+    try testing.expectEqual(@as(usize, 1), aux2.len);
+    switch (aux2.get(0)) {
+        .key => |k| try testing.expect(!k.pressed),
+        else => return error.WrongType,
+    }
+}
+
 test "macro_player: two players advance step_index independently" {
     const allocator = testing.allocator;
     const steps_a = [_]MacroStep{ .{ .tap = "KEY_A" }, .{ .tap = "KEY_B" } };
     const steps_b = [_]MacroStep{.{ .tap = "KEY_C" }};
     const ma = Macro{ .name = "a", .steps = &steps_a };
     const mb = Macro{ .name = "b", .steps = &steps_b };
-    var pa = MacroPlayer.init(&ma, 1);
-    var pb = MacroPlayer.init(&mb, 2);
+    var pa = MacroPlayer.init(&ma, 1, 0);
+    var pb = MacroPlayer.init(&mb, 2, 0);
     var q = dummyQueue(allocator);
     defer q.deinit();
 

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -232,15 +232,19 @@ pub const Mapper = struct {
                 },
                 .disabled => {},
                 .macro => |name| {
-                    // Trigger macro on rising edge only.
                     if (pressed and !prev_pressed) {
                         if (self.findMacro(name)) |m| {
                             const token = self.next_token;
                             self.next_token +%= 1;
-                            const player = MacroPlayer.init(m, token);
+                            const player = MacroPlayer.init(m, token, @intCast(i));
                             self.active_macros.append(self.allocator, player) catch |err| {
                                 std.log.warn("macro queue failed: {}", .{err});
                             };
+                        }
+                    } else if (!pressed and prev_pressed) {
+                        for (self.active_macros.items) |*p| {
+                            if (p.trigger_src_idx == @as(u6, @intCast(i)) and p.waiting_for_release)
+                                p.notifyTriggerReleased();
                         }
                     }
                 },

--- a/src/main.zig
+++ b/src/main.zig
@@ -713,6 +713,9 @@ pub fn main() !void {
                 std.log.err("failed to parse mapping '{s}': {}", .{ path, err });
                 std.process.exit(1);
             };
+            config.mapping.validate(&mapping_pr.?.value) catch |err| {
+                std.log.warn("mapping '{s}' validation warning: {}", .{ path, err });
+            };
             break :blk &mapping_pr.?.value;
         }
         // No --mapping: try user config default
@@ -724,7 +727,12 @@ pub fn main() !void {
                         std.log.warn("failed to parse default mapping '{s}': {}", .{ mp, err });
                         break :blk2 null;
                     };
-                    if (mapping_pr) |*pr| break :blk &pr.value;
+                    if (mapping_pr) |*pr| {
+                        config.mapping.validate(&pr.value) catch |err| {
+                            std.log.warn("mapping '{s}' validation warning: {}", .{ mp, err });
+                        };
+                        break :blk &pr.value;
+                    }
                 } else {
                     std.log.warn("default mapping '{s}' not found in XDG paths", .{name});
                 }
@@ -744,6 +752,7 @@ pub fn main() !void {
 
 test {
     std.testing.refAllDecls(@This());
+    _ = @import("test/macro_e2e_test.zig");
     _ = @import("test/bugfix_regression_test.zig");
     _ = @import("test/properties/config_props.zig");
     _ = @import("test/properties/contract_props.zig");

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -934,6 +934,9 @@ pub const Supervisor = struct {
                 cs.sendResponse(fd, "ERR mapping-parse-failed\n");
                 return;
             };
+            mapping_cfg.validate(&parsed.value) catch |err| {
+                std.log.warn("mapping \"{s}\" validation warning: {}", .{ path.?, err });
+            };
             const parsed_ptr = self.allocator.create(mapping_cfg.ParseResult) catch {
                 parsed.deinit();
                 cs.sendResponse(fd, "ERR oom\n");
@@ -1063,6 +1066,9 @@ pub const Supervisor = struct {
         }
         defer self.allocator.free(path.?);
         const result = mapping_cfg.parseFile(self.allocator, path.?) catch return null;
+        mapping_cfg.validate(&result.value) catch |err| {
+            std.log.warn("mapping \"{s}\" validation warning: {}", .{ mapping_name, err });
+        };
         std.log.info("mapping discovery: device \"{s}\" mapping \"{s}\" from \"{s}\"", .{ device_name, mapping_name, path.? });
         return result;
     }

--- a/src/test/macro_e2e_test.zig
+++ b/src/test/macro_e2e_test.zig
@@ -457,3 +457,47 @@ test "macro: mapper macro trigger — no second player on held button (no re-tri
     _ = try m.apply(.{ .buttons = m1_mask }, 16);
     try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
 }
+
+test "macro: mapper pause_for_release — falling edge calls notifyTriggerReleased, player completes" {
+    const allocator = testing.allocator;
+
+    var ctx = try makeMapper(
+        \\[[macro]]
+        \\name = "shift_hold"
+        \\steps = [{ hold = "KEY_LEFTSHIFT" }, { pause_for_release = true }, { release = "KEY_LEFTSHIFT" }]
+        \\
+        \\[remap]
+        \\M1 = "macro:shift_hold"
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const m1_mask = btnMask(.M1);
+
+    // Rising edge: macro starts, emits LSHIFT down, then halts at pause_for_release.
+    const ev1 = try m.apply(.{ .buttons = m1_mask }, 16);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
+    try testing.expect(m.active_macros.items[0].waiting_for_release);
+    // LSHIFT down event emitted.
+    try testing.expectEqual(@as(usize, 1), ev1.aux.len);
+    switch (ev1.aux.get(0)) {
+        .key => |k| {
+            try testing.expectEqual(KEY_LEFTSHIFT, k.code);
+            try testing.expect(k.pressed);
+        },
+        else => return error.WrongType,
+    }
+
+    // Falling edge: notifyTriggerReleased fired via mapper falling-edge branch.
+    const ev2 = try m.apply(.{ .buttons = 0 }, 16);
+    // Player resumed: LSHIFT up emitted, macro removed.
+    try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
+    try testing.expectEqual(@as(usize, 1), ev2.aux.len);
+    switch (ev2.aux.get(0)) {
+        .key => |k| {
+            try testing.expectEqual(KEY_LEFTSHIFT, k.code);
+            try testing.expect(!k.pressed);
+        },
+        else => return error.WrongType,
+    }
+}

--- a/src/test/macro_e2e_test.zig
+++ b/src/test/macro_e2e_test.zig
@@ -72,6 +72,9 @@ fn testInstance(
         .mapper = null,
         .uinput_dev = null,
         .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
         .device_cfg = cfg,
         .pending_mapping = null,
         .stopped = false,
@@ -153,7 +156,7 @@ test "macro: macro playback — tap B, delay 50, tap LEFT sequence" {
         .{ .tap = "KEY_LEFT" },
     };
     const m = Macro{ .name = "dodge_roll", .steps = &steps };
-    var player = MacroPlayer.init(&m, 1);
+    var player = MacroPlayer.init(&m, 1, 0);
     var q = TimerQueue.init(allocator, -1);
     defer q.deinit();
 
@@ -210,7 +213,7 @@ test "macro: pause_for_release — down LSHIFT, pause, no output until released"
         .{ .up = "KEY_LEFTSHIFT" },
     };
     const m = Macro{ .name = "shift_hold", .steps = &steps };
-    var player = MacroPlayer.init(&m, 1);
+    var player = MacroPlayer.init(&m, 1, 0);
     var q = TimerQueue.init(allocator, -1);
     defer q.deinit();
 
@@ -348,6 +351,9 @@ test "macro: hot-reload — updateMapping swaps config; next apply uses new mapp
         .mapper = try Mapper.init(&parsed_initial.value, loop.timer_fd, allocator),
         .uinput_dev = null,
         .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
         .device_cfg = &parsed_dev.value,
         .pending_mapping = null,
         .stopped = false,
@@ -464,7 +470,7 @@ test "macro: mapper pause_for_release — falling edge calls notifyTriggerReleas
     var ctx = try makeMapper(
         \\[[macro]]
         \\name = "shift_hold"
-        \\steps = [{ hold = "KEY_LEFTSHIFT" }, { pause_for_release = true }, { release = "KEY_LEFTSHIFT" }]
+        \\steps = [{ down = "KEY_LEFTSHIFT" }, "pause_for_release", { up = "KEY_LEFTSHIFT" }]
         \\
         \\[remap]
         \\M1 = "macro:shift_hold"


### PR DESCRIPTION
## Summary

Fixes two bugs causing macros to silently fail on Vader 5 Pro (#72).

**Bug 1 — `pause_for_release` deadlock:**
`notifyTriggerReleased()` existed on `MacroPlayer` but was never called in production. A macro with `pause_for_release` would set `waiting_for_release = true` and stall forever.

Fix: `MacroPlayer` now stores the source button index (`trigger_src_idx: u6`) set at trigger time. In the `[6]` remap loop in `mapper.zig`, a falling-edge branch on the same button calls `notifyTriggerReleased()` on any matching player that is waiting.

**Bug 2 — `macro:` remap targets ignored by aux caps derivation:**
`scanRemapTargets` in `mapping.zig` only set `needs_keyboard = true` for values starting with `KEY_`. A `macro:<name>` value was not inspected, so the aux uinput device was never created and macro key events were silently dropped.

Fix: `scanRemapTargets` now resolves `macro:` values by looking up the referenced `[[macro]]` and scanning its steps for `KEY_`, mouse button, or REL targets. Unknown macro names are silently skipped (already validated by `checkRemapMacros`).

## Tests added

- `macro_player: shift_hold — down pause_for_release up`: verifies KEY_LEFTSHIFT goes down on press and up after `notifyTriggerReleased` + resume.
- `deriveAuxFromMapping: macro:dodge_roll emitting KEY_B sets needs_keyboard`: verifies transitive macro step scanning sets `needs_keyboard`.

## Test plan

- [x] `zig build test` passes on `origin/main` baseline (exit 0)
- [x] `zig build test` passes on this branch (exit 0)
- [x] `zig build test-tsan` passes via pre-push hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Macro capability detection now recognizes key presses inside macros and marks keyboard aux as required.
  * Macro triggers now honor release events, enabling pause-for-release patterns (e.g., shift-hold) to emit press on start and release on release.
* **Behavior**
  * Mapping validation runs after parsing and emits warnings on issues without failing load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->