### PR TITLE
fix(scripts): add brew opt PATH for versioned zig formula

### DIFF
--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -105,13 +105,16 @@ install_brew_pkg() {
 
 if command -v brew &>/dev/null; then
     # Pin zig@0.15 — padctl does not yet support 0.16+
-    if command -v zig &>/dev/null; then
-        ok "zig already installed: $(zig version)"
+    # Versioned formulas are keg-only: install then prepend opt path to PATH
+    if brew list zig@0.15 &>/dev/null; then
+        ok "zig@0.15 already installed"
     else
         info "Installing zig@0.15 via brew..."
         brew install zig@0.15 || brew install zig
-        ok "zig installed: $(zig version)"
+        ok "zig@0.15 installed"
     fi
+    export PATH="$(brew --prefix)/opt/zig@0.15/bin:$PATH"
+    ok "zig on PATH: $(zig version)"
     install_brew_pkg libusb
 else
     # Non-brew: check if zig and libusb are available


### PR DESCRIPTION
## Summary

Homebrew versioned formulas (`zig@0.15`) are keg-only — installed but not linked to `$(brew --prefix)/bin/`. Users had to manually `brew link zig@0.15` for the build to find zig.

- Check `brew list zig@0.15` instead of `command -v zig` (detects formula regardless of PATH)
- After install, prepend `$(brew --prefix)/opt/zig@0.15/bin` to PATH (non-destructive, script-session only)

Related issue: #108 (reporter should verify).

## Test plan

- [x] `bash -n` syntax check passes
- [ ] Manual: fresh Bazzite with no zig → script installs zig@0.15 and builds successfully