### PR TITLE
log(supervisor): diagnostic logs for issue #93 reconnect

### DIFF
--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -1608,10 +1608,17 @@ pub const Supervisor = struct {
         const phys = try readPhysicalPath(self.allocator, path);
         defer self.allocator.free(phys);
 
+        std.log.info("hotplug: {s} VID={x:0>4} PID={x:0>4} phys=\"{s}\" iface={d}", .{
+            devname, vid, pid, phys, iface_id,
+        });
+
         // Check for a suspended instance with the same VID:PID to rebind
         for (self.managed.items) |*m| {
             if (!m.suspended) continue;
             const mcfg = m.instance.device_cfg;
+            std.log.debug("hotplug: suspended candidate vid={x:0>4} pid={x:0>4} phys_key=\"{s}\" new_phys=\"{s}\" phys_match={}", .{
+                @as(u16, @intCast(mcfg.device.vid)), @as(u16, @intCast(mcfg.device.pid)), m.phys_key, phys, std.mem.eql(u8, m.phys_key, phys),
+            });
             // Match by physical topology path (stable across sleep/wake)
             // rather than VID:PID (ambiguous with identical controllers)
             if (!std.mem.eql(u8, m.phys_key, phys)) continue;
@@ -1629,6 +1636,7 @@ pub const Supervisor = struct {
                     for (new_devices[0..opened]) |dev| dev.close();
                     self.allocator.free(new_devices);
                     if (isTransientOpenError(err)) return error.HotplugTransient;
+                    std.log.warn("hotplug: suspended instance found but resume aborted: open failed", .{});
                     return;
                 };
                 opened += 1;
@@ -1639,17 +1647,22 @@ pub const Supervisor = struct {
             m.instance.rerunInitSequence();
             m.suspended = false;
 
-            const dn_copy = self.allocator.dupe(u8, devname) catch return;
+            const dn_copy = self.allocator.dupe(u8, devname) catch {
+                std.log.warn("hotplug: suspended instance found but resume aborted: rebind failed", .{});
+                return;
+            };
             m.devname = dn_copy;
             const dev_copy = self.allocator.dupe(u8, devname) catch {
                 self.allocator.free(dn_copy);
                 m.devname = null;
+                std.log.warn("hotplug: suspended instance found but resume aborted: rebind failed", .{});
                 return;
             };
             const phys_copy = self.allocator.dupe(u8, phys) catch {
                 self.allocator.free(dn_copy);
                 self.allocator.free(dev_copy);
                 m.devname = null;
+                std.log.warn("hotplug: suspended instance found but resume aborted: rebind failed", .{});
                 return;
             };
             self.devname_map.put(dev_copy, phys_copy) catch {
@@ -1657,6 +1670,7 @@ pub const Supervisor = struct {
                 self.allocator.free(dev_copy);
                 self.allocator.free(phys_copy);
                 m.devname = null;
+                std.log.warn("hotplug: suspended instance found but resume aborted: rebind failed", .{});
                 return;
             };
 
@@ -1664,8 +1678,10 @@ pub const Supervisor = struct {
                 std.log.err("rebind restart failed: {}", .{err});
                 m.suspended = true;
                 m.instance.closeDeviceIO();
+                std.log.warn("hotplug: suspended instance found but resume aborted: restart failed", .{});
                 return;
             };
+            std.log.info("hotplug: resumed suspended instance (phys_key match) for {s}", .{devname});
             std.log.info("device resumed: \"{s}\" {s}/{s}", .{ mcfg.device.name, dev_root, devname });
             return;
         }


### PR DESCRIPTION
## Goal

Observability-only PR to help classify the root cause of [issue #93](https://github.com/BANANASJIM/padctl/issues/93) (wireless controller reconnect -> no input). No behavior change; pure log additions in the hotplug / suspended-resume path of `src/supervisor.zig`.

## What this adds

Three log call sites inside `Supervisor.attachWithRoot`:

1. `info` — at every hotplug attach, emits `VID / PID / phys / iface` so we can see what udev delivered.
2. `debug` — inside the suspended-instance match loop, dumps each candidate's `phys_key` vs the incoming `phys` and whether they match.
3. `warn` — one line before each suspended-resume early `return`, classifying the failure as `open failed` / `rebind failed` / `restart failed`.

Plus a success-path `info` summarizing `resumed suspended instance (phys_key match)` before the existing `device resumed:` line.

## Hypotheses to classify (from internal investigation)

1. **phys_key drift** — Dongle RF re-associate changes HID_PHYS -> suspend-match fails -> fresh instance created, Steam still bound to stale uinput
2. **sysfs race** — udev `add@hidrawN` fires before sysfs `HID_PHYS` is populated -> `readInterfaceId` retries exhausted -> event dropped silently
3. **init sequence timing** — `rerunInitSequence` from supervisor thread; device response queued; loop reads stale frames on restart
4. **stale pollfd** — partial rebind leaves closed-fd pointers in event loop; next poll sees `EBADF` -> treated as disconnect

Which `info` / `debug` / `warn` line fires (and which does not) will tell us which hypothesis is live.

## Request for reporters

@Harbdrain @0x-ur — if you can help:

1. Pull this branch (`git fetch && git checkout diag/issue-93-reconnect-logs`) and `zig build`, OR wait for a release build.
2. Reproduce the reconnect bug the usual way.
3. Share `journalctl --user -u padctl.service -n 200` spanning the broken reconnect (please enable debug-level logging to capture the `suspended candidate ...` line — info+warn alone will catch most hypotheses but debug is ideal).

The phrase to grep for is `hotplug:` — all four new lines share that prefix.

## Safety / risk

- No behavior change. The only non-log edits are a `catch return` -> `catch { log; return; }` reformat (functionally identical).
- Build: OK (`zig build -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false -Doptimize=ReleaseSafe`).
- Format: OK (`zig build check-fmt`).
- ROF for log adds is near-zero; safe to merge as-is.

## Follow-up

Once reporters' logs pin down which hypothesis is firing, a targeted fix PR will follow (likely touching phys_key normalization or sysfs-retry for #1–#2, or event-loop rebind sequencing for #3–#4).

Refs: #93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced logging for device hotplug attach and resume operations with improved diagnostic information
  * Added warning messages for device resume failures including interface issues and restart problems
  * Improved success logging visibility for resumed devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->