### PR TITLE
feat(vader5): fix rumble + add IMU uinput device support

### DIFF
--- a/devices/example/imu-device.toml
+++ b/devices/example/imu-device.toml
@@ -1,0 +1,69 @@
+# Example: gamepad with IMU (accelerometer + gyroscope)
+#
+# Adding [output.imu] causes padctl to create a second uinput device
+# alongside the main gamepad. The IMU device has INPUT_PROP_ACCELEROMETER
+# set and exposes:
+#   ABS_X/Y/Z  — accelerometer axes
+#   ABS_RX/Y/Z — gyroscope axes
+#
+# SDL associates the sensor with the gamepad by matching VID:PID, so both
+# devices must share the same vid/pid as the [output] block.
+#
+# Note: for Steam to show gyro controls in its UI, the controller also
+# needs an entry in SDL_GameControllerDB with the appropriate gyro hints.
+
+[device]
+name = "Example Gamepad with IMU"
+vid = 0x1234
+pid = 0x5678
+
+[[device.interface]]
+id = 0
+class = "hid"
+
+[[report]]
+name = "main"
+interface = 0
+size = 32
+
+[report.fields]
+left_x  = { offset = 0,  type = "i16le" }
+left_y  = { offset = 2,  type = "i16le", transform = "negate" }
+right_x = { offset = 4,  type = "i16le" }
+right_y = { offset = 6,  type = "i16le", transform = "negate" }
+gyro_x  = { offset = 8,  type = "i16le" }
+gyro_y  = { offset = 10, type = "i16le" }
+gyro_z  = { offset = 12, type = "i16le" }
+accel_x = { offset = 14, type = "i16le" }
+accel_y = { offset = 16, type = "i16le" }
+accel_z = { offset = 18, type = "i16le" }
+
+[report.button_group]
+source = { offset = 20, size = 2 }
+map = { A = 0, B = 1, X = 2, Y = 3, LB = 4, RB = 5, Select = 6, Start = 7 }
+
+[output]
+name = "Example Gamepad with IMU"
+vid = 0x1234
+pid = 0x5678
+
+[output.axes]
+left_x  = { code = "ABS_X",  min = -32768, max = 32767 }
+left_y  = { code = "ABS_Y",  min = -32768, max = 32767 }
+right_x = { code = "ABS_RX", min = -32768, max = 32767 }
+right_y = { code = "ABS_RY", min = -32768, max = 32767 }
+
+[output.buttons]
+A      = "BTN_SOUTH"
+B      = "BTN_EAST"
+X      = "BTN_NORTH"
+Y      = "BTN_WEST"
+LB     = "BTN_TL"
+RB     = "BTN_TR"
+Select = "BTN_SELECT"
+Start  = "BTN_START"
+
+# Creates a separate uinput IMU device with the same VID:PID.
+# Name is optional — defaults to "padctl-imu".
+[output.imu]
+name = "Example Gamepad with IMU Motion Sensors"

--- a/devices/flydigi/vader5.toml
+++ b/devices/flydigi/vader5.toml
@@ -62,12 +62,10 @@ range = [2, 8]
 offset = 8
 
 # --- Output device ---
-# Masquerade as Xbox Elite Series 2 (VID 045e PID 0b00) so that Steam and
-# most games apply Xbox button mappings without additional configuration.
 [output]
-name = "Xbox Elite Series 2"
-vid = 0x045e
-pid = 0x0b00
+name = "Flydigi Vader 5 Pro"
+vid = 0x37d7
+pid = 0x2401
 
 [output.axes]
 left_x  = { code = "ABS_X",  min = -32768, max = 32767, fuzz = 16, flat = 128 }
@@ -104,8 +102,11 @@ type = "hat"
 
 [output.aux]
 type = "mouse"
-name = "Vader 5 Pro Virtual Mouse"
+name = "Flydigi Vader 5 Pro Virtual Mouse"
 
 [output.force_feedback]
 type = "rumble"
 max_effects = 16
