### PR TITLE
fix(scripts): add Zig version check to bazzite-setup.sh

### DIFF
--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -115,6 +115,17 @@ else
     ok "zig found: $(zig version)"
 fi
 
+# Verify Zig version >= 0.15.0
+ZIG_VER=$(zig version 2>/dev/null || echo "0.0.0")
+ZIG_MAJOR=$(echo "$ZIG_VER" | cut -d. -f1)
+ZIG_MINOR=$(echo "$ZIG_VER" | cut -d. -f2)
+if [ "$ZIG_MAJOR" -eq 0 ] && [ "$ZIG_MINOR" -lt 15 ]; then
+    err "padctl requires Zig >= 0.15.0, found $ZIG_VER"
+    echo "Install from https://ziglang.org/download/ or update Homebrew formula"
+    exit 1
+fi
+ok "Zig version $ZIG_VER meets minimum requirement (>= 0.15.0)"
+
 # --- 4. Locate or clone padctl repo ---
 if [[ -z "$PADCTL_REPO" ]]; then
     # Try to detect: are we in the repo?


### PR DESCRIPTION
## Summary

The Bazzite bootstrap script installed Zig via unpinned `brew install zig`, which could provide a version older than the 0.15.0 minimum. Build then failed with `no field named linkSystemLibrary`.

**Fix**: add a version check after Zig installation. If `zig version` reports < 0.15.0, exit with a clear error message pointing to the download page.

Related issue: #108 (reporter should verify).

## Test plan

- [x] Script syntax valid (`bash -n`)
- [ ] Manual: run on a system with old Zig → clear error message