### PR TITLE
fix(config): escape TOML string values in writeConfigToml

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -982,6 +982,18 @@ fn runSudoMkdir(dir: []const u8, err_writer: anytype) bool {
     };
 }
 
+fn escapeTomlString(writer: anytype, s: []const u8) !void {
+    for (s) |c| {
+        switch (c) {
+            '\\' => try writer.writeAll("\\\\"),
+            '"' => try writer.writeAll("\\\""),
+            '\n' => try writer.writeAll("\\n"),
+            '\t' => try writer.writeAll("\\t"),
+            else => try writer.writeByte(c),
+        }
+    }
+}
+
 /// Write a config.toml with a single device binding. Reads existing file
 /// to preserve other device entries.
 fn writeConfigToml(
@@ -1011,18 +1023,30 @@ fn writeConfigToml(
     if (devices) |devs| {
         for (devs) |d| {
             if (std.ascii.eqlIgnoreCase(d.name, device_name)) {
-                try w.print("\n[[device]]\nname = \"{s}\"\ndefault_mapping = \"{s}\"\n", .{ device_name, mapping_name });
+                try w.writeAll("\n[[device]]\nname = \"");
+                try escapeTomlString(w, device_name);
+                try w.writeAll("\"\ndefault_mapping = \"");
+                try escapeTomlString(w, mapping_name);
+                try w.writeAll("\"\n");
                 wrote_target = true;
             } else {
-                try w.print("\n[[device]]\nname = \"{s}\"\n", .{d.name});
+                try w.writeAll("\n[[device]]\nname = \"");
+                try escapeTomlString(w, d.name);
+                try w.writeAll("\"\n");
                 if (d.default_mapping) |m| {
-                    try w.print("default_mapping = \"{s}\"\n", .{m});
+                    try w.writeAll("default_mapping = \"");
+                    try escapeTomlString(w, m);
+                    try w.writeAll("\"\n");
                 }
             }
         }
     }
     if (!wrote_target) {
-        try w.print("\n[[device]]\nname = \"{s}\"\ndefault_mapping = \"{s}\"\n", .{ device_name, mapping_name });
+        try w.writeAll("\n[[device]]\nname = \"");
+        try escapeTomlString(w, device_name);
+        try w.writeAll("\"\ndefault_mapping = \"");
+        try escapeTomlString(w, mapping_name);
+        try w.writeAll("\"\n");
     }
 
     const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir});
@@ -1062,6 +1086,13 @@ test "main: parseDeviceFromStatus extracts device name" {
 test "main: parseDeviceFromStatus returns null for empty response" {
     try testing.expectEqual(@as(?[]const u8, null), parseDeviceFromStatus(""));
     try testing.expectEqual(@as(?[]const u8, null), parseDeviceFromStatus("OK\n"));
+}
+
+test "escapeTomlString: escapes special characters" {
+    var buf = std.ArrayList(u8){};
+    defer buf.deinit(testing.allocator);
+    try escapeTomlString(buf.writer(testing.allocator), "Device \"X\"\\\nTab\there");
+    try testing.expectEqualStrings("Device \\\"X\\\"\\\\\\nTab\\there", buf.items);
 }
 
 test "main: parseHexBytes via init_seq" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -988,7 +988,15 @@ fn escapeTomlString(writer: anytype, s: []const u8) !void {
             '\\' => try writer.writeAll("\\\\"),
             '"' => try writer.writeAll("\\\""),
             '\n' => try writer.writeAll("\\n"),
+            '\r' => try writer.writeAll("\\r"),
             '\t' => try writer.writeAll("\\t"),
+            0x08 => try writer.writeAll("\\b"),
+            0x0C => try writer.writeAll("\\f"),
+            0...0x07, 0x0B, 0x0E...0x1F, 0x7F => {
+                var buf: [6]u8 = undefined;
+                const escaped = std.fmt.bufPrint(&buf, "\\u{X:0>4}", .{c}) catch unreachable;
+                try writer.writeAll(escaped);
+            },
             else => try writer.writeByte(c),
         }
     }
@@ -1093,6 +1101,14 @@ test "escapeTomlString: escapes special characters" {
     defer buf.deinit(testing.allocator);
     try escapeTomlString(buf.writer(testing.allocator), "Device \"X\"\\\nTab\there");
     try testing.expectEqualStrings("Device \\\"X\\\"\\\\\\nTab\\there", buf.items);
+}
+
+test "escapeTomlString: covers full TOML control-char set" {
+    var buf = std.ArrayList(u8){};
+    defer buf.deinit(testing.allocator);
+    // \r → \r, \b (0x08) → \b, \f (0x0C) → \f, 0x01 → \u0001
+    try escapeTomlString(buf.writer(testing.allocator), "\r\x08\x0C\x01");
+    try testing.expectEqualStrings("\\r\\b\\f\\u0001", buf.items);
 }
 
 test "main: parseHexBytes via init_seq" {


### PR DESCRIPTION
## Summary

- Add `escapeTomlString` helper that escapes `\`, `"`, `\n`, and `\t`
- Apply it to all four quoted-string write sites in `writeConfigToml` (device name and mapping name in the match, non-match, and new-entry branches)
- Add unit test that round-trips a name containing all four special characters

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced configuration file writing to properly handle and escape special characters (quotes, backslashes, line breaks, and tabs) in configuration values, preventing TOML format corruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->