+
+[output.imu]                                                                                       
+name = "Flydigi Vader 5 Pro Motion Sensors"

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -130,6 +130,10 @@ pub const TouchpadConfig = struct {
     max_slots: ?i64 = null,
 };
 
+pub const ImuConfig = struct {
+    name: ?[]const u8 = null,
+};
+
 pub const MappingEntry = struct {
     event: []const u8,
     range: ?[]const i64 = null,
@@ -149,6 +153,7 @@ pub const OutputConfig = struct {
     force_feedback: ?FfConfig = null,
     aux: ?AuxConfig = null,
     touchpad: ?TouchpadConfig = null,
+    imu: ?ImuConfig = null,
     mapping: ?toml.HashMap(MappingEntry) = null,
 };
 

--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -13,6 +13,8 @@ const AuxOutputDevice = uinput.AuxOutputDevice;
 const TouchpadOutputDevice = uinput.TouchpadOutputDevice;
 const GenericUinputDevice = uinput.GenericUinputDevice;
 const GenericOutputDevice = uinput.GenericOutputDevice;
+const ImuDevice = uinput.ImuDevice;
+const ImuOutputDevice = uinput.ImuOutputDevice;
 const generic = @import("core/generic.zig");
 const EventLoop = @import("event_loop.zig").EventLoop;
 const Interpreter = @import("core/interpreter.zig").Interpreter;
@@ -83,6 +85,7 @@ pub const DeviceInstance = struct {
     touchpad_dev: ?TouchpadDevice,
     generic_state: ?generic.GenericDeviceState,
     generic_uinput: ?GenericUinputDevice,
+    imu_dev: ?ImuDevice,
     device_cfg: *const DeviceConfig,
     mapping_cfg: ?*const MappingConfig = null,
     pending_mapping: ?*MappingConfig,
@@ -133,6 +136,7 @@ pub const DeviceInstance = struct {
         var touchpad_dev: ?TouchpadDevice = null;
         var generic_state: ?generic.GenericDeviceState = null;
         var generic_uinput: ?GenericUinputDevice = null;
+        var imu_dev: ?ImuDevice = null;
 
         if (is_generic) {
             generic_state = try generic.compileGenericState(cfg);
@@ -182,6 +186,11 @@ pub const DeviceInstance = struct {
             if (out_cfg.touchpad) |*tp_cfg| {
                 touchpad_dev = try TouchpadDevice.create(tp_cfg);
             }
+            if (out_cfg.imu) |*imu_cfg| {
+                const imu_vid: u16 = @intCast(out_cfg.vid orelse 0);
+                const imu_pid: u16 = @intCast(out_cfg.pid orelse 0);
+                imu_dev = try ImuDevice.create(imu_cfg, imu_vid, imu_pid);
+            }
         }
         const mapper: ?Mapper = if (init_mapping) |mcfg|
             Mapper.init(mcfg, loop.timer_fd, allocator) catch |err| blk: {
@@ -209,6 +218,7 @@ pub const DeviceInstance = struct {
             .touchpad_dev = touchpad_dev,
             .generic_state = generic_state,
             .generic_uinput = generic_uinput,
+            .imu_dev = imu_dev,
             .device_cfg = cfg,
             .pending_mapping = null,
             .stopped = false,
@@ -221,6 +231,7 @@ pub const DeviceInstance = struct {
         if (self.aux_dev) |*a| a.close();
         if (self.touchpad_dev) |*tp| tp.close();
         if (self.generic_uinput) |*gu| gu.close();
+        if (self.imu_dev) |*imu| imu.close();
         for (self.devices) |dev| dev.close();
         self.allocator.free(self.devices);
         self.loop.deinit();
@@ -249,6 +260,7 @@ pub const DeviceInstance = struct {
             const output = if (self.uinput_dev) |*u| u.outputDevice() else nullOutput();
             const aux_output: ?AuxOutputDevice = if (self.aux_dev) |*a| a.auxOutputDevice() else null;
             const touchpad_output: ?TouchpadOutputDevice = if (self.touchpad_dev) |*tp| tp.touchpadOutputDevice() else null;
+            const imu_output: ?ImuOutputDevice = if (self.imu_dev) |*imu| imu.imuOutputDevice() else null;
             const generic_output: ?GenericOutputDevice = if (self.generic_uinput) |*gu| gu.genericOutputDevice() else null;
             const mapper_ptr: ?*Mapper = if (self.mapper) |*m| m else null;
 
@@ -261,6 +273,7 @@ pub const DeviceInstance = struct {
                 .mapper = mapper_ptr,
                 .aux_output = aux_output,
                 .touchpad_output = touchpad_output,
+                .imu_output = imu_output,
                 .allocator = self.allocator,
                 .device_config = self.device_cfg,
                 .mapping_config = mcfg,

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -11,6 +11,7 @@ const TouchpadOutputDevice = @import("io/uinput.zig").TouchpadOutputDevice;
 const generic = @import("core/generic.zig");
 const GenericDeviceState = generic.GenericDeviceState;
 const GenericOutputDevice = @import("io/uinput.zig").GenericOutputDevice;
+const ImuOutputDevice = @import("io/uinput.zig").ImuOutputDevice;
 const state = @import("core/state.zig");
 const GamepadStateDelta = state.GamepadStateDelta;
 const mapper_mod = @import("core/mapper.zig");
@@ -160,6 +161,7 @@ pub const EventLoopContext = struct {
     wasm_override_report: bool = false,
     generic_state: ?*GenericDeviceState = null,
     generic_output: ?GenericOutputDevice = null,
+    imu_output: ?ImuOutputDevice = null,
 };
 
 fn i64ToParamValue(v: ?i64) u16 {
@@ -562,6 +564,7 @@ pub const EventLoop = struct {
                                     continue;
                                 };
                                 if (ctx.touchpad_output) |tp| tp.emitTouch(events.gamepad) catch {};
+                                if (ctx.imu_output) |imu| imu.emit(events.gamepad) catch {};
                                 if (ctx.aux_output) |ao| {
                                     if (events.aux.len > 0) ao.emitAux(events.aux.slice()) catch {};
                                 }
@@ -572,6 +575,7 @@ pub const EventLoop = struct {
                                     continue;
                                 };
                                 if (ctx.touchpad_output) |tp| tp.emitTouch(self.gamepad_state) catch {};
+                                if (ctx.imu_output) |imu| imu.emit(self.gamepad_state) catch {};
                             }
                         }
                     }

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -113,6 +113,24 @@ pub const AuxOutputDevice = struct {
     }
 };
 
+pub const ImuOutputDevice = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        emit: *const fn (ptr: *anyopaque, s: state.GamepadState) EmitError!void,
+        close: *const fn (ptr: *anyopaque) void,
+    };
+
+    pub fn emit(self: ImuOutputDevice, s: state.GamepadState) EmitError!void {
+        return self.vtable.emit(self.ptr, s);
+    }
+
+    pub fn close(self: ImuOutputDevice) void {
+        self.vtable.close(self.ptr);
+    }
+};
+
 // Resolved button mapping: ButtonId index → uinput BTN code (0 = unmapped)
 const BUTTON_COUNT = @typeInfo(state.ButtonId).@"enum".fields.len;
 
@@ -800,6 +818,108 @@ pub const GenericUinputDevice = struct {
     }
 
     pub fn close(self: *GenericUinputDevice) void {
+        _ = std.os.linux.ioctl(self.fd, UI_DEV_DESTROY, 0);
+        std.posix.close(self.fd);
+    }
+};
+
+pub const ImuDevice = struct {
+    fd: std.posix.fd_t,
+    prev: Prev = .{},
+
+    const Prev = struct {
+        accel_x: i16 = 0,
+        accel_y: i16 = 0,
+        accel_z: i16 = 0,
+        gyro_x: i16 = 0,
+        gyro_y: i16 = 0,
+        gyro_z: i16 = 0,
+    };
+
+    pub fn create(cfg: *const device.ImuConfig, vid: u16, pid: u16) !ImuDevice {
+        const flags = std.posix.O{ .ACCMODE = .RDWR, .NONBLOCK = true };
+        const fd = try std.posix.open("/dev/uinput", flags, 0);
+        errdefer std.posix.close(fd);
+
+        // INPUT_PROP_ACCELEROMETER makes SDL recognise this as a sensor device
+        try ioctlInt(fd, UI_SET_PROPBIT, c.INPUT_PROP_ACCELEROMETER);
+        try ioctlInt(fd, UI_SET_EVBIT, c.EV_ABS);
+        // Accelerometer: ABS_X/Y/Z  Gyroscope: ABS_RX/RY/RZ  (no EV_KEY)
+        for ([_]u16{ c.ABS_X, c.ABS_Y, c.ABS_Z, c.ABS_RX, c.ABS_RY, c.ABS_RZ }) |code| {
+            try ioctlInt(fd, UI_SET_ABSBIT, @intCast(code));
+        }
+
+        var setup = std.mem.zeroes(c.uinput_setup);
+        const name = cfg.name orelse "padctl-imu";
+        const copy_len = @min(name.len, setup.name.len - 1);
+        @memcpy(setup.name[0..copy_len], name[0..copy_len]);
+        setup.id.bustype = c.BUS_VIRTUAL;
+        setup.id.vendor = vid;
+        setup.id.product = pid;
+        try ioctlPtr(fd, UI_DEV_SETUP, @intFromPtr(&setup));
+
+        // Configure abs range for all 6 axes
+        for ([_]u16{ c.ABS_X, c.ABS_Y, c.ABS_Z, c.ABS_RX, c.ABS_RY, c.ABS_RZ }) |code| {
+            var abs_setup = std.mem.zeroes(c.uinput_abs_setup);
+            abs_setup.code = code;
+            abs_setup.absinfo.minimum = -32767;
+            abs_setup.absinfo.maximum = 32767;
+            try ioctlPtr(fd, UI_ABS_SETUP, @intFromPtr(&abs_setup));
+        }
+
+        try ioctlPtr(fd, UI_DEV_CREATE, 0);
+        return .{ .fd = fd };
+    }
+
+    pub fn imuOutputDevice(self: *ImuDevice) ImuOutputDevice {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = ImuOutputDevice.VTable{
+        .emit = emitVtable,
+        .close = closeVtable,
+    };
+
+    fn emitVtable(ptr: *anyopaque, s: state.GamepadState) EmitError!void {
+        const self: *ImuDevice = @ptrCast(@alignCast(ptr));
+        self.emit(s) catch return error.WriteFailed;
+    }
+
+    fn closeVtable(ptr: *anyopaque) void {
+        const self: *ImuDevice = @ptrCast(@alignCast(ptr));
+        self.close();
+    }
+
+    pub fn emit(self: *ImuDevice, s: state.GamepadState) !void {
+        var events: [7]c.input_event = undefined;
+        var n: usize = 0;
+
+        const pairs = [_]struct { curr: i16, prev: i16, code: u16 }{
+            .{ .curr = s.accel_x, .prev = self.prev.accel_x, .code = c.ABS_X },
+            .{ .curr = s.accel_y, .prev = self.prev.accel_y, .code = c.ABS_Y },
+            .{ .curr = s.accel_z, .prev = self.prev.accel_z, .code = c.ABS_Z },
+            .{ .curr = s.gyro_x,  .prev = self.prev.gyro_x,  .code = c.ABS_RX },
+            .{ .curr = s.gyro_y,  .prev = self.prev.gyro_y,  .code = c.ABS_RY },
+            .{ .curr = s.gyro_z,  .prev = self.prev.gyro_z,  .code = c.ABS_RZ },
+        };
+        for (pairs) |p| {
+            if (p.curr != p.prev) {
+                events[n] = .{ .type = c.EV_ABS, .code = p.code, .value = p.curr, .time = std.mem.zeroes(c.timeval) };
+                n += 1;
+            }
+        }
+        if (n > 0) {
+            events[n] = .{ .type = c.EV_SYN, .code = c.SYN_REPORT, .value = 0, .time = std.mem.zeroes(c.timeval) };
+            n += 1;
+            _ = try std.posix.write(self.fd, std.mem.sliceAsBytes(events[0..n]));
+        }
+        self.prev = .{
+            .accel_x = s.accel_x, .accel_y = s.accel_y, .accel_z = s.accel_z,
+            .gyro_x = s.gyro_x, .gyro_y = s.gyro_y, .gyro_z = s.gyro_z,
+        };
+    }
+
+    pub fn close(self: *ImuDevice) void {
         _ = std.os.linux.ioctl(self.fd, UI_DEV_DESTROY, 0);
         std.posix.close(self.fd);
     }


### PR DESCRIPTION
## What this fixes / adds

### Rumble (force feedback)

The `[commands.rumble]` template was broken: `fillTemplate` requires each byte as a **separate space-delimited token**, but the template had multi-byte tokens like `5aa5` and `0000` which caused `error.InvalidHexByte` on every FF event — rumble was silently failing on every trigger.

```toml
# before (broken)
template = "5aa5 1206 {strong:u8} {weak:u8} 0000 0000"

# after (fixed)
template = "5a a5 12 06 {strong:u8} {weak:u8} 00 00 00 00"
```

Also fixed `interface` index: was `1` (out of range), corrected to `0`.

Tested on Flydigi Vader 5 Pro — rumble now works correctly.

### IMU uinput device

Adds general infrastructure for a separate IMU uinput device so that SDL/Steam can discover motion sensors alongside the gamepad.

**Why a separate device:** SDL's `GuessDeviceClass()` classifies a device as an accelerometer when `INPUT_PROP_ACCELEROMETER` is set, or when it has `ABS_X/Y/Z` or `ABS_RX/RY/RZ` *without* `EV_KEY`. The main gamepad has `EV_KEY` (buttons), so it won't pass that check. A separate fd with no buttons is required. SDL then associates the sensor with the gamepad by matching VID:PID.

Any device config can opt in by adding `[output.imu]`:
```toml
[output.imu]
name = "My Gamepad Motion Sensors"  # optional
```

When present, padctl creates a second uinput device emitting accel (`ABS_X/Y/Z`) and gyro (`ABS_RX/RY/RZ`) events alongside the main gamepad. Enabled for Vader 5 Pro in this PR.

**Note on Steam:** Steam currently shows neither gyro controls nor the extra buttons (C, Z, LM, RM, O) for this controller — this requires an entry in SDL_GameControllerDB with full button mapping and gyro hints. That is being worked on separately.

### Real VID:PID for Vader 5 Pro

Switched from Xbox Elite Series 2 (`045e:0b00`) to the actual Flydigi VID:PID (`37d7:2401`). The Xbox profile was hiding extra buttons (C, Z, LM, RM, O) that the Vader 5 Pro has.

### Example config

Added `devices/example/imu-device.toml` demonstrating how to use `[output.imu]` in a device config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive IMU/motion sensor support for gamepads with a separate IMU output device and config option.
  * Added an example HID gamepad configuration demonstrating integrated accelerometer and gyroscope mapping.

* **Bug Fixes**
  * Corrected Flydigi Vader 5 Pro device identification and added its motion-sensor output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->