### PR TITLE
fix(uinput): make AuxDevice EV_REL registration conditional

### DIFF
--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -751,6 +751,20 @@ test "deriveAuxFromMapping: BTN_FORWARD alias sets bit 32" {
     try std.testing.expect(caps.mouse_buttons & 32 != 0);
 }
 
+test "deriveAuxFromMapping: pure KEY_ remap yields needs_rel=false and needs_keyboard=true" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\C = "KEY_M"
+    );
+    defer result.deinit();
+    const caps = deriveAuxFromMapping(&result.value);
+    try std.testing.expect(!caps.needs_rel);
+    try std.testing.expect(caps.needs_keyboard);
+    try std.testing.expect(caps.mouse_buttons == 0);
+    try std.testing.expect(caps.needsAux());
+}
+
 test "deriveAuxFromMapping: BTN_BACK alias sets bit 64" {
     const allocator = std.testing.allocator;
     const result = try parseString(allocator,

--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -154,7 +154,7 @@ pub const DeviceInstance = struct {
                 if (out_cfg.aux != null or caps.needsAux()) {
                     var buf: [mapping_mod.AUX_KEY_CODES_MAX]u16 = undefined;
                     const key_codes = mapping_mod.buildAuxKeyCodes(caps, &buf);
-                    aux_dev = try AuxDevice.create(key_codes);
+                    aux_dev = try AuxDevice.create(key_codes, caps.needs_rel);
                     var cap_buf: [64]u8 = undefined;
                     var cap_fbs = std.io.fixedBufferStream(&cap_buf);
                     const cap_w = cap_fbs.writer();
@@ -292,7 +292,7 @@ pub const DeviceInstance = struct {
         if (new_caps.needsAux() or self.device_cfg.output.?.aux != null) {
             var buf: [mapping_mod.AUX_KEY_CODES_MAX]u16 = undefined;
             const key_codes = mapping_mod.buildAuxKeyCodes(new_caps, &buf);
-            if (AuxDevice.create(key_codes)) |dev| {
+            if (AuxDevice.create(key_codes, new_caps.needs_rel)) |dev| {
                 self.aux_dev = dev;
             } else |err| {
                 std.log.warn("aux device rebuild failed: {}, old device closed", .{err});
@@ -310,7 +310,7 @@ pub const DeviceInstance = struct {
         if (!caps.needsAux() and out_cfg.aux == null) return;
         var buf: [mapping_mod.AUX_KEY_CODES_MAX]u16 = undefined;
         const key_codes = mapping_mod.buildAuxKeyCodes(caps, &buf);
-        self.aux_dev = try AuxDevice.create(key_codes);
+        self.aux_dev = try AuxDevice.create(key_codes, caps.needs_rel);
     }
 
     /// Signal the event loop to stop. run() returns after the current ppoll.

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -435,7 +435,7 @@ pub const UinputDevice = struct {
 pub const AuxDevice = struct {
     fd: std.posix.fd_t,
 
-    pub fn create(key_codes: []const u16) !AuxDevice {
+    pub fn create(key_codes: []const u16, needs_rel: bool) !AuxDevice {
         const flags = std.posix.O{ .ACCMODE = .WRONLY, .NONBLOCK = true };
         const fd = try std.posix.open("/dev/uinput", flags, 0);
         errdefer std.posix.close(fd);
@@ -445,9 +445,11 @@ pub const AuxDevice = struct {
             try ioctlInt(fd, UI_SET_KEYBIT, @intCast(code));
         }
 
-        try ioctlInt(fd, UI_SET_EVBIT, c.EV_REL);
-        for ([_]u16{ c.REL_X, c.REL_Y, c.REL_WHEEL, c.REL_HWHEEL }) |rel_code| {
-            try ioctlInt(fd, UI_SET_RELBIT, @intCast(rel_code));
+        if (needs_rel) {
+            try ioctlInt(fd, UI_SET_EVBIT, c.EV_REL);
+            for ([_]u16{ c.REL_X, c.REL_Y, c.REL_WHEEL, c.REL_HWHEEL }) |rel_code| {
+                try ioctlInt(fd, UI_SET_RELBIT, @intCast(rel_code));
+            }
         }
 
         var setup = std.mem.zeroes(c.uinput_setup);


### PR DESCRIPTION
## Summary

Remap targets like `KEY_M` or `mouse_right` were silently dropped on Wayland compositors (Hyprland, Sway). The aux uinput device (`padctl-aux`) unconditionally registered `EV_REL` capabilities, making libinput classify it as a pointer/mouse device. Keyboard events (`EV_KEY`) emitted from a pointer-classified device are not routed to the active window's keyboard focus on Wayland.

**Root cause**: `src/io/uinput.zig` `AuxDevice.create` registered `EV_REL` + `REL_X/Y/WHEEL/HWHEEL` regardless of whether the mapping actually needed relative axes (gyro-to-mouse, stick-to-mouse). A pure keyboard remap (e.g., `C = "KEY_M"`) still got a pointer-classified aux device.

**Fix**: `AuxDevice.create` gains a `needs_rel: bool` parameter. The `EV_REL` block is guarded with `if (needs_rel)`. All 3 call sites in `device_instance.zig` pass `caps.needs_rel` from the already-correct `DerivedAuxCaps`. When only keyboard remaps exist, the aux device is now a pure keyboard device that Wayland routes correctly.

Gyro-to-mouse and stick-to-mouse mappings are unaffected: `deriveAuxFromMapping` already sets `needs_rel = true` for those cases.

**Reproducer test**: `deriveAuxFromMapping` with a pure `KEY_M` remap asserts `needs_rel == false` and `needs_keyboard == true`, proving the caps derivation contract that the fix depends on.

Related issue: #100 (reporter should verify before closing).

## Test plan

- [x] `zig build test` passes (including reproducer test)
- [ ] CI green
- [ ] Manual: pure KEY_ remap on Hyprland/Sway delivers keypress to focused window