### PR TITLE
fix(scripts): check padctl-resume.service in correct systemd scope

### DIFF
--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -289,8 +289,9 @@ else
     warn "Service: not running — check 'systemctl --user status padctl' and 'journalctl --user -u padctl -n 30'"
 fi
 
-# Check resume service
-if systemctl --user is-enabled padctl-resume.service &>/dev/null; then
+# Check resume service — installed system-scope (see install.zig ~628),
+# so we check via `systemctl` (not `systemctl --user`)
+if systemctl is-enabled padctl-resume.service &>/dev/null; then
     ok "Resume service: enabled"
 fi
 


### PR DESCRIPTION
## Summary

Follow-up to #120. The bazzite-setup.sh verify block probes padctl-resume.service with \`systemctl --user is-enabled\`, but that service is installed to system scope (\`install.zig:628\` writes to \`/lib/systemd/system/\` or \`/etc/systemd/system/\` on immutable OSes). The \`--user\` probe always silently returns non-zero, so the "Resume service: enabled" ok-line never prints even when install succeeded — harmless but confusing for users running the bootstrap script.

Single-line fix: drop the \`--user\` flag on that one check.

## Test plan

- [x] Verify \`padctl-resume.service\` is installed system-scope (confirmed via \`src/cli/install.zig:628\` and uninstall paths at :874, :920)
- [x] No other \`--user\` checks in the verify block need updating — \`padctl.service\` is correctly user-scope
- [ ] Run \`scripts/bazzite-setup.sh --mapping <foo>\` on an actual Bazzite/SteamOS system and confirm both "Service: running" and "Resume service: enabled" print in the green path

Refs: #85 #120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resume service enablement check to properly query system-wide settings instead of user-level settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->