### PR TITLE
chore(release): bump version to 0.1.2

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.0",
+    .version = "0.1.2",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/refs/heads/main.tar.gz",


### PR DESCRIPTION
Release prep. After merge, create & push tag `v0.1.2` to trigger release workflow.

## What's in this release

Since v0.1.1 (2026-04-18), 10 merged PRs:

### Fixes
- **#120** rumble: prevent EV_FF coalescing in pollFf drain + immutable install drop-in
- **#122** Steam Deck HID: interface/offset/button_group corrections + `bit_idx` widened u5→u6 for 8-byte button groups (L4/R4 at bits 41/42)
- **#124** install: sudo→user-scope bridge for `systemctl --user`; devices dir warning demoted when prefix-packaged; config-list daemon probe uses socket
- **#125** logs: diagnostic logging in supervisor hotplug path (issue #93 triage)
- **#118** macro: wire `pause_for_release` + scan macro `KEY_` targets
- **#117** scripts: brew opt PATH for versioned zig formula
- **#116** install: remove `SupplementaryGroups=input` from user service
- **#114** supervisor: keep uinput alive across device sleep/wake
- **#113** scripts: pin zig@0.15 in bazzite-setup, reject 0.16+
- **#112** install: add `SupplementaryGroups=input` to systemd user service

### Breaking change
- Vader 5 Pro C/Z/LM/RM buttons are now **opt-in** via `[output.buttons]` comments in `devices/flydigi/vader5.toml`. Users relying on `BTN_TRIGGER_HAPPY1-4` from these buttons must uncomment after upgrade.

## Test plan

- [x] CI on main green prior to tag
- [ ] Post-merge: `git tag v0.1.2 && git push origin v0.1.2` — triggers `.github/workflows/release.yml`
- [ ] Verify release artifacts (musl x86_64 tarball, musl aarch64 tarball, .deb for amd64/arm64, SHA256SUMS.txt) appear on GitHub Releases

Refs: #120 #122 #124 #125