### PR TITLE
fix(rumble): prevent EV_FF coalescing in pollFf drain loop + make immutable install reliable (#65)

### DIFF
--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -227,12 +227,35 @@ fi
 sudo ./zig-out/bin/padctl "${install_args[@]}"
 ok "padctl installed to $PREFIX"
 
-# --- 7b. Apply mapping to the running daemon (config.toml persists for future boots,
-#         but the already-running daemon needs an explicit switch for the current session) ---
+# --- 7b. Guarantee the daemon is running as the invoking user ---
+# `padctl install` runs via sudo (writes to /usr/local, /etc), so the
+# `systemctl --user ...` trio it invokes internally executes as root and
+# does not reliably reach the invoking user's systemd instance. Redo the
+# daemon-reload/enable/restart sequence here from the user's shell so the
+# freshly-installed unit files take effect and the IPC socket is bound
+# before we apply the mapping and verify.
+info "Ensuring daemon is running as user..."
+systemctl --user daemon-reload 2>/dev/null || true
+systemctl --user enable padctl.service &>/dev/null || true
+systemctl --user restart padctl.service 2>/dev/null || true
+
+# --- 7c. Apply mapping to the running daemon (config.toml persists for future boots,
+#         but the already-running daemon needs an explicit switch for the current session).
+#         Don't pin --socket to the system path — user-service installs bind
+#         their IPC socket under $XDG_RUNTIME_DIR (/run/user/<uid>/padctl.sock),
+#         and the CLI's default resolver finds it correctly from the user shell.
+#         The daemon needs a few seconds post-restart to run device init + bind
+#         its IPC socket, so retry a few times before giving up. ---
 if [[ -n "$MAPPING" ]]; then
-    info "Waiting for daemon to initialize..."
-    sleep 3
-    if "$PREFIX/bin/padctl" switch "$MAPPING" --socket /run/padctl/padctl.sock 2>/dev/null; then
+    mapping_applied=false
+    for attempt in 1 2 3 4 5 6; do
+        sleep 1
+        if "$PREFIX/bin/padctl" switch "$MAPPING" 2>/dev/null; then
+            mapping_applied=true
+            break
+        fi
+    done
+    if $mapping_applied; then
         ok "Mapping applied: $MAPPING (persisted for future boots via /etc/padctl/config.toml)"
     else
         warn "Could not apply mapping to running daemon (it will auto-apply on next boot). Run manually: padctl switch $MAPPING"
@@ -260,7 +283,10 @@ fi
 if systemctl --user is-active padctl.service &>/dev/null; then
     ok "Service: running"
 else
-    warn "Service: not running (plug in a controller)"
+    # The daemon should always be running after a successful install — it
+    # waits for hotplug internally and does NOT require a controller to be
+    # present at startup. If we reach this branch, something failed above.
+    warn "Service: not running — check 'systemctl --user status padctl' and 'journalctl --user -u padctl -n 30'"
 fi
 
 # Check resume service

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -85,8 +85,15 @@ const immutable_dropin_content =
     \\# Bare DeviceAllow= clears the list; with no further entries, cgroup device
     \\# controller falls back to allowing all device access.
     \\DeviceAllow=
-    \\# Allow reading user mapping configs from ~/.config/padctl/
+    \\# Allow reading user mapping configs from ~/.config/padctl/.
+    \\# ProtectHome=read-only also covers /run/user/%U per systemd.exec(5),
+    \\# so we must punch a hole for the daemon's IPC socket below.
     \\ProtectHome=read-only
+    \\# ProtectHome=read-only locks /run/user/%U, which would otherwise make
+    \\# the daemon's $XDG_RUNTIME_DIR/padctl.sock bind fail with EROFS and
+    \\# silently break `padctl status`/`switch`/`devices`. Grant write access
+    \\# back to just the runtime dir without loosening the $HOME protection.
+    \\ReadWritePaths=/run/user/%U
     \\# Short timeout for processes stuck in uninterruptible I/O
     \\TimeoutStopSec=3
     \\# SIGTERM main + SIGKILL stuck threads simultaneously
@@ -1792,6 +1799,12 @@ test "install: immutable dropin content has required directives" {
     try testing.expect(std.mem.indexOf(u8, immutable_dropin_content, "ProtectHome=read-only") != null);
     try testing.expect(std.mem.indexOf(u8, immutable_dropin_content, "TimeoutStopSec=3") != null);
     try testing.expect(std.mem.indexOf(u8, immutable_dropin_content, "KillMode=mixed") != null);
+    // ProtectHome=read-only also makes /run/user/%U read-only (per
+    // systemd.exec(5)), which silently broke the daemon's IPC socket
+    // bind(). ReadWritePaths=/run/user/%U must stay present alongside
+    // ProtectHome to keep `padctl status`/`switch`/`devices` working
+    // on immutable-OS user-service installs.
+    try testing.expect(std.mem.indexOf(u8, immutable_dropin_content, "ReadWritePaths=/run/user/%U") != null);
 }
 
 // --- Phase 3: resume service, reconnect script, hotplug rules ---

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -376,7 +376,14 @@ pub const UinputDevice = struct {
                 if (ev.code == c.UI_FF_UPLOAD) {
                     var upload = std.mem.zeroes(c.uinput_ff_upload);
                     upload.request_id = @intCast(ev.value);
-                    _ = std.os.linux.ioctl(self.fd, UI_BEGIN_FF_UPLOAD, @intFromPtr(&upload));
+                    const begin_rc = std.os.linux.ioctl(self.fd, UI_BEGIN_FF_UPLOAD, @intFromPtr(&upload));
+                    if (begin_rc != 0) {
+                        // BEGIN failed — the upload struct is still zeroed. Skip
+                        // the rest of the branch so we don't touch ff_effects or
+                        // call UI_END_FF_UPLOAD with retval=0 (which would
+                        // falsely acknowledge the kernel request).
+                        continue;
+                    }
                     if (upload.effect.type == c.FF_RUMBLE and upload.effect.id < 16) {
                         self.ff_effects[@intCast(upload.effect.id)] = .{
                             .strong = upload.effect.u.rumble.strong_magnitude,
@@ -389,7 +396,11 @@ pub const UinputDevice = struct {
                 } else if (ev.code == c.UI_FF_ERASE) {
                     var erase = std.mem.zeroes(c.uinput_ff_erase);
                     erase.request_id = @intCast(ev.value);
-                    _ = std.os.linux.ioctl(self.fd, UI_BEGIN_FF_ERASE, @intFromPtr(&erase));
+                    const begin_rc = std.os.linux.ioctl(self.fd, UI_BEGIN_FF_ERASE, @intFromPtr(&erase));
+                    if (begin_rc != 0) {
+                        // BEGIN failed — see comment above for UPLOAD path.
+                        continue;
+                    }
                     if (erase.effect_id < 16) {
                         self.ff_effects[@intCast(erase.effect_id)] = .{};
                     }
@@ -421,6 +432,13 @@ pub const UinputDevice = struct {
                         .duration_ms = eff.length_ms,
                     };
                 }
+                // Return on the first EV_FF observed. Any remaining events
+                // stay in the kernel socket buffer; level-triggered ppoll
+                // on the fd will re-fire on the next loop iteration so
+                // they are drained one-per-call in FIFO order (fix for
+                // issue #65: rapid PLAY+STOP bursts used to collapse to
+                // the last event and lose the earlier one).
+                break;
             }
         }
         return result;
@@ -1042,12 +1060,16 @@ test "uinput: pollFf drain loop: empty pipe returns null without blocking" {
     try std.testing.expectEqual(@as(?FfEvent, null), result);
 }
 
-test "uinput: pollFf drain loop: drains multiple events and returns last EV_FF" {
+test "uinput: pollFf: two EV_FF events on the wire are observed one per call (no coalescing)" {
+    // Regression for #65: when multiple EV_FF events arrive in a single
+    // ppoll wake, each successive pollFf() call must return the next one
+    // in FIFO order — the drain loop must NOT collapse the batch into
+    // the last event and discard the rest. Level-triggered ppoll will
+    // re-fire as long as any remaining event is still unread.
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
 
-    // Write two EV_FF events to the pipe
     const ev1 = c.input_event{ .type = c.EV_FF, .code = 0, .value = 1, .time = std.mem.zeroes(c.timeval) };
     const ev2 = c.input_event{ .type = c.EV_FF, .code = 1, .value = 0, .time = std.mem.zeroes(c.timeval) };
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev1));
@@ -1057,10 +1079,59 @@ test "uinput: pollFf drain loop: drains multiple events and returns last EV_FF" 
         .fd = pfds[0],
         .button_codes = [_]u16{0} ** BUTTON_COUNT,
     };
-    const result = try dev.pollFf();
-    // Both events processed; last one wins — result is non-null FfEvent
-    try std.testing.expect(result != null);
-    try std.testing.expectEqual(@as(u16, c.FF_RUMBLE), result.?.effect_type);
+
+    const first = try dev.pollFf();
+    try std.testing.expect(first != null);
+    try std.testing.expectEqual(@as(u8, 0), first.?.effect_id);
+
+    const second = try dev.pollFf();
+    try std.testing.expect(second != null);
+    try std.testing.expectEqual(@as(u8, 1), second.?.effect_id);
+
+    const third = try dev.pollFf();
+    try std.testing.expectEqual(@as(?FfEvent, null), third);
+}
+
+test "uinput: pollFf: rapid PLAY+STOP on same slot both observed" {
+    // Regression for #65 (Vader 5 Pro stuck rumble class of bug). A game
+    // sending PLAY followed by STOP for the same effect slot in one
+    // ppoll wake must have BOTH events reach the scheduler, otherwise
+    // the rumble motor stays on until the next unrelated event clears
+    // the slot by coincidence. The old drain loop lost the PLAY because
+    // the STOP overwrote `result` before returning.
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    // Game uploaded a 65.5s rumble on slot 0, then told uinput to play
+    // it, then stopped it ~50ms later. The scheduler needs to see both.
+    dev.ff_effects[0] = .{ .strong = 0xf000, .weak = 0x0f00, .length_ms = 65535 };
+
+    const ev_play = c.input_event{ .type = c.EV_FF, .code = 0, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    const ev_stop = c.input_event{ .type = c.EV_FF, .code = 0, .value = 0, .time = std.mem.zeroes(c.timeval) };
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev_play));
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev_stop));
+
+    const first = try dev.pollFf();
+    try std.testing.expect(first != null);
+    try std.testing.expectEqual(@as(u8, 0), first.?.effect_id);
+    try std.testing.expectEqual(@as(u16, 0xf000), first.?.strong);
+    try std.testing.expectEqual(@as(u16, 0x0f00), first.?.weak);
+    try std.testing.expectEqual(@as(u16, 65535), first.?.duration_ms);
+
+    const second = try dev.pollFf();
+    try std.testing.expect(second != null);
+    try std.testing.expectEqual(@as(u8, 0), second.?.effect_id);
+    try std.testing.expectEqual(@as(u16, 0), second.?.strong);
+    try std.testing.expectEqual(@as(u16, 0), second.?.weak);
+    try std.testing.expectEqual(@as(u16, 0), second.?.duration_ms);
+
+    const third = try dev.pollFf();
+    try std.testing.expectEqual(@as(?FfEvent, null), third);
 }
 
 test "uinput: pollFfFd returns the fd" {


### PR DESCRIPTION
## Summary

Two narrow fixes, split out of #103 per @BANANASJIM's review:

1. **Fix the `pollFf()` drain-loop coalescing bug** with the minimal `break`-after-first-EV_FF approach. Per-wake latency difference confirmed behaviour-equivalent to the batch variant on real hardware (Flydigi Vader 5 Pro, ~2.5 h live gameplay + Steam Ping).
2. **Fix the `bazzite-setup.sh` immutable-OS install** which was silently leaving users with a dead IPC socket and, under some sudo flows, a non-running daemon. Drop-in now punches a targeted `ReadWritePaths=/run/user/%U` hole through `ProtectHome=read-only` so the daemon can bind its socket; the script now explicitly reloads + restarts the user service after install and retries the mapping apply to absorb the daemon's device-init window.

## Drain-loop fix (commit 1)

### Problem

`pollFf()` drained every queued uinput event until EAGAIN and kept overwriting `result` on each `EV_FF` match. A rapid `PLAY+STOP` burst landing in one ppoll wake collapsed to whichever event came last - the earlier `PLAY` or `STOP` was lost entirely. In Unreal-style games that clear rumble via zero-magnitude writes, that could leave the motor running until coincidence cleared the slot.

### Fix

Break out of the drain loop after the first `EV_FF` observation. Remaining events stay in the kernel socket buffer; level-triggered ppoll on the fd re-fires on the next iteration so every event reaches the scheduler in FIFO order.

Also gate the `UI_BEGIN_FF_UPLOAD` / `UI_BEGIN_FF_ERASE` paths with a `continue;` on non-zero ioctl return — without it, a failed BEGIN would still flow into `ff_effects` mutation and a `UI_END_FF_*` with `retval=0`, falsely acknowledging a request whose upload/erase struct was never populated.

### Tests

Two regression tests exercise the new contract:

1. Two `EV_FF` events with different effect ids come back one per `pollFf` call (no coalescing).
2. A rapid PLAY+STOP on the same slot both reach the caller with their correct magnitudes (the Vader-5-class scenario).

### Hardware equivalence

~2.5 hours of real gameplay on a Flydigi Vader 5 Pro including multiple Steam Ping invocations:

- **0 errors** in the daemon journal
- **0 unexpected detaches / crashes**
- **No stuck rumble observed**
- **No input regressions** (buttons, sticks, layers all responsive)
- Warnings present (`evdev grab` on IF02, `hotplug ... will retry` on startup) are all pre-existing on `main` and cosmetic.

## Install reliability fix (commit 2)

### Bug A — IPC socket binds in a read-only filesystem

The immutable-OS drop-in sets `ProtectHome=read-only`, which per `systemd.exec(5)` also makes `/run/user/%U` read-only inside the service namespace. The daemon's `bind()` for `$XDG_RUNTIME_DIR/padctl.sock` then failed with `EROFS` (`warning: control socket unavailable: error.ReadOnlyFileSystem`), silently breaking `padctl status`, `padctl switch`, `padctl devices`, and the `padctl-reconnect` hotplug hook.

Adding `ReadWritePaths=/run/user/%U` to the drop-in punches a targeted hole for just the IPC socket path, **without** loosening the `$HOME` protection. A regression test in `install.zig` locks the line in.

### Bug B — post-install daemon not reliably running

`padctl install` runs via `sudo` (writes under `/usr`, `/etc`), so the `systemctl --user daemon-reload/enable/start` trio it invokes internally executes as root and does not reliably reach the invoking user's systemd instance. Result: after `bazzite-setup.sh` finishes, the daemon was sometimes not running and the verify block printed a misleading `"Service: not running (plug in a controller)"` hint.

`bazzite-setup.sh` now has an explicit post-install block that re-runs `daemon-reload` + `enable` + `restart` as the real user, retries the mapping apply for up to 6 seconds to absorb the daemon's device-init startup window, and rewrites the verify warning to point at the actual diagnostic commands. Bash-only; `install.zig` behaviour unchanged.

## Test plan

- [x] `zig build check-all` — green
- [x] Two new regression tests — pass
- [x] Existing 787 tests — still pass
- [x] `bazzite-setup.sh` fresh install on Bazzite — daemon active, IPC socket bound, mapping applied on first attempt
- [x] ~2.5 h live gameplay — no rumble stuck, no input regressions

Refs #65, #103.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon initialization and service restart handling in setup script with retry logic for mapping application
  * Fixed compatibility with immutable filesystems by ensuring IPC socket paths remain writable
  * Fixed force feedback event processing to handle multiple events correctly and improve error handling for rumble operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->