### PR TITLE
fix(install): remove SupplementaryGroups=input from user service

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -21,7 +21,6 @@ fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8) ![]c
         \\NoNewPrivileges=true
         \\LockPersonality=true
         \\ProtectClock=true
-        \\SupplementaryGroups=input
         \\
         \\[Install]
         \\WantedBy=default.target
@@ -2552,7 +2551,7 @@ test "install: service content has hardening directives" {
     try testing.expect(std.mem.indexOf(u8, content, "NoNewPrivileges=true") != null);
     try testing.expect(std.mem.indexOf(u8, content, "LockPersonality=true") != null);
     try testing.expect(std.mem.indexOf(u8, content, "ProtectClock=true") != null);
-    try testing.expect(std.mem.indexOf(u8, content, "SupplementaryGroups=input") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "SupplementaryGroups") == null);
 }
 
 test "install: old system unit triggers migration hint" {


### PR DESCRIPTION
## Summary

PR #112 added `SupplementaryGroups=input` to the systemd user service unit. systemd user services cannot change group credentials (requires `CAP_SETGID`) — the daemon crashed with `status=216/GROUP` on every start.

evdev/hidraw access is already provided by the `TAG+="uaccess"` udev rules. `SupplementaryGroups` is only meaningful for system services.

**Fix**: remove `SupplementaryGroups=input` from the service template. Regression test updated to assert the directive is absent.

Related issue: #115 (reporter should verify).

## Test plan

- [x] `zig build test` passes (regression test asserts SupplementaryGroups absent)
- [ ] CI green
- [ ] Manual: `systemctl --user start padctl` no longer fails with status=216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed supplementary group setting from systemd service configuration to adjust unit hardening directives.

* **Tests**
  * Updated service configuration tests to reflect changes in hardening directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->