### PR TITLE
fix(cli): return XDG socket path unconditionally for non-root user

### DIFF
--- a/src/cli/socket_client.zig
+++ b/src/cli/socket_client.zig
@@ -4,20 +4,20 @@ const linux = std.os.linux;
 
 pub const DEFAULT_SOCKET_PATH = "/run/padctl/padctl.sock";
 
-/// Non-root: prefer $XDG_RUNTIME_DIR/padctl.sock if it exists, else fall back
-/// to the system path. The daemon always creates the socket at the system path
-/// (/run/padctl/padctl.sock), so the fallback is needed for non-root clients
-/// to reach a root-running daemon.
+/// Non-root user with XDG_RUNTIME_DIR set → use XDG socket path
+/// (daemon binds there before the file exists; no existence check here).
+/// Root or missing XDG_RUNTIME_DIR → system path for system-service compatibility.
 pub fn resolveSocketPath(buf: []u8) []const u8 {
     if (posix.geteuid() != 0) {
         if (posix.getenv("XDG_RUNTIME_DIR")) |xrd| {
-            const xrd_path = std.fmt.bufPrint(buf, "{s}/padctl.sock", .{xrd}) catch return DEFAULT_SOCKET_PATH;
-            // Only use XDG path if the socket actually exists there
-            std.fs.accessAbsolute(xrd_path, .{}) catch return DEFAULT_SOCKET_PATH;
-            return xrd_path;
+            return resolveSocketPathForXrd(buf, xrd);
         }
     }
     return DEFAULT_SOCKET_PATH;
+}
+
+fn resolveSocketPathForXrd(buf: []u8, xrd: []const u8) []const u8 {
+    return std.fmt.bufPrint(buf, "{s}/padctl.sock", .{xrd}) catch DEFAULT_SOCKET_PATH;
 }
 
 pub const ConnectError = posix.SocketError || posix.ConnectError || error{ PathTooLong, InvalidPath };
@@ -75,6 +75,15 @@ const testing = std.testing;
 test "resolveSocketPath: root returns system path" {
     // This test only verifies the default fallback path constant.
     try testing.expectEqualStrings("/run/padctl/padctl.sock", DEFAULT_SOCKET_PATH);
+}
+
+test "resolveSocketPath: XDG path returned even when socket does not exist" {
+    // Regression for chicken-and-egg: old code called accessAbsolute, which
+    // caused fall-through to DEFAULT_SOCKET_PATH when the socket didn't exist yet.
+    // Test the pure helper directly to avoid env manipulation in the test suite.
+    var buf: [256]u8 = undefined;
+    const result = resolveSocketPathForXrd(&buf, "/nonexistent/padctl-test-xdg");
+    try testing.expectEqualStrings("/nonexistent/padctl-test-xdg/padctl.sock", result);
 }
 
 test "resolveSocketPath: buf large enough for XDG path" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -412,11 +412,11 @@ fn printHelp() void {
         \\  switch [name]         Switch mapping (omit name to re-apply from user config)
         \\    --persist           Copy mapping + config to /etc/padctl/ (survives reboot, uses sudo)
         \\    --device <id>       Apply only to specific device
-        \\    --socket <path>     Socket path (default: /run/padctl/padctl.sock)
+        \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
         \\  status                Show daemon status (current mapping, devices)
-        \\    --socket <path>     Socket path (default: /run/padctl/padctl.sock)
+        \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
         \\  devices               List connected devices via daemon
-        \\    --socket <path>     Socket path (default: /run/padctl/padctl.sock)
+        \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
         \\  config list           List XDG-layer device and mapping configs
         \\  config init           Interactively create a mapping in ~/.config/padctl/mappings/
         \\    --device <name>     Skip device selection prompt


### PR DESCRIPTION
## Summary

After PR #77 (systemd `--user` service), users who enabled the user service per docs hit `padctl status → error: cannot connect to padctl daemon`. Running as sudo / system service still worked.

**Root cause**: `src/cli/socket_client.zig` `resolveSocketPath` had a chicken-and-egg check — it only returned `$XDG_RUNTIME_DIR/padctl.sock` if the socket already existed there. The same function is used by the daemon to decide where to bind. On startup the XDG socket doesn't exist yet, so the daemon fell through to `/run/padctl/padctl.sock` (the pre-#77 system path) where a non-root user-service daemon has no permission to bind.

**Fix**: when `euid != 0` and `XDG_RUNTIME_DIR` is set, return the XDG path unconditionally. Root and shells without `XDG_RUNTIME_DIR` still fall back to the system path.

- Factored the path build into a pure `resolveSocketPathForXrd` helper
- Updated the stale comment block
- Updated 3 `--socket` help-text lines in `main.zig` that hardcoded the old default path
- Regression test asserts the XDG path is returned even when the socket file does not exist

## Upgrade note

Users still running an old root-level daemon on `/run/padctl/padctl.sock` after upgrading the CLI will get "cannot connect" — they should complete the `padctl install` migration to the user service.

Related issue: #86 (reporter should verify before closing).

## Test plan

- [x] `zig build test` passes on the branch (including the new regression test)
- [ ] CI green
- [ ] Manual: user-service daemon + non-root `padctl status` returns OK