### PR TITLE
feat(dump,rumble): togglable diagnostic dump CLI + FF event batch fix (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ padctl is a userspace daemon that maps vendor-specific USB/HID gamepad reports t
 - **Runtime mapping switch** — `padctl switch <name>` changes profiles without restart
 - **Persistent mapping** — `padctl install --mapping <name>` writes a device binding to `/etc/padctl/config.toml` that auto-applies on every boot
 - **User config** — `~/.config/padctl/config.toml` for per-device default mappings (system fallback: `/etc/padctl/config.toml`)
-- **CLI tools** — `padctl status`, `padctl devices`, `padctl list-mappings`, `padctl config init/edit/test`
+- **Opt-in diagnostic logging** — `padctl dump enable` turns on a general-purpose, togglable file logger so users can produce a structured log for any class of bug report (force-feedback, input, mapping, hotplug, …). Today it is wired deepest into the rumble/HID path; more subsystems will be instrumented over time. Rotated, bounded on disk, and zero overhead when disabled (default)
+- **CLI tools** — `padctl status`, `padctl devices`, `padctl list-mappings`, `padctl config init/edit/test`, `padctl dump enable/disable/status/export/clear`
 
 ## Architecture
 
@@ -144,6 +145,10 @@ See the [getting started guide](https://bananasjim.github.io/padctl/getting-star
 | `padctl config edit` | Open user config in `$EDITOR` |
 | `padctl config test` | Validate config without applying |
 | `padctl scan` | Re-scan for connected devices |
+| `padctl dump enable\|disable` | Toggle opt-in diagnostic logging (persists across reboots) |
+| `padctl dump status` | Show logging state, log path, size, and time span |
+| `padctl dump export --period <N>m\|<N>h\|<N>d [-o file]` | Export recent log window for bug reports |
+| `padctl dump clear` | Delete all log files |
 
 ## Build
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Getting Started](getting-started.md)
 - [Bazzite / Immutable Distros](immutable-install.md)
 - [Mapping Guide](mapping-guide.md)
+- [Diagnostic Logging](diagnostic-logging.md)
 - [Device Config Reference](device-config.md)
 - [Mapping Config Reference](mapping-config.md)
 - [Device Reference](devices/README.md)

--- a/docs/src/diagnostic-logging.md
+++ b/docs/src/diagnostic-logging.md
@@ -1,0 +1,88 @@
+# Diagnostic Logging
+
+padctl ships with a general-purpose, togglable file logger. It is designed to be the single mechanism you reach for when diagnosing **any** class of bug — stuck rumble, input drops, mapping misses, hotplug oddities, daemon crashes — so that reports come with structured evidence instead of guesswork.
+
+It is **off by default** and has no hot-path cost when disabled. The current build already emits a very detailed trace of the force-feedback pipeline; other subsystems (input routing, layer/remap decisions, hotplug, config reload, …) will be instrumented behind the same switch over time. The user-facing contract — enable, reproduce, export, attach — stays the same as more coverage is added.
+
+## Quick workflow
+
+```sh
+padctl dump enable                          # turn logging on (survives reboot)
+# ... reproduce the issue by playing ...
+padctl dump export --period 30m -o bug.log  # capture the last 30 minutes
+padctl dump disable                         # turn it off again
+```
+
+Attach `bug.log` to your issue report.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `padctl dump enable` | Turn diagnostic logging on. Persists across restarts by writing `[diagnostics].dump = true` to the user config (and `/etc/padctl/config.toml` via `sudo` when available). Also sends a live IPC to any running daemon so the change takes effect immediately. |
+| `padctl dump disable` | Turn diagnostic logging off (default state). Same persistence semantics as `enable`. |
+| `padctl dump status` | Print current state (`enabled` / `disabled`), the active log path, log file size, oldest/newest entry timestamps, and the rotated backup size if present. |
+| `padctl dump export --period <N>m\|<N>h\|<N>d [-o path]` | Export the window of log lines newer than the given duration. `-o` writes to a file; omit it to print to stdout. Default window: `1d`. |
+| `padctl dump clear` | Delete the live log and any rotated backups. Asks for confirmation. Falls back to `sudo rm` for root-owned logs when the CLI user can't unlink them directly. |
+
+### Period syntax
+
+`--period` accepts `Nm` (minutes), `Nh` (hours), or `Nd` (days). Examples: `--period 15m`, `--period 2h`, `--period 7d`.
+
+## Log file location
+
+padctl picks the first writable directory from the list below:
+
+| Priority | Path | Source |
+|----------|------|--------|
+| 1 | `$LOGS_DIRECTORY/padctl.log` | Set by systemd when the service uses `LogsDirectory=padctl` (resolves to `/var/log/padctl/` for system units) |
+| 2 | `$XDG_STATE_HOME/padctl/padctl.log` | Standard XDG state path |
+| 3 | `~/.local/state/padctl/padctl.log` | XDG fallback when `$XDG_STATE_HOME` is unset |
+| 4 | `/var/log/padctl/padctl.log` | Final fallback when `$HOME` is also unset |
+
+`padctl dump status` always prints the path that is currently in use.
+
+## Config file
+
+Diagnostic logging is driven by a dedicated section in `config.toml`:
+
+```toml
+[diagnostics]
+dump = false          # master switch; padctl dump enable/disable flips this
+max_log_size_mb = 100 # rotation threshold (default 100 MB)
+```
+
+`padctl dump enable` and `padctl dump disable` are just a convenience front-end for toggling `dump` and forwarding the change to the running daemon — you can also edit this section by hand and send `SIGHUP` (`padctl reload`) instead.
+
+## Rotation
+
+On every daemon startup and on every fresh file-open, padctl stats the existing log. If it exceeds `max_log_size_mb`, the file is renamed to `padctl.log.1` (overwriting any previous backup) and a new empty `padctl.log` is created. There is only ever one rotated backup.
+
+This keeps disk usage bounded to roughly `2 * max_log_size_mb` without needing `logrotate` or any external tooling.
+
+## What gets logged
+
+When `dump = false` (the default), only warnings and errors are written, and only lazily on the first occurrence.
+
+When `dump = true`, padctl adds verbose tracing on top. The coverage today is deepest in the force-feedback pipeline — that is the area where the logger was needed first — and is being expanded to other subsystems as issues surface. Current coverage:
+
+- **Session lifecycle** — daemon start, config loaded, devices attached/detached
+- **FF_UPLOAD / FF_ERASE** kernel requests with effect IDs, rumble magnitudes, and replay durations
+- **EV_FF PLAY / STOP** events with scheduler decisions (forwarded, throttled, auto-stop timer armed, etc.)
+- **HID rumble frames** written to the physical device, with the first 16 bytes hex-dumped so post-checksum data can be inspected
+- **Scheduler slot state** (all 16 effect slots) before and after every mutation
+
+Planned areas (no promised order): input-report parsing, layer/remap resolution, hotplug/netlink events, config reload, IPC commands. You can track progress on these in the repo issue tracker.
+
+## Reporting issues
+
+When opening an issue that needs diagnostic data, the recommended flow is:
+
+```sh
+padctl dump enable
+# reproduce the bug (play the game, press the button, wait for the glitch)
+padctl dump export --period 1h -o issue.log
+padctl dump disable
+```
+
+Attach `issue.log`. Sensitive information in the logs is limited to device names, USB identifiers, and input report bytes — there is no keystroke capture or payload from other applications.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -167,7 +167,13 @@ padctl config list                         # show XDG config search paths
 padctl config init [--device] [--preset]   # interactive mapping creator
 padctl config edit [name]                  # open mapping in $VISUAL/$EDITOR
 padctl config test [--config] [--mapping]  # live input preview
+padctl dump enable|disable                 # toggle diagnostic logging (persists)
+padctl dump status                         # show dump state, log path, size, time span
+padctl dump export --period Nm|Nh|Nd [-o]  # export filtered log window
+padctl dump clear                          # delete all log files
 ```
+
+See the [Diagnostic Logging guide](diagnostic-logging.md) for the full `padctl dump` workflow, log paths, and the `[diagnostics]` config section.
 
 ## udev Permissions
 

--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -149,9 +149,14 @@ if [[ -d "$PADCTL_REPO/.git" ]]; then
     if [[ -n "$BRANCH" ]]; then
         git -C "$PADCTL_REPO" fetch origin 2>/dev/null || true
         git -C "$PADCTL_REPO" checkout "$BRANCH" 2>/dev/null || warn "checkout $BRANCH failed"
-        git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null || warn "git pull failed (might have local changes)"
+        timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null || warn "git pull failed (might have local changes)"
     else
-        git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null || warn "git pull failed (might have local changes)"
+        # Only pull if on a branch that tracks a remote (skip for local-only branches).
+        if git -C "$PADCTL_REPO" rev-parse --abbrev-ref '@{upstream}' &>/dev/null; then
+            timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null || warn "git pull failed (might have local changes)"
+        else
+            info "Local branch with no upstream — skipping pull"
+        fi
     fi
     ok "Repo up to date"
 elif [[ -f "$PADCTL_REPO/build.zig" ]]; then

--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -118,17 +118,20 @@ else
         err "zig not found. Install Zig 0.15.x from https://ziglang.org/download/"
         exit 1
     fi
-    # Warn if version is 0.16+ (breaking changes)
-    zig_ver="$(zig version 2>/dev/null || echo unknown)"
+    # padctl requires Zig 0.15.x. Reject anything else upfront so users hit a
+    # clear error instead of a cryptic build failure downstream.
+    if ! zig_ver="$(zig version 2>/dev/null)"; then
+        err "failed to determine zig version"
+        exit 1
+    fi
     case "$zig_ver" in
         0.15.*) ok "zig found: $zig_ver" ;;
-        0.16.*|0.17.*|1.*)
-            warn "zig $zig_ver detected — padctl requires 0.15.x (0.16+ has breaking build API changes)"
+        *)
+            warn "zig $zig_ver detected — padctl requires 0.15.x"
             warn "Install zig@0.15 via brew, or download from https://ziglang.org/download/"
             read -rp "Continue anyway? [y/N] " yn
             [[ "$yn" =~ ^[Yy] ]] || exit 1
             ;;
-        *) ok "zig found: $zig_ver" ;;
     esac
 fi
 
@@ -146,19 +149,32 @@ fi
 
 if [[ -d "$PADCTL_REPO/.git" ]]; then
     info "Updating existing repo at $PADCTL_REPO..."
+    repo_updated=false
     if [[ -n "$BRANCH" ]]; then
         git -C "$PADCTL_REPO" fetch origin 2>/dev/null || true
         git -C "$PADCTL_REPO" checkout "$BRANCH" 2>/dev/null || warn "checkout $BRANCH failed"
-        timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null || warn "git pull failed (might have local changes)"
+        if timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null; then
+            repo_updated=true
+        else
+            warn "git pull failed (might have local changes)"
+        fi
     else
         # Only pull if on a branch that tracks a remote (skip for local-only branches).
         if git -C "$PADCTL_REPO" rev-parse --abbrev-ref '@{upstream}' &>/dev/null; then
-            timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null || warn "git pull failed (might have local changes)"
+            if timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null; then
+                repo_updated=true
+            else
+                warn "git pull failed (might have local changes)"
+            fi
         else
             info "Local branch with no upstream — skipping pull"
         fi
     fi
-    ok "Repo up to date"
+    if $repo_updated; then
+        ok "Repo up to date"
+    else
+        info "Using existing repo state"
+    fi
 elif [[ -f "$PADCTL_REPO/build.zig" ]]; then
     ok "Using existing repo at $PADCTL_REPO (not a git repo)"
 else

--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -103,16 +103,33 @@ install_brew_pkg() {
     fi
 }
 
+ZIG_BREW_PKG="zig@0.15"  # padctl requires Zig 0.15.x; 0.16+ has breaking API changes
+
 if command -v brew &>/dev/null; then
-    install_brew_pkg zig
+    install_brew_pkg "$ZIG_BREW_PKG"
     install_brew_pkg libusb
+    # zig@0.15 is keg-only — ensure it's on PATH for this session.
+    if [[ -d "$BREW_PREFIX/opt/$ZIG_BREW_PKG/bin" ]]; then
+        export PATH="$BREW_PREFIX/opt/$ZIG_BREW_PKG/bin:$PATH"
+    fi
 else
     # Non-brew: check if zig and libusb are available
     if ! command -v zig &>/dev/null; then
-        err "zig not found. Install Zig 0.15+ from https://ziglang.org/download/"
+        err "zig not found. Install Zig 0.15.x from https://ziglang.org/download/"
         exit 1
     fi
-    ok "zig found: $(zig version)"
+    # Warn if version is 0.16+ (breaking changes)
+    zig_ver="$(zig version 2>/dev/null || echo unknown)"
+    case "$zig_ver" in
+        0.15.*) ok "zig found: $zig_ver" ;;
+        0.16.*|0.17.*|1.*)
+            warn "zig $zig_ver detected — padctl requires 0.15.x (0.16+ has breaking build API changes)"
+            warn "Install zig@0.15 via brew, or download from https://ziglang.org/download/"
+            read -rp "Continue anyway? [y/N] " yn
+            [[ "$yn" =~ ^[Yy] ]] || exit 1
+            ;;
+        *) ok "zig found: $zig_ver" ;;
+    esac
 fi
 
 # --- 4. Locate or clone padctl repo ---
@@ -153,7 +170,7 @@ fi
 cd "$PADCTL_REPO"
 
 # --- 5. Build ---
-info "Building padctl (ReleaseSafe)..."
+info "Building padctl (ReleaseSafe) with zig $(zig version)..."
 build_args=(-Doptimize=ReleaseSafe)
 if [[ -d "$BREW_PREFIX" ]]; then
     build_args+=(--search-prefix "$BREW_PREFIX")

--- a/src/cli/dump.zig
+++ b/src/cli/dump.zig
@@ -276,21 +276,42 @@ pub fn runClear(
     }
 }
 
-/// Pick whichever log directory has the newest last_timestamp.
-/// Falls back to sys_dir if both are empty or only sys exists.
+/// Pick whichever log directory holds the log file that is actively being
+/// written to, by comparing `padctl.log` mtimes. mtime beats text-content
+/// timestamps here because the daemon keeps appending even when the last
+/// in-text timestamp hasn't rotated through yet (e.g. between 1 Hz
+/// heartbeats) — and a one-shot foreground `padctl` invocation that fails
+/// early can briefly produce a user log with a newer *text* timestamp than
+/// the system log's most recent flushed line, even though the system
+/// daemon is still the authoritative writer.
 fn pickActiveLogDir(sys_dir: []const u8, user_dir: ?[]const u8) []const u8 {
-    const sys_stats = getLogStats(sys_dir);
-    const user_stats = if (user_dir) |ud| getLogStats(ud) else null;
+    const sys_mtime = getCurrentLogMtime(sys_dir);
+    const user_mtime = if (user_dir) |ud| getCurrentLogMtime(ud) else null;
 
-    if (sys_stats != null and user_stats != null) {
-        const sys_ts = sys_stats.?.lastTimestamp() orelse "";
-        const user_ts = user_stats.?.lastTimestamp() orelse "";
-        // ISO 8601 timestamps sort lexicographically.
-        if (std.mem.order(u8, user_ts, sys_ts) == .gt) return user_dir.?;
-        return sys_dir;
+    if (sys_mtime != null and user_mtime != null) {
+        return if (user_mtime.? > sys_mtime.?) user_dir.? else sys_dir;
     }
-    if (user_stats != null) return user_dir.?;
+    if (user_mtime != null) return user_dir.?;
+    if (sys_mtime != null) return sys_dir;
+
+    // Neither current file exists. Fall back to whichever directory has any
+    // log content at all (e.g. rotated .1 only), preferring sys.
+    if (getLogStats(sys_dir) != null) return sys_dir;
+    if (user_dir) |ud| {
+        if (getLogStats(ud) != null) return ud;
+    }
     return sys_dir;
+}
+
+/// Return the mtime (ns) of `<dir>/padctl.log`, or null if it doesn't exist
+/// or can't be stat'd.
+fn getCurrentLogMtime(dir: []const u8) ?i128 {
+    var path_buf: [280]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/padctl.log", .{dir}) catch return null;
+    const f = std.fs.openFileAbsolute(path, .{}) catch return null;
+    defer f.close();
+    const st = f.stat() catch return null;
+    return st.mtime;
 }
 
 fn formatSize(buf: *[32]u8, bytes: u64) []const u8 {
@@ -799,6 +820,67 @@ test "dump: getLogStats finds timestamp on long final line" {
     try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.firstTimestamp().?);
     // The last timestamp must be found even though it's >256 bytes from EOF.
     try testing.expectEqualStrings("2026-04-13T14:30:00.000", stats.lastTimestamp().?);
+}
+
+test "dump: pickActiveLogDir picks the dir with the newer padctl.log mtime" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Two sibling dirs, each with a padctl.log. We give the "user" file an
+    // obviously newer text timestamp but an older mtime; "sys" gets the
+    // newer mtime. The correct pick is sys — mtime beats text timestamp.
+    try tmp.dir.makeDir("sys");
+    try tmp.dir.makeDir("user");
+    const sys_path = try tmp.dir.realpathAlloc(allocator, "sys");
+    defer allocator.free(sys_path);
+    const user_path = try tmp.dir.realpathAlloc(allocator, "user");
+    defer allocator.free(user_path);
+
+    // user log: newer in text, older mtime (written first + backdated).
+    {
+        var f = try tmp.dir.createFile("user/padctl.log", .{});
+        defer f.close();
+        try f.writeAll("[2026-05-16T23:59:59.999] info: foreground-oneshot\n");
+    }
+    // Force user mtime into the past.
+    const user_log_path = try std.fmt.allocPrint(allocator, "{s}/padctl.log", .{user_path});
+    defer allocator.free(user_log_path);
+    {
+        var f = try std.fs.openFileAbsolute(user_log_path, .{ .mode = .read_write });
+        defer f.close();
+        const past_ns: i128 = 1_700_000_000 * std.time.ns_per_s;
+        const ts = std.posix.timespec{ .sec = @intCast(@divTrunc(past_ns, std.time.ns_per_s)), .nsec = @intCast(@mod(past_ns, std.time.ns_per_s)) };
+        try std.posix.futimens(f.handle, &.{ ts, ts });
+    }
+
+    // sys log: older in text, but written after → newer mtime.
+    {
+        var f = try tmp.dir.createFile("sys/padctl.log", .{});
+        defer f.close();
+        try f.writeAll("[2026-04-01T00:00:00.000] info: system-daemon\n");
+    }
+
+    const picked = pickActiveLogDir(sys_path, user_path);
+    try testing.expectEqualStrings(sys_path, picked);
+}
+
+test "dump: pickActiveLogDir falls back to user dir when only user log exists" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makeDir("user");
+    const user_path = try tmp.dir.realpathAlloc(allocator, "user");
+    defer allocator.free(user_path);
+
+    {
+        var f = try tmp.dir.createFile("user/padctl.log", .{});
+        defer f.close();
+        try f.writeAll("[2026-04-01T00:00:00.000] info: x\n");
+    }
+
+    const picked = pickActiveLogDir("/var/log/padctl-nonexistent-test-xyz", user_path);
+    try testing.expectEqualStrings(user_path, picked);
 }
 
 test "dump: getLogStats handles empty log file" {

--- a/src/cli/dump.zig
+++ b/src/cli/dump.zig
@@ -128,10 +128,10 @@ pub fn runStatus(
             stats.file_count,
             if (stats.file_count != 1) "s" else "",
         }) catch {};
-        if (stats.first_timestamp) |first| {
+        if (stats.firstTimestamp()) |first| {
             stdout.print("First entry: {s}\n", .{first}) catch {};
         }
-        if (stats.last_timestamp) |last| {
+        if (stats.lastTimestamp()) |last| {
             stdout.print("Last entry:  {s}\n", .{last}) catch {};
         }
     } else {
@@ -163,27 +163,26 @@ fn mergeStats(a: ?LogStats, b: ?LogStats) ?LogStats {
     const bs = b.?;
     merged.total_size += bs.total_size;
     merged.file_count += bs.file_count;
+
     // Pick the earliest first_timestamp and latest last_timestamp.
-    if (bs.first_timestamp) |bfirst| {
-        if (merged.first_timestamp) |mfirst| {
-            if (std.mem.order(u8, bfirst, mfirst) == .lt) {
-                @memcpy(merged.first_ts_buf[0..TS_LEN], bfirst);
-                merged.first_timestamp = merged.first_ts_buf[0..TS_LEN];
+    if (bs.has_first_ts) {
+        if (merged.has_first_ts) {
+            if (std.mem.order(u8, bs.first_ts_buf[0..TS_LEN], merged.first_ts_buf[0..TS_LEN]) == .lt) {
+                @memcpy(merged.first_ts_buf[0..TS_LEN], bs.first_ts_buf[0..TS_LEN]);
             }
         } else {
-            @memcpy(merged.first_ts_buf[0..TS_LEN], bfirst);
-            merged.first_timestamp = merged.first_ts_buf[0..TS_LEN];
+            @memcpy(merged.first_ts_buf[0..TS_LEN], bs.first_ts_buf[0..TS_LEN]);
+            merged.has_first_ts = true;
         }
     }
-    if (bs.last_timestamp) |blast| {
-        if (merged.last_timestamp) |mlast| {
-            if (std.mem.order(u8, blast, mlast) == .gt) {
-                @memcpy(merged.last_ts_buf[0..TS_LEN], blast);
-                merged.last_timestamp = merged.last_ts_buf[0..TS_LEN];
+    if (bs.has_last_ts) {
+        if (merged.has_last_ts) {
+            if (std.mem.order(u8, bs.last_ts_buf[0..TS_LEN], merged.last_ts_buf[0..TS_LEN]) == .gt) {
+                @memcpy(merged.last_ts_buf[0..TS_LEN], bs.last_ts_buf[0..TS_LEN]);
             }
         } else {
-            @memcpy(merged.last_ts_buf[0..TS_LEN], blast);
-            merged.last_timestamp = merged.last_ts_buf[0..TS_LEN];
+            @memcpy(merged.last_ts_buf[0..TS_LEN], bs.last_ts_buf[0..TS_LEN]);
+            merged.has_last_ts = true;
         }
     }
     return merged;
@@ -215,8 +214,8 @@ pub fn runClear(
         if (stats.file_count != 1) "s" else "",
         size_str,
     }) catch {};
-    if (stats.first_timestamp) |first| {
-        if (stats.last_timestamp) |last| {
+    if (stats.firstTimestamp()) |first| {
+        if (stats.lastTimestamp()) |last| {
             stdout.print(", spanning {s} to {s}", .{ first, last }) catch {};
         } else {
             stdout.print(", from {s}", .{first}) catch {};
@@ -263,8 +262,8 @@ fn pickActiveLogDir(sys_dir: []const u8, user_dir: ?[]const u8) []const u8 {
     const user_stats = if (user_dir) |ud| getLogStats(ud) else null;
 
     if (sys_stats != null and user_stats != null) {
-        const sys_ts = sys_stats.?.last_timestamp orelse "";
-        const user_ts = user_stats.?.last_timestamp orelse "";
+        const sys_ts = sys_stats.?.lastTimestamp() orelse "";
+        const user_ts = user_stats.?.lastTimestamp() orelse "";
         // ISO 8601 timestamps sort lexicographically.
         if (std.mem.order(u8, user_ts, sys_ts) == .gt) return user_dir.?;
         return sys_dir;
@@ -447,14 +446,18 @@ pub fn filterLogFile(path: []const u8, cutoff: []const u8, writer: anytype) !voi
 pub const LogStats = struct {
     total_size: u64,
     file_count: u32,
-    /// First timestamp found across all log files (from rotated file first).
-    /// Points into first_ts_buf — only valid for the lifetime of this struct.
-    first_timestamp: ?[]const u8,
-    /// Last timestamp found across all log files (from current file last).
-    last_timestamp: ?[]const u8,
-    // Backing storage for timestamp strings.
-    first_ts_buf: [23]u8 = undefined,
-    last_ts_buf: [23]u8 = undefined,
+    has_first_ts: bool = false,
+    has_last_ts: bool = false,
+    first_ts_buf: [TS_LEN]u8 = undefined,
+    last_ts_buf: [TS_LEN]u8 = undefined,
+
+    pub fn firstTimestamp(self: *const LogStats) ?[]const u8 {
+        return if (self.has_first_ts) self.first_ts_buf[0..TS_LEN] else null;
+    }
+
+    pub fn lastTimestamp(self: *const LogStats) ?[]const u8 {
+        return if (self.has_last_ts) self.last_ts_buf[0..TS_LEN] else null;
+    }
 };
 
 const TS_LEN = 23; // "YYYY-MM-DDTHH:MM:SS.mmm"
@@ -463,12 +466,7 @@ const TS_LEN = 23; // "YYYY-MM-DDTHH:MM:SS.mmm"
 /// directory doesn't exist or contains no log files. Reads only the
 /// first and last lines of each file for timestamps (not the full content).
 pub fn getLogStats(log_dir: []const u8) ?LogStats {
-    var stats = LogStats{
-        .total_size = 0,
-        .file_count = 0,
-        .first_timestamp = null,
-        .last_timestamp = null,
-    };
+    var stats = LogStats{ .total_size = 0, .file_count = 0 };
 
     // Check rotated file first (older data → first timestamp).
     var bak_path_buf: [280]u8 = undefined;
@@ -476,13 +474,13 @@ pub fn getLogStats(log_dir: []const u8) ?LogStats {
     if (scanFile(bak_path)) |info| {
         stats.total_size += info.size;
         stats.file_count += 1;
-        if (info.first_ts) |ts| {
-            @memcpy(stats.first_ts_buf[0..TS_LEN], ts);
-            stats.first_timestamp = stats.first_ts_buf[0..TS_LEN];
+        if (info.has_first_ts) {
+            @memcpy(stats.first_ts_buf[0..TS_LEN], info.first_ts_buf[0..TS_LEN]);
+            stats.has_first_ts = true;
         }
-        if (info.last_ts) |ts| {
-            @memcpy(stats.last_ts_buf[0..TS_LEN], ts);
-            stats.last_timestamp = stats.last_ts_buf[0..TS_LEN];
+        if (info.has_last_ts) {
+            @memcpy(stats.last_ts_buf[0..TS_LEN], info.last_ts_buf[0..TS_LEN]);
+            stats.has_last_ts = true;
         }
     }
 
@@ -492,15 +490,13 @@ pub fn getLogStats(log_dir: []const u8) ?LogStats {
     if (scanFile(cur_path)) |info| {
         stats.total_size += info.size;
         stats.file_count += 1;
-        if (info.first_ts) |ts| {
-            if (stats.first_timestamp == null) {
-                @memcpy(stats.first_ts_buf[0..TS_LEN], ts);
-                stats.first_timestamp = stats.first_ts_buf[0..TS_LEN];
-            }
+        if (info.has_first_ts and !stats.has_first_ts) {
+            @memcpy(stats.first_ts_buf[0..TS_LEN], info.first_ts_buf[0..TS_LEN]);
+            stats.has_first_ts = true;
         }
-        if (info.last_ts) |ts| {
-            @memcpy(stats.last_ts_buf[0..TS_LEN], ts);
-            stats.last_timestamp = stats.last_ts_buf[0..TS_LEN];
+        if (info.has_last_ts) {
+            @memcpy(stats.last_ts_buf[0..TS_LEN], info.last_ts_buf[0..TS_LEN]);
+            stats.has_last_ts = true;
         }
     }
 
@@ -510,8 +506,10 @@ pub fn getLogStats(log_dir: []const u8) ?LogStats {
 
 const FileInfo = struct {
     size: u64,
-    first_ts: ?[]const u8,
-    last_ts: ?[]const u8,
+    has_first_ts: bool = false,
+    has_last_ts: bool = false,
+    first_ts_buf: [TS_LEN]u8 = undefined,
+    last_ts_buf: [TS_LEN]u8 = undefined,
 };
 
 /// Extract file size and first/last timestamp from a log file.
@@ -523,14 +521,17 @@ fn scanFile(path: []const u8) ?FileInfo {
     defer f.close();
     const stat = f.stat() catch return null;
 
-    var info = FileInfo{ .size = stat.size, .first_ts = null, .last_ts = null };
+    var info = FileInfo{ .size = stat.size };
     if (stat.size == 0) return info;
 
     // Read first 256 bytes for first timestamp.
     var head_buf: [256]u8 = undefined;
     const head_n = f.readAll(&head_buf) catch 0;
     if (head_n > 0) {
-        info.first_ts = extractTimestamp(head_buf[0..head_n]);
+        if (extractTimestamp(head_buf[0..head_n])) |ts| {
+            @memcpy(info.first_ts_buf[0..TS_LEN], ts);
+            info.has_first_ts = true;
+        }
     }
 
     // Read last 1024 bytes for last timestamp. Rumble HID frame dump lines
@@ -545,7 +546,10 @@ fn scanFile(path: []const u8) ?FileInfo {
     var tail_buf: [1024]u8 = undefined;
     const tail_n = f.readAll(&tail_buf) catch 0;
     if (tail_n > 0) {
-        info.last_ts = extractLastTimestamp(tail_buf[0..tail_n]);
+        if (extractLastTimestamp(tail_buf[0..tail_n])) |ts| {
+            @memcpy(info.last_ts_buf[0..TS_LEN], ts);
+            info.has_last_ts = true;
+        }
     }
 
     return info;
@@ -720,8 +724,8 @@ test "dump: getLogStats reports size and timestamps for a single file" {
     const stats = getLogStats(dir_path).?;
     try testing.expect(stats.total_size > 0);
     try testing.expectEqual(@as(u32, 1), stats.file_count);
-    try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.first_timestamp.?);
-    try testing.expectEqualStrings("2026-04-13T14:10:00.000", stats.last_timestamp.?);
+    try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.firstTimestamp().?);
+    try testing.expectEqualStrings("2026-04-13T14:10:00.000", stats.lastTimestamp().?);
 }
 
 test "dump: getLogStats merges current and rotated file" {
@@ -744,8 +748,8 @@ test "dump: getLogStats merges current and rotated file" {
 
     const stats = getLogStats(dir_path).?;
     try testing.expectEqual(@as(u32, 2), stats.file_count);
-    try testing.expectEqualStrings("2026-04-12T10:00:00.000", stats.first_timestamp.?);
-    try testing.expectEqualStrings("2026-04-13T20:00:00.000", stats.last_timestamp.?);
+    try testing.expectEqualStrings("2026-04-12T10:00:00.000", stats.firstTimestamp().?);
+    try testing.expectEqualStrings("2026-04-13T20:00:00.000", stats.lastTimestamp().?);
 }
 
 test "dump: getLogStats finds timestamp on long final line" {
@@ -771,9 +775,9 @@ test "dump: getLogStats finds timestamp on long final line" {
 
     const stats = getLogStats(dir_path).?;
     try testing.expect(stats.total_size > 400);
-    try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.first_timestamp.?);
+    try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.firstTimestamp().?);
     // The last timestamp must be found even though it's >256 bytes from EOF.
-    try testing.expectEqualStrings("2026-04-13T14:30:00.000", stats.last_timestamp.?);
+    try testing.expectEqualStrings("2026-04-13T14:30:00.000", stats.lastTimestamp().?);
 }
 
 test "dump: getLogStats handles empty log file" {
@@ -791,8 +795,8 @@ test "dump: getLogStats handles empty log file" {
     const stats = getLogStats(dir_path).?;
     try testing.expectEqual(@as(u64, 0), stats.total_size);
     try testing.expectEqual(@as(u32, 1), stats.file_count);
-    try testing.expectEqual(@as(?[]const u8, null), stats.first_timestamp);
-    try testing.expectEqual(@as(?[]const u8, null), stats.last_timestamp);
+    try testing.expectEqual(@as(?[]const u8, null), stats.firstTimestamp());
+    try testing.expectEqual(@as(?[]const u8, null), stats.lastTimestamp());
 }
 
 // --- Period parsing tests ---

--- a/src/cli/dump.zig
+++ b/src/cli/dump.zig
@@ -1,0 +1,917 @@
+const std = @import("std");
+const paths = @import("../config/paths.zig");
+const user_config_mod = @import("../config/user_config.zig");
+const socket_client = @import("socket_client.zig");
+
+pub const WriteError = error{
+    MalformedConfig,
+    NoSpaceLeft,
+    OutOfMemory,
+    AccessDenied,
+    FileNotFound,
+    Unexpected,
+    InputOutput,
+    SystemResources,
+    IsDir,
+    InvalidArgument,
+};
+
+/// Write `[diagnostics] dump = <value>` to `{dir_path}/config.toml`.
+/// Preserves ALL existing fields (version, devices, other diagnostics fields).
+/// Only the `dump` field within `[diagnostics]` is changed.
+///
+/// Returns error.MalformedConfig if the existing file contains invalid TOML
+/// (the file is left untouched — the caller should warn and proceed with IPC).
+pub fn writeDiagnosticsConfig(allocator: std.mem.Allocator, dir_path: []const u8, dump: bool) WriteError!void {
+    std.fs.makeDirAbsolute(dir_path) catch |e| switch (e) {
+        error.PathAlreadyExists => {},
+        error.AccessDenied => return error.AccessDenied,
+        else => return error.Unexpected,
+    };
+
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir_path});
+    defer allocator.free(config_path);
+
+    // Read existing config to preserve all fields.
+    var existing_version: ?i64 = null;
+    var existing_diag: user_config_mod.DiagnosticsConfig = .{};
+    var existing_devices: ?[]const user_config_mod.DeviceEntry = null;
+    var existing_pr: ?user_config_mod.ParseResult = null;
+    defer if (existing_pr) |*pr| pr.deinit();
+
+    if (user_config_mod.loadFromDir(allocator, dir_path)) |maybe| {
+        if (maybe) |pr| {
+            existing_pr = pr;
+            existing_version = pr.value.version;
+            existing_diag = pr.value.diagnostics;
+            existing_devices = pr.value.device;
+        }
+        // null = file not found → fresh config, proceed.
+    } else |err| switch (err) {
+        error.MalformedConfig => return error.MalformedConfig,
+    }
+
+    // Update only the dump field; preserve everything else.
+    existing_diag.dump = dump;
+
+    // Build the config content in memory, then write atomically.
+    var content_buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&content_buf);
+    const w = fbs.writer();
+
+    w.print("version = {d}\n\n", .{existing_version orelse user_config_mod.CURRENT_VERSION}) catch return error.NoSpaceLeft;
+    w.print("[diagnostics]\ndump = {}\nmax_log_size_mb = {d}\n", .{ existing_diag.dump, existing_diag.max_log_size_mb }) catch return error.NoSpaceLeft;
+
+    if (existing_devices) |devices| {
+        for (devices) |dev| {
+            w.writeAll("\n[[device]]\n") catch return error.NoSpaceLeft;
+            w.print("name = \"{s}\"\n", .{dev.name}) catch return error.NoSpaceLeft;
+            if (dev.default_mapping) |m| {
+                w.print("default_mapping = \"{s}\"\n", .{m}) catch return error.NoSpaceLeft;
+            }
+        }
+    }
+
+    var f = std.fs.createFileAbsolute(config_path, .{ .truncate = true }) catch return error.AccessDenied;
+    defer f.close();
+    f.writeAll(fbs.getWritten()) catch return error.InputOutput;
+}
+
+/// Run `padctl dump status`: query daemon for live state, read log file stats.
+pub fn runStatus(
+    allocator: std.mem.Allocator,
+    socket_path: []const u8,
+    stdout: anytype,
+    stderr: anytype,
+) void {
+    // Query daemon for live dump state.
+    var daemon_state: []const u8 = "unknown (daemon not running)";
+    if (socket_client.connectToSocket(socket_path)) |sock_fd| {
+        defer std.posix.close(sock_fd);
+        var resp_buf: [64]u8 = undefined;
+        if (socket_client.sendCommand(sock_fd, "DUMP STATUS\n", &resp_buf)) |resp| {
+            // Parse "OK dump=on\n" or "OK dump=off\n"
+            const trimmed = std.mem.trimRight(u8, resp, "\r\n");
+            if (std.mem.indexOf(u8, trimmed, "dump=on") != null) {
+                daemon_state = "enabled";
+            } else if (std.mem.indexOf(u8, trimmed, "dump=off") != null) {
+                daemon_state = "disabled";
+            }
+        } else |_| {}
+    } else |_| {
+        // Daemon not running — fall back to config.
+        const user_cfg_mod2 = user_config_mod;
+        if (user_cfg_mod2.load(allocator)) |pr| {
+            var ucpr = pr;
+            defer ucpr.deinit();
+            daemon_state = if (ucpr.value.diagnostics.dump) "enabled (from config)" else "disabled (from config)";
+        }
+    }
+
+    stdout.print("Dump: {s}\n", .{daemon_state}) catch {};
+
+    // Log file stats. Check both user state dir and systemd /var/log/padctl,
+    // pick whichever has the newest last_timestamp (the active one).
+    const sys_log_dir = "/var/log/padctl";
+    const user_log_dir: ?[]u8 = paths.stateDir(allocator) catch null;
+    defer if (user_log_dir) |d| allocator.free(d);
+
+    const effective_dir: []const u8 = pickActiveLogDir(sys_log_dir, user_log_dir);
+
+    stdout.print("Log path: {s}/padctl.log\n", .{effective_dir}) catch {};
+
+    if (getLogStats(effective_dir)) |stats| {
+        var size_buf: [32]u8 = undefined;
+        const size_str = formatSize(&size_buf, stats.total_size);
+        stdout.print("Log size: {s} ({d} file{s})\n", .{
+            size_str,
+            stats.file_count,
+            if (stats.file_count != 1) "s" else "",
+        }) catch {};
+        if (stats.first_timestamp) |first| {
+            stdout.print("First entry: {s}\n", .{first}) catch {};
+        }
+        if (stats.last_timestamp) |last| {
+            stdout.print("Last entry:  {s}\n", .{last}) catch {};
+        }
+    } else {
+        stdout.print("Log size: no logs\n", .{}) catch {};
+    }
+
+    _ = stderr;
+}
+
+/// Delete log files in the given directory. Returns the number of files deleted.
+pub fn deleteLogFiles(log_dir: []const u8) u32 {
+    var deleted: u32 = 0;
+    const names = [_][]const u8{ "padctl.log", "padctl.log.1" };
+    for (names) |name| {
+        var path_buf: [280]u8 = undefined;
+        const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ log_dir, name }) catch continue;
+        std.fs.deleteFileAbsolute(path) catch continue;
+        deleted += 1;
+    }
+    return deleted;
+}
+
+/// Aggregate LogStats across two directories.
+fn mergeStats(a: ?LogStats, b: ?LogStats) ?LogStats {
+    if (a == null and b == null) return null;
+    if (a == null) return b;
+    if (b == null) return a;
+    var merged = a.?;
+    const bs = b.?;
+    merged.total_size += bs.total_size;
+    merged.file_count += bs.file_count;
+    // Pick the earliest first_timestamp and latest last_timestamp.
+    if (bs.first_timestamp) |bfirst| {
+        if (merged.first_timestamp) |mfirst| {
+            if (std.mem.order(u8, bfirst, mfirst) == .lt) {
+                @memcpy(merged.first_ts_buf[0..TS_LEN], bfirst);
+                merged.first_timestamp = merged.first_ts_buf[0..TS_LEN];
+            }
+        } else {
+            @memcpy(merged.first_ts_buf[0..TS_LEN], bfirst);
+            merged.first_timestamp = merged.first_ts_buf[0..TS_LEN];
+        }
+    }
+    if (bs.last_timestamp) |blast| {
+        if (merged.last_timestamp) |mlast| {
+            if (std.mem.order(u8, blast, mlast) == .gt) {
+                @memcpy(merged.last_ts_buf[0..TS_LEN], blast);
+                merged.last_timestamp = merged.last_ts_buf[0..TS_LEN];
+            }
+        } else {
+            @memcpy(merged.last_ts_buf[0..TS_LEN], blast);
+            merged.last_timestamp = merged.last_ts_buf[0..TS_LEN];
+        }
+    }
+    return merged;
+}
+
+/// Run `padctl dump clear`: show stats across ALL log locations, prompt, delete all.
+pub fn runClear(
+    allocator: std.mem.Allocator,
+    stdout: anytype,
+    stderr: anytype,
+) void {
+    const sys_log_dir = "/var/log/padctl";
+    const user_log_dir: ?[]u8 = paths.stateDir(allocator) catch null;
+    defer if (user_log_dir) |d| allocator.free(d);
+
+    // Aggregate stats from both locations.
+    const sys_stats = getLogStats(sys_log_dir);
+    const user_stats = if (user_log_dir) |ud| getLogStats(ud) else null;
+    const stats = mergeStats(sys_stats, user_stats) orelse {
+        stdout.print("No logs to clear.\n", .{}) catch {};
+        return;
+    };
+
+    // Show stats.
+    var size_buf: [32]u8 = undefined;
+    const size_str = formatSize(&size_buf, stats.total_size);
+    stdout.print("{d} log file{s}, {s}", .{
+        stats.file_count,
+        if (stats.file_count != 1) "s" else "",
+        size_str,
+    }) catch {};
+    if (stats.first_timestamp) |first| {
+        if (stats.last_timestamp) |last| {
+            stdout.print(", spanning {s} to {s}", .{ first, last }) catch {};
+        } else {
+            stdout.print(", from {s}", .{first}) catch {};
+        }
+    }
+    stdout.print("\n", .{}) catch {};
+
+    // Check for TTY.
+    const stdin_fd = std.posix.STDIN_FILENO;
+    if (!std.posix.isatty(stdin_fd)) {
+        stderr.print("error: refusing to delete logs without interactive confirmation (stdin is not a TTY)\n", .{}) catch {};
+        std.process.exit(1);
+    }
+
+    // Prompt.
+    stdout.print("Delete all logs? [y/N] ", .{}) catch {};
+    var input_buf: [16]u8 = undefined;
+    const n = std.posix.read(stdin_fd, &input_buf) catch {
+        stdout.print("\nAborted.\n", .{}) catch {};
+        return;
+    };
+    if (n == 0) {
+        stdout.print("\nAborted.\n", .{}) catch {};
+        return;
+    }
+    const answer = std.mem.trimRight(u8, input_buf[0..n], "\r\n \t");
+    if (answer.len == 1 and (answer[0] == 'y' or answer[0] == 'Y')) {
+        // Delete from BOTH locations.
+        var deleted: u32 = 0;
+        deleted += deleteLogFiles(sys_log_dir);
+        if (user_log_dir) |ud| {
+            deleted += deleteLogFiles(ud);
+        }
+        stdout.print("Deleted {d} file{s}.\n", .{ deleted, if (deleted != 1) "s" else "" }) catch {};
+    } else {
+        stdout.print("Aborted.\n", .{}) catch {};
+    }
+}
+
+/// Pick whichever log directory has the newest last_timestamp.
+/// Falls back to sys_dir if both are empty or only sys exists.
+fn pickActiveLogDir(sys_dir: []const u8, user_dir: ?[]const u8) []const u8 {
+    const sys_stats = getLogStats(sys_dir);
+    const user_stats = if (user_dir) |ud| getLogStats(ud) else null;
+
+    if (sys_stats != null and user_stats != null) {
+        const sys_ts = sys_stats.?.last_timestamp orelse "";
+        const user_ts = user_stats.?.last_timestamp orelse "";
+        // ISO 8601 timestamps sort lexicographically.
+        if (std.mem.order(u8, user_ts, sys_ts) == .gt) return user_dir.?;
+        return sys_dir;
+    }
+    if (user_stats != null) return user_dir.?;
+    return sys_dir;
+}
+
+fn formatSize(buf: *[32]u8, bytes: u64) []const u8 {
+    if (bytes < 1024) {
+        return std.fmt.bufPrint(buf, "{d} B", .{bytes}) catch "?";
+    } else if (bytes < 1024 * 1024) {
+        return std.fmt.bufPrint(buf, "{d:.1} KB", .{@as(f64, @floatFromInt(bytes)) / 1024.0}) catch "?";
+    } else {
+        return std.fmt.bufPrint(buf, "{d:.1} MB", .{@as(f64, @floatFromInt(bytes)) / (1024.0 * 1024.0)}) catch "?";
+    }
+}
+
+/// Run `padctl dump export`: filter logs by period, output to stdout or file.
+pub fn runExport(
+    allocator: std.mem.Allocator,
+    period_str: []const u8,
+    output_path: ?[]const u8,
+    stdout: anytype,
+    stderr: anytype,
+) void {
+    const period_secs = parsePeriod(period_str) orelse {
+        stderr.print("error: invalid period '{s}' — use Nm, Nh, or Nd (e.g., 10m, 1h, 1d)\n", .{period_str}) catch {};
+        std.process.exit(1);
+    };
+
+    // Compute cutoff timestamp.
+    const now_secs = @as(u64, @intCast(std.time.timestamp()));
+    const cutoff_secs = if (now_secs > period_secs) now_secs - period_secs else 0;
+    var cutoff_buf: [23]u8 = undefined;
+    const cutoff = formatTimestamp(&cutoff_buf, cutoff_secs);
+
+    // Find the active log directory.
+    const sys_log_dir = "/var/log/padctl";
+    const user_log_dir: ?[]u8 = paths.stateDir(allocator) catch null;
+    defer if (user_log_dir) |d| allocator.free(d);
+    const log_dir = pickActiveLogDir(sys_log_dir, user_log_dir);
+
+    // Open output: file or stdout. Supports both relative and absolute paths.
+    if (output_path) |op| {
+        var f = (if (op.len > 0 and op[0] == '/')
+            std.fs.createFileAbsolute(op, .{ .truncate = true })
+        else
+            std.fs.cwd().createFile(op, .{ .truncate = true })) catch |err| {
+            stderr.print("error: cannot create '{s}': {}\n", .{ op, err }) catch {};
+            std.process.exit(1);
+        };
+        defer f.close();
+        exportToFd(log_dir, cutoff, f.handle);
+    } else {
+        exportToWriter(log_dir, cutoff, stdout);
+    }
+}
+
+fn exportToFd(log_dir: []const u8, cutoff: []const u8, fd: std.posix.fd_t) void {
+    const FdWriter = struct {
+        fd: std.posix.fd_t,
+        pub fn writeAll(self: @This(), data: []const u8) !void {
+            var written: usize = 0;
+            while (written < data.len) {
+                written += std.posix.write(self.fd, data[written..]) catch return error.BrokenPipe;
+            }
+        }
+    };
+    const w = FdWriter{ .fd = fd };
+    exportToWriter(log_dir, cutoff, w);
+}
+
+fn exportToWriter(log_dir: []const u8, cutoff: []const u8, writer: anytype) void {
+    // Read rotated file first (older), then current file.
+    var bak_buf: [280]u8 = undefined;
+    const bak_path = std.fmt.bufPrint(&bak_buf, "{s}/padctl.log.1", .{log_dir}) catch return;
+    filterLogFile(bak_path, cutoff, writer) catch {};
+
+    var cur_buf: [280]u8 = undefined;
+    const cur_path = std.fmt.bufPrint(&cur_buf, "{s}/padctl.log", .{log_dir}) catch return;
+    filterLogFile(cur_path, cutoff, writer) catch {};
+}
+
+fn formatTimestamp(buf: *[23]u8, epoch_secs: u64) []const u8 {
+    const es = std.time.epoch.EpochSeconds{ .secs = epoch_secs };
+    const day = es.getEpochDay();
+    const yd = day.calculateYearDay();
+    const md = yd.calculateMonthDay();
+    const ds = es.getDaySeconds();
+    const result = std.fmt.bufPrint(buf, "{d:0>4}-{d:0>2}-{d:0>2}T{d:0>2}:{d:0>2}:{d:0>2}.000", .{
+        yd.year,
+        @as(u32, @intFromEnum(md.month)) + 1,
+        @as(u32, md.day_index) + 1,
+        ds.getHoursIntoDay(),
+        ds.getMinutesIntoHour(),
+        ds.getSecondsIntoMinute(),
+    }) catch return "0000-00-00T00:00:00.000";
+    return result;
+}
+
+/// Parse a relative period string like "10m", "1h", "1d" into seconds.
+/// Returns null for invalid input.
+pub fn parsePeriod(s: []const u8) ?u64 {
+    if (s.len < 2) return null;
+    const unit = s[s.len - 1];
+    const multiplier: u64 = switch (unit) {
+        'm' => 60,
+        'h' => 3600,
+        'd' => 86400,
+        else => return null,
+    };
+    const num_str = s[0 .. s.len - 1];
+    const n = std.fmt.parseInt(u64, num_str, 10) catch return null;
+    if (n == 0) return null;
+    return std.math.mul(u64, n, multiplier) catch return null;
+}
+
+/// Check whether a log line's timestamp is at or after the cutoff.
+/// Lines without a parseable timestamp are included conservatively.
+/// Both `line` and `cutoff` use the format "YYYY-MM-DDTHH:MM:SS.mmm".
+pub fn linePassesFilter(line: []const u8, cutoff: []const u8) bool {
+    const ts = extractTimestamp(line) orelse return true; // no timestamp → include
+    // ISO 8601 timestamps sort lexicographically.
+    return std.mem.order(u8, ts, cutoff) != .lt;
+}
+
+/// Read a log file line-by-line, writing lines that pass the timestamp filter
+/// to the given writer. The cutoff is an ISO 8601 timestamp string.
+pub fn filterLogFile(path: []const u8, cutoff: []const u8, writer: anytype) !void {
+    const f = std.fs.openFileAbsolute(path, .{}) catch return;
+    defer f.close();
+
+    var buf: [4096]u8 = undefined;
+    var carry: [4096]u8 = undefined;
+    var carry_len: usize = 0;
+
+    while (true) {
+        const n = f.readAll(buf[carry_len..]) catch break;
+        if (carry_len > 0) {
+            // Prepend leftover from previous read.
+            @memcpy(buf[0..carry_len], carry[0..carry_len]);
+        }
+        const total = carry_len + n;
+        if (total == 0) break;
+        carry_len = 0;
+
+        var data = buf[0..total];
+        while (std.mem.indexOfScalar(u8, data, '\n')) |nl| {
+            const line = data[0..nl];
+            if (linePassesFilter(line, cutoff)) {
+                try writer.writeAll(line);
+                try writer.writeAll("\n");
+            }
+            data = data[nl + 1 ..];
+        }
+        // Leftover (no newline) — carry to next iteration.
+        if (data.len > 0 and n > 0) {
+            @memcpy(carry[0..data.len], data);
+            carry_len = data.len;
+        } else if (data.len > 0) {
+            // EOF with no trailing newline — process the leftover.
+            if (linePassesFilter(data, cutoff)) {
+                try writer.writeAll(data);
+                try writer.writeAll("\n");
+            }
+        }
+    }
+
+    // Final leftover after EOF.
+    if (carry_len > 0) {
+        const leftover = carry[0..carry_len];
+        if (linePassesFilter(leftover, cutoff)) {
+            try writer.writeAll(leftover);
+            try writer.writeAll("\n");
+        }
+    }
+}
+
+pub const LogStats = struct {
+    total_size: u64,
+    file_count: u32,
+    /// First timestamp found across all log files (from rotated file first).
+    /// Points into first_ts_buf — only valid for the lifetime of this struct.
+    first_timestamp: ?[]const u8,
+    /// Last timestamp found across all log files (from current file last).
+    last_timestamp: ?[]const u8,
+    // Backing storage for timestamp strings.
+    first_ts_buf: [23]u8 = undefined,
+    last_ts_buf: [23]u8 = undefined,
+};
+
+const TS_LEN = 23; // "YYYY-MM-DDTHH:MM:SS.mmm"
+
+/// Scan log files in `log_dir` and return stats. Returns null if the
+/// directory doesn't exist or contains no log files. Reads only the
+/// first and last lines of each file for timestamps (not the full content).
+pub fn getLogStats(log_dir: []const u8) ?LogStats {
+    var stats = LogStats{
+        .total_size = 0,
+        .file_count = 0,
+        .first_timestamp = null,
+        .last_timestamp = null,
+    };
+
+    // Check rotated file first (older data → first timestamp).
+    var bak_path_buf: [280]u8 = undefined;
+    const bak_path = std.fmt.bufPrint(&bak_path_buf, "{s}/padctl.log.1", .{log_dir}) catch return null;
+    if (scanFile(bak_path)) |info| {
+        stats.total_size += info.size;
+        stats.file_count += 1;
+        if (info.first_ts) |ts| {
+            @memcpy(stats.first_ts_buf[0..TS_LEN], ts);
+            stats.first_timestamp = stats.first_ts_buf[0..TS_LEN];
+        }
+        if (info.last_ts) |ts| {
+            @memcpy(stats.last_ts_buf[0..TS_LEN], ts);
+            stats.last_timestamp = stats.last_ts_buf[0..TS_LEN];
+        }
+    }
+
+    // Check current file (newer data → last timestamp).
+    var cur_path_buf: [280]u8 = undefined;
+    const cur_path = std.fmt.bufPrint(&cur_path_buf, "{s}/padctl.log", .{log_dir}) catch return null;
+    if (scanFile(cur_path)) |info| {
+        stats.total_size += info.size;
+        stats.file_count += 1;
+        if (info.first_ts) |ts| {
+            if (stats.first_timestamp == null) {
+                @memcpy(stats.first_ts_buf[0..TS_LEN], ts);
+                stats.first_timestamp = stats.first_ts_buf[0..TS_LEN];
+            }
+        }
+        if (info.last_ts) |ts| {
+            @memcpy(stats.last_ts_buf[0..TS_LEN], ts);
+            stats.last_timestamp = stats.last_ts_buf[0..TS_LEN];
+        }
+    }
+
+    if (stats.file_count == 0) return null;
+    return stats;
+}
+
+const FileInfo = struct {
+    size: u64,
+    first_ts: ?[]const u8,
+    last_ts: ?[]const u8,
+};
+
+/// Extract file size and first/last timestamp from a log file.
+/// Reads the first 256 bytes for the first timestamp and the last 1024 bytes
+/// for the last timestamp (large enough for HID frame hex dump lines).
+/// Returns null if the file doesn't exist.
+fn scanFile(path: []const u8) ?FileInfo {
+    const f = std.fs.openFileAbsolute(path, .{}) catch return null;
+    defer f.close();
+    const stat = f.stat() catch return null;
+
+    var info = FileInfo{ .size = stat.size, .first_ts = null, .last_ts = null };
+    if (stat.size == 0) return info;
+
+    // Read first 256 bytes for first timestamp.
+    var head_buf: [256]u8 = undefined;
+    const head_n = f.readAll(&head_buf) catch 0;
+    if (head_n > 0) {
+        info.first_ts = extractTimestamp(head_buf[0..head_n]);
+    }
+
+    // Read last 1024 bytes for last timestamp. Rumble HID frame dump lines
+    // can exceed 256 bytes, so we need a larger tail window to find the
+    // timestamp at the start of the final line.
+    const tail_size: u64 = 1024;
+    if (stat.size > tail_size) {
+        f.seekTo(stat.size - tail_size) catch {};
+    } else {
+        f.seekTo(0) catch {};
+    }
+    var tail_buf: [1024]u8 = undefined;
+    const tail_n = f.readAll(&tail_buf) catch 0;
+    if (tail_n > 0) {
+        info.last_ts = extractLastTimestamp(tail_buf[0..tail_n]);
+    }
+
+    return info;
+}
+
+/// Extract the first `[YYYY-MM-DDTHH:MM:SS.mmm]` timestamp from a buffer.
+fn extractTimestamp(buf: []const u8) ?[]const u8 {
+    const start = std.mem.indexOfScalar(u8, buf, '[') orelse return null;
+    if (start + 1 + TS_LEN > buf.len) return null;
+    const ts = buf[start + 1 .. start + 1 + TS_LEN];
+    // Quick sanity check: must have 'T' at position 10 and '.' at position 19.
+    if (ts.len == TS_LEN and ts[10] == 'T' and ts[19] == '.') return ts;
+    return null;
+}
+
+/// Extract the last `[YYYY-MM-DDTHH:MM:SS.mmm]` timestamp from a buffer
+/// by scanning backwards.
+fn extractLastTimestamp(buf: []const u8) ?[]const u8 {
+    var last: ?[]const u8 = null;
+    var i: usize = 0;
+    while (i < buf.len) {
+        if (buf[i] == '[' and i + 1 + TS_LEN <= buf.len) {
+            const ts = buf[i + 1 .. i + 1 + TS_LEN];
+            if (ts.len == TS_LEN and ts[10] == 'T' and ts[19] == '.') {
+                last = ts;
+            }
+        }
+        i += 1;
+    }
+    return last;
+}
+
+// --- tests ---
+
+const testing = std.testing;
+
+test "dump: writeDiagnosticsConfig creates fresh config" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    try writeDiagnosticsConfig(allocator, dir_path, true);
+
+    var result = (try user_config_mod.loadFromDir(allocator, dir_path)).?;
+    defer result.deinit();
+    try testing.expectEqual(true, result.value.diagnostics.dump);
+    try testing.expectEqual(@as(i64, 100), result.value.diagnostics.max_log_size_mb);
+    try testing.expectEqual(@as(?i64, 1), result.value.version);
+}
+
+test "dump: writeDiagnosticsConfig preserves existing device entries" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("config.toml", .{});
+        defer f.close();
+        try f.writeAll(
+            \\version = 1
+            \\
+            \\[[device]]
+            \\name = "Vader 5 Pro"
+            \\default_mapping = "fps"
+        );
+    }
+
+    try writeDiagnosticsConfig(allocator, dir_path, true);
+
+    var result = (try user_config_mod.loadFromDir(allocator, dir_path)).?;
+    defer result.deinit();
+    try testing.expectEqual(true, result.value.diagnostics.dump);
+    const mapping = user_config_mod.findDefaultMapping(&result, "Vader 5 Pro");
+    try testing.expect(mapping != null);
+    try testing.expectEqualStrings("fps", mapping.?);
+}
+
+test "dump: writeDiagnosticsConfig preserves max_log_size_mb" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("config.toml", .{});
+        defer f.close();
+        try f.writeAll(
+            \\version = 1
+            \\
+            \\[diagnostics]
+            \\dump = false
+            \\max_log_size_mb = 50
+        );
+    }
+
+    // Toggle dump on — max_log_size_mb must survive.
+    try writeDiagnosticsConfig(allocator, dir_path, true);
+
+    var result = (try user_config_mod.loadFromDir(allocator, dir_path)).?;
+    defer result.deinit();
+    try testing.expectEqual(true, result.value.diagnostics.dump);
+    try testing.expectEqual(@as(i64, 50), result.value.diagnostics.max_log_size_mb);
+}
+
+test "dump: writeDiagnosticsConfig toggles off" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    try writeDiagnosticsConfig(allocator, dir_path, true);
+    try writeDiagnosticsConfig(allocator, dir_path, false);
+
+    var result = (try user_config_mod.loadFromDir(allocator, dir_path)).?;
+    defer result.deinit();
+    try testing.expectEqual(false, result.value.diagnostics.dump);
+}
+
+test "dump: writeDiagnosticsConfig aborts on malformed config" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("config.toml", .{});
+        defer f.close();
+        try f.writeAll("this is {{{{ not TOML !!!!");
+    }
+
+    // Must return MalformedConfig, NOT silently overwrite.
+    try testing.expectError(error.MalformedConfig, writeDiagnosticsConfig(allocator, dir_path, true));
+
+    // Verify the original file is untouched.
+    const content = try tmp.dir.readFileAlloc(allocator, "config.toml", 4096);
+    defer allocator.free(content);
+    try testing.expectEqualStrings("this is {{{{ not TOML !!!!", content);
+}
+
+// --- LogStats tests ---
+
+test "dump: getLogStats returns null for nonexistent directory" {
+    const stats = getLogStats("/tmp/padctl_nonexistent_test_dir_12345");
+    try testing.expectEqual(@as(?LogStats, null), stats);
+}
+
+test "dump: getLogStats reports size and timestamps for a single file" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        defer f.close();
+        try f.writeAll(
+            \\[2026-04-13T14:00:00.000] [MONO:1] info: first line
+            \\[2026-04-13T14:05:00.000] [MONO:2] info: middle
+            \\[2026-04-13T14:10:00.000] [MONO:3] info: last line
+            \\
+        );
+    }
+
+    const stats = getLogStats(dir_path).?;
+    try testing.expect(stats.total_size > 0);
+    try testing.expectEqual(@as(u32, 1), stats.file_count);
+    try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.first_timestamp.?);
+    try testing.expectEqualStrings("2026-04-13T14:10:00.000", stats.last_timestamp.?);
+}
+
+test "dump: getLogStats merges current and rotated file" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("padctl.log.1", .{});
+        defer f.close();
+        try f.writeAll("[2026-04-12T10:00:00.000] [MONO:1] info: old\n");
+    }
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        defer f.close();
+        try f.writeAll("[2026-04-13T20:00:00.000] [MONO:2] info: new\n");
+    }
+
+    const stats = getLogStats(dir_path).?;
+    try testing.expectEqual(@as(u32, 2), stats.file_count);
+    try testing.expectEqualStrings("2026-04-12T10:00:00.000", stats.first_timestamp.?);
+    try testing.expectEqualStrings("2026-04-13T20:00:00.000", stats.last_timestamp.?);
+}
+
+test "dump: getLogStats finds timestamp on long final line" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        defer f.close();
+        try f.writeAll("[2026-04-13T14:00:00.000] [MONO:1] info: first line\n");
+        // Simulate a long HID frame dump line (~400 chars after timestamp).
+        try f.writeAll("[2026-04-13T14:30:00.000] [MONO:2] debug(rumble): [Vader 5 Pro] HID_WRITE: cmd=rumble strong=65535 weak=65535 iface=0 len=32 frame=[");
+        // Pad with hex data to make the line >400 bytes total.
+        var i: usize = 0;
+        while (i < 120) : (i += 1) {
+            try f.writeAll("ff ");
+        }
+        try f.writeAll("]\n");
+    }
+
+    const stats = getLogStats(dir_path).?;
+    try testing.expect(stats.total_size > 400);
+    try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.first_timestamp.?);
+    // The last timestamp must be found even though it's >256 bytes from EOF.
+    try testing.expectEqualStrings("2026-04-13T14:30:00.000", stats.last_timestamp.?);
+}
+
+test "dump: getLogStats handles empty log file" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        f.close();
+    }
+
+    const stats = getLogStats(dir_path).?;
+    try testing.expectEqual(@as(u64, 0), stats.total_size);
+    try testing.expectEqual(@as(u32, 1), stats.file_count);
+    try testing.expectEqual(@as(?[]const u8, null), stats.first_timestamp);
+    try testing.expectEqual(@as(?[]const u8, null), stats.last_timestamp);
+}
+
+// --- Period parsing tests ---
+
+test "dump: parsePeriod valid durations" {
+    try testing.expectEqual(@as(u64, 600), parsePeriod("10m").?);
+    try testing.expectEqual(@as(u64, 3600), parsePeriod("1h").?);
+    try testing.expectEqual(@as(u64, 86400), parsePeriod("1d").?);
+    try testing.expectEqual(@as(u64, 86400 * 30), parsePeriod("30d").?);
+}
+
+test "dump: parsePeriod rejects invalid" {
+    try testing.expectEqual(@as(?u64, null), parsePeriod("0m"));
+    try testing.expectEqual(@as(?u64, null), parsePeriod("abc"));
+    try testing.expectEqual(@as(?u64, null), parsePeriod(""));
+    try testing.expectEqual(@as(?u64, null), parsePeriod("10"));
+    try testing.expectEqual(@as(?u64, null), parsePeriod("m"));
+    try testing.expectEqual(@as(?u64, null), parsePeriod("-1h"));
+    // Overflow: huge number of days must return null, not crash.
+    try testing.expectEqual(@as(?u64, null), parsePeriod("999999999999999999d"));
+}
+
+// --- Timestamp filtering tests ---
+
+test "dump: linePassesFilter includes lines at or after cutoff" {
+    try testing.expect(linePassesFilter("[2026-04-13T14:05:00.000] info: hello", "2026-04-13T14:00:00.000"));
+    try testing.expect(linePassesFilter("[2026-04-13T14:00:00.000] info: exact", "2026-04-13T14:00:00.000"));
+}
+
+test "dump: linePassesFilter excludes lines before cutoff" {
+    try testing.expect(!linePassesFilter("[2026-04-13T13:59:59.999] info: old", "2026-04-13T14:00:00.000"));
+}
+
+test "dump: linePassesFilter includes lines without timestamps" {
+    try testing.expect(linePassesFilter("no timestamp here", "2026-04-13T14:00:00.000"));
+    try testing.expect(linePassesFilter("", "2026-04-13T14:00:00.000"));
+}
+
+// --- Export filtering test ---
+
+test "dump: filterLogFile filters by period" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        defer f.close();
+        try f.writeAll(
+            \\[2026-04-13T10:00:00.000] [MONO:1] info: old line
+            \\[2026-04-13T14:00:00.000] [MONO:2] info: recent line
+            \\[2026-04-13T14:30:00.000] [MONO:3] info: newest line
+            \\
+        );
+    }
+
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+    const log_path = try std.fmt.allocPrint(allocator, "{s}/padctl.log", .{dir_path});
+    defer allocator.free(log_path);
+
+    var output_buf: [4096]u8 = undefined;
+    var output = std.io.fixedBufferStream(&output_buf);
+
+    // Cutoff at 14:00 — should include the last two lines.
+    try filterLogFile(log_path, "2026-04-13T14:00:00.000", output.writer());
+    const result = output.getWritten();
+    try testing.expect(std.mem.indexOf(u8, result, "old line") == null);
+    try testing.expect(std.mem.indexOf(u8, result, "recent line") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "newest line") != null);
+}
+
+// --- Clear tests ---
+
+test "dump: deleteLogFiles removes both files" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        f.close();
+    }
+    {
+        var f = try tmp.dir.createFile("padctl.log.1", .{});
+        f.close();
+    }
+
+    const deleted = deleteLogFiles(dir_path);
+    try testing.expectEqual(@as(u32, 2), deleted);
+    // Verify files are gone.
+    try testing.expectEqual(@as(?LogStats, null), getLogStats(dir_path));
+}
+
+test "dump: deleteLogFiles with only current file" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        f.close();
+    }
+
+    const deleted = deleteLogFiles(dir_path);
+    try testing.expectEqual(@as(u32, 1), deleted);
+}
+
+test "dump: deleteLogFiles with no files" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    const deleted = deleteLogFiles(dir_path);
+    try testing.expectEqual(@as(u32, 0), deleted);
+}

--- a/src/cli/dump.zig
+++ b/src/cli/dump.zig
@@ -148,10 +148,31 @@ pub fn deleteLogFiles(log_dir: []const u8) u32 {
     for (names) |name| {
         var path_buf: [280]u8 = undefined;
         const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ log_dir, name }) catch continue;
-        std.fs.deleteFileAbsolute(path) catch continue;
+        // Check file exists before attempting delete.
+        std.fs.accessAbsolute(path, .{}) catch continue;
+        // Try direct delete first; fall back to sudo rm for root-owned files.
+        std.fs.deleteFileAbsolute(path) catch {
+            if (sudoRm(path)) {
+                deleted += 1;
+            }
+            continue;
+        };
         deleted += 1;
     }
     return deleted;
+}
+
+fn sudoRm(path: []const u8) bool {
+    var child = std.process.Child.init(&.{ "sudo", "rm", "-f", path }, std.heap.page_allocator);
+    child.stdin_behavior = .Inherit;
+    child.stdout_behavior = .Inherit;
+    child.stderr_behavior = .Inherit;
+    child.spawn() catch return false;
+    const result = child.wait() catch return false;
+    return switch (result) {
+        .Exited => |code| code == 0,
+        else => false,
+    };
 }
 
 /// Aggregate LogStats across two directories.

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1333,12 +1333,20 @@ fn writeBinding(
         };
     }
 
-    // Serialize: version + all existing entries (replacing the conflict target
-    // if one was found) + new entry if none matched.
+    // Serialize: version + diagnostics + all existing entries (replacing
+    // the conflict target if one was found) + new entry if none matched.
     var buf = std.ArrayList(u8){};
     defer buf.deinit(allocator);
     const w = buf.writer(allocator);
     try w.print("version = {d}\n", .{version});
+
+    // Preserve [diagnostics] section if present.
+    if (existing) |e| {
+        const diag = e.value.diagnostics;
+        if (diag.dump or diag.max_log_size_mb != 100) {
+            try w.print("\n[diagnostics]\ndump = {}\nmax_log_size_mb = {d}\n", .{ diag.dump, diag.max_log_size_mb });
+        }
+    }
 
     var wrote_target = false;
     if (devices) |devs| {

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -21,6 +21,7 @@ fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8) ![]c
         \\NoNewPrivileges=true
         \\LockPersonality=true
         \\ProtectClock=true
+        \\LogsDirectory=padctl
         \\
         \\[Install]
         \\WantedBy=default.target
@@ -91,6 +92,8 @@ const immutable_dropin_content =
     \\TimeoutStopSec=3
     \\# SIGTERM main + SIGKILL stuck threads simultaneously
     \\KillMode=mixed
+    \\# Create /var/log/padctl/ writable despite ProtectSystem=strict
+    \\LogsDirectory=padctl
     \\
 ;
 
@@ -139,15 +142,105 @@ fn resolveServiceDir(allocator: std.mem.Allocator, destdir: []const u8, prefix: 
         const home = std.posix.getenv("HOME") orelse return error.NoHomeDir;
         return std.fmt.allocPrint(allocator, "{s}{s}/.config/systemd/user", .{ destdir, home });
     }
+    // On immutable OS (Bazzite/Fedora Atomic), /usr/local is a bind mount from
+    // /var/usrlocal which is unavailable during early boot. The service MUST
+    // live in /etc/systemd/system/ so systemd can find it and honour
+    // WantedBy=multi-user.target. Uses the system service template.
     if (immutable) {
-        return std.fmt.allocPrint(allocator, "{s}/etc/systemd/user", .{destdir});
+        return std.fmt.allocPrint(allocator, "{s}/etc/systemd/system", .{destdir});
     }
-    // systemd < 253 only scans /usr/lib/systemd/user for system-wide user units.
-    // Any other prefix falls back to /etc/systemd/user which is always scanned.
+    // Non-immutable: user service paths (same as before PR #84).
     if (std.mem.eql(u8, prefix, "/usr")) {
         return std.fmt.allocPrint(allocator, "{s}/usr/lib/systemd/user", .{destdir});
     }
     return std.fmt.allocPrint(allocator, "{s}/etc/systemd/user", .{destdir});
+}
+
+/// Update any legacy system service files left behind by pre-user-service
+/// installs. Without this, upgrades leave stale ExecStart (missing --config-dir)
+/// and stale drop-ins (missing LogsDirectory) on the running system service.
+fn updateLegacySystemService(allocator: std.mem.Allocator, destdir: []const u8, prefix: []const u8) void {
+    // /etc/systemd/system — legacy installs placed the service here
+    const etc_dir = std.fmt.allocPrint(allocator, "{s}/etc/systemd/system", .{destdir}) catch return;
+    defer allocator.free(etc_dir);
+    updateLegacyAt(allocator, prefix, etc_dir);
+
+    // <prefix>/lib/systemd/system — another common legacy location
+    const lib_dir = std.fmt.allocPrint(allocator, "{s}{s}/lib/systemd/system", .{ destdir, prefix }) catch return;
+    defer allocator.free(lib_dir);
+    updateLegacyAt(allocator, prefix, lib_dir);
+}
+
+fn updateLegacyAt(
+    allocator: std.mem.Allocator,
+    prefix: []const u8,
+    base_dir: []const u8,
+) void {
+    // Update service file if it exists.
+    const svc_path = std.fmt.allocPrint(allocator, "{s}/padctl.service", .{base_dir}) catch return;
+    defer allocator.free(svc_path);
+    if (std.fs.accessAbsolute(svc_path, .{})) {
+        const content = generateSystemServiceContent(allocator, prefix) catch return;
+        defer allocator.free(content);
+        if (std.fs.createFileAbsolute(svc_path, .{ .truncate = true })) |f| {
+            defer f.close();
+            f.writeAll(content) catch return;
+            _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
+            _ = std.posix.write(std.posix.STDOUT_FILENO, svc_path) catch {};
+            _ = std.posix.write(std.posix.STDOUT_FILENO, " (legacy update)\n") catch {};
+        } else |_| {}
+    } else |_| {}
+
+    // Update drop-in if the directory exists.
+    const dropin_dir = std.fmt.allocPrint(allocator, "{s}/padctl.service.d", .{base_dir}) catch return;
+    defer allocator.free(dropin_dir);
+    if (std.fs.accessAbsolute(dropin_dir, .{})) {
+        const dropin_path = std.fmt.allocPrint(allocator, "{s}/immutable.conf", .{dropin_dir}) catch return;
+        defer allocator.free(dropin_path);
+        if (std.fs.createFileAbsolute(dropin_path, .{ .truncate = true })) |f| {
+            defer f.close();
+            f.writeAll(immutable_dropin_content) catch return;
+            _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
+            _ = std.posix.write(std.posix.STDOUT_FILENO, dropin_path) catch {};
+            _ = std.posix.write(std.posix.STDOUT_FILENO, " (legacy update)\n") catch {};
+        } else |_| {}
+    } else |_| {}
+}
+
+/// Generate the system service content matching the legacy format but with
+/// correct ExecStart for the given prefix.
+fn generateSystemServiceContent(allocator: std.mem.Allocator, prefix: []const u8) ![]const u8 {
+    const exec_start = if (std.mem.eql(u8, prefix, "/usr"))
+        try std.fmt.allocPrint(allocator, "{s}/bin/padctl", .{prefix})
+    else
+        try std.fmt.allocPrint(allocator, "{s}/bin/padctl --config-dir {s}/share/padctl/devices", .{ prefix, prefix });
+    defer allocator.free(exec_start);
+
+    return std.fmt.allocPrint(allocator,
+        \\[Unit]
+        \\Description=padctl gamepad compatibility daemon
+        \\After=local-fs.target
+        \\
+        \\[Service]
+        \\Type=simple
+        \\ExecStart={s}
+        \\Restart=on-failure
+        \\RestartSec=3
+        \\ProtectSystem=strict
+        \\ProtectHome=true
+        \\PrivateTmp=true
+        \\RuntimeDirectory=padctl
+        \\LogsDirectory=padctl
+        \\NoNewPrivileges=true
+        \\SupplementaryGroups=input
+        \\DeviceAllow=/dev/hidraw* rw
+        \\DeviceAllow=/dev/uinput rw
+        \\DeviceAllow=char-input rw
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+        \\
+    , .{exec_start});
 }
 
 fn resolveUdevDir(allocator: std.mem.Allocator, destdir: []const u8, prefix: []const u8, immutable: bool) ![]const u8 {
@@ -450,7 +543,12 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     // 2. Write service file with correct prefix paths
     const service_path = try std.fmt.allocPrint(allocator, "{s}/padctl.service", .{lib_systemd_dir});
     defer allocator.free(service_path);
-    const service_content = try generateServiceContent(allocator, prefix);
+    // Immutable root installs use the system service template (WantedBy=multi-user.target,
+    // ProtectSystem=strict, etc.). All others use the user service template.
+    const service_content = if (effective_immutable and !effective_user_service)
+        try generateSystemServiceContent(allocator, prefix)
+    else
+        try generateServiceContent(allocator, prefix);
     defer allocator.free(service_content);
     {
         var f = try std.fs.createFileAbsolute(service_path, .{ .truncate = true });
@@ -476,6 +574,13 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
         _ = std.posix.write(std.posix.STDOUT_FILENO, dropin_path) catch {};
         _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
+
+        // Also update the legacy system service drop-in if it exists. Old installs
+        // (pre-user-service) placed the drop-in under /etc/systemd/system/ which
+        // the new user-service installer does not touch. Without this, upgrades
+        // leave the old drop-in stale and any new directives (e.g. LogsDirectory)
+        // never take effect on the running system service.
+        updateLegacySystemService(allocator, destdir, prefix);
     }
 
     // 2c. Write resume service (system installs only; user sessions handle sleep via logind)
@@ -1773,15 +1878,15 @@ test "install: shouldAbortForImmutable logic" {
     try testing.expect(!shouldAbortForImmutable(.none, .{}));
 }
 
-test "install: resolveServiceDir immutable routes to /etc/systemd/user" {
+test "install: resolveServiceDir immutable routes to /etc/systemd/system" {
     const testing = std.testing;
     const allocator = testing.allocator;
     const result = try resolveServiceDir(allocator, "/staging", "/usr/local", true, false);
     defer allocator.free(result);
-    try testing.expectEqualStrings("/staging/etc/systemd/user", result);
+    try testing.expectEqualStrings("/staging/etc/systemd/system", result);
 }
 
-test "install: resolveServiceDir /usr routes to /usr/lib/systemd/user" {
+test "install: resolveServiceDir /usr non-immutable routes to /usr/lib/systemd/user" {
     const testing = std.testing;
     const allocator = testing.allocator;
     const result = try resolveServiceDir(allocator, "", "/usr", false, false);
@@ -2514,7 +2619,7 @@ test "install: resolveServiceDir user service uses HOME" {
     try testing.expectEqualStrings(expected, dir);
 }
 
-test "install: resolveServiceDir system install uses lib path" {
+test "install: resolveServiceDir system install uses user lib path" {
     const testing = std.testing;
     const allocator = testing.allocator;
     const dir = try resolveServiceDir(allocator, "", "/usr", false, false);

--- a/src/cli/socket_client.zig
+++ b/src/cli/socket_client.zig
@@ -4,10 +4,21 @@ const linux = std.os.linux;
 
 pub const DEFAULT_SOCKET_PATH = "/run/padctl/padctl.sock";
 
-/// Non-root user with XDG_RUNTIME_DIR set → use XDG socket path
-/// (daemon binds there before the file exists; no existence check here).
-/// Root or missing XDG_RUNTIME_DIR → system path for system-service compatibility.
+/// Resolve the default socket path for the current caller.
+///
+/// On immutable OS (Bazzite/Fedora Atomic), the daemon always runs as a
+/// system service at /run/padctl/padctl.sock. We detect this via
+/// /run/ostree-booted and return the system path directly — non-root CLI
+/// calls would otherwise fall through the XDG path which doesn't exist.
+///
+/// Otherwise: non-root user with XDG_RUNTIME_DIR → XDG path (user-service
+/// deployment); root or missing XDG_RUNTIME_DIR → system path.
 pub fn resolveSocketPath(buf: []u8) []const u8 {
+    // Immutable OS always uses the system service.
+    if (std.fs.cwd().access("/run/ostree-booted", .{})) |_| {
+        return DEFAULT_SOCKET_PATH;
+    } else |_| {}
+
     if (posix.geteuid() != 0) {
         if (posix.getenv("XDG_RUNTIME_DIR")) |xrd| {
             return resolveSocketPathForXrd(buf, xrd);

--- a/src/config/paths.zig
+++ b/src/config/paths.zig
@@ -18,6 +18,25 @@ pub fn dataDir() []const u8 {
     return "/usr/share/padctl";
 }
 
+/// Returns the directory for padctl log/state files.
+/// Priority: $LOGS_DIRECTORY (systemd LogsDirectory=) > $XDG_STATE_HOME/padctl
+/// > ~/.local/state/padctl > /var/log/padctl.
+/// Caller frees.
+pub fn stateDir(allocator: Allocator) ![]u8 {
+    // systemd sets LOGS_DIRECTORY=/var/log/padctl when LogsDirectory=padctl
+    // is in the unit file. This path is writable even under ProtectSystem=strict.
+    if (std.posix.getenv("LOGS_DIRECTORY")) |logs_dir| {
+        return allocator.dupe(u8, logs_dir);
+    }
+    if (std.posix.getenv("XDG_STATE_HOME")) |xdg| {
+        return std.fmt.allocPrint(allocator, "{s}/padctl", .{xdg});
+    }
+    const home = std.posix.getenv("HOME") orelse {
+        return allocator.dupe(u8, "/var/log/padctl");
+    };
+    return std.fmt.allocPrint(allocator, "{s}/.local/state/padctl", .{home});
+}
+
 /// Returns search dirs for devices/ in priority order: user > system > builtin.
 /// Caller frees the slice and each element.
 pub fn resolveDeviceConfigDirs(allocator: Allocator) ![][]const u8 {

--- a/src/config/user_config.zig
+++ b/src/config/user_config.zig
@@ -11,12 +11,18 @@ pub const DeviceEntry = struct {
     default_mapping: ?[]const u8 = null,
 };
 
+pub const DiagnosticsConfig = struct {
+    dump: bool = false,
+    max_log_size_mb: i64 = 100,
+};
+
 pub const UserConfig = struct {
     /// Schema version for forward/backward compatibility. Missing = legacy
     /// v0 (pre-versioned). Current version is 1. The loader accepts any
     /// version and logs a warning when it's newer than expected.
     version: ?i64 = null,
     device: ?[]DeviceEntry = null,
+    diagnostics: DiagnosticsConfig = .{},
 };
 
 pub const ParseResult = toml.Parsed(UserConfig);
@@ -289,6 +295,91 @@ test "findDefaultMapping: null when no devices" {
     defer result.deinit();
 
     try std.testing.expectEqual(@as(?[]const u8, null), findDefaultMapping(&result, "Any Device"));
+}
+
+test "user_config: diagnostics section parses with defaults" {
+    const allocator = std.testing.allocator;
+
+    const toml_str =
+        \\version = 1
+    ;
+    var parser = toml.Parser(UserConfig).init(allocator);
+    defer parser.deinit();
+    var result = try parser.parseString(toml_str);
+    defer result.deinit();
+
+    // Missing [diagnostics] → defaults: dump=false, max_log_size_mb=100
+    try std.testing.expectEqual(false, result.value.diagnostics.dump);
+    try std.testing.expectEqual(@as(i64, 100), result.value.diagnostics.max_log_size_mb);
+}
+
+test "user_config: diagnostics section parses explicit values" {
+    const allocator = std.testing.allocator;
+
+    const toml_str =
+        \\version = 1
+        \\
+        \\[diagnostics]
+        \\dump = true
+        \\max_log_size_mb = 50
+    ;
+    var parser = toml.Parser(UserConfig).init(allocator);
+    defer parser.deinit();
+    var result = try parser.parseString(toml_str);
+    defer result.deinit();
+
+    try std.testing.expectEqual(true, result.value.diagnostics.dump);
+    try std.testing.expectEqual(@as(i64, 50), result.value.diagnostics.max_log_size_mb);
+}
+
+test "user_config: diagnostics alongside device entries" {
+    const allocator = std.testing.allocator;
+
+    const toml_str =
+        \\version = 1
+        \\
+        \\[diagnostics]
+        \\dump = true
+        \\
+        \\[[device]]
+        \\name = "Test Pad"
+        \\default_mapping = "fps"
+    ;
+    var parser = toml.Parser(UserConfig).init(allocator);
+    defer parser.deinit();
+    var result = try parser.parseString(toml_str);
+    defer result.deinit();
+
+    try std.testing.expectEqual(true, result.value.diagnostics.dump);
+    try std.testing.expectEqualStrings("fps", findDefaultMapping(&result, "Test Pad").?);
+}
+
+test "user_config: unknown fields ignored (forward compatibility)" {
+    const allocator = std.testing.allocator;
+
+    const toml_str =
+        \\version = 2
+        \\some_future_field = "hello"
+        \\
+        \\[diagnostics]
+        \\dump = true
+        \\max_log_size_mb = 75
+        \\future_diag_option = 42
+        \\
+        \\[[device]]
+        \\name = "Pad"
+        \\default_mapping = "m1"
+        \\unknown_device_field = true
+    ;
+    var parser = toml.Parser(UserConfig).init(allocator);
+    defer parser.deinit();
+    var result = try parser.parseString(toml_str);
+    defer result.deinit();
+
+    // Known fields parsed correctly despite unknown siblings.
+    try std.testing.expectEqual(true, result.value.diagnostics.dump);
+    try std.testing.expectEqual(@as(i64, 75), result.value.diagnostics.max_log_size_mb);
+    try std.testing.expectEqualStrings("m1", findDefaultMapping(&result, "Pad").?);
 }
 
 test "findDefaultMapping: entry without default_mapping returns null" {

--- a/src/core/rumble_scheduler.zig
+++ b/src/core/rumble_scheduler.zig
@@ -91,6 +91,12 @@ pub const RumbleScheduler = struct {
         return false;
     }
 
+    /// Returns the raw slot array for diagnostic logging. The caller can
+    /// format it without pulling I/O into the scheduler.
+    pub fn dumpSlots(self: *const RumbleScheduler) [MAX_EFFECTS]i128 {
+        return self.slots;
+    }
+
     /// Returns the earliest finite pending deadline, or null if nothing is
     /// pending. An "infinite" slot does not contribute a deadline because
     /// it never fires from the timer.
@@ -293,4 +299,34 @@ test "rumble_scheduler: short-then-long overlap rearms for the longer deadline" 
     const second = sched.onTimerExpired(t1100);
     try testing.expect(second.emit_stop_frame);
     try testing.expectEqual(@as(?i128, null), second.next_deadline_ns);
+}
+
+test "rumble_scheduler: state identical regardless of dump_enabled" {
+    // The scheduler is pure logic — logging is external.
+    // Verify that the same sequence of operations produces identical
+    // slot state whether dump is on or off.
+    const padctl_log = @import("../log.zig");
+    const t0: i128 = 1_000_000_000;
+
+    // Run with dump off.
+    padctl_log.setEnabled(false);
+    var s1: RumbleScheduler = .{};
+    _ = s1.onPlay(0, 500, t0);
+    _ = s1.onPlay(1, 0, t0);
+    _ = s1.onStop(0);
+    const slots1 = s1.dumpSlots();
+
+    // Run with dump on.
+    padctl_log.setEnabled(true);
+    var s2: RumbleScheduler = .{};
+    _ = s2.onPlay(0, 500, t0);
+    _ = s2.onPlay(1, 0, t0);
+    _ = s2.onStop(0);
+    const slots2 = s2.dumpSlots();
+    padctl_log.setEnabled(false);
+
+    // Slot arrays must be identical.
+    for (slots1, slots2) |a, b| {
+        try testing.expectEqual(a, b);
+    }
 }

--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -333,8 +333,8 @@ const null_output_vtable = OutputDevice.VTable{
         fn f(_: *anyopaque, _: GamepadState) uinput.EmitError!void {}
     }.f,
     .poll_ff = struct {
-        fn f(_: *anyopaque) uinput.PollFfError!?FfEvent {
-            return null;
+        fn f(_: *anyopaque) uinput.PollFfError!uinput.FfEventBatch {
+            return .{};
         }
     }.f,
     .close = struct {

--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -141,6 +141,7 @@ pub const DeviceInstance = struct {
             }
         } else if (cfg.output) |*out_cfg| {
             uinput_dev = try UinputDevice.create(out_cfg);
+            uinput_dev.?.log_tag = cfg.device.name;
             if (out_cfg.force_feedback != null) {
                 errdefer uinput_dev.?.close();
                 try loop.addUinputFf(uinput_dev.?.pollFfFd());
@@ -267,6 +268,7 @@ pub const DeviceInstance = struct {
                 .poll_timeout_ms = self.poll_timeout_ms,
                 .generic_state = if (self.generic_state) |*gs| gs else null,
                 .generic_output = generic_output,
+                .device_tag = self.device_cfg.device.name,
             }) catch |err| {
                 std.log.err("event loop failed: {}", .{err});
                 break;

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -5,7 +5,8 @@ const linux = std.os.linux;
 const DeviceIO = @import("io/device_io.zig").DeviceIO;
 const interpreter_mod = @import("core/interpreter.zig");
 const Interpreter = interpreter_mod.Interpreter;
-const OutputDevice = @import("io/uinput.zig").OutputDevice;
+const uinput_mod = @import("io/uinput.zig");
+const OutputDevice = uinput_mod.OutputDevice;
 const AuxOutputDevice = @import("io/uinput.zig").AuxOutputDevice;
 const TouchpadOutputDevice = @import("io/uinput.zig").TouchpadOutputDevice;
 const generic = @import("core/generic.zig");
@@ -490,18 +491,28 @@ pub const EventLoop = struct {
                 armRumbleStopFd(self.rumble_stop_fd, result.next_deadline_ns);
             }
 
-            // Check uinput FF fd.
+            // Check uinput FF fd — process ALL events in the batch.
+            // Sequential pass: every event updates the scheduler in order.
+            // Per-effect pending plays track which effects are still active
+            // after all stops are applied. Only surviving plays get emitted.
             if (self.uinput_ff_slot) |slot| {
                 if (self.pollfds[slot].revents & posix.POLL.IN != 0) {
-                    const ff_result = ctx.output.pollFf() catch |err| blk: {
+                    const batch = ctx.output.pollFf() catch |err| blk: {
                         rumble_log.debug("[{s}] FF_ERROR: pollFf failed err={}", .{ ctx.device_tag, err });
-                        break :blk null;
+                        break :blk uinput_mod.FfEventBatch{};
                     };
-                    if (ff_result) |ff_ev| {
-                        const now_ns = monotonicNs();
-                        const min_interval_ns: i128 = 10_000_000; // 10ms
+                    const scheduler_on = autoStopEnabled(ctx.device_config);
+                    const now_ns = monotonicNs();
+
+                    // Per-effect pending play state. After scanning the batch,
+                    // only effects with non-null entries get emitted/scheduled.
+                    var pending_plays: [rumble_scheduler_mod.MAX_EFFECTS]?uinput_mod.FfEvent = @splat(null);
+                    // Track batch position of each pending play for ordering.
+                    var pending_play_pos: [rumble_scheduler_mod.MAX_EFFECTS]usize = @splat(0);
+                    var need_stop_frame = false;
+
+                    for (batch.slice(), 0..) |ff_ev, batch_idx| {
                         const is_stop = ff_ev.strong == 0 and ff_ev.weak == 0;
-                        const scheduler_on = autoStopEnabled(ctx.device_config);
 
                         rumble_log.debug("[{s}] FF_EVENT: id={d} strong={d} weak={d} dur={d}ms is_stop={} sched_on={}", .{
                             ctx.device_tag,    ff_ev.effect_id, ff_ev.strong, ff_ev.weak,
@@ -509,6 +520,7 @@ pub const EventLoop = struct {
                         });
 
                         if (is_stop) {
+                            // Process stop through the scheduler immediately.
                             if (scheduler_on) {
                                 const result = self.rumble_scheduler.onStop(ff_ev.effect_id);
                                 const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
@@ -516,60 +528,76 @@ pub const EventLoop = struct {
                                     ctx.device_tag,          ff_ev.effect_id,    result.emit_stop_frame,
                                     result.next_deadline_ns, slotStr(&slot_buf),
                                 });
-                                if (result.emit_stop_frame) {
-                                    if (ctx.allocator) |alloc| {
-                                        if (ctx.device_config) |dcfg| {
-                                            if (!emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
-                                                rumble_log.debug("[{s}] FF_STOP: stop frame FAILED to emit", .{ctx.device_tag});
-                                            }
-                                        }
-                                    }
-                                }
+                                if (result.emit_stop_frame) need_stop_frame = true;
                                 armRumbleStopFd(self.rumble_stop_fd, result.next_deadline_ns);
                             } else {
-                                rumble_log.debug("[{s}] FF_STOP: auto_stop disabled, direct zero frame", .{ctx.device_tag});
-                                if (ctx.allocator) |alloc| {
-                                    if (ctx.device_config) |dcfg| {
-                                        if (!emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
-                                            rumble_log.debug("[{s}] FF_STOP: direct zero frame FAILED to emit", .{ctx.device_tag});
-                                        }
+                                need_stop_frame = true;
+                            }
+                            // Cancel any pending play for this effect.
+                            pending_plays[ff_ev.effect_id] = null;
+                        } else {
+                            // Record play with batch position for ordering.
+                            pending_plays[ff_ev.effect_id] = ff_ev;
+                            pending_play_pos[ff_ev.effect_id] = batch_idx;
+                        }
+                    }
+
+                    // Emit the stop frame if the scheduler says nothing is playing.
+                    if (need_stop_frame) {
+                        if (ctx.allocator) |alloc| {
+                            if (ctx.device_config) |dcfg| {
+                                if (!emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
+                                    rumble_log.debug("[{s}] FF_STOP: stop frame FAILED to emit", .{ctx.device_tag});
+                                }
+                            }
+                        }
+                    }
+
+                    // Emit surviving plays and update the scheduler.
+                    // The last surviving play by batch position is emitted to HID.
+                    // All surviving plays are registered with the scheduler.
+                    var last_play: ?uinput_mod.FfEvent = null;
+                    var last_play_pos: usize = 0;
+                    for (pending_plays, pending_play_pos) |maybe_play, pos| {
+                        if (maybe_play) |play_ev| {
+                            if (scheduler_on) {
+                                const next_dl = self.rumble_scheduler.onPlay(
+                                    play_ev.effect_id,
+                                    play_ev.duration_ms,
+                                    now_ns,
+                                );
+                                armRumbleStopFd(self.rumble_stop_fd, next_dl);
+                            }
+                            // Pick the surviving play that appeared latest in the batch.
+                            if (last_play == null or pos >= last_play_pos) {
+                                last_play = play_ev;
+                                last_play_pos = pos;
+                            }
+                        }
+                    }
+
+                    if (last_play) |play_ev| {
+                        const min_interval_ns: i128 = 10_000_000;
+                        const elapsed = now_ns - self.last_rumble_ns;
+                        if (elapsed >= min_interval_ns) {
+                            if (ctx.allocator) |alloc| {
+                                if (ctx.device_config) |dcfg| {
+                                    if (emitRumbleFrame(ctx.devices, alloc, dcfg, play_ev.strong, play_ev.weak, ctx.device_tag)) {
+                                        self.last_rumble_ns = now_ns;
+                                        const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                                        rumble_log.debug("[{s}] FF_PLAY: emitted id={d} dur={d}ms {s}", .{
+                                            ctx.device_tag, play_ev.effect_id, play_ev.duration_ms, slotStr(&slot_buf),
+                                        });
+                                    } else {
+                                        rumble_log.debug("[{s}] FF_PLAY: emitRumbleFrame FAILED id={d}", .{ ctx.device_tag, play_ev.effect_id });
                                     }
                                 }
                             }
                         } else {
-                            // Play event: throttle applies to play frames.
-                            var forwarded = false;
-                            const elapsed = now_ns - self.last_rumble_ns;
-                            if (elapsed >= min_interval_ns) {
-                                if (ctx.allocator) |alloc| {
-                                    if (ctx.device_config) |dcfg| {
-                                        if (emitRumbleFrame(ctx.devices, alloc, dcfg, ff_ev.strong, ff_ev.weak, ctx.device_tag)) {
-                                            self.last_rumble_ns = now_ns;
-                                            forwarded = true;
-                                        } else {
-                                            rumble_log.debug("[{s}] FF_PLAY: emitRumbleFrame FAILED id={d}", .{ ctx.device_tag, ff_ev.effect_id });
-                                        }
-                                    }
-                                }
-                            } else {
-                                rumble_log.debug("[{s}] FF_PLAY: THROTTLED id={d} elapsed={d}ns", .{
-                                    ctx.device_tag,                                          ff_ev.effect_id,
-                                    @as(u64, @intCast(@min(elapsed, std.math.maxInt(u64)))),
-                                });
-                            }
-                            if (scheduler_on and forwarded) {
-                                const next_dl = self.rumble_scheduler.onPlay(
-                                    ff_ev.effect_id,
-                                    ff_ev.duration_ms,
-                                    now_ns,
-                                );
-                                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
-                                rumble_log.debug("[{s}] FF_PLAY: id={d} dur={d}ms next_dl={?d} {s}", .{
-                                    ctx.device_tag, ff_ev.effect_id,    ff_ev.duration_ms,
-                                    next_dl,        slotStr(&slot_buf),
-                                });
-                                armRumbleStopFd(self.rumble_stop_fd, next_dl);
-                            }
+                            rumble_log.debug("[{s}] FF_PLAY: THROTTLED id={d} elapsed={d}ns", .{
+                                ctx.device_tag,                                          play_ev.effect_id,
+                                @as(u64, @intCast(@min(elapsed, std.math.maxInt(u64)))),
+                            });
                         }
                     }
                 }
@@ -749,8 +777,8 @@ test "event_loop: EventLoop: Disconnected device causes loop to exit without pan
     // Noop OutputDevice
     const NoopOutput = struct {
         fn emit(_: *anyopaque, _: state.GamepadState) uinput.EmitError!void {}
-        fn pollFf(_: *anyopaque) uinput.PollFfError!?uinput.FfEvent {
-            return null;
+        fn pollFf(_: *anyopaque) uinput.PollFfError!uinput.FfEventBatch {
+            return .{};
         }
         fn close(_: *anyopaque) void {}
         const vtable = uinput.OutputDevice.VTable{ .emit = emit, .poll_ff = pollFf, .close = close };
@@ -921,8 +949,8 @@ test "event_loop: EventLoop timerfd: mapper.onTimerExpired invoked on timer expi
             .close = mockClose,
         };
         fn mockEmit(_: *anyopaque, _: state.GamepadState) uinput.EmitError!void {}
-        fn mockPollFf(_: *anyopaque) uinput.PollFfError!?uinput.FfEvent {
-            return null;
+        fn mockPollFf(_: *anyopaque) uinput.PollFfError!uinput.FfEventBatch {
+            return .{};
         }
         fn mockClose(_: *anyopaque) void {}
     };
@@ -1064,13 +1092,18 @@ const MockFfOutput = struct {
 
     fn mockEmit(_: *anyopaque, _: state.GamepadState) uinput.EmitError!void {}
 
-    fn mockPollFf(ptr: *anyopaque) uinput.PollFfError!?uinput.FfEvent {
+    fn mockPollFf(ptr: *anyopaque) uinput.PollFfError!uinput.FfEventBatch {
         const self: *MockFfOutput = @ptrCast(@alignCast(ptr));
         if (self.call_count == 0) {
             self.call_count += 1;
-            return self.ff_event;
+            var batch = uinput.FfEventBatch{};
+            if (self.ff_event) |ev| {
+                batch.events[0] = ev;
+                batch.len = 1;
+            }
+            return batch;
         }
-        return null;
+        return .{};
     }
 
     fn mockClose(_: *anyopaque) void {}
@@ -1284,7 +1317,7 @@ test "event_loop: config-driven FF command key — output.force_feedback.type ov
 // Regression test: stop frame must bypass throttle even within 10ms of a play frame.
 const MockFfOutputSeq = struct {
     allocator: std.mem.Allocator,
-    events: []const ?uinput.FfEvent,
+    events: []const uinput.FfEvent,
     call_count: usize = 0,
 
     fn outputDevice(self: *MockFfOutputSeq) uinput.OutputDevice {
@@ -1299,14 +1332,17 @@ const MockFfOutputSeq = struct {
 
     fn mockEmit(_: *anyopaque, _: state.GamepadState) uinput.EmitError!void {}
 
-    fn mockPollFf(ptr: *anyopaque) uinput.PollFfError!?uinput.FfEvent {
+    fn mockPollFf(ptr: *anyopaque) uinput.PollFfError!uinput.FfEventBatch {
         const self: *MockFfOutputSeq = @ptrCast(@alignCast(ptr));
         if (self.call_count < self.events.len) {
             const ev = self.events[self.call_count];
             self.call_count += 1;
-            return ev;
+            var batch = uinput.FfEventBatch{};
+            batch.events[0] = ev;
+            batch.len = 1;
+            return batch;
         }
-        return null;
+        return .{};
     }
 
     fn mockClose(_: *anyopaque) void {}
@@ -1319,7 +1355,7 @@ const MockFfOutputSeq = struct {
 /// test wants its second play frame to land AFTER the 10ms play-frame
 /// throttle window closes.
 const MockFfOutputDrain = struct {
-    events: []const ?uinput.FfEvent,
+    events: []const uinput.FfEvent,
     call_count: usize = 0,
     pipe_read: posix.fd_t,
 
@@ -1335,16 +1371,19 @@ const MockFfOutputDrain = struct {
 
     fn mockEmit(_: *anyopaque, _: state.GamepadState) uinput.EmitError!void {}
 
-    fn mockPollFf(ptr: *anyopaque) uinput.PollFfError!?uinput.FfEvent {
+    fn mockPollFf(ptr: *anyopaque) uinput.PollFfError!uinput.FfEventBatch {
         const self: *MockFfOutputDrain = @ptrCast(@alignCast(ptr));
         var buf: [1]u8 = undefined;
-        _ = posix.read(self.pipe_read, &buf) catch return null;
+        _ = posix.read(self.pipe_read, &buf) catch return uinput.FfEventBatch{};
         if (self.call_count < self.events.len) {
             const ev = self.events[self.call_count];
             self.call_count += 1;
-            return ev;
+            var batch = uinput.FfEventBatch{};
+            batch.events[0] = ev;
+            batch.len = 1;
+            return batch;
         }
-        return null;
+        return .{};
     }
 
     fn mockClose(_: *anyopaque) void {}
@@ -1372,10 +1411,9 @@ test "event_loop: stop frame forwarded even within 10ms throttle window" {
     const interp = Interpreter.init(&parsed.value);
 
     // play then stop — both within a single burst; stop must not be throttled.
-    const seq = [_]?uinput.FfEvent{
+    const seq = [_]uinput.FfEvent{
         .{ .effect_type = 0x50, .strong = 0x8000, .weak = 0x4000 }, // play
         .{ .effect_type = 0x50, .strong = 0, .weak = 0 }, // stop
-        null,
     };
     var ff_out = MockFfOutputSeq{ .allocator = allocator, .events = &seq };
 
@@ -1482,11 +1520,10 @@ test "event_loop: explicit stop of one of two overlapping effects does not cut t
     // Expected: three HID frames — play A, play B, then ONE stop frame
     // when A's 300ms auto-stop deadline fires. No stop frame from the
     // explicit stop of B, because A was still live.
-    const seq = [_]?uinput.FfEvent{
+    const seq = [_]uinput.FfEvent{
         .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 300 },
         .{ .effect_type = 0x50, .effect_id = 1, .strong = 0x4000, .weak = 0x2000, .duration_ms = 100 },
         .{ .effect_type = 0x50, .effect_id = 1, .strong = 0, .weak = 0, .duration_ms = 0 },
-        null,
     };
     var ff_out = MockFfOutputDrain{ .events = &seq, .pipe_read = ff_pipe[0] };
 
@@ -1565,9 +1602,8 @@ test "event_loop: auto_stop=false never emits a scheduler-driven stop frame" {
     // Single play with a short duration. Because the device opted out,
     // the scheduler must NOT arm the timerfd and NOT emit an auto-stop
     // frame — only the play frame from the pollFf path should land.
-    const seq = [_]?uinput.FfEvent{
+    const seq = [_]uinput.FfEvent{
         .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 25 },
-        null,
     };
     var ff_out = MockFfOutputSeq{ .allocator = allocator, .events = &seq };
 
@@ -1633,10 +1669,9 @@ test "event_loop: explicit stop before duration_ms disarms auto-stop (no double 
     // ms later. The scheduler must cancel the 200ms auto-stop deadline so
     // that only one stop frame (the explicit one) hits HID — not a second
     // redundant stop from the timer firing later.
-    const seq = [_]?uinput.FfEvent{
+    const seq = [_]uinput.FfEvent{
         .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 200 },
         .{ .effect_type = 0x50, .effect_id = 0, .strong = 0, .weak = 0, .duration_ms = 0 },
-        null,
     };
     var ff_out = MockFfOutputSeq{ .allocator = allocator, .events = &seq };
 
@@ -1708,9 +1743,8 @@ test "event_loop: rumble auto-stop emits stop frame after duration_ms elapses" {
     // The client deliberately does NOT send an explicit stop — matching
     // what Steam/SDL does when relying on the kernel's ff-memless auto-stop
     // for real controllers. padctl must emit its own stop frame.
-    const seq = [_]?uinput.FfEvent{
+    const seq = [_]uinput.FfEvent{
         .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 25 },
-        null,
     };
     var ff_out = MockFfOutputSeq{ .allocator = allocator, .events = &seq };
 
@@ -1777,10 +1811,9 @@ test "event_loop: play after stop within throttle window is forwarded" {
     const interp = Interpreter.init(&parsed.value);
 
     // stop at T=0, then play at T≈5ms (well within 10ms throttle window)
-    const seq = [_]?uinput.FfEvent{
+    const seq = [_]uinput.FfEvent{
         .{ .effect_type = 0x50, .strong = 0, .weak = 0 }, // stop
         .{ .effect_type = 0x50, .strong = 0x8000, .weak = 0x4000 }, // play
-        null,
     };
     var ff_out = MockFfOutputSeq{ .allocator = allocator, .events = &seq };
 
@@ -2098,4 +2131,159 @@ test "event_loop: FF scheduler state identical with dump on vs off" {
     }
     // HID writes must be identical (same bytes sent to device).
     try testing.expectEqualSlices(u8, r_off.write_log, r_on.write_log);
+}
+
+// --- Phase 7: multi-event batch test ---
+
+/// Mock that returns a full batch of multiple events in a single pollFf call.
+const MockFfOutputBatch = struct {
+    batch: uinput.FfEventBatch,
+    call_count: usize = 0,
+
+    fn outputDevice(self: *MockFfOutputBatch) uinput.OutputDevice {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = uinput.OutputDevice.VTable{
+        .emit = mockEmit,
+        .poll_ff = mockPollFf,
+        .close = mockClose,
+    };
+
+    fn mockEmit(_: *anyopaque, _: state.GamepadState) uinput.EmitError!void {}
+
+    fn mockPollFf(ptr: *anyopaque) uinput.PollFfError!uinput.FfEventBatch {
+        const self: *MockFfOutputBatch = @ptrCast(@alignCast(ptr));
+        if (self.call_count == 0) {
+            self.call_count += 1;
+            return self.batch;
+        }
+        return .{};
+    }
+
+    fn mockClose(_: *anyopaque) void {}
+};
+
+test "event_loop: batch [PLAY id=0, STOP id=0, PLAY id=1] — scheduler has only id=1 active" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var mock_dev = try MockDeviceIO.init(allocator, &.{});
+    defer mock_dev.deinit();
+    const dev = mock_dev.deviceIO();
+    try loop.addDevice(dev);
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    // Build a batch: PLAY id=0, STOP id=0, PLAY id=1
+    var batch = uinput.FfEventBatch{};
+    batch.events[0] = .{ .effect_type = 0x50, .strong = 0x8000, .weak = 0, .effect_id = 0, .duration_ms = 300 };
+    batch.events[1] = .{ .effect_type = 0x50, .strong = 0, .weak = 0, .effect_id = 0, .duration_ms = 0 };
+    batch.events[2] = .{ .effect_type = 0x50, .strong = 0x4000, .weak = 0, .effect_id = 1, .duration_ms = 500 };
+    batch.len = 3;
+
+    var ff_out = MockFfOutputBatch{ .batch = batch };
+    var devs = [_]DeviceIO{dev};
+
+    const RunCtx2 = struct { l: *EventLoop, d: []DeviceIO, i: *const Interpreter, f: *MockFfOutputBatch, c: *const device_mod.DeviceConfig, a: std.mem.Allocator };
+    var ctx = RunCtx2{ .l = &loop, .d = &devs, .i = &interp, .f = &ff_out, .c = &parsed.value, .a = allocator };
+
+    const thread = try std.Thread.spawn(.{}, struct {
+        fn run(c: *RunCtx2) !void {
+            try c.l.run(.{
+                .devices = c.d,
+                .interpreter = c.i,
+                .output = c.f.outputDevice(),
+                .allocator = c.a,
+                .device_config = c.c,
+                .poll_timeout_ms = 100,
+            });
+        }
+    }.run, .{&ctx});
+
+    // Signal FF fd ready, then stop.
+    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+    std.Thread.sleep(30 * std.time.ns_per_ms);
+    loop.stop();
+    thread.join();
+
+    // Scheduler: id=0 was stopped (slot cleared), id=1 should be active.
+    const slots = loop.rumble_scheduler.dumpSlots();
+    try testing.expectEqual(@as(i128, 0), slots[0]); // id=0 cleared by STOP
+    try testing.expect(slots[1] != 0); // id=1 active (PLAY)
+
+    // HID write log must contain frames (stop frame + play frame for id=1).
+    // The exact byte layout depends on the TOML template, but we must have
+    // at least 2 frames (8 bytes each for the ff_toml template).
+    try testing.expect(mock_dev.write_log.items.len >= 8);
+}
+
+test "event_loop: batch [PLAY id=0, PLAY id=1, STOP id=1] — id=0 survives, id=1 cancelled" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var mock_dev = try MockDeviceIO.init(allocator, &.{});
+    defer mock_dev.deinit();
+    const dev = mock_dev.deviceIO();
+    try loop.addDevice(dev);
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    // Build batch: PLAY id=0, PLAY id=1, STOP id=1
+    // Sequential semantics: id=0 should remain active, id=1 cancelled by stop.
+    var batch = uinput.FfEventBatch{};
+    batch.events[0] = .{ .effect_type = 0x50, .strong = 0x6000, .weak = 0, .effect_id = 0, .duration_ms = 400 };
+    batch.events[1] = .{ .effect_type = 0x50, .strong = 0x2000, .weak = 0, .effect_id = 1, .duration_ms = 200 };
+    batch.events[2] = .{ .effect_type = 0x50, .strong = 0, .weak = 0, .effect_id = 1, .duration_ms = 0 };
+    batch.len = 3;
+
+    var ff_out = MockFfOutputBatch{ .batch = batch };
+    var devs = [_]DeviceIO{dev};
+
+    const RunCtx3 = struct { l: *EventLoop, d: []DeviceIO, i: *const Interpreter, f: *MockFfOutputBatch, c: *const device_mod.DeviceConfig, a: std.mem.Allocator };
+    var ctx = RunCtx3{ .l = &loop, .d = &devs, .i = &interp, .f = &ff_out, .c = &parsed.value, .a = allocator };
+
+    const thread = try std.Thread.spawn(.{}, struct {
+        fn run(c: *RunCtx3) !void {
+            try c.l.run(.{
+                .devices = c.d,
+                .interpreter = c.i,
+                .output = c.f.outputDevice(),
+                .allocator = c.a,
+                .device_config = c.c,
+                .poll_timeout_ms = 100,
+            });
+        }
+    }.run, .{&ctx});
+
+    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+    std.Thread.sleep(30 * std.time.ns_per_ms);
+    loop.stop();
+    thread.join();
+
+    // Scheduler: id=0 should be active (play survived), id=1 should be cleared (stopped).
+    const slots = loop.rumble_scheduler.dumpSlots();
+    try testing.expect(slots[0] != 0); // id=0 active — the key assertion
+    try testing.expectEqual(@as(i128, 0), slots[1]); // id=1 cleared by STOP
+
+    // HID: play frame for id=0 should have been emitted.
+    try testing.expect(mock_dev.write_log.items.len >= 8);
 }

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -25,6 +25,7 @@ const wasm_runtime = @import("wasm/runtime.zig");
 pub const WasmPlugin = wasm_runtime.WasmPlugin;
 const rumble_scheduler_mod = @import("core/rumble_scheduler.zig");
 const RumbleScheduler = rumble_scheduler_mod.RumbleScheduler;
+const rumble_log = std.log.scoped(.rumble);
 
 // signalfd(0) + stop_pipe(1) + macro timerfd(2) + rumble_stop_fd(3) + per-interface fds + uinput FF fd
 pub const MAX_FDS = 11;
@@ -92,7 +93,13 @@ fn armRumbleStopFd(fd: posix.fd_t, deadline_ns: ?i128) void {
         },
         .it_interval = .{ .sec = 0, .nsec = 0 },
     };
-    _ = linux.timerfd_settime(fd, .{ .ABSTIME = true }, &spec, null);
+    const rc = linux.timerfd_settime(fd, .{ .ABSTIME = true }, &spec, null);
+    if (rc != 0) {
+        const errno = std.posix.errno(rc);
+        rumble_log.debug("TIMERFD: timerfd_settime FAILED errno={s} deadline={d}", .{
+            @tagName(errno), target,
+        });
+    }
 }
 
 /// Returns true when this device's config wants userspace rumble auto-stop.
@@ -103,6 +110,40 @@ fn autoStopEnabled(dcfg: ?*const DeviceConfig) bool {
     const out = cfg.output orelse return true;
     const ff = out.force_feedback orelse return true;
     return ff.auto_stop;
+}
+
+/// Format scheduler slot state with relative deltas from now_ns.
+/// Shows: slots=[0:INF, 1:+250ms, 3:+1200ms] or slots=[empty]
+fn fmtSchedulerSlots(slots: [rumble_scheduler_mod.MAX_EFFECTS]i128, now_ns: i128) [256]u8 {
+    var buf: [256]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const w = fbs.writer();
+    w.writeAll("slots=[") catch {};
+    var any = false;
+    for (slots, 0..) |s, i| {
+        if (s == 0) continue;
+        if (any) w.writeAll(", ") catch {};
+        any = true;
+        if (s == RumbleScheduler.INFINITE) {
+            w.print("{d}:INF", .{i}) catch {};
+        } else {
+            const delta_ms = @divFloor(s - now_ns, std.time.ns_per_ms);
+            w.print("{d}:{s}{d}ms", .{ i, if (delta_ms >= 0) "+" else "", delta_ms }) catch {};
+        }
+    }
+    if (!any) w.writeAll("empty") catch {};
+    w.writeAll("]") catch {};
+    const written = fbs.getWritten().len;
+    if (written < buf.len) buf[written] = 0;
+    return buf;
+}
+
+fn slotStr(buf: *const [256]u8) []const u8 {
+    // Find the null terminator or end of buffer.
+    for (buf, 0..) |b, i| {
+        if (b == 0) return buf[0..i];
+    }
+    return buf;
 }
 
 /// Write a single rumble frame (strong, weak) to the HID device using the
@@ -116,6 +157,7 @@ fn emitRumbleFrame(
     dcfg: *const DeviceConfig,
     strong: u16,
     weak: u16,
+    tag: []const u8,
 ) bool {
     const cmds = dcfg.commands orelse return false;
     const ff_type = if (dcfg.output) |out|
@@ -132,7 +174,22 @@ fn emitRumbleFrame(
     const bytes = fillTemplate(alloc, cmd.template, &params) catch return false;
     defer alloc.free(bytes);
     if (cmd.checksum) |*cs| applyChecksum(bytes, cs);
-    devices[iface_idx].write(bytes) catch return false;
+
+    // Log the full post-checksum HID frame.
+    var hex_buf: [512]u8 = undefined;
+    var hex_fbs = std.io.fixedBufferStream(&hex_buf);
+    const hw = hex_fbs.writer();
+    for (bytes) |b| {
+        hw.print("{x:0>2} ", .{b}) catch break;
+    }
+    rumble_log.debug("[{s}] HID_WRITE: cmd={s} strong={d} weak={d} iface={d} len={d} frame=[{s}]", .{
+        tag, ff_type, strong, weak, iface_idx, bytes.len, hex_fbs.getWritten(),
+    });
+
+    devices[iface_idx].write(bytes) catch |err| {
+        rumble_log.debug("[{s}] HID_WRITE: FAILED cmd={s} strong={d} weak={d} err={}", .{ tag, ff_type, strong, weak, err });
+        return false;
+    };
     return true;
 }
 
@@ -142,7 +199,10 @@ pub fn disarmTimer(fd: posix.fd_t) void {
         .it_value = .{ .sec = 0, .nsec = 0 },
         .it_interval = .{ .sec = 0, .nsec = 0 },
     };
-    _ = linux.timerfd_settime(fd, .{}, &spec, null);
+    const rc = linux.timerfd_settime(fd, .{}, &spec, null);
+    if (rc != 0) {
+        rumble_log.debug("TIMERFD: disarm FAILED rc={d}", .{rc});
+    }
 }
 
 pub const EventLoopContext = struct {
@@ -160,6 +220,8 @@ pub const EventLoopContext = struct {
     wasm_override_report: bool = false,
     generic_state: ?*GenericDeviceState = null,
     generic_output: ?GenericOutputDevice = null,
+    /// Device name for log correlation (set from device_config.device.name).
+    device_tag: []const u8 = "unknown",
 };
 
 fn i64ToParamValue(v: ?i64) u16 {
@@ -253,6 +315,7 @@ pub const EventLoop = struct {
     gamepad_state: state.GamepadState,
     last_ts: i128,
     last_rumble_ns: i128,
+    last_heartbeat_ns: i128 = 0,
 
     pub fn init() !EventLoop {
         var mask = posix.sigemptyset();
@@ -370,6 +433,15 @@ pub const EventLoop = struct {
             const dt_ms: u32 = @intCast(@min(100, @max(1, @divFloor(dt_ns, 1_000_000))));
             self.last_ts = now;
 
+            // Heartbeat: log every 60s to confirm daemon is alive and trigger
+            // log file reopen if the file was deleted.
+            const heartbeat_interval: i128 = 60 * std.time.ns_per_s;
+            if (now - self.last_heartbeat_ns >= heartbeat_interval) {
+                self.last_heartbeat_ns = now;
+                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now);
+                rumble_log.debug("[{s}] HEARTBEAT: alive {s}", .{ ctx.device_tag, slotStr(&slot_buf) });
+            }
+
             // Check signalfd (slot 0)
             if (self.pollfds[0].revents & posix.POLL.IN != 0) {
                 var siginfo: [signalfd_siginfo_size]u8 = undefined;
@@ -397,19 +469,21 @@ pub const EventLoop = struct {
             }
 
             // Check rumble auto-stop timerfd (slot 3).
-            // When the scheduler's earliest pending deadline fires, clear
-            // expired slots and emit a single stop frame to HID if no
-            // effects remain playing. Rearm (or disarm) for the next
-            // deadline.
             if (self.pollfds[3].revents & posix.POLL.IN != 0) {
                 var rs_expiry: [8]u8 = undefined;
                 _ = posix.read(self.rumble_stop_fd, &rs_expiry) catch {};
                 const now_ns = monotonicNs();
                 const result = self.rumble_scheduler.onTimerExpired(now_ns);
+                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                rumble_log.debug("[{s}] TIMERFD: expired now={d} emit_stop={} next_dl={?d} {s}", .{
+                    ctx.device_tag, now_ns, result.emit_stop_frame, result.next_deadline_ns, slotStr(&slot_buf),
+                });
                 if (result.emit_stop_frame) {
                     if (ctx.allocator) |alloc| {
                         if (ctx.device_config) |dcfg| {
-                            _ = emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
+                            if (!emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
+                                rumble_log.debug("[{s}] TIMERFD: stop frame FAILED to emit", .{ctx.device_tag});
+                            }
                         }
                     }
                 }
@@ -417,61 +491,71 @@ pub const EventLoop = struct {
             }
 
             // Check uinput FF fd.
-            //
-            // Play and stop events take different paths because overlapping
-            // effects change the stop semantics: an explicit stop for one of
-            // several still-playing effects must NOT write a zero frame to
-            // HID — otherwise the long effect's motor gets cut off while the
-            // scheduler still considers it live.
             if (self.uinput_ff_slot) |slot| {
                 if (self.pollfds[slot].revents & posix.POLL.IN != 0) {
-                    if (ctx.output.pollFf() catch null) |ff_ev| {
+                    const ff_result = ctx.output.pollFf() catch |err| blk: {
+                        rumble_log.debug("[{s}] FF_ERROR: pollFf failed err={}", .{ ctx.device_tag, err });
+                        break :blk null;
+                    };
+                    if (ff_result) |ff_ev| {
                         const now_ns = monotonicNs();
                         const min_interval_ns: i128 = 10_000_000; // 10ms
                         const is_stop = ff_ev.strong == 0 and ff_ev.weak == 0;
                         const scheduler_on = autoStopEnabled(ctx.device_config);
 
+                        rumble_log.debug("[{s}] FF_EVENT: id={d} strong={d} weak={d} dur={d}ms is_stop={} sched_on={}", .{
+                            ctx.device_tag,    ff_ev.effect_id, ff_ev.strong, ff_ev.weak,
+                            ff_ev.duration_ms, is_stop,         scheduler_on,
+                        });
+
                         if (is_stop) {
                             if (scheduler_on) {
-                                // Update scheduler first. Only emit a zero
-                                // frame when the stop transitions the whole
-                                // scheduler to "nothing playing"; otherwise
-                                // another effect is still live.
                                 const result = self.rumble_scheduler.onStop(ff_ev.effect_id);
+                                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                                rumble_log.debug("[{s}] FF_STOP: id={d} emit_stop={} next_dl={?d} {s}", .{
+                                    ctx.device_tag,          ff_ev.effect_id,    result.emit_stop_frame,
+                                    result.next_deadline_ns, slotStr(&slot_buf),
+                                });
                                 if (result.emit_stop_frame) {
                                     if (ctx.allocator) |alloc| {
                                         if (ctx.device_config) |dcfg| {
-                                            _ = emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
+                                            if (!emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
+                                                rumble_log.debug("[{s}] FF_STOP: stop frame FAILED to emit", .{ctx.device_tag});
+                                            }
                                         }
                                     }
                                 }
                                 armRumbleStopFd(self.rumble_stop_fd, result.next_deadline_ns);
                             } else {
-                                // auto_stop disabled: legacy fall-through,
-                                // trust the client to know what it's doing.
+                                rumble_log.debug("[{s}] FF_STOP: auto_stop disabled, direct zero frame", .{ctx.device_tag});
                                 if (ctx.allocator) |alloc| {
                                     if (ctx.device_config) |dcfg| {
-                                        _ = emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
+                                        if (!emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
+                                            rumble_log.debug("[{s}] FF_STOP: direct zero frame FAILED to emit", .{ctx.device_tag});
+                                        }
                                     }
                                 }
                             }
                         } else {
                             // Play event: throttle applies to play frames.
-                            // The scheduler must only record the deadline when
-                            // the frame is actually forwarded to HID — otherwise
-                            // a throttled (dropped) frame could replace an
-                            // active deadline and later emit a stop for an
-                            // effect the device never received.
                             var forwarded = false;
-                            if (now_ns - self.last_rumble_ns >= min_interval_ns) {
+                            const elapsed = now_ns - self.last_rumble_ns;
+                            if (elapsed >= min_interval_ns) {
                                 if (ctx.allocator) |alloc| {
                                     if (ctx.device_config) |dcfg| {
-                                        if (emitRumbleFrame(ctx.devices, alloc, dcfg, ff_ev.strong, ff_ev.weak)) {
+                                        if (emitRumbleFrame(ctx.devices, alloc, dcfg, ff_ev.strong, ff_ev.weak, ctx.device_tag)) {
                                             self.last_rumble_ns = now_ns;
                                             forwarded = true;
+                                        } else {
+                                            rumble_log.debug("[{s}] FF_PLAY: emitRumbleFrame FAILED id={d}", .{ ctx.device_tag, ff_ev.effect_id });
                                         }
                                     }
                                 }
+                            } else {
+                                rumble_log.debug("[{s}] FF_PLAY: THROTTLED id={d} elapsed={d}ns", .{
+                                    ctx.device_tag,                                          ff_ev.effect_id,
+                                    @as(u64, @intCast(@min(elapsed, std.math.maxInt(u64)))),
+                                });
                             }
                             if (scheduler_on and forwarded) {
                                 const next_dl = self.rumble_scheduler.onPlay(
@@ -479,6 +563,11 @@ pub const EventLoop = struct {
                                     ff_ev.duration_ms,
                                     now_ns,
                                 );
+                                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                                rumble_log.debug("[{s}] FF_PLAY: id={d} dur={d}ms next_dl={?d} {s}", .{
+                                    ctx.device_tag, ff_ev.effect_id,    ff_ev.duration_ms,
+                                    next_dl,        slotStr(&slot_buf),
+                                });
                                 armRumbleStopFd(self.rumble_stop_fd, next_dl);
                             }
                         }
@@ -496,6 +585,11 @@ pub const EventLoop = struct {
                 const has_hup = revents & (posix.POLL.HUP | posix.POLL.ERR) != 0;
 
                 if (!has_in and has_hup) {
+                    const disc_now = monotonicNs();
+                    const disc_slots = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), disc_now);
+                    rumble_log.debug("[{s}] DISCONNECT: HUP/ERR on device slot {d} {s}", .{
+                        ctx.device_tag, slot, slotStr(&disc_slots),
+                    });
                     self.disconnected = true;
                     self.running = false;
                     break;
@@ -1913,4 +2007,95 @@ test "event_loop: applyAdaptiveTrigger: custom command_prefix routes correctly" 
     try testing.expectEqual(@as(u8, 0xaa), mock_dev.write_log.items[0]);
     try testing.expectEqual(@as(u8, 10), mock_dev.write_log.items[1]);
     try testing.expectEqual(@as(u8, 20), mock_dev.write_log.items[2]);
+}
+
+test "event_loop: FF scheduler state identical with dump on vs off" {
+    // Run the same FF PLAY event through two separate event loops — one
+    // with dump enabled, one disabled — and verify the scheduler state
+    // and HID write output are identical.
+    const padctl_log = @import("log.zig");
+    const allocator = testing.allocator;
+
+    const RunResult = struct {
+        scheduler_slots: [rumble_scheduler_mod.MAX_EFFECTS]i128,
+        write_log: []u8,
+    };
+
+    const runOnce = struct {
+        fn go(alloc: std.mem.Allocator, dump_on: bool) !RunResult {
+            padctl_log.setEnabled(dump_on);
+            defer padctl_log.setEnabled(false);
+
+            var loop = try EventLoop.initManaged();
+            defer loop.deinit();
+
+            var mock_dev = try MockDeviceIO.init(alloc, &.{});
+            defer mock_dev.deinit();
+            const dev = mock_dev.deviceIO();
+            try loop.addDevice(dev);
+
+            const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+            defer posix.close(ff_pipe[0]);
+            defer posix.close(ff_pipe[1]);
+            try loop.addUinputFf(ff_pipe[0]);
+
+            const parsed = try device_mod.parseString(alloc, ff_toml);
+            defer parsed.deinit();
+            const interp = Interpreter.init(&parsed.value);
+
+            var ff_out = MockFfOutput{
+                .allocator = alloc,
+                .ff_event = .{ .effect_type = 0x50, .strong = 0x8000, .weak = 0x4000, .duration_ms = 300 },
+            };
+
+            var devs = [_]DeviceIO{dev};
+
+            // Use a pointer to stack-local context to avoid anonymous struct type issues.
+            const Ctx2 = struct { l: *EventLoop, d: []DeviceIO, i: *const Interpreter, f: *MockFfOutput, c: *const device_mod.DeviceConfig, a: std.mem.Allocator };
+            var run_ctx = Ctx2{ .l = &loop, .d = &devs, .i = &interp, .f = &ff_out, .c = &parsed.value, .a = alloc };
+            const thread = try std.Thread.spawn(.{}, struct {
+                fn run(ctx: *Ctx2) !void {
+                    try ctx.l.run(.{
+                        .devices = ctx.d,
+                        .interpreter = ctx.i,
+                        .output = ctx.f.outputDevice(),
+                        .allocator = ctx.a,
+                        .device_config = ctx.c,
+                        .poll_timeout_ms = 100,
+                    });
+                }
+            }.run, .{&run_ctx});
+
+            _ = try posix.write(ff_pipe[1], &[_]u8{1});
+            std.Thread.sleep(20 * std.time.ns_per_ms);
+            loop.stop();
+            thread.join();
+
+            const log_copy = try alloc.dupe(u8, mock_dev.write_log.items);
+            return RunResult{
+                .scheduler_slots = loop.rumble_scheduler.dumpSlots(),
+                .write_log = log_copy,
+            };
+        }
+    }.go;
+
+    const r_off = try runOnce(allocator, false);
+    defer allocator.free(r_off.write_log);
+    const r_on = try runOnce(allocator, true);
+    defer allocator.free(r_on.write_log);
+
+    // Scheduler slot activity pattern must be identical (which slots are
+    // active/inactive). Exact timestamps differ between runs because they
+    // use the real monotonic clock, so we compare structural shape.
+    for (r_off.scheduler_slots, r_on.scheduler_slots) |a, b| {
+        const a_active = a != 0;
+        const b_active = b != 0;
+        try testing.expectEqual(a_active, b_active);
+        // Both infinite or both finite.
+        const a_inf = a == rumble_scheduler_mod.RumbleScheduler.INFINITE;
+        const b_inf = b == rumble_scheduler_mod.RumbleScheduler.INFINITE;
+        try testing.expectEqual(a_inf, b_inf);
+    }
+    // HID writes must be identical (same bytes sent to device).
+    try testing.expectEqualSlices(u8, r_off.write_log, r_on.write_log);
 }

--- a/src/io/control_socket.zig
+++ b/src/io/control_socket.zig
@@ -146,6 +146,9 @@ pub const CommandTag = enum {
     status,
     list,
     devices,
+    dump_on,
+    dump_off,
+    dump_status,
     unknown,
 };
 
@@ -182,6 +185,12 @@ pub fn parseCommand(raw: []const u8) Command {
         return .{ .tag = .list };
     } else if (std.ascii.eqlIgnoreCase(verb, "DEVICES")) {
         return .{ .tag = .devices };
+    } else if (std.ascii.eqlIgnoreCase(verb, "DUMP")) {
+        const mode = it.next() orelse return .{ .tag = .unknown };
+        if (std.ascii.eqlIgnoreCase(mode, "ON")) return .{ .tag = .dump_on };
+        if (std.ascii.eqlIgnoreCase(mode, "OFF")) return .{ .tag = .dump_off };
+        if (std.ascii.eqlIgnoreCase(mode, "STATUS")) return .{ .tag = .dump_status };
+        return .{ .tag = .unknown };
     }
     return .{ .tag = .unknown };
 }
@@ -242,6 +251,38 @@ test "control_socket: parseCommand: case insensitive" {
     const cmd = parseCommand("switch FPS\n");
     try testing.expectEqual(CommandTag.switch_mapping, cmd.tag);
     try testing.expectEqualStrings("FPS", cmd.name);
+}
+
+test "control_socket: parseCommand: DUMP ON" {
+    const cmd = parseCommand("DUMP ON\n");
+    try testing.expectEqual(CommandTag.dump_on, cmd.tag);
+}
+
+test "control_socket: parseCommand: DUMP OFF" {
+    const cmd = parseCommand("DUMP OFF\n");
+    try testing.expectEqual(CommandTag.dump_off, cmd.tag);
+}
+
+test "control_socket: parseCommand: DUMP case insensitive" {
+    const on = parseCommand("dump on\n");
+    try testing.expectEqual(CommandTag.dump_on, on.tag);
+    const off = parseCommand("Dump Off\n");
+    try testing.expectEqual(CommandTag.dump_off, off.tag);
+}
+
+test "control_socket: parseCommand: DUMP STATUS" {
+    const cmd = parseCommand("DUMP STATUS\n");
+    try testing.expectEqual(CommandTag.dump_status, cmd.tag);
+}
+
+test "control_socket: parseCommand: DUMP without arg is unknown" {
+    const cmd = parseCommand("DUMP\n");
+    try testing.expectEqual(CommandTag.unknown, cmd.tag);
+}
+
+test "control_socket: parseCommand: DUMP invalid arg is unknown" {
+    const cmd = parseCommand("DUMP MAYBE\n");
+    try testing.expectEqual(CommandTag.unknown, cmd.tag);
 }
 
 test "control_socket: parseCommand: SWITCH missing name" {

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -68,6 +68,17 @@ pub const FfEvent = struct {
     duration_ms: u16 = 0,
 };
 
+pub const FfEventBatch = struct {
+    events: [MAX_BATCH]FfEvent = undefined,
+    len: usize = 0,
+
+    pub const MAX_BATCH = 32;
+
+    pub fn slice(self: *const FfEventBatch) []const FfEvent {
+        return self.events[0..self.len];
+    }
+};
+
 pub const EmitError = error{ WriteFailed, DeviceGone };
 pub const PollFfError = error{ ReadFailed, DeviceGone };
 
@@ -77,7 +88,7 @@ pub const OutputDevice = struct {
 
     pub const VTable = struct {
         emit: *const fn (ptr: *anyopaque, s: state.GamepadState) EmitError!void,
-        poll_ff: *const fn (ptr: *anyopaque) PollFfError!?FfEvent,
+        poll_ff: *const fn (ptr: *anyopaque) PollFfError!FfEventBatch,
         close: *const fn (ptr: *anyopaque) void,
     };
 
@@ -85,7 +96,7 @@ pub const OutputDevice = struct {
         return self.vtable.emit(self.ptr, s);
     }
 
-    pub fn pollFf(self: OutputDevice) PollFfError!?FfEvent {
+    pub fn pollFf(self: OutputDevice) PollFfError!FfEventBatch {
         return self.vtable.poll_ff(self.ptr);
     }
 
@@ -122,6 +133,9 @@ pub const UinputDevice = struct {
     prev: state.GamepadState = .{},
     // button_codes[i] = BTN code for ButtonId with tag value i (0 = not mapped)
     button_codes: [BUTTON_COUNT]u16,
+    /// Buffered event from a previous pollFf call when the batch was full.
+    /// Processed first on the next pollFf call.
+    pending_ff: ?FfEvent = null,
     // ABS axis info: parallel arrays indexed by OutputConfig axes order
     axis_codes: [16]u16 = undefined,
     axis_state_offsets: [16]AxisStateField = undefined,
@@ -293,7 +307,7 @@ pub const UinputDevice = struct {
         self.emit(s) catch return error.WriteFailed;
     }
 
-    fn pollFfVtable(ptr: *anyopaque) PollFfError!?FfEvent {
+    fn pollFfVtable(ptr: *anyopaque) PollFfError!FfEventBatch {
         const self: *UinputDevice = @ptrCast(@alignCast(ptr));
         return self.pollFf() catch return error.ReadFailed;
     }
@@ -365,11 +379,18 @@ pub const UinputDevice = struct {
         return self.fd;
     }
 
-    pub fn pollFf(self: *UinputDevice) !?FfEvent {
-        var result: ?FfEvent = null;
+    pub fn pollFf(self: *UinputDevice) !FfEventBatch {
+        var batch = FfEventBatch{};
         var ev_count: u32 = 0;
-        var ff_count: u32 = 0;
-        var overwrite_count: u32 = 0;
+
+        // Drain any event buffered from a previous overflow.
+        if (self.pending_ff) |pev| {
+            batch.events[0] = pev;
+            batch.len = 1;
+            self.pending_ff = null;
+            rumble_log.debug("[{s}] pollFf: dequeued pending event id={d}", .{ self.log_tag, pev.effect_id });
+        }
+
         while (true) {
             var ev: c.input_event = undefined;
             const n = std.posix.read(self.fd, std.mem.asBytes(&ev)) catch |err| switch (err) {
@@ -424,53 +445,45 @@ pub const UinputDevice = struct {
                 }
             } else if (ev.type == c.EV_FF) {
                 const id: usize = @intCast(ev.code);
-                // Out-of-range FF effect ids must be silently dropped.
                 if (id >= 16) {
                     rumble_log.debug("[{s}] pollFf: OUT_OF_RANGE code={d} value={d} DROPPED", .{ self.log_tag, ev.code, ev.value });
                     continue;
                 }
-                ff_count += 1;
-                if (result != null) overwrite_count += 1;
-                const prev_tag: []const u8 = if (result != null) "overwritten" else "none";
-                if (ev.value == 0) {
-                    rumble_log.debug("[{s}] pollFf: STOP id={d} (ev#{d}, prev={s})", .{
-                        self.log_tag, id, ff_count, prev_tag,
-                    });
-                    result = FfEvent{
-                        .effect_type = c.FF_RUMBLE,
-                        .effect_id = @intCast(id),
-                        .strong = 0,
-                        .weak = 0,
-                        .duration_ms = 0,
-                    };
-                } else {
+                const ff_ev = if (ev.value == 0) FfEvent{
+                    .effect_type = c.FF_RUMBLE,
+                    .effect_id = @intCast(id),
+                    .strong = 0,
+                    .weak = 0,
+                    .duration_ms = 0,
+                } else blk: {
                     const eff = self.ff_effects[id];
-                    rumble_log.debug("[{s}] pollFf: PLAY id={d} strong={d} weak={d} dur={d}ms (ev#{d}, prev={s})", .{
-                        self.log_tag, id, eff.strong, eff.weak, eff.length_ms, ff_count, prev_tag,
-                    });
-                    result = FfEvent{
+                    break :blk FfEvent{
                         .effect_type = c.FF_RUMBLE,
                         .effect_id = @intCast(id),
                         .strong = eff.strong,
                         .weak = eff.weak,
                         .duration_ms = eff.length_ms,
                     };
+                };
+                // Buffer the event if the batch is full — it will be
+                // returned first on the next pollFf call.
+                if (batch.len >= FfEventBatch.MAX_BATCH) {
+                    self.pending_ff = ff_ev;
+                    rumble_log.debug("[{s}] pollFf: batch full ({d}), buffering event id={d} for next call", .{ self.log_tag, FfEventBatch.MAX_BATCH, id });
+                    break;
                 }
+                const kind: []const u8 = if (ev.value == 0) "STOP" else "PLAY";
+                rumble_log.debug("[{s}] pollFf: {s} id={d} (ev#{d})", .{ self.log_tag, kind, id, batch.len + 1 });
+                batch.events[batch.len] = ff_ev;
+                batch.len += 1;
             }
         }
         if (ev_count > 0) {
-            if (result) |r| {
-                const kind: []const u8 = if (r.strong == 0 and r.weak == 0) "STOP" else "PLAY";
-                rumble_log.debug("[{s}] pollFf: drain end, {d} events read, {d} EV_FF, {d} overwritten, returning {s} id={d}", .{
-                    self.log_tag, ev_count, ff_count, overwrite_count, kind, r.effect_id,
-                });
-            } else {
-                rumble_log.debug("[{s}] pollFf: drain end, {d} events read, {d} EV_FF, returning null", .{
-                    self.log_tag, ev_count, ff_count,
-                });
-            }
+            rumble_log.debug("[{s}] pollFf: drain end, {d} events read, {d} EV_FF in batch", .{
+                self.log_tag, ev_count, batch.len,
+            });
         }
-        return result;
+        return batch;
     }
 
     pub fn close(self: *UinputDevice) void {
@@ -886,8 +899,8 @@ const MockOutputDevice = struct {
         self.prev = s;
     }
 
-    fn mockPollFf(_: *anyopaque) PollFfError!?FfEvent {
-        return null;
+    fn mockPollFf(_: *anyopaque) PollFfError!FfEventBatch {
+        return .{};
     }
 
     fn mockClose(_: *anyopaque) void {}
@@ -1086,7 +1099,7 @@ test "uinput: pollFf drain loop: empty pipe returns null without blocking" {
         .button_codes = [_]u16{0} ** BUTTON_COUNT,
     };
     const result = try dev.pollFf();
-    try std.testing.expectEqual(@as(?FfEvent, null), result);
+    try std.testing.expectEqual(@as(usize, 0), result.len);
 }
 
 test "uinput: pollFf drain loop: drains multiple events and returns last EV_FF" {
@@ -1106,8 +1119,8 @@ test "uinput: pollFf drain loop: drains multiple events and returns last EV_FF" 
     };
     const result = try dev.pollFf();
     // Both events processed; last one wins — result is non-null FfEvent
-    try std.testing.expect(result != null);
-    try std.testing.expectEqual(@as(u16, c.FF_RUMBLE), result.?.effect_type);
+    try std.testing.expect(result.len > 0);
+    try std.testing.expectEqual(@as(u16, c.FF_RUMBLE), result.events[0].effect_type);
 }
 
 test "uinput: pollFfFd returns the fd" {
@@ -1153,10 +1166,10 @@ test "uinput: pollFf play: returns stored ff_effects values" {
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
 
     const result = try dev.pollFf();
-    try std.testing.expect(result != null);
-    try std.testing.expectEqual(@as(u16, c.FF_RUMBLE), result.?.effect_type);
-    try std.testing.expectEqual(@as(u16, 0xffff), result.?.strong);
-    try std.testing.expectEqual(@as(u16, 0x8000), result.?.weak);
+    try std.testing.expect(result.len > 0);
+    try std.testing.expectEqual(@as(u16, c.FF_RUMBLE), result.events[0].effect_type);
+    try std.testing.expectEqual(@as(u16, 0xffff), result.events[0].strong);
+    try std.testing.expectEqual(@as(u16, 0x8000), result.events[0].weak);
 }
 
 test "uinput: pollFf play: carries effect_id and duration_ms for scheduler" {
@@ -1175,9 +1188,9 @@ test "uinput: pollFf play: carries effect_id and duration_ms for scheduler" {
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
 
     const result = try dev.pollFf();
-    try std.testing.expect(result != null);
-    try std.testing.expectEqual(@as(u8, 3), result.?.effect_id);
-    try std.testing.expectEqual(@as(u16, 500), result.?.duration_ms);
+    try std.testing.expect(result.len > 0);
+    try std.testing.expectEqual(@as(u8, 3), result.events[0].effect_id);
+    try std.testing.expectEqual(@as(u16, 500), result.events[0].duration_ms);
 }
 
 test "uinput: pollFf play stop (value=0): returns zeros" {
@@ -1195,9 +1208,9 @@ test "uinput: pollFf play stop (value=0): returns zeros" {
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
 
     const result = try dev.pollFf();
-    try std.testing.expect(result != null);
-    try std.testing.expectEqual(@as(u16, 0), result.?.strong);
-    try std.testing.expectEqual(@as(u16, 0), result.?.weak);
+    try std.testing.expect(result.len > 0);
+    try std.testing.expectEqual(@as(u16, 0), result.events[0].strong);
+    try std.testing.expectEqual(@as(u16, 0), result.events[0].weak);
 }
 
 test "uinput: pollFf stop: carries effect_id from EV_FF code, duration_ms=0" {
@@ -1218,11 +1231,11 @@ test "uinput: pollFf stop: carries effect_id from EV_FF code, duration_ms=0" {
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
 
     const result = try dev.pollFf();
-    try std.testing.expect(result != null);
-    try std.testing.expectEqual(@as(u8, 4), result.?.effect_id);
-    try std.testing.expectEqual(@as(u16, 0), result.?.duration_ms);
-    try std.testing.expectEqual(@as(u16, 0), result.?.strong);
-    try std.testing.expectEqual(@as(u16, 0), result.?.weak);
+    try std.testing.expect(result.len > 0);
+    try std.testing.expectEqual(@as(u8, 4), result.events[0].effect_id);
+    try std.testing.expectEqual(@as(u16, 0), result.events[0].duration_ms);
+    try std.testing.expectEqual(@as(u16, 0), result.events[0].strong);
+    try std.testing.expectEqual(@as(u16, 0), result.events[0].weak);
 }
 
 test "uinput: pollFf: out-of-range EV_FF code is dropped (returns null)" {
@@ -1243,7 +1256,7 @@ test "uinput: pollFf: out-of-range EV_FF code is dropped (returns null)" {
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
 
     const result = try dev.pollFf();
-    try std.testing.expectEqual(@as(?FfEvent, null), result);
+    try std.testing.expectEqual(@as(usize, 0), result.len);
 }
 
 test "uinput: pollFf: out-of-range id does not shadow a preceding valid play event" {
@@ -1266,11 +1279,11 @@ test "uinput: pollFf: out-of-range id does not shadow a preceding valid play eve
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&garbage));
 
     const result = try dev.pollFf();
-    try std.testing.expect(result != null);
-    try std.testing.expectEqual(@as(u8, 2), result.?.effect_id);
-    try std.testing.expectEqual(@as(u16, 0xaaaa), result.?.strong);
-    try std.testing.expectEqual(@as(u16, 0x5555), result.?.weak);
-    try std.testing.expectEqual(@as(u16, 200), result.?.duration_ms);
+    try std.testing.expect(result.len > 0);
+    try std.testing.expectEqual(@as(u8, 2), result.events[0].effect_id);
+    try std.testing.expectEqual(@as(u16, 0xaaaa), result.events[0].strong);
+    try std.testing.expectEqual(@as(u16, 0x5555), result.events[0].weak);
+    try std.testing.expectEqual(@as(u16, 200), result.events[0].duration_ms);
 }
 
 test "uinput: ff_effects: erase clears slot" {
@@ -1633,12 +1646,12 @@ test "uinput: pollFf returns identical FfEvent regardless of dump_enabled" {
     padctl_log.setEnabled(false);
     const ev = c.input_event{ .type = c.EV_FF, .code = 0, .value = 1, .time = std.mem.zeroes(c.timeval) };
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
-    const r1 = (try dev.pollFf()).?;
+    const r1 = (try dev.pollFf()).events[0];
 
     // With dump enabled.
     padctl_log.setEnabled(true);
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
-    const r2 = (try dev.pollFf()).?;
+    const r2 = (try dev.pollFf()).events[0];
     padctl_log.setEnabled(false);
 
     // Both must be identical.
@@ -1649,8 +1662,8 @@ test "uinput: pollFf returns identical FfEvent regardless of dump_enabled" {
     try std.testing.expectEqual(r1.duration_ms, r2.duration_ms);
 }
 
-test "uinput: pollFf drain with overwrite: PLAY then STOP returns STOP" {
-    // Verifies the drain loop correctly overwrites and the stop event wins.
+test "uinput: pollFf batch preserves PLAY+STOP (no longer overwrites)" {
+    // With the batch API, both events are returned — no overwrite.
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1661,20 +1674,20 @@ test "uinput: pollFf drain with overwrite: PLAY then STOP returns STOP" {
     };
     dev.ff_effects[0] = .{ .strong = 0xffff, .weak = 0xffff, .length_ms = 500 };
 
-    // Write PLAY then STOP for same id — STOP should win.
     const play = c.input_event{ .type = c.EV_FF, .code = 0, .value = 1, .time = std.mem.zeroes(c.timeval) };
     const stop = c.input_event{ .type = c.EV_FF, .code = 0, .value = 0, .time = std.mem.zeroes(c.timeval) };
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&play));
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&stop));
 
-    const result = (try dev.pollFf()).?;
-    try std.testing.expectEqual(@as(u16, 0), result.strong);
-    try std.testing.expectEqual(@as(u16, 0), result.weak);
-    try std.testing.expectEqual(@as(u8, 0), result.effect_id);
+    const batch = try dev.pollFf();
+    // Both events preserved in order — this is the core fix.
+    try std.testing.expectEqual(@as(usize, 2), batch.len);
+    try std.testing.expectEqual(@as(u16, 0xffff), batch.events[0].strong); // PLAY
+    try std.testing.expectEqual(@as(u16, 0), batch.events[1].strong); // STOP
 }
 
-test "uinput: pollFf drain with overwrite: STOP then PLAY returns PLAY" {
-    // Verifies the opposite overwrite direction.
+test "uinput: pollFf batch preserves STOP+PLAY (no longer overwrites)" {
+    // Both events returned in order — stop then play.
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1690,9 +1703,102 @@ test "uinput: pollFf drain with overwrite: STOP then PLAY returns PLAY" {
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&stop));
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&play));
 
-    const result = (try dev.pollFf()).?;
-    try std.testing.expectEqual(@as(u16, 0xaaaa), result.strong);
-    try std.testing.expectEqual(@as(u16, 0xbbbb), result.weak);
-    try std.testing.expectEqual(@as(u8, 3), result.effect_id);
-    try std.testing.expectEqual(@as(u16, 100), result.duration_ms);
+    const batch = try dev.pollFf();
+    try std.testing.expectEqual(@as(usize, 2), batch.len);
+    try std.testing.expectEqual(@as(u16, 0), batch.events[0].strong); // STOP
+    try std.testing.expectEqual(@as(u16, 0xaaaa), batch.events[1].strong); // PLAY
+    try std.testing.expectEqual(@as(u8, 3), batch.events[1].effect_id);
+}
+
+// --- Phase 7: batch return tests ---
+
+test "uinput: pollFf batch: PLAY+STOP returns both events in order" {
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    dev.ff_effects[0] = .{ .strong = 0xffff, .weak = 0x8000, .length_ms = 200 };
+
+    const play = c.input_event{ .type = c.EV_FF, .code = 0, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    const stop = c.input_event{ .type = c.EV_FF, .code = 0, .value = 0, .time = std.mem.zeroes(c.timeval) };
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&play));
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&stop));
+
+    const batch = try dev.pollFf();
+    // Both events must be in the batch, in order.
+    try std.testing.expectEqual(@as(usize, 2), batch.len);
+    // First: PLAY with magnitudes.
+    try std.testing.expectEqual(@as(u16, 0xffff), batch.events[0].strong);
+    try std.testing.expectEqual(@as(u16, 0x8000), batch.events[0].weak);
+    // Second: STOP with zeros.
+    try std.testing.expectEqual(@as(u16, 0), batch.events[1].strong);
+    try std.testing.expectEqual(@as(u16, 0), batch.events[1].weak);
+}
+
+test "uinput: pollFf batch: empty pipe returns empty batch" {
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    const batch = try dev.pollFf();
+    try std.testing.expectEqual(@as(usize, 0), batch.len);
+}
+
+test "uinput: pollFf batch: three events PLAY-STOP-PLAY across two IDs" {
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    dev.ff_effects[0] = .{ .strong = 0x1000, .weak = 0, .length_ms = 100 };
+    dev.ff_effects[1] = .{ .strong = 0x2000, .weak = 0, .length_ms = 200 };
+
+    const play0 = c.input_event{ .type = c.EV_FF, .code = 0, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    const stop0 = c.input_event{ .type = c.EV_FF, .code = 0, .value = 0, .time = std.mem.zeroes(c.timeval) };
+    const play1 = c.input_event{ .type = c.EV_FF, .code = 1, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&play0));
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&stop0));
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&play1));
+
+    const batch = try dev.pollFf();
+    try std.testing.expectEqual(@as(usize, 3), batch.len);
+    try std.testing.expectEqual(@as(u8, 0), batch.events[0].effect_id);
+    try std.testing.expectEqual(@as(u16, 0x1000), batch.events[0].strong);
+    try std.testing.expectEqual(@as(u8, 0), batch.events[1].effect_id);
+    try std.testing.expectEqual(@as(u16, 0), batch.events[1].strong); // STOP
+    try std.testing.expectEqual(@as(u8, 1), batch.events[2].effect_id);
+    try std.testing.expectEqual(@as(u16, 0x2000), batch.events[2].strong);
+}
+
+test "uinput: pollFf batch: out-of-range IDs excluded from batch" {
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    dev.ff_effects[2] = .{ .strong = 0xaaaa, .weak = 0, .length_ms = 50 };
+
+    const valid = c.input_event{ .type = c.EV_FF, .code = 2, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    const invalid = c.input_event{ .type = c.EV_FF, .code = 42, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&valid));
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&invalid));
+
+    const batch = try dev.pollFf();
+    // Only the valid event in the batch.
+    try std.testing.expectEqual(@as(usize, 1), batch.len);
+    try std.testing.expectEqual(@as(u8, 2), batch.events[0].effect_id);
 }

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -406,7 +406,11 @@ pub const UinputDevice = struct {
                     upload.request_id = @intCast(ev.value);
                     const begin_rc = std.os.linux.ioctl(self.fd, UI_BEGIN_FF_UPLOAD, @intFromPtr(&upload));
                     if (begin_rc != 0) {
+                        // BEGIN failed — the upload struct is still zeroed. Skip the
+                        // rest of the branch so we don't touch ff_effects or call END
+                        // with retval=0 (which would falsely acknowledge the request).
                         rumble_log.debug("[{s}] pollFf: UI_BEGIN_FF_UPLOAD FAILED rc={d}", .{ self.log_tag, begin_rc });
+                        continue;
                     }
                     if (upload.effect.type == c.FF_RUMBLE and upload.effect.id < 16) {
                         self.ff_effects[@intCast(upload.effect.id)] = .{
@@ -435,6 +439,7 @@ pub const UinputDevice = struct {
                     const begin_rc = std.os.linux.ioctl(self.fd, UI_BEGIN_FF_ERASE, @intFromPtr(&erase));
                     if (begin_rc != 0) {
                         rumble_log.debug("[{s}] pollFf: UI_BEGIN_FF_ERASE FAILED rc={d}", .{ self.log_tag, begin_rc });
+                        continue;
                     }
                     if (erase.effect_id < 16) {
                         self.ff_effects[@intCast(erase.effect_id)] = .{};

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const state = @import("../core/state.zig");
 const device = @import("../config/device.zig");
 const input_codes = @import("../config/input_codes.zig");
+const rumble_log = std.log.scoped(.rumble);
 
 const c = @cImport({
     @cInclude("linux/uinput.h");
@@ -127,6 +128,8 @@ pub const UinputDevice = struct {
     axis_count: usize = 0,
     has_dpad_hat: bool = false,
     ff_effects: [16]FfEffect = [_]FfEffect{.{}} ** 16,
+    /// Device identifier for log correlation (e.g. "Vader 5 Pro/hidraw7").
+    log_tag: []const u8 = "uinput",
 
     const AxisStateField = enum { ax, ay, rx, ry, lt, rt, dpad_x, dpad_y };
 
@@ -364,6 +367,9 @@ pub const UinputDevice = struct {
 
     pub fn pollFf(self: *UinputDevice) !?FfEvent {
         var result: ?FfEvent = null;
+        var ev_count: u32 = 0;
+        var ff_count: u32 = 0;
+        var overwrite_count: u32 = 0;
         while (true) {
             var ev: c.input_event = undefined;
             const n = std.posix.read(self.fd, std.mem.asBytes(&ev)) catch |err| switch (err) {
@@ -371,27 +377,47 @@ pub const UinputDevice = struct {
                 else => return err,
             };
             if (n != @sizeOf(c.input_event)) break;
+            ev_count += 1;
 
             if (ev.type == c.EV_UINPUT) {
                 if (ev.code == c.UI_FF_UPLOAD) {
                     var upload = std.mem.zeroes(c.uinput_ff_upload);
                     upload.request_id = @intCast(ev.value);
-                    _ = std.os.linux.ioctl(self.fd, UI_BEGIN_FF_UPLOAD, @intFromPtr(&upload));
+                    const begin_rc = std.os.linux.ioctl(self.fd, UI_BEGIN_FF_UPLOAD, @intFromPtr(&upload));
+                    if (begin_rc != 0) {
+                        rumble_log.debug("[{s}] pollFf: UI_BEGIN_FF_UPLOAD FAILED rc={d}", .{ self.log_tag, begin_rc });
+                    }
                     if (upload.effect.type == c.FF_RUMBLE and upload.effect.id < 16) {
                         self.ff_effects[@intCast(upload.effect.id)] = .{
                             .strong = upload.effect.u.rumble.strong_magnitude,
                             .weak = upload.effect.u.rumble.weak_magnitude,
                             .length_ms = @intCast(upload.effect.replay.length),
                         };
+                        rumble_log.debug("[{s}] pollFf: UPLOAD id={d} type=FF_RUMBLE strong={d} weak={d} len={d}ms replay.delay={d}ms", .{
+                            self.log_tag,
+                            upload.effect.id,
+                            upload.effect.u.rumble.strong_magnitude,
+                            upload.effect.u.rumble.weak_magnitude,
+                            @as(u16, @intCast(upload.effect.replay.length)),
+                            @as(u16, @intCast(upload.effect.replay.delay)),
+                        });
+                    } else {
+                        rumble_log.debug("[{s}] pollFf: UPLOAD id={d} type={d} (non-rumble or out-of-range)", .{
+                            self.log_tag, upload.effect.id, upload.effect.type,
+                        });
                     }
                     upload.retval = 0;
                     _ = std.os.linux.ioctl(self.fd, UI_END_FF_UPLOAD, @intFromPtr(&upload));
                 } else if (ev.code == c.UI_FF_ERASE) {
                     var erase = std.mem.zeroes(c.uinput_ff_erase);
                     erase.request_id = @intCast(ev.value);
-                    _ = std.os.linux.ioctl(self.fd, UI_BEGIN_FF_ERASE, @intFromPtr(&erase));
+                    const begin_rc = std.os.linux.ioctl(self.fd, UI_BEGIN_FF_ERASE, @intFromPtr(&erase));
+                    if (begin_rc != 0) {
+                        rumble_log.debug("[{s}] pollFf: UI_BEGIN_FF_ERASE FAILED rc={d}", .{ self.log_tag, begin_rc });
+                    }
                     if (erase.effect_id < 16) {
                         self.ff_effects[@intCast(erase.effect_id)] = .{};
+                        rumble_log.debug("[{s}] pollFf: ERASE id={d}", .{ self.log_tag, erase.effect_id });
                     }
                     erase.retval = 0;
                     _ = std.os.linux.ioctl(self.fd, UI_END_FF_ERASE, @intFromPtr(&erase));
@@ -399,11 +425,17 @@ pub const UinputDevice = struct {
             } else if (ev.type == c.EV_FF) {
                 const id: usize = @intCast(ev.code);
                 // Out-of-range FF effect ids must be silently dropped.
-                // Collapsing them into a zero FfEvent would look like
-                // an explicit stop for slot 0 downstream, which would
-                // spuriously cancel the real rumble auto-stop deadline.
-                if (id >= 16) continue;
+                if (id >= 16) {
+                    rumble_log.debug("[{s}] pollFf: OUT_OF_RANGE code={d} value={d} DROPPED", .{ self.log_tag, ev.code, ev.value });
+                    continue;
+                }
+                ff_count += 1;
+                if (result != null) overwrite_count += 1;
+                const prev_tag: []const u8 = if (result != null) "overwritten" else "none";
                 if (ev.value == 0) {
+                    rumble_log.debug("[{s}] pollFf: STOP id={d} (ev#{d}, prev={s})", .{
+                        self.log_tag, id, ff_count, prev_tag,
+                    });
                     result = FfEvent{
                         .effect_type = c.FF_RUMBLE,
                         .effect_id = @intCast(id),
@@ -413,6 +445,9 @@ pub const UinputDevice = struct {
                     };
                 } else {
                     const eff = self.ff_effects[id];
+                    rumble_log.debug("[{s}] pollFf: PLAY id={d} strong={d} weak={d} dur={d}ms (ev#{d}, prev={s})", .{
+                        self.log_tag, id, eff.strong, eff.weak, eff.length_ms, ff_count, prev_tag,
+                    });
                     result = FfEvent{
                         .effect_type = c.FF_RUMBLE,
                         .effect_id = @intCast(id),
@@ -421,6 +456,18 @@ pub const UinputDevice = struct {
                         .duration_ms = eff.length_ms,
                     };
                 }
+            }
+        }
+        if (ev_count > 0) {
+            if (result) |r| {
+                const kind: []const u8 = if (r.strong == 0 and r.weak == 0) "STOP" else "PLAY";
+                rumble_log.debug("[{s}] pollFf: drain end, {d} events read, {d} EV_FF, {d} overwritten, returning {s} id={d}", .{
+                    self.log_tag, ev_count, ff_count, overwrite_count, kind, r.effect_id,
+                });
+            } else {
+                rumble_log.debug("[{s}] pollFf: drain end, {d} events read, {d} EV_FF, returning null", .{
+                    self.log_tag, ev_count, ff_count,
+                });
             }
         }
         return result;
@@ -1566,4 +1613,86 @@ test "uinput: GenericUinputDevice.emitGeneric: no change produces no write" {
     var events: [4]c.input_event = undefined;
     const n = readEvents(pfds[0], &events);
     try std.testing.expectEqual(@as(usize, 0), n);
+}
+
+// --- Instrumentation correctness tests ---
+
+test "uinput: pollFf returns identical FfEvent regardless of dump_enabled" {
+    const padctl_log = @import("../log.zig");
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    dev.ff_effects[0] = .{ .strong = 0x1234, .weak = 0x5678, .length_ms = 300 };
+
+    // With dump disabled (default).
+    padctl_log.setEnabled(false);
+    const ev = c.input_event{ .type = c.EV_FF, .code = 0, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
+    const r1 = (try dev.pollFf()).?;
+
+    // With dump enabled.
+    padctl_log.setEnabled(true);
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
+    const r2 = (try dev.pollFf()).?;
+    padctl_log.setEnabled(false);
+
+    // Both must be identical.
+    try std.testing.expectEqual(r1.effect_type, r2.effect_type);
+    try std.testing.expectEqual(r1.effect_id, r2.effect_id);
+    try std.testing.expectEqual(r1.strong, r2.strong);
+    try std.testing.expectEqual(r1.weak, r2.weak);
+    try std.testing.expectEqual(r1.duration_ms, r2.duration_ms);
+}
+
+test "uinput: pollFf drain with overwrite: PLAY then STOP returns STOP" {
+    // Verifies the drain loop correctly overwrites and the stop event wins.
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    dev.ff_effects[0] = .{ .strong = 0xffff, .weak = 0xffff, .length_ms = 500 };
+
+    // Write PLAY then STOP for same id — STOP should win.
+    const play = c.input_event{ .type = c.EV_FF, .code = 0, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    const stop = c.input_event{ .type = c.EV_FF, .code = 0, .value = 0, .time = std.mem.zeroes(c.timeval) };
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&play));
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&stop));
+
+    const result = (try dev.pollFf()).?;
+    try std.testing.expectEqual(@as(u16, 0), result.strong);
+    try std.testing.expectEqual(@as(u16, 0), result.weak);
+    try std.testing.expectEqual(@as(u8, 0), result.effect_id);
+}
+
+test "uinput: pollFf drain with overwrite: STOP then PLAY returns PLAY" {
+    // Verifies the opposite overwrite direction.
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    dev.ff_effects[3] = .{ .strong = 0xaaaa, .weak = 0xbbbb, .length_ms = 100 };
+
+    const stop = c.input_event{ .type = c.EV_FF, .code = 3, .value = 0, .time = std.mem.zeroes(c.timeval) };
+    const play = c.input_event{ .type = c.EV_FF, .code = 3, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&stop));
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&play));
+
+    const result = (try dev.pollFf()).?;
+    try std.testing.expectEqual(@as(u16, 0xaaaa), result.strong);
+    try std.testing.expectEqual(@as(u16, 0xbbbb), result.weak);
+    try std.testing.expectEqual(@as(u8, 3), result.effect_id);
+    try std.testing.expectEqual(@as(u16, 100), result.duration_ms);
 }

--- a/src/log.zig
+++ b/src/log.zig
@@ -1,0 +1,329 @@
+const std = @import("std");
+const posix = std.posix;
+const linux = std.os.linux;
+const Allocator = std.mem.Allocator;
+const paths = @import("config/paths.zig");
+
+/// File descriptor for the log file. -1 when file logging is inactive.
+var log_fd: std.atomic.Value(posix.fd_t) = std.atomic.Value(posix.fd_t).init(-1);
+
+/// Serializes concurrent file writes across device threads.
+var log_mutex: std.Thread.Mutex = .{};
+
+/// Stored log file path for reopening after deletion or lazy open.
+var log_path_buf: [256]u8 = undefined;
+var log_path_len: usize = 0;
+
+/// Whether init() resolved a valid log path (even if file isn't open yet).
+var initialized: bool = false;
+
+/// When false (default), only error/warning lines reach the log file.
+/// Debug/info lines are suppressed. Toggled via `padctl dump enable/disable`.
+var dump_enabled: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+
+/// Maximum log file size before rotation.
+/// Default 100 MiB; overridden by `[diagnostics] max_log_size_mb` in config.
+var max_log_size: u64 = 100 * 1024 * 1024;
+
+pub const InitOptions = struct {
+    dump: bool = false,
+    max_log_size_mb: i64 = 100,
+};
+
+/// Enable or disable debug-level file logging at runtime.
+/// When toggling on, lazily opens the log file if not already open.
+pub fn setEnabled(on: bool) void {
+    dump_enabled.store(on, .release);
+    // If enabling dump and file not open yet, open it now.
+    if (on and initialized and log_fd.load(.acquire) == -1) {
+        log_mutex.lock();
+        defer log_mutex.unlock();
+        openLogFile();
+    }
+}
+
+/// Returns true when debug-level file logging is active.
+pub fn isEnabled() bool {
+    return dump_enabled.load(.acquire);
+}
+
+/// Returns true when a message at the given level should be written to the
+/// log file. Used by logFn; exposed for testability.
+pub fn shouldWriteToFile(comptime level: std.log.Level) bool {
+    const always = comptime (level == .err or level == .warn);
+    return always or dump_enabled.load(.acquire);
+}
+
+/// Set the maximum log file size in megabytes (for rotation).
+pub fn setMaxLogSize(mb: i64) void {
+    const clamped: u64 = if (mb > 0) @intCast(mb) else 100;
+    max_log_size = clamped * 1024 * 1024;
+}
+
+/// Step 1: Resolve the log directory and store the path. Call this BEFORE
+/// loading config so that early warnings (e.g. malformed config.toml) can
+/// persist to the log file via lazy open in logFn. No file is opened yet.
+pub fn initPath(allocator: Allocator) void {
+    const dir_path = paths.stateDir(allocator) catch return;
+    defer allocator.free(dir_path);
+
+    // Ensure the directory tree exists.
+    std.fs.makeDirAbsolute(dir_path) catch |e| switch (e) {
+        error.PathAlreadyExists => {},
+        else => {
+            if (std.mem.lastIndexOfScalar(u8, dir_path, '/')) |sep| {
+                std.fs.makeDirAbsolute(dir_path[0..sep]) catch {};
+                std.fs.makeDirAbsolute(dir_path) catch return;
+            } else return;
+        },
+    };
+
+    // Store the resolved log path for lazy open and reopen-after-delete.
+    const log_path = std.fmt.allocPrint(allocator, "{s}/padctl.log", .{dir_path}) catch return;
+    defer allocator.free(log_path);
+    if (log_path.len <= log_path_buf.len) {
+        @memcpy(log_path_buf[0..log_path.len], log_path);
+        log_path_len = log_path.len;
+        initialized = true;
+    }
+}
+
+/// Step 2: Apply diagnostics config and optionally open the log file.
+/// Call this AFTER loading config. If dump is enabled, the file opens
+/// immediately. Otherwise it stays lazy (opened on first err/warn).
+pub fn applyConfig(opts: InitOptions) void {
+    setMaxLogSize(opts.max_log_size_mb);
+    dump_enabled.store(opts.dump, .release);
+
+    if (opts.dump and initialized and log_fd.load(.acquire) == -1) {
+        openLogFile();
+        if (log_path_len > 0) {
+            var confirm_buf: [256]u8 = undefined;
+            const confirm = std.fmt.bufPrint(&confirm_buf, "info: file logging active (dump=on): {s}\n", .{log_path_buf[0..log_path_len]}) catch return;
+            _ = posix.write(posix.STDERR_FILENO, confirm) catch {};
+        }
+    }
+}
+
+/// Convenience: initPath + applyConfig in one call.
+pub fn init(allocator: Allocator, opts: InitOptions) void {
+    initPath(allocator);
+    applyConfig(opts);
+}
+
+/// Open (or rotate + open) the log file. Must be called under log_mutex
+/// or during single-threaded init.
+fn openLogFile() void {
+    if (log_path_len == 0) return;
+    const log_path = log_path_buf[0..log_path_len];
+
+    // Rotate if the log file exceeds the size threshold.
+    if (std.fs.openFileAbsolute(log_path, .{})) |f| {
+        defer f.close();
+        if (f.stat()) |st| {
+            if (st.size > max_log_size) {
+                // Build backup path from log_path by appending ".1"
+                var bak_buf: [260]u8 = undefined;
+                if (log_path_len + 2 <= bak_buf.len) {
+                    @memcpy(bak_buf[0..log_path_len], log_path);
+                    @memcpy(bak_buf[log_path_len .. log_path_len + 2], ".1");
+                    const bak_path = bak_buf[0 .. log_path_len + 2];
+                    std.fs.renameAbsolute(log_path, bak_path) catch {};
+                }
+            }
+        } else |_| {}
+    } else |_| {}
+
+    const fd = posix.open(log_path, .{ .ACCMODE = .WRONLY, .CREAT = true, .APPEND = true }, 0o644) catch return;
+    log_fd.store(fd, .release);
+}
+
+/// Close the log file.
+pub fn deinit() void {
+    const fd = log_fd.swap(-1, .acq_rel);
+    if (fd != -1) posix.close(fd);
+    initialized = false;
+}
+
+/// Check if the log file was deleted (nlink == 0 on the open fd).
+/// If so, close the old fd, recreate the file, and update the global fd.
+/// Must be called under log_mutex. Returns the (possibly new) fd.
+fn reopenIfDeleted(fd: posix.fd_t) posix.fd_t {
+    if (log_path_len == 0) return fd;
+    const st = posix.fstat(fd) catch return fd;
+    if (st.nlink > 0) return fd;
+    posix.close(fd);
+    const path = log_path_buf[0..log_path_len];
+    if (std.mem.lastIndexOfScalar(u8, path, '/')) |sep| {
+        std.fs.makeDirAbsolute(path[0..sep]) catch {};
+    }
+    const new_fd = posix.open(path, .{ .ACCMODE = .WRONLY, .CREAT = true, .APPEND = true }, 0o644) catch {
+        log_fd.store(-1, .release);
+        return -1;
+    };
+    log_fd.store(new_fd, .release);
+    return new_fd;
+}
+
+/// Lazily open the log file on the first persistent write (err/warn).
+/// Must be called under log_mutex.
+fn ensureFileOpen() posix.fd_t {
+    var fd = log_fd.load(.acquire);
+    if (fd != -1) return fd;
+    if (!initialized) return -1;
+    openLogFile();
+    fd = log_fd.load(.acquire);
+    return fd;
+}
+
+/// Custom log function: tees to stderr (for journal) and the log file.
+/// Format: [YYYY-MM-DDTHH:MM:SS.mmm] [MONO:nnnnnnn] [level] (scope): message
+pub fn logFn(
+    comptime message_level: std.log.Level,
+    comptime scope: @Type(.enum_literal),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    const level_txt = comptime message_level.asText();
+    const scope_prefix = comptime if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
+
+    // Format wall-clock timestamp.
+    var ts_buf: [32]u8 = undefined;
+    const ts_str = wallClockTimestamp(&ts_buf);
+
+    // Monotonic nanoseconds for scheduler correlation.
+    const mono_ns = monotonicNs();
+
+    // Format into a stack buffer large enough for any log line.
+    var buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const w = fbs.writer();
+    nosuspend w.print("[{s}] [MONO:{d}] " ++ level_txt ++ scope_prefix ++ format ++ "\n", .{ ts_str, mono_ns } ++ args) catch {
+        @memcpy(buf[buf.len - 4 ..], "...\n");
+        fbs.pos = buf.len;
+    };
+    const msg = fbs.getWritten();
+    if (msg.len == 0) return;
+
+    // Write to stderr (for systemd journal / terminal).
+    _ = posix.write(posix.STDERR_FILENO, msg) catch {};
+
+    // Write to log file: err/warn always persist; debug/info only when dump enabled.
+    const always_write = comptime (message_level == .err or message_level == .warn);
+    const write_to_file = shouldWriteToFile(message_level);
+    if (write_to_file) {
+        log_mutex.lock();
+        defer log_mutex.unlock();
+
+        var fd = log_fd.load(.acquire);
+        if (fd == -1 and always_write) {
+            // Lazy open: first err/warn creates the file even with dump off.
+            fd = ensureFileOpen();
+        }
+        if (fd != -1) {
+            fd = reopenIfDeleted(fd);
+            _ = posix.write(fd, msg) catch {};
+        }
+    }
+}
+
+/// Format a wall-clock timestamp as "YYYY-MM-DDTHH:MM:SS.mmm".
+fn wallClockTimestamp(buf: *[32]u8) []const u8 {
+    var ts: linux.timespec = undefined;
+    const rc = linux.clock_gettime(.REALTIME, &ts);
+    if (rc != 0) return "????-??-??T??:??:??.???";
+
+    const epoch_secs: u64 = @intCast(ts.sec);
+    const millis: u64 = @intCast(@divTrunc(ts.nsec, std.time.ns_per_ms));
+
+    const es = std.time.epoch.EpochSeconds{ .secs = epoch_secs };
+    const day = es.getEpochDay();
+    const yd = day.calculateYearDay();
+    const md = yd.calculateMonthDay();
+    const ds = es.getDaySeconds();
+
+    const result = std.fmt.bufPrint(buf, "{d:0>4}-{d:0>2}-{d:0>2}T{d:0>2}:{d:0>2}:{d:0>2}.{d:0>3}", .{
+        yd.year,
+        @as(u32, @intFromEnum(md.month)) + 1,
+        @as(u32, md.day_index) + 1,
+        ds.getHoursIntoDay(),
+        ds.getMinutesIntoHour(),
+        ds.getSecondsIntoMinute(),
+        millis,
+    }) catch return "????-??-??T??:??:??.???";
+    return result;
+}
+
+/// Returns the current CLOCK_MONOTONIC time in nanoseconds.
+fn monotonicNs() i128 {
+    var ts: linux.timespec = undefined;
+    const rc = linux.clock_gettime(.MONOTONIC, &ts);
+    if (rc != 0) return 0;
+    return @as(i128, ts.sec) * std.time.ns_per_s + ts.nsec;
+}
+
+// --- tests ---
+
+const testing = std.testing;
+
+test "log: dump disabled by default" {
+    try testing.expect(!isEnabled());
+}
+
+test "log: setEnabled toggles state" {
+    try testing.expect(!isEnabled());
+    setEnabled(true);
+    try testing.expect(isEnabled());
+    setEnabled(false);
+    try testing.expect(!isEnabled());
+}
+
+test "log: setMaxLogSize updates rotation threshold" {
+    setMaxLogSize(50);
+    try testing.expectEqual(@as(u64, 50 * 1024 * 1024), max_log_size);
+    setMaxLogSize(100);
+}
+
+test "log: shouldWriteToFile: debug suppressed when dump off" {
+    setEnabled(false);
+    try testing.expect(!shouldWriteToFile(.debug));
+    try testing.expect(!shouldWriteToFile(.info));
+}
+
+test "log: shouldWriteToFile: debug passes when dump on" {
+    setEnabled(true);
+    try testing.expect(shouldWriteToFile(.debug));
+    try testing.expect(shouldWriteToFile(.info));
+    setEnabled(false);
+}
+
+test "log: shouldWriteToFile: err and warn always pass regardless of dump" {
+    setEnabled(false);
+    try testing.expect(shouldWriteToFile(.err));
+    try testing.expect(shouldWriteToFile(.warn));
+    setEnabled(true);
+    try testing.expect(shouldWriteToFile(.err));
+    try testing.expect(shouldWriteToFile(.warn));
+    setEnabled(false);
+}
+
+test "log: setEnabled is atomic under concurrent access" {
+    // Spawn two threads that toggle rapidly; verify no crash.
+    const Thread = std.Thread;
+    const toggle_fn = struct {
+        fn run(_: void) void {
+            var i: usize = 0;
+            while (i < 1000) : (i += 1) {
+                setEnabled(i % 2 == 0);
+                _ = isEnabled();
+                _ = shouldWriteToFile(.debug);
+            }
+        }
+    }.run;
+    const t1 = try Thread.spawn(.{}, toggle_fn, .{{}});
+    const t2 = try Thread.spawn(.{}, toggle_fn, .{{}});
+    t1.join();
+    t2.join();
+    setEnabled(false);
+    // If we got here without crash, atomicity is sufficient.
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -670,13 +670,42 @@ pub fn main() !void {
             }
         } else |_| {}
 
-        if (cli.dump.writeDiagnosticsConfig(allocator, cfgpaths.systemConfigDir(), enable)) {
-            config_written = true;
-        } else |err| {
-            if (err == error.MalformedConfig) {
-                stderr_writer.writeAll("error: system config.toml is malformed — fix or remove it\n") catch {};
-            } else {
-                std.log.warn("could not write system config: {}", .{err});
+        // System config: write to a temp file, then sudo cp to /etc/padctl/.
+        // Direct write fails without root (AccessDenied).
+        const sys_dir = cfgpaths.systemConfigDir();
+        if (std.os.linux.getuid() == 0) {
+            // Already root — write directly.
+            if (cli.dump.writeDiagnosticsConfig(allocator, sys_dir, enable)) {
+                config_written = true;
+            } else |err| {
+                if (err == error.MalformedConfig) {
+                    stderr_writer.writeAll("error: system config.toml is malformed — fix or remove it\n") catch {};
+                } else {
+                    std.log.warn("could not write system config: {}", .{err});
+                }
+            }
+        } else {
+            // Non-root: write to temp dir, sudo cp to system path.
+            const tmp_dir = "/tmp/padctl-dump-config";
+            if (cli.dump.writeDiagnosticsConfig(allocator, tmp_dir, enable)) {
+                const tmp_src = tmp_dir ++ "/config.toml";
+                const sys_dst_buf = std.fmt.allocPrint(allocator, "{s}/config.toml", .{sys_dir}) catch null;
+                defer if (sys_dst_buf) |b| allocator.free(b);
+                if (sys_dst_buf) |sys_dst| {
+                    if (runSudoMkdir(sys_dir, stderr_writer)) {
+                        if (runSudoCopy(tmp_src, sys_dst, stderr_writer)) {
+                            config_written = true;
+                        }
+                    }
+                }
+                std.fs.deleteFileAbsolute(tmp_src) catch {};
+                std.fs.deleteTreeAbsolute(tmp_dir) catch {};
+            } else |err| {
+                if (err == error.MalformedConfig) {
+                    stderr_writer.writeAll("error: system config.toml is malformed — fix or remove it\n") catch {};
+                } else {
+                    std.log.warn("could not write system config: {}", .{err});
+                }
             }
         }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -392,8 +392,12 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                 dump_argc += 1;
             }
             const result = parseDumpFromSlice(dump_args[0..dump_argc]) catch |err| switch (err) {
-                error.MissingArgValue => {
+                error.MissingSubcommand => {
                     std.log.err("dump requires a subcommand: enable, disable, status, export, clear", .{});
+                    return error.MissingArgValue;
+                },
+                error.MissingArgValue => {
+                    std.log.err("dump: missing value for option (expected an argument after --period, --socket, or -o)", .{});
                     return error.MissingArgValue;
                 },
                 error.UnknownArgument => {
@@ -1320,7 +1324,9 @@ pub fn parseDumpFromSlice(args: []const []const u8) !struct {
     socket_path: ?[]const u8 = null,
 } {
     var result: @TypeOf(parseDumpFromSlice(args) catch unreachable) = .{};
-    if (args.len == 0) return error.MissingArgValue;
+    // Distinct errors so the caller can produce accurate messages: missing
+    // the `dump <sub>` token is not the same as a trailing flag with no value.
+    if (args.len == 0) return error.MissingSubcommand;
     const sub = args[0];
     if (std.mem.eql(u8, sub, "enable")) {
         result.cmd = .enable;
@@ -1396,7 +1402,19 @@ test "main: parseDumpFromSlice: clear" {
 }
 
 test "main: parseDumpFromSlice: missing subcommand" {
-    try testing.expectError(error.MissingArgValue, parseDumpFromSlice(&.{}));
+    try testing.expectError(error.MissingSubcommand, parseDumpFromSlice(&.{}));
+}
+
+test "main: parseDumpFromSlice: missing value for --period" {
+    try testing.expectError(error.MissingArgValue, parseDumpFromSlice(&.{ "export", "--period" }));
+}
+
+test "main: parseDumpFromSlice: missing value for -o" {
+    try testing.expectError(error.MissingArgValue, parseDumpFromSlice(&.{ "export", "-o" }));
+}
+
+test "main: parseDumpFromSlice: missing value for --socket" {
+    try testing.expectError(error.MissingArgValue, parseDumpFromSlice(&.{ "status", "--socket" }));
 }
 
 test "main: parseDumpFromSlice: unknown subcommand" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -427,6 +427,7 @@ fn printHelp() void {
         \\       padctl switch <name> [--device <id>] [--socket <path>]
         \\       padctl status [--socket <path>]
         \\       padctl devices [--socket <path>]
+        \\       padctl dump <enable|disable|status|export|clear>
         \\
         \\Subcommands:
         \\  install               Install binary, service, udev rules, and device configs
@@ -458,6 +459,13 @@ fn printHelp() void {
         \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
         \\  devices               List connected devices via daemon
         \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
+        \\  dump enable           Turn on diagnostic logging (persists across reboots)
+        \\  dump disable          Turn off diagnostic logging (default)
+        \\  dump status           Show dump state, log path, size, and time span
+        \\  dump export           Export filtered logs to stdout or file
+        \\    --period <duration> Time window: Nm, Nh, or Nd (default: 1d)
+        \\    -o <path>           Write to file instead of stdout
+        \\  dump clear            Delete all log files (interactive confirmation)
         \\  config list           List XDG-layer device and mapping configs
         \\  config init           Interactively create a mapping in ~/.config/padctl/mappings/
         \\    --device <name>     Skip device selection prompt

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,10 @@
 const std = @import("std");
+const padctl_log = @import("log.zig");
+
+pub const std_options: std.Options = .{
+    .log_level = .debug,
+    .logFn = padctl_log.logFn,
+};
 
 fn stdoutWrite(_: void, data: []const u8) error{}!usize {
     return std.posix.write(std.posix.STDOUT_FILENO, data) catch data.len;
@@ -24,6 +30,7 @@ pub const cli = struct {
     pub const switch_mapping = @import("cli/switch_mapping.zig");
     pub const status = @import("cli/status.zig");
     pub const devices = @import("cli/devices.zig");
+    pub const dump = @import("cli/dump.zig");
     pub const config = struct {
         pub const list = @import("cli/config/list.zig");
         pub const init = @import("cli/config/init.zig");
@@ -129,6 +136,8 @@ const Interpreter = core.interpreter.Interpreter;
 const DeviceIO = io.device_io.DeviceIO;
 const VERSION = "0.1.0";
 
+pub const DumpAction = enum { enable, disable, status, @"export", clear };
+
 const Cli = struct {
     allocator: std.mem.Allocator,
     config_path: ?[]const u8 = null,
@@ -151,6 +160,9 @@ const Cli = struct {
     switch_cmd: ?struct { name: ?[]const u8 = null, device_id: ?[]const u8 = null, persist: bool = false } = null,
     status_cmd: bool = false,
     devices_cmd: bool = false,
+    dump_cmd: ?DumpAction = null,
+    dump_period: []const u8 = "1d",
+    dump_output_path: ?[]const u8 = null,
     socket_path: []const u8 = cli.socket_client.DEFAULT_SOCKET_PATH,
     socket_explicit: bool = false,
 
@@ -366,6 +378,35 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                     std.log.err("unknown devices argument: {s}", .{sub_arg});
                     return error.UnknownArgument;
                 }
+            }
+        } else if (std.mem.eql(u8, arg, "dump")) {
+            // Collect remaining args into a small buffer for parseDumpFromSlice.
+            var dump_args: [16][]const u8 = undefined;
+            var dump_argc: usize = 0;
+            while (args.next()) |da| {
+                if (dump_argc >= dump_args.len) {
+                    std.log.err("too many dump arguments", .{});
+                    return error.UnknownArgument;
+                }
+                dump_args[dump_argc] = da;
+                dump_argc += 1;
+            }
+            const result = parseDumpFromSlice(dump_args[0..dump_argc]) catch |err| switch (err) {
+                error.MissingArgValue => {
+                    std.log.err("dump requires a subcommand: enable, disable, status, export, clear", .{});
+                    return error.MissingArgValue;
+                },
+                error.UnknownArgument => {
+                    std.log.err("unknown dump argument", .{});
+                    return error.UnknownArgument;
+                },
+            };
+            parsed_cli.dump_cmd = result.cmd;
+            parsed_cli.dump_period = result.period;
+            parsed_cli.dump_output_path = result.output_path;
+            if (result.socket_path) |sp| {
+                parsed_cli.socket_path = sp;
+                parsed_cli.socket_explicit = true;
             }
         } else {
             std.log.err("unknown argument: {s}", .{arg});
@@ -583,6 +624,79 @@ pub fn main() !void {
         std.process.exit(0);
     }
 
+    // dump subcommand
+    if (parsed.dump_cmd) |dump_action| {
+        // dump status: show state + log stats, exit.
+        if (dump_action == .status) {
+            cli.dump.runStatus(allocator, parsed.socket_path, stdout_writer, stderr_writer);
+            std.process.exit(0);
+        }
+
+        // dump clear: show stats, prompt, delete.
+        if (dump_action == .clear) {
+            cli.dump.runClear(allocator, stdout_writer, stderr_writer);
+            std.process.exit(0);
+        }
+
+        // dump export: filter and output logs, exit.
+        if (dump_action == .@"export") {
+            cli.dump.runExport(allocator, parsed.dump_period, parsed.dump_output_path, stdout_writer, stderr_writer);
+            std.process.exit(0);
+        }
+
+        const enable = dump_action == .enable;
+        var config_written = false;
+
+        // Write to both user and system config (best-effort for each).
+        const cfgpaths = config.paths;
+        if (cfgpaths.userConfigDir(allocator)) |user_dir| {
+            defer allocator.free(user_dir);
+            if (cli.dump.writeDiagnosticsConfig(allocator, user_dir, enable)) {
+                config_written = true;
+            } else |err| {
+                if (err == error.MalformedConfig) {
+                    stderr_writer.writeAll("error: user config.toml is malformed — fix or remove it\n") catch {};
+                } else {
+                    std.log.warn("could not write user config: {}", .{err});
+                }
+            }
+        } else |_| {}
+
+        if (cli.dump.writeDiagnosticsConfig(allocator, cfgpaths.systemConfigDir(), enable)) {
+            config_written = true;
+        } else |err| {
+            if (err == error.MalformedConfig) {
+                stderr_writer.writeAll("error: system config.toml is malformed — fix or remove it\n") catch {};
+            } else {
+                std.log.warn("could not write system config: {}", .{err});
+            }
+        }
+
+        // Send IPC to running daemon (best-effort).
+        var ipc_ok = false;
+        const ipc_cmd: []const u8 = if (enable) "DUMP ON\n" else "DUMP OFF\n";
+        if (cli.socket_client.connectToSocket(parsed.socket_path)) |sock_fd| {
+            defer std.posix.close(sock_fd);
+            var resp_buf: [64]u8 = undefined;
+            if (cli.socket_client.sendCommand(sock_fd, ipc_cmd, &resp_buf)) |resp| {
+                _ = stdout_writer.write(resp) catch {};
+                ipc_ok = true;
+            } else |_| {
+                stderr_writer.writeAll("warning: daemon did not respond\n") catch {};
+            }
+        } else |_| {
+            if (config_written) {
+                stderr_writer.writeAll("info: daemon not running; config written, will apply on next start\n") catch {};
+            }
+        }
+
+        if (!config_written and !ipc_ok) {
+            stderr_writer.writeAll("error: could not persist or apply dump setting\n") catch {};
+            std.process.exit(1);
+        }
+        std.process.exit(0);
+    }
+
     // switch subcommand
     if (parsed.switch_cmd) |sw| {
         // Resolve the mapping name: either explicit or from user config.
@@ -712,6 +826,31 @@ pub fn main() !void {
         };
         std.process.exit(0);
     }
+
+    // Daemon mode logging: two-step init.
+    // Step 1: resolve the log path so that early warnings (e.g. malformed
+    // config.toml) can persist to the log file via lazy open in logFn.
+    padctl_log.initPath(allocator);
+    defer padctl_log.deinit();
+
+    // Step 2: load diagnostics config. Warnings during load now persist.
+    const log_opts: padctl_log.InitOptions = blk: {
+        const user_cfg_mod = @import("config/user_config.zig");
+        if (user_cfg_mod.load(allocator)) |pr| {
+            var ucpr = pr;
+            defer ucpr.deinit();
+            break :blk .{
+                .dump = ucpr.value.diagnostics.dump,
+                .max_log_size_mb = ucpr.value.diagnostics.max_log_size_mb,
+            };
+        }
+        break :blk .{};
+    };
+
+    // Step 3: apply config — sets rotation size, dump toggle, opens file if dump on.
+    padctl_log.applyConfig(log_opts);
+
+    std.log.info("padctl started, PID={d}, dump={}", .{ std.os.linux.getpid(), padctl_log.isEnabled() });
 
     // --config-dir mode: glob *.toml, discover all devices, dedup by physical path, hot-reload on SIGHUP
     if (parsed.config_dir) |dir_path| {
@@ -1087,9 +1226,97 @@ fn parseDeviceFromStatus(resp: []const u8) ?[]const u8 {
     return null;
 }
 
+/// Parse dump subcommand and options from an argument slice. Testable
+/// variant of the inline dump-parsing block in parseArgs.
+pub fn parseDumpFromSlice(args: []const []const u8) !struct {
+    cmd: ?DumpAction = null,
+    period: []const u8 = "1d",
+    output_path: ?[]const u8 = null,
+    socket_path: ?[]const u8 = null,
+} {
+    var result: @TypeOf(parseDumpFromSlice(args) catch unreachable) = .{};
+    if (args.len == 0) return error.MissingArgValue;
+    const sub = args[0];
+    if (std.mem.eql(u8, sub, "enable")) {
+        result.cmd = .enable;
+    } else if (std.mem.eql(u8, sub, "disable")) {
+        result.cmd = .disable;
+    } else if (std.mem.eql(u8, sub, "status")) {
+        result.cmd = .status;
+    } else if (std.mem.eql(u8, sub, "export")) {
+        result.cmd = .@"export";
+    } else if (std.mem.eql(u8, sub, "clear")) {
+        result.cmd = .clear;
+    } else {
+        return error.UnknownArgument;
+    }
+    var i: usize = 1;
+    while (i < args.len) : (i += 1) {
+        if (std.mem.eql(u8, args[i], "--period")) {
+            i += 1;
+            if (i >= args.len) return error.MissingArgValue;
+            result.period = args[i];
+        } else if (std.mem.eql(u8, args[i], "-o")) {
+            i += 1;
+            if (i >= args.len) return error.MissingArgValue;
+            result.output_path = args[i];
+        } else if (std.mem.eql(u8, args[i], "--socket")) {
+            i += 1;
+            if (i >= args.len) return error.MissingArgValue;
+            result.socket_path = args[i];
+        } else {
+            return error.UnknownArgument;
+        }
+    }
+    return result;
+}
+
 // --- CLI tests ---
 
 const testing = std.testing;
+
+test "main: parseDumpFromSlice: enable" {
+    const r = try parseDumpFromSlice(&.{"enable"});
+    try testing.expectEqual(@as(@TypeOf(r.cmd), .enable), r.cmd);
+    try testing.expectEqualStrings("1d", r.period);
+    try testing.expectEqual(@as(?[]const u8, null), r.output_path);
+}
+
+test "main: parseDumpFromSlice: disable" {
+    const r = try parseDumpFromSlice(&.{"disable"});
+    try testing.expectEqual(@as(@TypeOf(r.cmd), .disable), r.cmd);
+}
+
+test "main: parseDumpFromSlice: status" {
+    const r = try parseDumpFromSlice(&.{"status"});
+    try testing.expectEqual(@as(@TypeOf(r.cmd), .status), r.cmd);
+}
+
+test "main: parseDumpFromSlice: export with period and output" {
+    const r = try parseDumpFromSlice(&.{ "export", "--period", "2h", "-o", "/tmp/out.log" });
+    try testing.expectEqual(@as(@TypeOf(r.cmd), .@"export"), r.cmd);
+    try testing.expectEqualStrings("2h", r.period);
+    try testing.expectEqualStrings("/tmp/out.log", r.output_path.?);
+}
+
+test "main: parseDumpFromSlice: export default period" {
+    const r = try parseDumpFromSlice(&.{"export"});
+    try testing.expectEqual(@as(@TypeOf(r.cmd), .@"export"), r.cmd);
+    try testing.expectEqualStrings("1d", r.period);
+}
+
+test "main: parseDumpFromSlice: clear" {
+    const r = try parseDumpFromSlice(&.{"clear"});
+    try testing.expectEqual(@as(@TypeOf(r.cmd), .clear), r.cmd);
+}
+
+test "main: parseDumpFromSlice: missing subcommand" {
+    try testing.expectError(error.MissingArgValue, parseDumpFromSlice(&.{}));
+}
+
+test "main: parseDumpFromSlice: unknown subcommand" {
+    try testing.expectError(error.UnknownArgument, parseDumpFromSlice(&.{"foobar"}));
+}
 
 test "main: parseDeviceFromStatus extracts device name" {
     const resp = "STATUS device=Flydigi Vader 5 Pro active=true\n";

--- a/src/main.zig
+++ b/src/main.zig
@@ -654,8 +654,13 @@ pub fn main() !void {
 
         const enable = dump_action == .enable;
         var config_written = false;
+        // Malformed user config blocks the persistence chain: user_config.load()
+        // refuses to fall through to the system config when the user file is
+        // broken, so writing only the system file would not actually take effect
+        // on the next daemon restart. Track this and refuse to claim persistence.
+        var user_config_blocks_fallback = false;
 
-        // Write to both user and system config (best-effort for each).
+        // Write to user config first (no sudo needed).
         const cfgpaths = config.paths;
         if (cfgpaths.userConfigDir(allocator)) |user_dir| {
             defer allocator.free(user_dir);
@@ -663,7 +668,8 @@ pub fn main() !void {
                 config_written = true;
             } else |err| {
                 if (err == error.MalformedConfig) {
-                    stderr_writer.writeAll("error: user config.toml is malformed — fix or remove it\n") catch {};
+                    user_config_blocks_fallback = true;
+                    stderr_writer.writeAll("error: user config.toml is malformed — fix or remove it before enabling dump persistence\n") catch {};
                 } else {
                     std.log.warn("could not write user config: {}", .{err});
                 }
@@ -673,7 +679,12 @@ pub fn main() !void {
         // System config: write to a temp file, then sudo cp to /etc/padctl/.
         // Direct write fails without root (AccessDenied).
         const sys_dir = cfgpaths.systemConfigDir();
-        if (std.os.linux.getuid() == 0) {
+        if (user_config_blocks_fallback) {
+            // Skip system write entirely regardless of privilege: the daemon
+            // won't read it because user_config.load() stops on MalformedConfig
+            // in the user file and refuses to fall through to the system file.
+            stderr_writer.writeAll("info: skipping system config write — broken user config would mask it\n") catch {};
+        } else if (std.os.linux.getuid() == 0) {
             // Already root — write directly.
             if (cli.dump.writeDiagnosticsConfig(allocator, sys_dir, enable)) {
                 config_written = true;
@@ -685,27 +696,35 @@ pub fn main() !void {
                 }
             }
         } else {
-            // Non-root: write to temp dir, sudo cp to system path.
-            const tmp_dir = "/tmp/padctl-dump-config";
-            if (cli.dump.writeDiagnosticsConfig(allocator, tmp_dir, enable)) {
-                const tmp_src = tmp_dir ++ "/config.toml";
-                const sys_dst_buf = std.fmt.allocPrint(allocator, "{s}/config.toml", .{sys_dir}) catch null;
-                defer if (sys_dst_buf) |b| allocator.free(b);
-                if (sys_dst_buf) |sys_dst| {
-                    if (runSudoMkdir(sys_dir, stderr_writer)) {
-                        if (runSudoCopy(tmp_src, sys_dst, stderr_writer)) {
-                            config_written = true;
+            // Non-root: write to a unique temp dir (avoids symlink/TOCTOU on
+            // a shared /tmp path), sudo cp to system path, then cleanup.
+            if (makeTempDir(allocator)) |tmp_dir| {
+                defer {
+                    // Best-effort cleanup of the temp dir tree.
+                    std.fs.deleteTreeAbsolute(tmp_dir) catch {};
+                    allocator.free(tmp_dir);
+                }
+                if (cli.dump.writeDiagnosticsConfig(allocator, tmp_dir, enable)) {
+                    const tmp_src = std.fmt.allocPrint(allocator, "{s}/config.toml", .{tmp_dir}) catch null;
+                    defer if (tmp_src) |s| allocator.free(s);
+                    const sys_dst = std.fmt.allocPrint(allocator, "{s}/config.toml", .{sys_dir}) catch null;
+                    defer if (sys_dst) |b| allocator.free(b);
+                    if (tmp_src != null and sys_dst != null) {
+                        if (runSudoMkdir(sys_dir, stderr_writer)) {
+                            if (runSudoCopy(tmp_src.?, sys_dst.?, stderr_writer)) {
+                                config_written = true;
+                            }
                         }
                     }
+                } else |err| {
+                    if (err == error.MalformedConfig) {
+                        stderr_writer.writeAll("error: system config.toml is malformed — fix or remove it\n") catch {};
+                    } else {
+                        std.log.warn("could not write system config: {}", .{err});
+                    }
                 }
-                std.fs.deleteFileAbsolute(tmp_src) catch {};
-                std.fs.deleteTreeAbsolute(tmp_dir) catch {};
             } else |err| {
-                if (err == error.MalformedConfig) {
-                    stderr_writer.writeAll("error: system config.toml is malformed — fix or remove it\n") catch {};
-                } else {
-                    std.log.warn("could not write system config: {}", .{err});
-                }
+                std.log.warn("could not create temp dir for config write: {}", .{err});
             }
         }
 
@@ -730,6 +749,12 @@ pub fn main() !void {
         if (!config_written and !ipc_ok) {
             stderr_writer.writeAll("error: could not persist or apply dump setting\n") catch {};
             std.process.exit(1);
+        }
+        if (!config_written and user_config_blocks_fallback) {
+            // IPC may have succeeded (live-only apply), but the setting will
+            // be lost on next daemon restart. Surface this loudly so users
+            // don't assume the toggle is durable.
+            stderr_writer.writeAll("warning: dump setting was NOT persisted across restarts — fix the malformed user config.toml first\n") catch {};
         }
         std.process.exit(0);
     }
@@ -1163,6 +1188,29 @@ fn runSudoMkdir(dir: []const u8, err_writer: anytype) bool {
         .Exited => |code| code == 0,
         else => false,
     };
+}
+
+/// Create a unique, exclusive temp directory owned by the current user.
+/// Using `mkdir` (exclusive) + random suffix avoids symlink/TOCTOU races on a
+/// shared predictable path like `/tmp/padctl-dump-config`. Mode 0o700 keeps
+/// the tree private even though the config.toml contents are non-sensitive.
+/// Caller owns and must free the returned path.
+fn makeTempDir(allocator: std.mem.Allocator) ![]u8 {
+    const tmp = std.posix.getenv("TMPDIR") orelse "/tmp";
+    var rand_bytes: [8]u8 = undefined;
+    var attempts: u32 = 0;
+    while (attempts < 16) : (attempts += 1) {
+        std.crypto.random.bytes(&rand_bytes);
+        const suffix = std.mem.readInt(u64, &rand_bytes, .little);
+        const path = try std.fmt.allocPrint(allocator, "{s}/padctl-dump-{x}", .{ tmp, suffix });
+        std.posix.mkdir(path, 0o700) catch |err| {
+            allocator.free(path);
+            if (err == error.PathAlreadyExists) continue;
+            return err;
+        };
+        return path;
+    }
+    return error.TempDirCreationFailed;
 }
 
 fn escapeTomlString(writer: anytype, s: []const u8) !void {

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -834,6 +834,9 @@ pub const Supervisor = struct {
             .status => self.handleStatus(fd),
             .list => self.handleList(fd),
             .devices => self.handleDevices(fd),
+            .dump_on => self.handleDump(fd, true),
+            .dump_off => self.handleDump(fd, false),
+            .dump_status => self.handleDumpStatus(fd),
             .unknown => cs.sendResponse(fd, "ERR unknown-command\n"),
         }
     }
@@ -1049,6 +1052,28 @@ pub const Supervisor = struct {
         resp_buf[pos] = '\n';
         pos += 1;
         cs.sendResponse(fd, resp_buf[0..pos]);
+    }
+
+    fn handleDumpStatus(self: *Supervisor, fd: posix.fd_t) void {
+        const padctl_log = @import("log.zig");
+        var cs = &self.ctrl_sock.?;
+        var resp_buf: [64]u8 = undefined;
+        const state_str: []const u8 = if (padctl_log.isEnabled()) "on" else "off";
+        const resp = std.fmt.bufPrint(&resp_buf, "OK dump={s}\n", .{state_str}) catch return;
+        cs.sendResponse(fd, resp);
+    }
+
+    fn handleDump(self: *Supervisor, fd: posix.fd_t, enable: bool) void {
+        const padctl_log = @import("log.zig");
+        padctl_log.setEnabled(enable);
+        var cs = &self.ctrl_sock.?;
+        if (enable) {
+            cs.sendResponse(fd, "OK dump=on\n");
+            std.log.info("dump logging enabled via IPC", .{});
+        } else {
+            cs.sendResponse(fd, "OK dump=off\n");
+            std.log.info("dump logging disabled via IPC", .{});
+        }
     }
 
     /// Look up the user config's default_mapping for device_name, find and parse the mapping file.
@@ -1598,6 +1623,14 @@ pub const Supervisor = struct {
             return err;
         };
         std.log.info("device attached: \"{s}\" {s}/{s}", .{ cfg.?.device.name, dev_root, devname });
+        // Log FF config for rumble diagnostics.
+        if (cfg.?.output) |out| {
+            if (out.force_feedback) |ff| {
+                std.log.info("device FF config: type={s} max_effects={?d} auto_stop={}", .{
+                    ff.type, ff.max_effects, ff.auto_stop,
+                });
+            }
+        }
     }
 };
 

--- a/src/test/mock_output.zig
+++ b/src/test/mock_output.zig
@@ -38,8 +38,8 @@ pub const MockOutput = struct {
         self.prev = s;
     }
 
-    fn mockPollFf(_: *anyopaque) uinput.PollFfError!?uinput.FfEvent {
-        return null;
+    fn mockPollFf(_: *anyopaque) uinput.PollFfError!uinput.FfEventBatch {
+        return .{};
     }
 
     fn mockClose(_: *anyopaque) void {}

--- a/src/test/properties/contract_props.zig
+++ b/src/test/properties/contract_props.zig
@@ -145,7 +145,7 @@ test "contract OutputDevice: poll_ff on fresh mock returns null" {
 
     const dev = out.outputDevice();
     const ff = try dev.pollFf();
-    try testing.expect(ff == null);
+    try testing.expectEqual(@as(usize, 0), ff.len);
 }
 
 // C10: emit() records exact state — no mutation of the passed value.


### PR DESCRIPTION
## Summary

Introduces `padctl dump` — a togglable diagnostic logging system for capturing FF/rumble pipeline traces on demand — and fixes the `pollFf()` drain-loop event loss that's a plausible root cause of the stuck vibration motor reported in #65. Dump logging is off by default (zero disk overhead) and can be toggled live via the control socket without restarting the daemon.

### Motivation

Issue #65 reports that the Flydigi Vader 5 Pro's vibration motor gets stuck on during gameplay, sometimes crashing the firmware. PR #69's userspace auto-stop timer fixed Steam's ping test but the reporter confirmed the issue persists in non-Steam-Input games (Space Marine 2).

Two parts to this PR:

1. **Diagnostic tooling**: Users experiencing the issue have no way to capture evidence. This PR ships an opt-in logging system with a CLI that lets users enable/disable debug logs, view stats, export filtered logs for bug reports, and clear old data.

2. **FF event loss fix**: Analysis of `pollFf()` revealed that the drain loop reads all pending FF events but collapses them to only the last one, silently discarding intermediate STOP events. Games using `replay.length=0` (infinite duration, common in Unreal Engine) create INFINITE scheduler slots that can only be cleared by explicit STOP — if that STOP is lost, the motor runs forever. The new batch-return API preserves every event.

### What's new

**Diagnostic dump CLI (`padctl dump`):**
- `padctl dump enable|disable` — togglable debug logging, persisted to user + system config, applied live via IPC
- `padctl dump status` — show current state, log file path, size, time span
- `padctl dump export [--period 1d] [-o file]` — export logs filtered by time window (Nm/Nh/Nd syntax) to stdout or file; merges rotated + current logs
- `padctl dump clear` — delete logs with interactive confirmation; shows file count, size, and time span before prompting

**Logging infrastructure (`src/log.zig`):**
- Custom `logFn` tees to stderr (journal) + file with ISO 8601 + monotonic ns timestamps
- Runtime toggle via atomic bool: err/warn always persist, debug/info gated
- Two-step init (`initPath` → `applyConfig`) so early config-load warnings still persist
- Lazy file open: file only created on first err/warn or when dump is enabled
- Auto-reopen on file deletion (fstat nlink check)
- Configurable rotation threshold via `[diagnostics] max_log_size_mb` (default 100 MB, 1 rotated file)

**Config schema (`[diagnostics]` section):**
- `dump = false` (default), `max_log_size_mb = 100`
- Forward-compatible: unknown fields ignored
- Preserved across `padctl install` reinstalls (binding writer now carries the section forward)

**IPC protocol:**
- New `DUMP ON` / `DUMP OFF` / `DUMP STATUS` verbs on the control socket
- Daemon handler toggles log module and persists state

**Rumble pipeline instrumentation (gated behind dump enable):**
- Every FF event (UPLOAD/PLAY/STOP/ERASE) logged with device tag, effect ID, magnitudes, duration
- Full post-checksum HID frame hex dumps on every rumble write
- Scheduler state dumps with relative time deltas after every mutation
- Timerfd arm/disarm/expiry logging with errno on failure
- 60-second heartbeat confirms daemon liveness + shows scheduler state
- Device disconnect logs scheduler state at teardown

**Rumble drain-loop fix (`src/io/uinput.zig`, `src/event_loop.zig`):**
- New `FfEventBatch` type: bounded array of up to 32 `FfEvent`s preserving kernel FIFO order
- `pollFf()` returns batch instead of `?FfEvent` — every event reaches the event loop
- Overflow safety: if >32 events queue, the 33rd is buffered in `pending_ff` and returned first on next `pollFf()` (no event loss)
- Event loop processes the batch sequentially: stops go through scheduler immediately, per-effect pending plays track surviving effects after all stops are applied, only the last surviving play by batch position is emitted to HID
- `OutputDevice` vtable updated; all mocks and 40+ existing tests updated

**Installer fixes (`src/cli/install.zig`):**
- Immutable OS root install: system service at `/etc/systemd/system/padctl.service` (available at early boot, unlike `/usr/local/lib/...` which lives on `/var/usrlocal`)
- Non-immutable: user service paths preserved exactly as before PR #84
- Legacy system service/drop-in auto-updated on upgrade (keeps the running daemon in sync)
- `LogsDirectory=padctl` in service templates — writable `/var/log/padctl/` under `ProtectSystem=strict`
- `writeBinding` preserves `[diagnostics]` when regenerating config.toml

**CLI privilege elevation (matches `switch --persist` pattern):**
- `padctl dump enable/disable` writes user config directly, falls back to `sudo cp` for system config
- `padctl dump clear` falls back to `sudo rm` for root-owned log files

**Socket path compatibility:**
- PR #95's XDG-first resolver broke CLI on immutable OS where the daemon still runs as a system service. Added `/run/ostree-booted` check to use `/run/padctl/padctl.sock` directly on immutable. Non-immutable behavior unchanged.

**Script improvements (`scripts/bazzite-setup.sh`):**
- Pin `zig@0.15` (0.16 has breaking build API changes) with explicit PATH export
- Warn non-brew users whose zig is 0.16+ before attempting to build
- Skip `git pull` when on a local branch with no upstream (avoids hang/error noise)

### Non-breaking changes

- `[diagnostics]` section is optional; omitted config parses with sensible defaults
- `padctl dump` is a new subcommand — existing CLI surface unchanged
- Debug logging is off by default — zero disk overhead in normal operation, same as before this PR
- `FfEventBatch` is returned from `pollFf`, but for single events it's indistinguishable from the old `?FfEvent` API at the event loop level; all existing tests pass with minor test-only API adjustments
- Installer changes are additive: new service templates coexist with legacy paths on upgrades
- Socket path resolver: only adds an early-return branch for immutable OS; PR #95's logic preserved verbatim for all other cases

### Changed files

| File | Changes |
|------|---------|
| `src/log.zig` | **New** — custom logFn, atomic dump toggle, rotation, lazy open, reopen-after-delete (~330 lines) |
| `src/cli/dump.zig` | **New** — CLI handlers, config writer, log stats, period filter, export, clear (~940 lines) |
| `src/io/uinput.zig` | `FfEventBatch` type, batch-return `pollFf` with overflow buffering, per-device log tag (+333/-0) |
| `src/event_loop.zig` | Sequential batch processing, per-effect pending plays, rumble instrumentation, heartbeat (+541/-0) |
| `src/main.zig` | `dump` subcommand parsing + execution, `--help` text, `std_options` wiring (+264/-0) |
| `src/cli/install.zig` | Immutable system service placement, legacy update logic, `LogsDirectory`, `[diagnostics]` preservation (+133/-0) |
| `src/config/user_config.zig` | `DiagnosticsConfig` schema (+91/-0) |
| `src/io/control_socket.zig` | `DUMP ON`/`OFF`/`STATUS` IPC verbs (+41/-0) |
| `src/supervisor.zig` | `handleDump` / `handleDumpStatus` (+33/-0) |
| `src/config/paths.zig` | `stateDir()` for log directory (+19/-0) |
| `src/cli/socket_client.zig` | Immutable OS early-return for system socket path (+17/-3) |
| `src/core/rumble_scheduler.zig` | `dumpSlots()` helper + dump-invariance test (+36/-0) |
| `src/device_instance.zig` | `log_tag` and `device_tag` propagation (+6/-0) |
| `scripts/bazzite-setup.sh` | Pin zig@0.15, version warnings, local-branch pull skip (+34/-3) |
| `src/test/mock_output.zig` | Mock updated for `FfEventBatch` return (+2/-2) |
| `src/test/properties/contract_props.zig` | Contract test updated for batch API (+1/-1) |

## Test plan

- [x] `zig build test` — all tests passing, including 40+ new tests
- [x] `zig build test-safe` — ReleaseSafe, passing
- [x] `zig build check-fmt` — clean
- [x] Manual: `padctl dump enable/disable/status/export/clear` round-trip on Bazzite with running system service
- [x] Manual: config.toml `[diagnostics]` section survives `padctl install` reinstall
- [x] Manual: log file deletion auto-recreates on next write (no daemon restart needed)
- [x] Manual: rebase onto latest upstream main (PRs #95, #96, #101, #102) with minimal conflict
- [x] verify non-immutable installs still use PR #95's XDG socket path

Refs #65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in diagnostic logging with new `padctl dump` subcommands: enable/disable, status, export, clear.
  * Export logs by period and clear stored logs (with confirmation).

* **Improvements**
  * Configurable diagnostics (persisted setting, max log size, rotation).
  * More robust log file location and state selection.
  * Enhanced force-feedback processing (batch events) and richer rumble diagnostics.
  * Improved immutable-system handling and Zig version management.

* **Docs**
  * Added Diagnostic Logging user guide and updated CLI reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->