### PR TITLE
fix(scan,install): quieter scan warnings + lock XDG service template

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -2571,3 +2571,21 @@ test "install: old system unit triggers migration hint" {
     // Verify the old unit is detectable (the migration hint logic reads this path)
     try std.fs.accessAbsolute(old_unit, .{});
 }
+
+test "install: generateServiceContent /usr prefix omits --config-dir" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const content = try generateServiceContent(allocator, "/usr");
+    defer allocator.free(content);
+    try testing.expect(std.mem.indexOf(u8, content, "--config-dir") == null);
+    try testing.expect(std.mem.indexOf(u8, content, "ExecStart=/usr/bin/padctl\n") != null);
+}
+
+test "install: generateServiceContent non-usr prefix includes --config-dir for its own share" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const content = try generateServiceContent(allocator, "/usr/local");
+    defer allocator.free(content);
+    try testing.expect(std.mem.indexOf(u8, content, "--config-dir /usr/local/share/padctl/devices") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "--config-dir /usr/share") == null);
+}

--- a/src/cli/scan.zig
+++ b/src/cli/scan.zig
@@ -40,6 +40,7 @@ pub fn scan(allocator: std.mem.Allocator, config_dir: []const u8) ![]ScanEntry {
         entries.deinit(allocator);
     }
 
+    var access_denied_hint_shown = false;
     var i: u8 = 0;
     while (i < MAX_HIDRAW) : (i += 1) {
         var path_buf: [32]u8 = undefined;
@@ -47,6 +48,13 @@ pub fn scan(allocator: std.mem.Allocator, config_dir: []const u8) ![]ScanEntry {
 
         const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch |err| switch (err) {
             error.FileNotFound => continue,
+            error.AccessDenied => {
+                if (!access_denied_hint_shown) {
+                    std.log.warn("scan: permission denied on {s} — run with sudo or add yourself to the 'input' group", .{path});
+                    access_denied_hint_shown = true;
+                }
+                continue;
+            },
             else => {
                 std.log.warn("scan: open {s} failed: {}", .{ path, err });
                 continue;
@@ -297,9 +305,15 @@ pub fn run(allocator: std.mem.Allocator, config_dirs: []const []const u8, writer
     }
 
     for (config_dirs) |dir| {
-        const entries = scan(allocator, dir) catch |err| {
-            std.log.warn("scan: failed to scan config dir '{s}': {}", .{ dir, err });
-            continue;
+        const entries = scan(allocator, dir) catch |err| switch (err) {
+            error.FileNotFound => {
+                std.log.debug("scan: config dir '{s}' not found, skipping", .{dir});
+                continue;
+            },
+            else => {
+                std.log.warn("scan: failed to scan config dir '{s}': {}", .{ dir, err });
+                continue;
+            },
         };
         defer allocator.free(entries);
         for (entries) |e| {

--- a/src/cli/scan.zig
+++ b/src/cli/scan.zig
@@ -304,6 +304,18 @@ pub fn run(allocator: std.mem.Allocator, config_dirs: []const []const u8, writer
         all_entries.deinit(allocator);
     }
 
+    // When the user explicitly passes --config-dir, treat a missing path as
+    // a hard error so the failure isn't silently masked as "no devices found".
+    if (config_dirs.len == 1) {
+        std.fs.accessAbsolute(config_dirs[0], .{}) catch |err| switch (err) {
+            error.FileNotFound => {
+                std.log.warn("scan: config dir '{s}' not found", .{config_dirs[0]});
+                return err;
+            },
+            else => {},
+        };
+    }
+
     for (config_dirs) |dir| {
         const entries = scan(allocator, dir) catch |err| switch (err) {
             error.FileNotFound => {
@@ -494,4 +506,11 @@ test "scan: matchInterfaceId: with constraint and null iface returns false" {
 test "scan: freeEntries: empty slice is a no-op" {
     const empty: []ScanEntry = &.{};
     freeEntries(std.testing.allocator, empty);
+}
+
+test "scan: run: explicit single missing config dir surfaces FileNotFound" {
+    var buf: [256]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const dirs = [_][]const u8{"/nonexistent/padctl/devices/path/for/test"};
+    try std.testing.expectError(error.FileNotFound, run(std.testing.allocator, &dirs, fbs.writer()));
 }


### PR DESCRIPTION
## Summary

Narrow sub-fix of the #53 UX cluster. Two parts, both aimed at reducing false-alarm noise and locking in already-correct behavior:

### scan.zig signal-to-noise

- `AccessDenied` on `/dev/hidraw*` previously logged one bare warning per failing node (up to 6). Now emits a single hint per \`scan()\` call: \`scan: permission denied on <path> — run with sudo or add yourself to the 'input' group\`.
- \`FileNotFound\` on a config dir is downgraded from \`warn\` to \`debug\`. \`~/.config/padctl/devices\` is an optional XDG user dir; its absence is normal. Other error classes (\`AccessDenied\` on the dir, \`NotDir\`, …) still \`warn\`.

### install.zig regression tests

Two new tests on \`generateServiceContent\` lock in the correct prefix behavior:

1. \`/usr\` prefix → \`ExecStart=/usr/bin/padctl\`, no \`--config-dir\` flag → daemon uses XDG three-layer search (\`resolveDeviceConfigDirs\`).
2. \`/usr/local\` prefix → \`ExecStart=/usr/local/bin/padctl --config-dir /usr/local/share/padctl/devices\` → daemon still finds its shipped device configs.

Background: a stale \`install/padctl.service\` static unit with hard-coded \`--config-dir /usr/share/padctl/devices/\` was already removed in #50, so no service file change is required — these tests prevent re-introduction.

Related issue: #53 (do not auto-close — the issue has 2 other sub-problems not covered here: the \`devices vs mappings\` conceptual docs gap, and the source-install \`ProtectHome=true\` interaction with \`switch_mapping\` client-side path resolution. Follow-ups TBD.)

## Test plan

- [x] \`zig build\` passes
- [x] \`zig build test\` passes, including both new \`generateServiceContent\` tests
- [ ] CI green
- [ ] Manual: run \`padctl scan\` as non-root, confirm a single sudo hint instead of N warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Device scanning now shows the access-permission hint only once per run and skips entries thereafter instead of repeating warnings.
  * Missing configuration directory handling tightened: a single explicitly specified missing config directory now yields a hard error; per-directory "not found" cases are logged at debug level and skipped.

* **Tests**
  * Added tests validating generated service configuration content across different installation prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->