### PR TITLE
fix(layer): use press timestamp to resolve tap/hold race

### DIFF
--- a/src/core/layer.zig
+++ b/src/core/layer.zig
@@ -18,6 +18,8 @@ pub const TapHoldState = struct {
     layer_name: []const u8,
     layer_activated: bool = false,
     phase: TapHoldPhase = .pending,
+    press_ns: i128 = 0,
+    hold_timeout_ns: i128 = 0,
 };
 
 pub const TapHoldResult = struct {
@@ -69,6 +71,7 @@ pub const LayerState = struct {
         configs: []const LayerConfig,
         buttons: u64,
         prev_buttons: u64,
+        now_ns: i128,
     ) LayerAction {
         var action = LayerAction{};
 
@@ -85,7 +88,7 @@ pub const LayerState = struct {
                         if (!std.mem.eql(u8, th.layer_name, cfg.name)) continue;
                     }
                     const timeout: u64 = @intCast(cfg.hold_timeout orelse 200);
-                    const res = self.onTriggerPress(cfg.name, timeout);
+                    const res = self.onTriggerPress(cfg.name, timeout, now_ns);
                     if (res.arm_timer_ms) |ms| {
                         action.arm_timer_ms = ms;
                         action.active_changed = true;
@@ -98,7 +101,7 @@ pub const LayerState = struct {
                         remap.resolveTarget(t) catch null
                     else
                         null;
-                    const res = self.onTriggerRelease(tap_target);
+                    const res = self.onTriggerRelease(tap_target, now_ns);
                     if (res.disarm_timer) action.disarm_timer = true;
                     if (res.tap_event) |ev| action.tap_event = ev;
                     if (res.layer_activated or res.layer_deactivated) action.active_changed = true;
@@ -124,32 +127,36 @@ pub const LayerState = struct {
         return action;
     }
 
-    /// IDLE → PENDING: arm timerfd
-    pub fn onTriggerPress(self: *LayerState, layer_name: []const u8, hold_timeout_ms: u64) TapHoldResult {
-        // already PENDING or ACTIVE for this layer: ignore re-press
+    pub fn onTriggerPress(self: *LayerState, layer_name: []const u8, hold_timeout_ms: u64, now_ns: i128) TapHoldResult {
         if (self.tap_hold) |th| {
             if (std.mem.eql(u8, th.layer_name, layer_name)) return .{};
         }
-        self.tap_hold = .{ .layer_name = layer_name, .phase = .pending };
+        self.tap_hold = .{
+            .layer_name = layer_name,
+            .phase = .pending,
+            .press_ns = now_ns,
+            .hold_timeout_ns = @as(i128, hold_timeout_ms) * 1_000_000,
+        };
         return .{ .arm_timer_ms = hold_timeout_ms };
     }
 
-    /// PENDING → IDLE + tap, or ACTIVE → IDLE
-    pub fn onTriggerRelease(self: *LayerState, tap_target: ?RemapTarget) TapHoldResult {
-        const th = self.tap_hold orelse return .{}; // IDLE: no-op
+    pub fn onTriggerRelease(self: *LayerState, tap_target: ?RemapTarget, now_ns: i128) TapHoldResult {
+        const th = self.tap_hold orelse return .{};
         defer self.tap_hold = null;
         return switch (th.phase) {
             .pending => .{
                 .disarm_timer = true,
                 .tap_event = tap_target,
             },
-            .active => .{
+            .active => if (th.hold_timeout_ns > 0 and (now_ns - th.press_ns) < th.hold_timeout_ns) .{
+                .tap_event = tap_target,
+                .layer_deactivated = true,
+            } else .{
                 .layer_deactivated = true,
             },
         };
     }
 
-    /// PENDING → ACTIVE; stale timer (IDLE) is ignored
     pub fn onTimerExpired(self: *LayerState) TapHoldResult {
         const th = &(self.tap_hold orelse return .{}); // IDLE: stale, no-op
         if (th.phase != .pending) return .{};
@@ -264,7 +271,7 @@ test "layer: tap-hold: press → PENDING, arm_timer_ms set" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
 
-    const res = ls.onTriggerPress("aim", 200);
+    const res = ls.onTriggerPress("aim", 200, 0);
     try testing.expectEqual(@as(?u64, 200), res.arm_timer_ms);
     try testing.expect(!res.disarm_timer);
     try testing.expect(res.tap_event == null);
@@ -277,7 +284,7 @@ test "layer: tap-hold: press → PENDING, arm_timer_ms set" {
 test "layer: tap-hold: PENDING + timer expired → ACTIVE, layer_activated = true" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
-    _ = ls.onTriggerPress("aim", 200);
+    _ = ls.onTriggerPress("aim", 200, 0);
 
     const res = ls.onTimerExpired();
     try testing.expect(res.layer_activated);
@@ -292,9 +299,9 @@ test "layer: tap-hold: PENDING + timer expired → ACTIVE, layer_activated = tru
 test "layer: tap-hold: PENDING + release → IDLE, tap_event has value" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
-    _ = ls.onTriggerPress("aim", 200);
+    _ = ls.onTriggerPress("aim", 200, 0);
 
-    const res = ls.onTriggerRelease(RemapTarget{ .key = 183 });
+    const res = ls.onTriggerRelease(RemapTarget{ .key = 183 }, 100_000_000);
     try testing.expect(res.disarm_timer);
     try testing.expect(res.tap_event != null);
     try testing.expect(!res.layer_activated);
@@ -305,21 +312,21 @@ test "layer: tap-hold: PENDING + release → IDLE, tap_event has value" {
 test "layer: tap-hold: PENDING + release with no tap target → IDLE, no tap_event" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
-    _ = ls.onTriggerPress("aim", 200);
+    _ = ls.onTriggerPress("aim", 200, 0);
 
-    const res = ls.onTriggerRelease(null);
+    const res = ls.onTriggerRelease(null, 100_000_000);
     try testing.expect(res.disarm_timer);
     try testing.expect(res.tap_event == null);
     try testing.expect(ls.tap_hold == null);
 }
 
-test "layer: tap-hold: ACTIVE + release → IDLE, layer_deactivated = true" {
+test "layer: tap-hold: ACTIVE + release (past timeout) → IDLE, no tap" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
-    _ = ls.onTriggerPress("aim", 200);
+    _ = ls.onTriggerPress("aim", 200, 0);
     _ = ls.onTimerExpired();
 
-    const res = ls.onTriggerRelease(RemapTarget{ .key = 183 });
+    const res = ls.onTriggerRelease(RemapTarget{ .key = 183 }, 500_000_000);
     try testing.expect(res.layer_deactivated);
     try testing.expect(!res.layer_activated);
     try testing.expect(!res.disarm_timer);
@@ -327,11 +334,25 @@ test "layer: tap-hold: ACTIVE + release → IDLE, layer_deactivated = true" {
     try testing.expect(ls.tap_hold == null);
 }
 
+test "layer: tap-hold: ACTIVE + release within timeout (race) → tap emitted (#79)" {
+    var ls = LayerState.init(testing.allocator);
+    defer ls.deinit();
+    const press_time: i128 = 1_000_000_000;
+    _ = ls.onTriggerPress("aim", 200, press_time);
+    _ = ls.onTimerExpired();
+
+    const release_time: i128 = press_time + 150_000_000;
+    const res2 = ls.onTriggerRelease(RemapTarget{ .key = 183 }, release_time);
+    try testing.expect(res2.layer_deactivated);
+    try testing.expect(res2.tap_event != null);
+    try testing.expect(ls.tap_hold == null);
+}
+
 test "layer: tap-hold: IDLE + release → no-op" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
 
-    const res = ls.onTriggerRelease(RemapTarget{ .key = 183 });
+    const res = ls.onTriggerRelease(RemapTarget{ .key = 183 }, 0);
     try testing.expect(!res.disarm_timer);
     try testing.expect(res.tap_event == null);
     try testing.expect(!res.layer_activated);
@@ -350,10 +371,10 @@ test "layer: tap-hold: IDLE + timer expired → no-op (stale timer)" {
 test "layer: tap-hold: ACTIVE re-press same trigger → ignored" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();
-    _ = ls.onTriggerPress("aim", 200);
+    _ = ls.onTriggerPress("aim", 200, 0);
     _ = ls.onTimerExpired();
 
-    const res = ls.onTriggerPress("aim", 200);
+    const res = ls.onTriggerPress("aim", 200, 0);
     try testing.expect(res.arm_timer_ms == null);
     try testing.expectEqual(TapHoldPhase.active, ls.tap_hold.?.phase);
 }
@@ -380,7 +401,7 @@ test "layer: processLayerTriggers: Hold press → PENDING, arm timer" {
     const configs = [_]LayerConfig{hold_aim};
     const lt = ltMask();
 
-    const action = ls.processLayerTriggers(&configs, lt, 0);
+    const action = ls.processLayerTriggers(&configs, lt, 0, 0);
     try testing.expect(action.arm_timer_ms != null);
     try testing.expectEqual(@as(?u64, 200), action.arm_timer_ms);
     try testing.expect(action.active_changed);
@@ -394,7 +415,7 @@ test "layer: processLayerTriggers: Hold PENDING + timer → ACTIVE, getActive re
     const configs = [_]LayerConfig{hold_aim};
     const lt = ltMask();
 
-    _ = ls.processLayerTriggers(&configs, lt, 0);
+    _ = ls.processLayerTriggers(&configs, lt, 0, 0);
     _ = ls.onTimerExpired();
 
     try testing.expect(ls.getActive(&configs) != null);
@@ -407,10 +428,10 @@ test "layer: processLayerTriggers: Hold ACTIVE + release → IDLE" {
     const configs = [_]LayerConfig{hold_aim};
     const lt = ltMask();
 
-    _ = ls.processLayerTriggers(&configs, lt, 0);
+    _ = ls.processLayerTriggers(&configs, lt, 0, 0);
     _ = ls.onTimerExpired();
 
-    const action = ls.processLayerTriggers(&configs, 0, lt);
+    const action = ls.processLayerTriggers(&configs, 0, lt, 0);
     try testing.expect(action.active_changed);
     try testing.expect(ls.tap_hold == null);
     try testing.expect(ls.getActive(&configs) == null);
@@ -423,8 +444,8 @@ test "layer: processLayerTriggers: Hold PENDING release → tap event + disarm" 
     const configs = [_]LayerConfig{tap_cfg};
     const lt = ltMask();
 
-    _ = ls.processLayerTriggers(&configs, lt, 0);
-    const action = ls.processLayerTriggers(&configs, 0, lt);
+    _ = ls.processLayerTriggers(&configs, lt, 0, 0);
+    const action = ls.processLayerTriggers(&configs, 0, lt, 0);
 
     try testing.expect(action.disarm_timer);
     try testing.expect(action.tap_event != null);
@@ -438,11 +459,11 @@ test "layer: processLayerTriggers: ADR-004 mutual exclusion — second Hold pres
     const lt = ltMask();
     const rb = rbMask();
 
-    _ = ls.processLayerTriggers(&configs, lt, 0);
+    _ = ls.processLayerTriggers(&configs, lt, 0, 0);
     try testing.expectEqualStrings("aim", ls.tap_hold.?.layer_name);
 
     // RB pressed while LT PENDING — must be ignored
-    const action = ls.processLayerTriggers(&configs, lt | rb, lt);
+    const action = ls.processLayerTriggers(&configs, lt | rb, lt, 0);
     try testing.expect(action.arm_timer_ms == null);
     try testing.expectEqualStrings("aim", ls.tap_hold.?.layer_name);
 }
@@ -454,10 +475,10 @@ test "layer: processLayerTriggers: ADR-004 mutual exclusion — second Hold pres
     const lt = ltMask();
     const rb = rbMask();
 
-    _ = ls.processLayerTriggers(&configs, lt, 0);
+    _ = ls.processLayerTriggers(&configs, lt, 0, 0);
     _ = ls.onTimerExpired();
 
-    const action = ls.processLayerTriggers(&configs, lt | rb, lt);
+    const action = ls.processLayerTriggers(&configs, lt | rb, lt, 0);
     try testing.expect(action.arm_timer_ms == null);
     try testing.expectEqualStrings("aim", ls.tap_hold.?.layer_name);
 }
@@ -468,7 +489,7 @@ test "layer: processLayerTriggers: Toggle release → layer on" {
     const configs = [_]LayerConfig{toggle_sel};
     const sel = selMask();
 
-    const action = ls.processLayerTriggers(&configs, 0, sel);
+    const action = ls.processLayerTriggers(&configs, 0, sel, 0);
     try testing.expect(action.active_changed);
     try testing.expect(ls.toggled.contains("sel"));
     try testing.expect(ls.getActive(&configs) != null);
@@ -480,8 +501,8 @@ test "layer: processLayerTriggers: Toggle second release → layer off" {
     const configs = [_]LayerConfig{toggle_sel};
     const sel = selMask();
 
-    _ = ls.processLayerTriggers(&configs, 0, sel);
-    const action = ls.processLayerTriggers(&configs, 0, sel);
+    _ = ls.processLayerTriggers(&configs, 0, sel, 0);
+    const action = ls.processLayerTriggers(&configs, 0, sel, 0);
     try testing.expect(action.active_changed);
     try testing.expect(!ls.toggled.contains("sel"));
     try testing.expect(ls.getActive(&configs) == null);
@@ -494,11 +515,11 @@ test "layer: processLayerTriggers: Toggle on blocked while Hold ACTIVE" {
     const lt = ltMask();
     const sel = selMask();
 
-    _ = ls.processLayerTriggers(&configs, lt, 0);
+    _ = ls.processLayerTriggers(&configs, lt, 0, 0);
     _ = ls.onTimerExpired();
 
     // Toggle release while Hold ACTIVE — must be blocked
-    _ = ls.processLayerTriggers(&configs, lt, lt | sel);
+    _ = ls.processLayerTriggers(&configs, lt, lt | sel, 0);
     try testing.expect(!ls.toggled.contains("sel"));
     try testing.expectEqualStrings("aim", ls.getActive(&configs).?.name);
 }
@@ -511,11 +532,11 @@ test "layer: processLayerTriggers: Toggle + Hold coexist, Hold takes priority in
     const sel = selMask();
 
     // Toggle on first (no active layer yet)
-    _ = ls.processLayerTriggers(&configs, 0, sel);
+    _ = ls.processLayerTriggers(&configs, 0, sel, 0);
     try testing.expect(ls.toggled.contains("sel"));
 
     // Hold press + activate
-    _ = ls.processLayerTriggers(&configs, lt, 0);
+    _ = ls.processLayerTriggers(&configs, lt, 0, 0);
     _ = ls.onTimerExpired();
 
     // Hold must take priority
@@ -532,11 +553,11 @@ test "layer: processLayerTriggers: multiple Toggles on — declaration order win
     const rb = rbMask();
 
     // Toggle "a" on
-    _ = ls.processLayerTriggers(&configs, 0, lb);
+    _ = ls.processLayerTriggers(&configs, 0, lb, 0);
     try testing.expect(ls.toggled.contains("a"));
 
     // "a" is active now; "b" toggle-on should be blocked
-    _ = ls.processLayerTriggers(&configs, 0, rb);
+    _ = ls.processLayerTriggers(&configs, 0, rb, 0);
     try testing.expect(!ls.toggled.contains("b"));
     try testing.expectEqualStrings("a", ls.getActive(&configs).?.name);
 }

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -10,6 +10,13 @@ const timer_queue_mod = @import("timer_queue.zig");
 const aux_event_mod = @import("aux_event.zig");
 const c = @cImport(@cInclude("linux/input-event-codes.h"));
 
+const posix = std.posix;
+
+fn monotonicNs() i128 {
+    const ts = posix.clock_gettime(.MONOTONIC) catch return 0;
+    return @as(i128, ts.sec) * std.time.ns_per_s + @as(i128, ts.nsec);
+}
+
 const REL_X: u16 = c.REL_X;
 const REL_Y: u16 = c.REL_Y;
 const REL_WHEEL: u16 = c.REL_WHEEL;
@@ -97,7 +104,7 @@ pub const Mapper = struct {
 
         // [2] layer trigger processing
         const configs = self.config.layer orelse &.{};
-        const now_ns = std.time.nanoTimestamp();
+        const now_ns = monotonicNs();
         const action = self.layer.processLayerTriggers(configs, self.state.buttons, self.prev.buttons, now_ns);
         var timer_request: ?TimerRequest = null;
         if (action.arm_timer_ms) |ms| {

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -97,7 +97,8 @@ pub const Mapper = struct {
 
         // [2] layer trigger processing
         const configs = self.config.layer orelse &.{};
-        const action = self.layer.processLayerTriggers(configs, self.state.buttons, self.prev.buttons);
+        const now_ns = std.time.nanoTimestamp();
+        const action = self.layer.processLayerTriggers(configs, self.state.buttons, self.prev.buttons, now_ns);
         var timer_request: ?TimerRequest = null;
         if (action.arm_timer_ms) |ms| {
             timer_request = .{ .arm = @intCast(ms) };
@@ -587,7 +588,7 @@ test "mapper: layer remap overrides base: base A->B, layer A->C" {
 
     // Activate hold layer by simulating PENDING → ACTIVE manually
     const configs = parsed.value.layer.?;
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
     const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
@@ -624,7 +625,7 @@ test "mapper: suppress accumulates: base suppress A + layer suppress B" {
     defer m.deinit();
 
     const configs = parsed.value.layer.?;
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
     const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
@@ -657,7 +658,7 @@ test "mapper: inject last-write wins: layer inject overrides base inject for sam
     defer m.deinit();
 
     const configs = parsed.value.layer.?;
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
     const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
@@ -714,7 +715,7 @@ test "mapper: onTimerExpired: PENDING -> ACTIVE activates layer" {
 
     const configs = parsed.value.layer.?;
     // Press LT — goes PENDING
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     try testing.expect(m.layer.tap_hold != null);
     try testing.expect(!m.layer.tap_hold.?.layer_activated);
 
@@ -751,7 +752,7 @@ test "mapper: layer gyro override: active layer gyro config used" {
     defer m.deinit();
 
     const configs = parsed.value.layer.?;
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
     // With layer active, gyro should be in mouse mode with the configured sensitivity
@@ -781,7 +782,7 @@ test "mapper: layer dpad override: active layer dpad config used" {
     defer m.deinit();
 
     const configs = parsed.value.layer.?;
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
     const dcfg = m.effectiveDpadConfig();

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -811,7 +811,7 @@ test "event_loop: EventLoop timerfd: mapper.onTimerExpired invoked on timer expi
     defer m.deinit();
 
     // Put layer in PENDING so timer expiry advances it to ACTIVE
-    _ = m.layer.onTriggerPress("aim", 200);
+    _ = m.layer.onTriggerPress("aim", 200, 0);
 
     const parsed = try device_mod.parseString(allocator, minimal_toml);
     defer parsed.deinit();

--- a/src/test/macro_e2e_test.zig
+++ b/src/test/macro_e2e_test.zig
@@ -281,7 +281,7 @@ test "macro: layer switch while macro active — held keys released, macros clea
 
     // Now activate layer (LT hold) — active_changed fires → macros cleared, releases emitted.
     const configs = ctx.parsed.value.layer.?;
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
     const ev = try m.apply(.{ .buttons = m1_mask }, 16);

--- a/src/test/mapper_e2e_test.zig
+++ b/src/test/mapper_e2e_test.zig
@@ -49,7 +49,7 @@ test "e2e: layer hold — PENDING → ACTIVE, layer remap activates" {
     const configs = ctx.parsed.value.layer.?;
 
     // Frame 1: LT press → PENDING
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     try testing.expect(m.layer.tap_hold != null);
     try testing.expect(!m.layer.tap_hold.?.layer_activated);
 
@@ -73,7 +73,7 @@ test "e2e: layer hold — PENDING → ACTIVE, layer remap activates" {
     try testing.expect(found_mouse_left);
 
     // Frame 3: LT release → layer IDLE, A restores
-    _ = m.layer.onTriggerRelease(null);
+    _ = m.layer.onTriggerRelease(null, 500_000_000);
     try testing.expect(m.layer.tap_hold == null);
     const ev2 = try m.apply(.{ .buttons = btnMask(.A) }, 16);
     try testing.expect((ev2.gamepad.buttons & btnMask(.A)) != 0);
@@ -96,11 +96,11 @@ test "e2e: layer tap — quick release emits tap event" {
     const configs = ctx.parsed.value.layer.?;
 
     // Frame 1: LT press → PENDING
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
 
     // Frame 2: LT release before timer → tap event
     const tap_target = mapper_mod.resolveTarget("mouse_left") catch unreachable;
-    const res = m.layer.onTriggerRelease(tap_target);
+    const res = m.layer.onTriggerRelease(tap_target, 100_000_000);
     try testing.expect(res.disarm_timer);
     try testing.expect(res.tap_event != null);
     try testing.expect(m.layer.tap_hold == null);
@@ -125,10 +125,10 @@ test "e2e: layer tap — no tap after timeout (ACTIVE release)" {
     var m = &ctx.mapper;
     const configs = ctx.parsed.value.layer.?;
 
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired(); // ACTIVE
 
-    const res = m.layer.onTriggerRelease(null);
+    const res = m.layer.onTriggerRelease(null, 500_000_000);
     try testing.expect(!res.disarm_timer);
     try testing.expect(res.tap_event == null);
     try testing.expect(res.layer_deactivated);
@@ -179,7 +179,7 @@ test "e2e: suppress/inject — layer ACTIVE: A→mouse_left overrides base A→K
     const configs = ctx.parsed.value.layer.?;
 
     // Activate layer
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
     const ev = try m.apply(.{ .buttons = btnMask(.A) }, 16);
@@ -445,7 +445,7 @@ test "e2e: prev-frame mask — layer activates mid-stream, no spurious release f
     try testing.expect((ev1.gamepad.buttons & btnMask(.B)) != 0);
 
     // Layer activates (simulate timer)
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
     // Frame N: B still held + layer ACTIVE → B suppressed in both current and masked_prev
@@ -476,8 +476,8 @@ test "e2e: toggle layer — Select release toggles fn layer on/off, A remap appl
     const sel = btnMask(.Select);
 
     // Toggle on: Select press then release
-    _ = m.layer.processLayerTriggers(configs, sel, 0); // press
-    _ = m.layer.processLayerTriggers(configs, 0, sel); // release → toggle on
+    _ = m.layer.processLayerTriggers(configs, sel, 0, 0); // press
+    _ = m.layer.processLayerTriggers(configs, 0, sel, 0); // release → toggle on
     try testing.expect(m.layer.toggled.contains("fn"));
 
     // A press → KEY_F1 in aux
@@ -495,8 +495,8 @@ test "e2e: toggle layer — Select release toggles fn layer on/off, A remap appl
     try testing.expectEqual(@as(u64, 0), ev1.gamepad.buttons & btnMask(.A));
 
     // Toggle off: Select press then release again
-    _ = m.layer.processLayerTriggers(configs, sel, 0);
-    _ = m.layer.processLayerTriggers(configs, 0, sel); // release → toggle off
+    _ = m.layer.processLayerTriggers(configs, sel, 0, 0);
+    _ = m.layer.processLayerTriggers(configs, 0, sel, 0); // release → toggle off
     try testing.expect(!m.layer.toggled.contains("fn"));
 
     // A press now → A passes through on main device
@@ -534,7 +534,7 @@ test "e2e: layer remap fall-through — button not in layer remap uses base rema
     var m = &ctx.mapper;
     const configs = ctx.parsed.value.layer.?;
 
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
     // X pressed — not in layer remap, should fall through to base (KEY_F13)
@@ -599,7 +599,7 @@ test "e2e: layer active — dpad mode switches to arrows" {
     var m = &ctx.mapper;
     const configs = ctx.parsed.value.layer.?;
 
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
     // dpad_y = -1 → KEY_UP (arrows mode active via layer)

--- a/src/test/properties/mapper_props.zig
+++ b/src/test/properties/mapper_props.zig
@@ -92,10 +92,10 @@ test "property: rapid hold layer toggle — state stays consistent" {
 
     for (0..1000) |_| {
         if (rng.boolean()) {
-            _ = m.layer.processLayerTriggers(configs, btnMask(.LT), 0);
+            _ = m.layer.processLayerTriggers(configs, btnMask(.LT), 0, 0);
             if (rng.boolean()) _ = m.layer.onTimerExpired();
         } else {
-            _ = m.layer.processLayerTriggers(configs, 0, btnMask(.LT));
+            _ = m.layer.processLayerTriggers(configs, 0, btnMask(.LT), 0);
         }
 
         // layer state must never reference out-of-bounds config
@@ -125,10 +125,10 @@ test "property: rapid toggle layer — state stays consistent" {
         const sel = btnMask(.Select);
         if (rng.boolean()) {
             // press
-            _ = m.layer.processLayerTriggers(configs, sel, 0);
+            _ = m.layer.processLayerTriggers(configs, sel, 0, 0);
         } else {
             // release (toggle fires on release)
-            _ = m.layer.processLayerTriggers(configs, 0, sel);
+            _ = m.layer.processLayerTriggers(configs, 0, sel, 0);
         }
 
         if (m.layer.getActive(configs)) |active| {
@@ -354,7 +354,7 @@ test "property: layer and base remap to same target — no crash" {
     const configs = ctx.parsed.value.layer.?;
 
     // activate layer
-    _ = m.layer.onTriggerPress(configs[0].name, 200);
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
     // both A and B pressed — both map to KEY_F1


### PR DESCRIPTION
## Summary

Tap-on-layer fires unreliably on Flydigi Vader 5 Pro (reported by multiple users). Quick press-and-release of a hold-activated layer trigger sometimes fails to emit the tap event.

**Root cause**: the event loop services timerfd before device fds in the same ppoll wakeup. When the hold_timeout timer and the button release arrive in the same cycle, `onTimerExpired()` transitions the layer from PENDING to ACTIVE before the release is processed. The release then takes the ACTIVE→IDLE branch which never emits the tap event.

**Fix**: store `press_ns` timestamp in `TapHoldState` at press time. On release, if the layer is ACTIVE but elapsed time is still within `hold_timeout`, treat it as a PENDING release and emit the tap. This makes the tap/hold decision timestamp-based rather than dependent on event-loop ordering, matching the approach used by QMK and kmonad.

**Reproducer test**: press → `onTimerExpired()` → release within timeout → assert tap event emitted. Fails against old code (ACTIVE→IDLE branch returns `layer_deactivated` without tap).

Related issue: #79 (reporter should verify before closing).

## Test plan

- [x] `zig build test` passes (including reproducer test)
- [ ] CI green
- [ ] Manual: rapid tap of hold-layer trigger consistently fires tap event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced layer trigger processing with nanosecond-precision timestamp tracking for more accurate event timing.
  * Improved tap and hold event differentiation for layer switches.
  * Layer state now correctly distinguishes between quick releases and sustained hold timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->