### PR TITLE
fix(supervisor): keep uinput alive across device sleep/wake

### DIFF
--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -313,6 +313,37 @@ pub const DeviceInstance = struct {
         self.aux_dev = try AuxDevice.create(key_codes, caps.needs_rel);
     }
 
+    /// Close physical device fds only, keeping uinput/aux/touchpad alive.
+    /// Used when suspending an instance across device sleep/wake.
+    pub fn closeDeviceIO(self: *DeviceInstance) void {
+        for (self.devices) |dev| dev.close();
+    }
+
+    /// Replace physical device fds with new ones and re-register them in the
+    /// event loop. Caller must provide the same number of DeviceIO entries as
+    /// the original devices[] slice.
+    pub fn rebindDeviceIO(self: *DeviceInstance, new_devices: []DeviceIO) void {
+        @memcpy(self.devices, new_devices);
+        self.loop.rebindDevices(self.devices);
+    }
+
+    /// Re-run the device init sequence (e.g. handshake packets) using the
+    /// current devices[] fds and device_cfg.
+    pub fn rerunInitSequence(self: *DeviceInstance) void {
+        if (self.device_cfg.device.init) |init_cfg| {
+            for (self.device_cfg.device.interface, self.devices) |iface, dev| {
+                const match = if (init_cfg.interface) |init_iface|
+                    iface.id == init_iface
+                else
+                    std.mem.eql(u8, iface.class, "vendor");
+                if (!match) continue;
+                init_seq.runInitSequence(self.allocator, dev, init_cfg) catch |err| {
+                    std.log.debug("re-init on interface {d}: {}", .{ iface.id, err });
+                };
+            }
+        }
+    }
+
     /// Signal the event loop to stop. run() returns after the current ppoll.
     pub fn stop(self: *DeviceInstance) void {
         @atomicStore(bool, &self.stopped, true, .release);
@@ -592,4 +623,54 @@ test "DeviceInstance: rebuildAuxIfChanged is no-op when device has no output con
     // no output config on minimal_toml device — rebuildAuxIfChanged must return without error
     try inst.rebuildAuxIfChanged(&mapping_parsed.value, null);
     try testing.expectEqual(@as(?AuxDevice, null), inst.aux_dev);
+}
+
+test "DeviceInstance: closeDeviceIO closes device fds without touching uinput" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, minimal_toml);
+    defer parsed.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+
+    var inst = try testInstance(allocator, &mock, &parsed.value);
+    defer {
+        inst.loop.deinit();
+        allocator.free(inst.devices);
+    }
+
+    // closeDeviceIO must not crash; uinput_dev stays null (not touched)
+    inst.closeDeviceIO();
+    try testing.expectEqual(@as(?@import("io/uinput.zig").UinputDevice, null), inst.uinput_dev);
+}
+
+test "DeviceInstance: rebindDeviceIO replaces device fds" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, minimal_toml);
+    defer parsed.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+
+    var inst = try testInstance(allocator, &mock_a, &parsed.value);
+    defer {
+        inst.loop.deinit();
+        allocator.free(inst.devices);
+    }
+
+    // Close old device IO
+    inst.closeDeviceIO();
+
+    // Create new mock and rebind
+    var mock_b = try MockDeviceIO.init(allocator, &.{});
+    defer mock_b.deinit();
+    var new_devs = [_]DeviceIO{mock_b.deviceIO()};
+    inst.rebindDeviceIO(&new_devs);
+
+    // Verify the device was replaced (new mock's pollfd)
+    const pfd = inst.devices[0].pollfd();
+    const expected_pfd = mock_b.deviceIO().pollfd();
+    try testing.expectEqual(expected_pfd.fd, pfd.fd);
 }

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -328,6 +328,14 @@ pub const EventLoop = struct {
         self.fd_count += 1;
     }
 
