### PR TITLE
fix(mapper,mapping): wire pause_for_release + scan macro KEY_ targets

### DIFF
--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -31,7 +31,7 @@ pub fn deriveAuxFromMapping(cfg: *const MappingConfig) DerivedAuxCaps {
         if (std.mem.eql(u8, d.mode, "arrows")) caps.needs_keyboard = true;
     }
 
-    if (cfg.remap) |*remap| scanRemapTargets(&caps, remap);
+    if (cfg.remap) |*remap| scanRemapTargets(&caps, cfg, remap);
 
     if (cfg.layer) |layers| {
         for (layers) |*layer| {
@@ -43,7 +43,7 @@ pub fn deriveAuxFromMapping(cfg: *const MappingConfig) DerivedAuxCaps {
             if (layer.dpad) |d| {
                 if (std.mem.eql(u8, d.mode, "arrows")) caps.needs_keyboard = true;
             }
-            if (layer.remap) |*remap| scanRemapTargets(&caps, remap);
+            if (layer.remap) |*remap| scanRemapTargets(&caps, cfg, remap);
         }
     }
 
@@ -56,26 +56,47 @@ fn scanStick(caps: *DerivedAuxCaps, stick: ?StickConfig) void {
         caps.needs_rel = true;
 }
 
-fn scanRemapTargets(caps: *DerivedAuxCaps, remap: *const toml.HashMap([]const u8)) void {
+fn scanTarget(caps: *DerivedAuxCaps, target: []const u8) void {
+    if (std.mem.startsWith(u8, target, "KEY_")) {
+        caps.needs_keyboard = true;
+    } else if (std.mem.eql(u8, target, "mouse_left") or std.mem.eql(u8, target, "BTN_LEFT")) {
+        caps.mouse_buttons |= 1;
+    } else if (std.mem.eql(u8, target, "mouse_right") or std.mem.eql(u8, target, "BTN_RIGHT")) {
+        caps.mouse_buttons |= 2;
+    } else if (std.mem.eql(u8, target, "mouse_middle") or std.mem.eql(u8, target, "BTN_MIDDLE")) {
+        caps.mouse_buttons |= 4;
+    } else if (std.mem.eql(u8, target, "mouse_side") or std.mem.eql(u8, target, "BTN_SIDE")) {
+        caps.mouse_buttons |= 8;
+    } else if (std.mem.eql(u8, target, "mouse_extra") or std.mem.eql(u8, target, "BTN_EXTRA")) {
+        caps.mouse_buttons |= 16;
+    } else if (std.mem.eql(u8, target, "mouse_forward") or std.mem.eql(u8, target, "BTN_FORWARD")) {
+        caps.mouse_buttons |= 32;
+    } else if (std.mem.eql(u8, target, "mouse_back") or std.mem.eql(u8, target, "BTN_BACK")) {
+        caps.mouse_buttons |= 64;
+    }
+}
+
+fn scanRemapTargets(caps: *DerivedAuxCaps, cfg: *const MappingConfig, remap: *const toml.HashMap([]const u8)) void {
     var it = remap.map.iterator();
     while (it.next()) |entry| {
         const target = entry.value_ptr.*;
-        if (std.mem.startsWith(u8, target, "KEY_")) {
-            caps.needs_keyboard = true;
-        } else if (std.mem.eql(u8, target, "mouse_left") or std.mem.eql(u8, target, "BTN_LEFT")) {
-            caps.mouse_buttons |= 1;
-        } else if (std.mem.eql(u8, target, "mouse_right") or std.mem.eql(u8, target, "BTN_RIGHT")) {
-            caps.mouse_buttons |= 2;
-        } else if (std.mem.eql(u8, target, "mouse_middle") or std.mem.eql(u8, target, "BTN_MIDDLE")) {
-            caps.mouse_buttons |= 4;
-        } else if (std.mem.eql(u8, target, "mouse_side") or std.mem.eql(u8, target, "BTN_SIDE")) {
-            caps.mouse_buttons |= 8;
-        } else if (std.mem.eql(u8, target, "mouse_extra") or std.mem.eql(u8, target, "BTN_EXTRA")) {
-            caps.mouse_buttons |= 16;
-        } else if (std.mem.eql(u8, target, "mouse_forward") or std.mem.eql(u8, target, "BTN_FORWARD")) {
-            caps.mouse_buttons |= 32;
-        } else if (std.mem.eql(u8, target, "mouse_back") or std.mem.eql(u8, target, "BTN_BACK")) {
-            caps.mouse_buttons |= 64;
+        if (std.mem.startsWith(u8, target, "macro:")) {
+            const macro_name = target["macro:".len..];
+            const macros = cfg.macro orelse continue;
+            for (macros) |*m| {
+                if (!std.mem.eql(u8, m.name, macro_name)) continue;
+                for (m.steps) |s| {
+                    switch (s) {
+                        .tap => |name| scanTarget(caps, name),
+                        .down => |name| scanTarget(caps, name),
+                        .up => |name| scanTarget(caps, name),
+                        .delay, .pause_for_release => {},
+                    }
+                }
+                break;
+            }
+        } else {
+            scanTarget(caps, target);
         }
     }
 }
@@ -790,6 +811,22 @@ test "mapping: trigger_threshold defaults to null" {
     const result = try parseString(allocator, "");
     defer result.deinit();
     try std.testing.expectEqual(@as(?u8, null), result.value.trigger_threshold);
+}
+
+test "deriveAuxFromMapping: macro:dodge_roll emitting KEY_B sets needs_keyboard" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[[macro]]
+        \\name = "dodge_roll"
+        \\steps = [{ tap = "KEY_B" }]
+        \\
+        \\[remap]
+        \\M1 = "macro:dodge_roll"
+    );
+    defer result.deinit();
+    const caps = deriveAuxFromMapping(&result.value);
+    try std.testing.expect(caps.needs_keyboard);
+    try std.testing.expect(caps.needsAux());
 }
 
 test "mapping: fuzz parseString: no panic on arbitrary input" {

--- a/src/core/macro_player.zig
+++ b/src/core/macro_player.zig
@@ -14,15 +14,16 @@ pub const MacroPlayer = struct {
     macro: *const Macro,
     step_index: usize,
     waiting_for_release: bool,
-    /// Token used when a delay deadline is armed in the TimerQueue.
     timer_token: u32,
+    trigger_src_idx: u6,
 
-    pub fn init(m: *const Macro, token: u32) MacroPlayer {
+    pub fn init(m: *const Macro, token: u32, src_idx: u6) MacroPlayer {
         return .{
             .macro = m,
             .step_index = 0,
             .waiting_for_release = false,
             .timer_token = token,
+            .trigger_src_idx = src_idx,
         };
     }
 
@@ -122,7 +123,7 @@ const testing = std.testing;
 const mapping = @import("../config/mapping.zig");
 
 fn makePlayer(m: *const Macro) MacroPlayer {
-    return MacroPlayer.init(m, 1);
+    return MacroPlayer.init(m, 1, 0);
 }
 
 fn dummyQueue(allocator: std.mem.Allocator) TimerQueue {
@@ -236,14 +237,42 @@ test "macro_player: emitPendingReleases down without up emits release" {
     }
 }
 
+test "macro_player: shift_hold — down pause_for_release up" {
+    const allocator = testing.allocator;
+    const steps = [_]MacroStep{ .{ .down = "KEY_LEFTSHIFT" }, .pause_for_release, .{ .up = "KEY_LEFTSHIFT" } };
+    const m = Macro{ .name = "shift_hold", .steps = &steps };
+    var player = makePlayer(&m);
+    var aux = AuxEventList{};
+    var q = dummyQueue(allocator);
+    defer q.deinit();
+
+    const done1 = try player.step(&aux, &q);
+    try testing.expect(!done1);
+    try testing.expectEqual(@as(usize, 1), aux.len);
+    switch (aux.get(0)) {
+        .key => |k| try testing.expect(k.pressed),
+        else => return error.WrongType,
+    }
+
+    player.notifyTriggerReleased();
+    var aux2 = AuxEventList{};
+    const done2 = try player.step(&aux2, &q);
+    try testing.expect(done2);
+    try testing.expectEqual(@as(usize, 1), aux2.len);
+    switch (aux2.get(0)) {
+        .key => |k| try testing.expect(!k.pressed),
+        else => return error.WrongType,
+    }
+}
+
 test "macro_player: two players advance step_index independently" {
     const allocator = testing.allocator;
     const steps_a = [_]MacroStep{ .{ .tap = "KEY_A" }, .{ .tap = "KEY_B" } };
     const steps_b = [_]MacroStep{.{ .tap = "KEY_C" }};
     const ma = Macro{ .name = "a", .steps = &steps_a };
     const mb = Macro{ .name = "b", .steps = &steps_b };
-    var pa = MacroPlayer.init(&ma, 1);
-    var pb = MacroPlayer.init(&mb, 2);
+    var pa = MacroPlayer.init(&ma, 1, 0);
+    var pb = MacroPlayer.init(&mb, 2, 1);
     var q = dummyQueue(allocator);
     defer q.deinit();
 

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -263,15 +263,19 @@ pub const Mapper = struct {
                 },
                 .disabled => {},
                 .macro => |name| {
-                    // Trigger macro on rising edge only.
                     if (pressed and !prev_pressed) {
                         if (self.findMacro(name)) |m| {
                             const token = self.next_token;
                             self.next_token +%= 1;
-                            const player = MacroPlayer.init(m, token);
+                            const player = MacroPlayer.init(m, token, @intCast(i));
                             self.active_macros.append(self.allocator, player) catch |err| {
                                 std.log.warn("macro queue failed: {}", .{err});
                             };
+                        }
+                    } else if (!pressed and prev_pressed) {
+                        for (self.active_macros.items) |*p| {
+                            if (p.trigger_src_idx == @as(u6, @intCast(i)) and p.waiting_for_release)
+                                p.notifyTriggerReleased();
                         }
                     }
                 },

--- a/src/test/macro_e2e_test.zig
+++ b/src/test/macro_e2e_test.zig
@@ -72,6 +72,9 @@ fn testInstance(
         .mapper = null,
         .uinput_dev = null,
         .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
         .device_cfg = cfg,
         .pending_mapping = null,
         .stopped = false,
@@ -153,7 +156,7 @@ test "macro: macro playback — tap B, delay 50, tap LEFT sequence" {
         .{ .tap = "KEY_LEFT" },
     };
     const m = Macro{ .name = "dodge_roll", .steps = &steps };
-    var player = MacroPlayer.init(&m, 1);
+    var player = MacroPlayer.init(&m, 1, 0);
     var q = TimerQueue.init(allocator, -1);
     defer q.deinit();
 
@@ -210,7 +213,7 @@ test "macro: pause_for_release — down LSHIFT, pause, no output until released"
         .{ .up = "KEY_LEFTSHIFT" },
     };
     const m = Macro{ .name = "shift_hold", .steps = &steps };
-    var player = MacroPlayer.init(&m, 1);
+    var player = MacroPlayer.init(&m, 1, 0);
     var q = TimerQueue.init(allocator, -1);
     defer q.deinit();
 


### PR DESCRIPTION
## Summary

Two bugs preventing macros from working (reimplemented from stale PR #74):

**Bug 1 — `pause_for_release` never unblocked**: the mapper never called `notifyTriggerReleased()` when the remap-source button was released, so macros with `pause_for_release` steps waited forever.

**Fix**: on falling edge in the remap loop, iterate active macro players and call `notifyTriggerReleased()` for matching `trigger_src_idx`.

**Bug 2 — macro KEY_ targets not registered on aux device**: `deriveAuxFromMapping` scanned `[remap]` targets but skipped `[[macro]]` step targets. Aux device lacked the needed keycodes → key events silently dropped.

**Fix**: extract `scanTarget()` helper, have `scanRemapTargets()` resolve `macro:` prefixes and scan each step's target.

**Tests**: 2 new — `pause_for_release` unblock test + `deriveAuxFromMapping` macro KEY_ test.

Related issue: #72 (reporter should verify). Supersedes stale PR #74.

## Test plan

- [x] `zig build test` passes (2 new tests)
- [ ] CI green
- [ ] Manual: macro with `pause_for_release` step fires correctly on Vader 5 Pro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Macros now support pause-for-release sequences, allowing keys to be held until the trigger is released
  * Remap targets can now reference macros using `macro:<name>` syntax

* **Tests**
  * Enhanced test coverage for macro pause-for-release behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->