### PR TITLE
fix(install): add SupplementaryGroups=input to systemd user service

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -21,6 +21,7 @@ fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8) ![]c
         \\NoNewPrivileges=true
         \\LockPersonality=true
         \\ProtectClock=true
+        \\SupplementaryGroups=input
         \\
         \\[Install]
         \\WantedBy=default.target
@@ -2551,6 +2552,7 @@ test "install: service content has hardening directives" {
     try testing.expect(std.mem.indexOf(u8, content, "NoNewPrivileges=true") != null);
     try testing.expect(std.mem.indexOf(u8, content, "LockPersonality=true") != null);
     try testing.expect(std.mem.indexOf(u8, content, "ProtectClock=true") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "SupplementaryGroups=input") != null);
 }
 
 test "install: old system unit triggers migration hint" {


### PR DESCRIPTION
## Summary
- Adds `SupplementaryGroups=input` to the generated systemd user service unit in `generateServiceContent`
- Ensures the daemon retains evdev node access in linger/headless scenarios where PAM group membership is not inherited
- Extends the hardening directives regression test to cover the new directive

## Context
The daemon needs the `input` group to access evdev device nodes, which udev creates with `GROUP="input"`. In linger/headless setups (e.g., Steam Deck gaming mode without active user login), PAM-managed supplementary groups are not inherited, so the user service unit must declare `SupplementaryGroups=input` to retain evdev access.

Main branch currently generates the unit without this directive.

## Test plan
- [x] `zig build test` passes (exit 0, all warnings are intentional test fixtures)
- [x] pre-push hook ran `zig build test-tsan` and passed
- [x] hardening directives regression test extended with `SupplementaryGroups=input` assertion