+    /// Replace pollfd entries for device slots with fds from new DeviceIO
+    /// slice. The number of devices must match the original count.
+    pub fn rebindDevices(self: *EventLoop, devices: []DeviceIO) void {
+        for (devices, 0..) |dev, i| {
+            self.pollfds[self.device_base + i] = dev.pollfd();
+        }
+    }
+
     pub fn addUinputFf(self: *EventLoop, fd: posix.fd_t) !void {
         const slot = self.fd_count;
         if (slot >= MAX_FDS) return error.TooManyFds;

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -3,7 +3,10 @@ const builtin = @import("builtin");
 const posix = std.posix;
 const linux = std.os.linux;
 
-const DeviceInstance = @import("device_instance.zig").DeviceInstance;
+const device_instance_mod = @import("device_instance.zig");
+const DeviceInstance = device_instance_mod.DeviceInstance;
+const openDeviceWithRetry = device_instance_mod.openDeviceWithRetry;
+const DeviceIO = @import("io/device_io.zig").DeviceIO;
 const MappingConfig = @import("config/mapping.zig").MappingConfig;
 const mapping_cfg = @import("config/mapping.zig");
 const DeviceConfig = @import("config/device.zig").DeviceConfig;
@@ -31,6 +34,7 @@ pub const ManagedInstance = struct {
     mapping_arena: std.heap.ArenaAllocator,
     switch_mapping: ?*mapping_cfg.ParseResult = null,
     default_mapping_pr: ?*mapping_cfg.ParseResult = null,
+    suspended: bool = false,
 };
 
 /// Config snapshot used for hot-reload diffing.
@@ -282,7 +286,10 @@ pub const Supervisor = struct {
         self.managed.items[self.managed.items.len - 1].devname = dn_copy;
     }
 
-    /// Stop and free the instance attached under devname. No-op if not found.
+    /// Stop and suspend the instance attached under devname. The uinput fds
+    /// stay open so consumers (e.g. Steam) keep their cached eventN
+    /// references. On reconnect, attachWithRoot() rebinds the new hidraw fds
+    /// to the existing instance.
     pub fn detach(self: *Supervisor, devname: []const u8) void {
         const entry = self.devname_map.fetchRemove(devname) orelse {
             std.log.debug("detach: {s} not in devname_map", .{devname});
@@ -292,21 +299,42 @@ pub const Supervisor = struct {
         const phys_key = entry.value;
         defer self.allocator.free(phys_key);
 
+        for (self.managed.items) |*m| {
+            if (!std.mem.eql(u8, m.phys_key, phys_key)) continue;
+            std.log.info("device suspended: \"{s}\" {s}", .{ m.instance.device_cfg.device.name, devname });
+            m.instance.stop();
+            m.thread.join();
+            m.instance.closeDeviceIO();
+            m.suspended = true;
+            if (m.devname) |dn| {
+                self.allocator.free(dn);
+                m.devname = null;
+            }
+            return;
+        }
+        std.log.debug("detach: no managed instance for phys {s}", .{phys_key});
+    }
+
+    /// Unconditionally tear down and remove a managed instance (used by
+    /// stopAll/reload — not by hotplug detach).
+    pub fn detachFull(self: *Supervisor, devname: []const u8) void {
+        const entry = self.devname_map.fetchRemove(devname) orelse return;
+        self.allocator.free(entry.key);
+        const phys_key = entry.value;
+        defer self.allocator.free(phys_key);
+
         var i: usize = self.managed.items.len;
-        var found = false;
         while (i > 0) {
             i -= 1;
             const m = &self.managed.items[i];
             if (std.mem.eql(u8, m.phys_key, phys_key)) {
-                std.log.info("device detached: \"{s}\" {s}", .{ m.instance.device_cfg.device.name, devname });
                 m.instance.stop();
                 m.thread.join();
                 self.teardownManaged(m);
                 _ = self.managed.swapRemove(i);
-                found = true;
+                return;
             }
         }
-        if (!found) std.log.debug("detach: no managed instance for phys {s}", .{phys_key});
     }
 
     fn spawnInstance(self: *Supervisor, phys_key: []const u8, instance: *DeviceInstance, default_pr: ?*mapping_cfg.ParseResult) !void {
@@ -369,6 +397,7 @@ pub const Supervisor = struct {
         var cs = &self.ctrl_sock.?;
         var found = false;
         for (self.managed.items) |*m| {
+            if (m.suspended) continue;
             if (device_id) |dev_id| {
                 const dn = m.devname orelse continue;
                 if (!std.mem.eql(u8, dn, dev_id)) continue;
@@ -521,8 +550,12 @@ pub const Supervisor = struct {
     }
 
     pub fn stopAll(self: *Supervisor) void {
-        for (self.managed.items) |*m| m.instance.stop();
-        for (self.managed.items) |*m| m.thread.join();
+        for (self.managed.items) |*m| {
+            if (!m.suspended) m.instance.stop();
+        }
+        for (self.managed.items) |*m| {
+            if (!m.suspended) m.thread.join();
+        }
         for (self.managed.items) |*m| self.teardownManaged(m);
         self.managed.clearRetainingCapacity();
     }
@@ -548,8 +581,10 @@ pub const Supervisor = struct {
             r -= 1;
             const idx = to_remove.items[r];
             const m = &self.managed.items[idx];
-            m.instance.stop();
-            m.thread.join();
+            if (!m.suspended) {
+                m.instance.stop();
+                m.thread.join();
+            }
             self.teardownManaged(m);
             _ = self.managed.swapRemove(idx);
         }
@@ -568,6 +603,7 @@ pub const Supervisor = struct {
                 try self.spawnInstance(nc.phys_key, instance, null);
             } else if (nc.mapping_cfg) |new_map| {
                 const m = found.?;
+                if (m.suspended) continue;
                 // Stop-Swap-Restart: stop thread before touching arena
                 m.instance.stop();
                 m.thread.join();
@@ -600,6 +636,7 @@ pub const Supervisor = struct {
                 }
             } else {
                 const m = found.?;
+                if (m.suspended) continue;
                 m.instance.stop();
                 m.thread.join();
                 self.clearSwitchMapping(m);
@@ -914,7 +951,8 @@ pub const Supervisor = struct {
                 return;
             }
         } else {
-            for (self.managed.items, 0..) |_, idx| {
+            for (self.managed.items, 0..) |*m, idx| {
+                if (m.suspended) continue;
                 targets.append(self.allocator, idx) catch {
                     cs.sendResponse(fd, "ERR oom\n");
                     return;
@@ -997,7 +1035,8 @@ pub const Supervisor = struct {
         w.writeAll("STATUS") catch return;
         for (self.managed.items) |*m| {
             const name = m.instance.device_cfg.device.name;
-            w.print(" device={s} active=true", .{name}) catch break;
+            const state_str: []const u8 = if (m.suspended) "suspended" else "active";
+            w.print(" device={s} state={s}", .{ name, state_str }) catch break;
         }
         w.writeByte('\n') catch return;
         cs.sendResponse(fd, stream.getWritten());
@@ -1569,6 +1608,65 @@ pub const Supervisor = struct {
         const phys = try readPhysicalPath(self.allocator, path);
         defer self.allocator.free(phys);
 
+        // Check for a suspended instance with the same VID:PID to rebind
+        for (self.managed.items) |*m| {
+            if (!m.suspended) continue;
+            const mcfg = m.instance.device_cfg;
+            if (@as(u16, @intCast(mcfg.device.vid)) != vid or
+                @as(u16, @intCast(mcfg.device.pid)) != pid) continue;
+
+            // Reopen all interface fds for the suspended instance
+            const new_devices = self.allocator.alloc(DeviceIO, mcfg.device.interface.len) catch return;
+            var opened: usize = 0;
+            errdefer {
+                for (new_devices[0..opened]) |dev| dev.close();
+                self.allocator.free(new_devices);
+            }
+            for (mcfg.device.interface, 0..) |iface, idx| {
+                new_devices[idx] = openDeviceWithRetry(self.allocator, iface, vid, pid) catch |err| {
+                    std.log.warn("rebind: open interface {d} failed: {}", .{ iface.id, err });
+                    for (new_devices[0..opened]) |dev| dev.close();
+                    self.allocator.free(new_devices);
+                    if (isTransientOpenError(err)) return error.HotplugTransient;
+                    return;
+                };
+                opened += 1;
+            }
+
+            m.instance.rebindDeviceIO(new_devices);
+            self.allocator.free(new_devices);
+            m.instance.rerunInitSequence();
+            m.suspended = false;
+
+            const dn_copy = self.allocator.dupe(u8, devname) catch return;
+            m.devname = dn_copy;
+            const dev_copy = self.allocator.dupe(u8, devname) catch {
+                self.allocator.free(dn_copy);
+                m.devname = null;
+                return;
+            };
+            const phys_copy = self.allocator.dupe(u8, phys) catch {
+                self.allocator.free(dn_copy);
+                self.allocator.free(dev_copy);
+                m.devname = null;
+                return;
+            };
+            self.devname_map.put(dev_copy, phys_copy) catch {
+                self.allocator.free(dn_copy);
+                self.allocator.free(dev_copy);
+                self.allocator.free(phys_copy);
+                m.devname = null;
+                return;
+            };
+
+            restartManagedThread(m) catch |err| {
+                std.log.err("rebind restart failed: {}", .{err});
+                return;
+            };
+            std.log.info("device resumed: \"{s}\" {s}/{s}", .{ mcfg.device.name, dev_root, devname });
+            return;
+        }
+
         const default_pr_ptr: ?*mapping_cfg.ParseResult = blk: {
             const pr = self.loadUserDefaultMapping(cfg.?.device.name) orelse break :blk null;
             const p = self.allocator.create(mapping_cfg.ParseResult) catch break :blk null;
@@ -1609,7 +1707,6 @@ const mapper_mod = @import("core/mapper.zig");
 const device_mod = @import("config/device.zig");
 const EventLoop = @import("event_loop.zig").EventLoop;
 const MockDeviceIO = @import("test/mock_device_io.zig").MockDeviceIO;
-const DeviceIO = @import("io/device_io.zig").DeviceIO;
 const uinput = @import("io/uinput.zig");
 const state_mod = @import("core/state.zig");
 
@@ -2104,7 +2201,7 @@ test "supervisor: Supervisor: detach unknown devname — no panic" {
     try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
 }
 
-test "supervisor: Supervisor: attach-detach-attach same devname — new instance after re-attach" {
+test "supervisor: Supervisor: detach suspends instance, keeps it in managed list" {
     const allocator = testing.allocator;
 
     const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
@@ -2112,24 +2209,140 @@ test "supervisor: Supervisor: attach-detach-attach same devname — new instance
 
     var mock_a = try MockDeviceIO.init(allocator, &.{});
     defer mock_a.deinit();
-    var mock_b = try MockDeviceIO.init(allocator, &.{});
-    defer mock_b.deinit();
     var sup = try Supervisor.initForTest(allocator);
 
     const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
     try sup.attachWithInstance("hidraw3", "usb-1-1", inst_a, null);
     try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
+    try testing.expect(!sup.managed.items[0].suspended);
 
     sup.detach("hidraw3");
-    try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
+    // Instance stays in managed list but is suspended
+    try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
+    try testing.expect(sup.managed.items[0].suspended);
+    try testing.expectEqual(@as(?[]const u8, null), sup.managed.items[0].devname);
+    // devname removed from map
+    try testing.expect(!sup.devname_map.contains("hidraw3"));
 
-    const inst_b = try makeTestInstance(allocator, &mock_b, &parsed_dev.value);
-    try sup.attachWithInstance("hidraw3", "usb-1-1", inst_b, null);
     defer {
         sup.stopAll();
         sup.deinit();
     }
-    try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
+}
+
+test "supervisor: Supervisor: suspend preserves instance, resume rebinds device IO" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+    var sup = try Supervisor.initForTest(allocator);
+
+    const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", inst_a, null);
+    const inst_ptr = sup.managed.items[0].instance;
+
+    // Detach suspends — instance stays, thread stops
+    sup.detach("hidraw3");
+    try testing.expect(sup.managed.items[0].suspended);
+    try testing.expectEqual(inst_ptr, sup.managed.items[0].instance);
+    try testing.expect(!sup.devname_map.contains("hidraw3"));
+
+    // Rebind with new mock device IO
+    var mock_b = try MockDeviceIO.init(allocator, &.{});
+    defer mock_b.deinit();
+    var new_devs = [_]DeviceIO{mock_b.deviceIO()};
+    inst_ptr.rebindDeviceIO(&new_devs);
+    sup.managed.items[0].suspended = false;
+
+    const dn = try allocator.dupe(u8, "hidraw5");
+    sup.managed.items[0].devname = dn;
+    const dk = try allocator.dupe(u8, "hidraw5");
+    const pk = try allocator.dupe(u8, "usb-1-1");
+    try sup.devname_map.put(dk, pk);
+
+    Supervisor.restartManagedThread(&sup.managed.items[0]) catch |err| {
+        std.log.err("restart failed: {}", .{err});
+        return err;
+    };
+
+    // Same instance pointer reused
+    try testing.expectEqual(inst_ptr, sup.managed.items[0].instance);
+    try testing.expect(!sup.managed.items[0].suspended);
+
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+}
+
+test "supervisor: Supervisor: stopAll handles suspended instances" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+    var sup = try Supervisor.initForTest(allocator);
+
+    const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", inst_a, null);
+    sup.detach("hidraw3");
+    try testing.expect(sup.managed.items[0].suspended);
+
+    // stopAll must not crash on suspended instances
+    sup.stopAll();
+    try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
+    sup.deinit();
+}
+
+test "supervisor: Supervisor: status shows suspended state" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+    var sup = try Supervisor.initForTest(allocator);
+
+    const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", inst_a, null);
+
+    // Create a control socket for status test
+    const resp_fds = try testSocketpair();
+    defer posix.close(resp_fds[0]);
+    defer posix.close(resp_fds[1]);
+    sup.ctrl_sock = .{
+        .listen_fd = -1,
+        .client_fds = .{ -1, -1, -1, -1 },
+        .client_count = 0,
+        .path = "",
+        .allocator = allocator,
+    };
+
+    // Status before suspend
+    sup.handleStatus(resp_fds[0]);
+    var resp_buf: [256]u8 = undefined;
+    var n = try posix.read(resp_fds[1], &resp_buf);
+    try testing.expect(std.mem.indexOf(u8, resp_buf[0..n], "state=active") != null);
+
+    // Suspend
+    sup.detach("hidraw3");
+
+    // Status after suspend
+    sup.handleStatus(resp_fds[0]);
+    n = try posix.read(resp_fds[1], &resp_buf);
+    try testing.expect(std.mem.indexOf(u8, resp_buf[0..n], "state=suspended") != null);
+
+    defer {
+        sup.stopAll();
+        sup.ctrl_sock = null;
+        sup.deinit();
+    }
 }
 
 test "supervisor: Supervisor: two devnames attached simultaneously — independent threads" {

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -1612,8 +1612,9 @@ pub const Supervisor = struct {
         for (self.managed.items) |*m| {
             if (!m.suspended) continue;
             const mcfg = m.instance.device_cfg;
-            if (@as(u16, @intCast(mcfg.device.vid)) != vid or
-                @as(u16, @intCast(mcfg.device.pid)) != pid) continue;
+            // Match by physical topology path (stable across sleep/wake)
+            // rather than VID:PID (ambiguous with identical controllers)
+            if (!std.mem.eql(u8, m.phys_key, phys)) continue;
 
             // Reopen all interface fds for the suspended instance
             const new_devices = self.allocator.alloc(DeviceIO, mcfg.device.interface.len) catch return;
@@ -1661,6 +1662,8 @@ pub const Supervisor = struct {
 
             restartManagedThread(m) catch |err| {
                 std.log.err("rebind restart failed: {}", .{err});
+                m.suspended = true;
+                m.instance.closeDeviceIO();
                 return;
             };
             std.log.info("device resumed: \"{s}\" {s}/{s}", .{ mcfg.device.name, dev_root, devname });

--- a/src/test/properties/supervisor_sm_props.zig
+++ b/src/test/properties/supervisor_sm_props.zig
@@ -122,7 +122,7 @@ test "SM: attach → attach-duplicate is no-op" {
     sup.stopAll();
 }
 
-test "SM: attach → detach → count == 0" {
+test "SM: attach → detach → suspended, count == 1" {
     const allocator = testing.allocator;
     const parsed = try device_mod.parseString(allocator, minimal_toml);
     defer parsed.deinit();
@@ -134,10 +134,12 @@ test "SM: attach → detach → count == 0" {
 
     try attach(&sup, allocator, &mock, &parsed.value, "hidraw0", "key0");
     sup.detach("hidraw0");
-    try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
+    try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
+    try testing.expect(sup.managed.items[0].suspended);
+    sup.stopAll();
 }
 
-test "SM: attach → detach → attach — second instance accepted" {
+test "SM: attach → detach → suspended instance blocks re-attach with same phys_key" {
     const allocator = testing.allocator;
     const parsed = try device_mod.parseString(allocator, minimal_toml);
     defer parsed.deinit();
@@ -151,7 +153,15 @@ test "SM: attach → detach → attach — second instance accepted" {
 
     try attach(&sup, allocator, &mock_a, &parsed.value, "hidraw0", "key0");
     sup.detach("hidraw0");
-    try attach(&sup, allocator, &mock_b, &parsed.value, "hidraw0", "key0");
+    try testing.expect(sup.managed.items[0].suspended);
+    // Same phys_key is rejected by dedup guard (suspended instance holds it)
+    const inst_b = try makeInstance(allocator, &mock_b, &parsed.value);
+    defer {
+        inst_b.deinit();
+        allocator.destroy(inst_b);
+    }
+    try sup.attachWithInstance("hidraw0", "key0", inst_b, null);
+    // Still only 1 instance (the suspended one)
     try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
     sup.stopAll();
 }
@@ -252,7 +262,7 @@ test "SM: stopAll on empty supervisor is no-op" {
     try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
 }
 
-test "SM: attach two devices → detach one → count == 1" {
+test "SM: attach two devices → detach one → count still 2, one suspended" {
     const allocator = testing.allocator;
     const parsed = try device_mod.parseString(allocator, minimal_toml);
     defer parsed.deinit();
@@ -269,6 +279,12 @@ test "SM: attach two devices → detach one → count == 1" {
     try testing.expectEqual(@as(usize, 2), sup.managed.items.len);
 
     sup.detach("hidraw0");
-    try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
+    try testing.expectEqual(@as(usize, 2), sup.managed.items.len);
+    // One is suspended, the other is still active
+    var suspended_count: usize = 0;
+    for (sup.managed.items) |*m| {
+        if (m.suspended) suspended_count += 1;
+    }
+    try testing.expectEqual(@as(usize, 1), suspended_count);
     sup.stopAll();
 }


### PR DESCRIPTION
## Summary

When a wireless controller (e.g., Vader 5 Pro via dongle) goes to sleep and wakes, padctl destroyed the entire DeviceInstance (including the uinput fd) on disconnect, then created a fresh one on reconnect. The new uinput got a different `/dev/input/eventN` — Steam's cached fd became stale → "no controller input until game restart."

**Fix**: introduce a "suspended" state for ManagedInstance:

- **Detach (sleep/disconnect)**: stop event loop thread, close only physical device fds (`closeDeviceIO`), keep uinput/aux fds alive, mark `suspended = true`
- **Attach (wake/reconnect)**: find suspended instance by VID:PID match, reopen physical fds, call `rebindDeviceIO` + `rerunInitSequence`, restart event loop thread
- Steam keeps its cached event fd reference → input resumes seamlessly

**Changes**: supervisor.zig (+251/-25), device_instance.zig (+81), event_loop.zig (+8), supervisor_sm_props.zig (+28/-3)

**Tests**: 6 new tests covering closeDeviceIO, rebindDeviceIO, suspend lifecycle, resume rebind, stopAll with suspended instances, status display.

Related issue: #93 (reporters should verify with real hardware).

## Test plan

- [x] `zig build test` passes (6 new tests)
- [ ] CI green
- [ ] Manual: turn off Vader 5 Pro → wait → turn on → verify input resumes without game restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Device suspension and automatic resume: devices now transition to suspended state when disconnected and automatically resume upon reconnection
  - Improved device status reporting to show suspended device state

* **Improvements**
  - Enhanced hotplug device reconnection handling for better device recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->