### PR TITLE
feat(gyro): add target field for left/right stick selection

### DIFF
--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -116,6 +116,7 @@ pub fn buildAuxKeyCodes(caps: DerivedAuxCaps, buf: []u16) []u16 {
 
 pub const GyroConfig = struct {
     mode: []const u8 = "off",
+    target: ?[]const u8 = null, // "right_stick" (default) or "left_stick"
     activate: ?[]const u8 = null,
     sensitivity: ?f64 = null,
     sensitivity_x: ?f64 = null,

--- a/src/core/gyro.zig
+++ b/src/core/gyro.zig
@@ -1,7 +1,10 @@
 const std = @import("std");
 
+pub const GyroTarget = enum { right_stick, left_stick };
+
 pub const GyroConfig = struct {
     mode: []const u8 = "off", // "off" | "mouse" | "joystick"
+    target: GyroTarget = .right_stick,
     sensitivity_x: f32 = 1.5,
     sensitivity_y: f32 = 1.5,
     deadzone: i16 = 0,

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -143,6 +143,7 @@ pub const Mapper = struct {
         // [3] mode processing
         var suppress_dpad_hat: bool = false;
         var suppress_right_stick_gyro: bool = false;
+        var suppress_left_stick_gyro: bool = false;
         var gyro_joy_x: ?i16 = null;
         var gyro_joy_y: ?i16 = null;
         {
@@ -161,11 +162,17 @@ pub const Mapper = struct {
                 } else if (std.mem.eql(u8, gcfg.mode, "joystick")) {
                     if (gout.joy_x) |jx| {
                         gyro_joy_x = jx;
-                        suppress_right_stick_gyro = true;
+                        switch (gcfg.target) {
+                            .right_stick => suppress_right_stick_gyro = true,
+                            .left_stick => suppress_left_stick_gyro = true,
+                        }
                     }
                     if (gout.joy_y) |jy| {
                         gyro_joy_y = jy;
-                        suppress_right_stick_gyro = true;
+                        switch (gcfg.target) {
+                            .right_stick => suppress_right_stick_gyro = true,
+                            .left_stick => suppress_left_stick_gyro = true,
+                        }
                     }
                 }
             } else {
@@ -283,16 +290,20 @@ pub const Mapper = struct {
             emit_state.dpad_y = 0;
         }
 
-        // gyro joystick mode: override right stick axes, suppress originals
+        // gyro joystick mode: override stick axes, suppress originals
         if (suppress_right_stick_gyro) {
             if (gyro_joy_x) |jx| emit_state.rx = jx;
             if (gyro_joy_y) |jy| emit_state.ry = jy;
+        }
+        if (suppress_left_stick_gyro) {
+            if (gyro_joy_x) |jx| emit_state.ax = jx;
+            if (gyro_joy_y) |jy| emit_state.ay = jy;
         }
 
         // suppress stick axes when mode != gamepad
         const left_cfg = self.effectiveStickConfig(.left);
         const right_cfg = self.effectiveStickConfig(.right);
-        if (left_cfg.suppress_gamepad or !std.mem.eql(u8, left_cfg.mode, "gamepad")) {
+        if (!suppress_left_stick_gyro and (left_cfg.suppress_gamepad or !std.mem.eql(u8, left_cfg.mode, "gamepad"))) {
             emit_state.ax = 0;
             emit_state.ay = 0;
         }
@@ -406,6 +417,7 @@ fn resolveGyroConfig2(mc: *const mapping.GyroConfig) gyro.GyroConfig {
         .max_val = if (mc.max_val) |v| @floatCast(v) else 32767.0,
         .invert_x = mc.invert_x orelse false,
         .invert_y = mc.invert_y orelse false,
+        .target = if (mc.target) |t| (if (std.mem.eql(u8, t, "left_stick")) .left_stick else .right_stick) else .right_stick,
     };
 }
 

--- a/src/test/gyro_stick_e2e_test.zig
+++ b/src/test/gyro_stick_e2e_test.zig
@@ -201,6 +201,60 @@ test "e2e: gyro joystick — zero gyro leaves rx/ry at zero (deadzone)" {
     try testing.expectEqual(@as(i16, 0), ev.gamepad.ry);
 }
 
+test "e2e: gyro joystick target=left_stick — gyro overrides ax/ay, not rx/ry" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[gyro]
+        \\mode = "joystick"
+        \\target = "left_stick"
+        \\sensitivity_x = 1000.0
+        \\sensitivity_y = 1000.0
+        \\smoothing = 0.0
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000, .ax = 5000, .ay = 5000, .rx = 1234, .ry = 4321 }, 16);
+
+    // ax/ay overridden by gyro (not original 5000)
+    try testing.expect(ev.gamepad.ax != 5000);
+    try testing.expect(ev.gamepad.ay != 5000);
+
+    // rx/ry untouched by gyro
+    try testing.expectEqual(@as(i16, 1234), ev.gamepad.rx);
+    try testing.expectEqual(@as(i16, 4321), ev.gamepad.ry);
+
+    // no REL events
+    for (ev.aux.slice()) |e| switch (e) {
+        .rel => return error.UnexpectedRelEvent,
+        else => {},
+    };
+}
+
+test "e2e: gyro joystick target=right_stick (explicit) — same as default" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[gyro]
+        \\mode = "joystick"
+        \\target = "right_stick"
+        \\sensitivity_x = 1000.0
+        \\sensitivity_y = 1000.0
+        \\smoothing = 0.0
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000, .rx = 5000, .ry = 5000, .ax = 1234, .ay = 4321 }, 16);
+
+    // rx/ry overridden by gyro
+    try testing.expect(ev.gamepad.rx != 5000);
+    try testing.expect(ev.gamepad.ry != 5000);
+
+    // ax/ay untouched
+    try testing.expectEqual(@as(i16, 1234), ev.gamepad.ax);
+    try testing.expectEqual(@as(i16, 4321), ev.gamepad.ay);
+}
+
 // --- Layer switch reset (L0) ---
 
 test "e2e: layer switch resets gyro EMA — no jump after activation" {


### PR DESCRIPTION
## Summary

Gyro joystick mode was hardcoded to the right stick (ABS_RX/RY). Users of games like Resident Evil 2 Remake that reject mixed mouse+gamepad input need gyro mapped to the left stick instead.

**Fix**: add optional `target` field to `[gyro]` config (`"right_stick"` default, `"left_stick"`). When `target = "left_stick"`, gyro values write to `emit_state.ax/ay` with a `suppress_left_stick_gyro` flag paralleling the existing right-stick path.

Two new tests: `target=left_stick` asserts gyro overrides ax/ay (not rx/ry); `target=right_stick` explicit asserts same as default.

Related issue: #80 (reporter should verify before closing).

## Test plan

- [x] `zig build test` passes (including 2 new gyro target tests)
- [ ] CI green
- [ ] Manual: set `target = "left_stick"` in mapping, verify gyro moves left stick in evtest