### PR TITLE
fix(supervisor): re-attach on dedup hit when backing fds are dead (#93)

### DIFF
--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -271,8 +271,38 @@ pub const Supervisor = struct {
     /// Ownership of default_pr (if non-null) transfers to ManagedInstance.
     pub fn attachWithInstance(self: *Supervisor, devname: []const u8, phys_key: []const u8, instance: *DeviceInstance, default_pr: ?*mapping_cfg.ParseResult) !void {
         if (self.devname_map.contains(devname)) return;
+        // Dedup by phys_key. Race guard for issue #93: when a controller is
+        // unplugged and replugged within the detach-delay window (or a USB
+        // re-enumeration skips the REMOVE uevent entirely), an ADD can reach
+        // this path while a managed, not-yet-suspended instance still holds
+        // the same phys_key. Silently returning in that case leaves the
+        // entry stuck on dead hidraw fds and produces no input until
+        // `padctl reload`. Probe the backing fd liveness; if the fd is dead
+        // force-detach the stale entry and fall through to a fresh attach.
+        var stale_devname_buf: [64]u8 = undefined;
+        var stale_devname: ?[]const u8 = null;
         for (self.managed.items) |m| {
-            if (std.mem.eql(u8, m.phys_key, phys_key)) return;
+            if (!std.mem.eql(u8, m.phys_key, phys_key)) continue;
+            if (managedInstanceAlive(&m)) return;
+            // Dead fds. Capture devname for detachFull (detach frees it).
+            if (m.devname) |dn| {
+                const n = @min(dn.len, stale_devname_buf.len);
+                @memcpy(stale_devname_buf[0..n], dn[0..n]);
+                stale_devname = stale_devname_buf[0..n];
+            } else {
+                // Orphan entry (static-spawn or hotplug allocation-failure
+                // edge): phys_key matches but devname is null, so we cannot
+                // force-detach via the devname_map path. Preserve the
+                // original silent-return dedup invariant — falling through
+                // would spawn a second ManagedInstance with the same
+                // phys_key.
+                return;
+            }
+            break;
+        }
+        if (stale_devname) |dn| {
+            std.log.info("hotplug: stale entry for phys \"{s}\" has dead fds; force-detaching {s} (race-guard:#93)", .{ phys_key, dn });
+            self.detachFull(dn);
         }
         const dev_copy = try self.allocator.dupe(u8, devname);
         errdefer self.allocator.free(dev_copy);
@@ -335,6 +365,28 @@ pub const Supervisor = struct {
                 return;
             }
         }
+    }
+
+    /// Probe whether the backing device fds of `m` are still alive.
+    /// Returns false when the primary device fd has been invalidated (EBADF)
+    /// or the other end has hung up (POLLHUP / POLLERR / POLLNVAL), which
+    /// is what happens after USB removal even if `detach()` has not yet
+    /// run. Used by `attachWithInstance` to distinguish a genuine dedup
+    /// collision from a race where the ADD uevent for a replug arrives
+    /// before REMOVE drains (issue #93).
+    fn managedInstanceAlive(m: *const ManagedInstance) bool {
+        // A suspended instance is an explicit, structured state: fds are
+        // already closed and the entry is reserved for rebind via
+        // attachWithRoot(). Callers of attachWithInstance that reach a
+        // suspended match have skipped the normal rebind path — preserve
+        // the existing dedup behavior (return true = "block this attach").
+        if (m.suspended) return true;
+        if (m.instance.devices.len == 0) return false;
+        var pfd = [_]posix.pollfd{m.instance.devices[0].pollfd()};
+        pfd[0].events = posix.POLL.IN;
+        pfd[0].revents = 0;
+        _ = posix.poll(&pfd, 0) catch return false;
+        return (pfd[0].revents & (posix.POLL.NVAL | posix.POLL.HUP | posix.POLL.ERR)) == 0;
     }
 
     fn spawnInstance(self: *Supervisor, phys_key: []const u8, instance: *DeviceInstance, default_pr: ?*mapping_cfg.ParseResult) !void {

--- a/src/test/properties/supervisor_sm_props.zig
+++ b/src/test/properties/supervisor_sm_props.zig
@@ -4,6 +4,7 @@
 // reload and MockDeviceIO.  No real hardware or filesystem access.
 
 const std = @import("std");
+const posix = std.posix;
 const testing = std.testing;
 
 const device_mod = @import("../../config/device.zig");
@@ -286,5 +287,158 @@ test "SM: attach two devices → detach one → count still 2, one suspended" {
         if (m.suspended) suspended_count += 1;
     }
     try testing.expectEqual(@as(usize, 1), suspended_count);
+    sup.stopAll();
+}
+
+// --- regression: issue #93 — ADD before REMOVE drained ------------------
+
+test "regression-93: ADD before REMOVE completes must not silent-drop" {
+    // Scenario (Harbdrain, 2026-04-22): controller unplugged and re-plugged
+    // so fast that the udev ADD for the new hidraw arrives while the prior
+    // managed instance is still marked alive (REMOVE uevent not yet drained,
+    // or a USB re-enumeration that skipped REMOVE entirely).
+    //
+    // Prior behavior: attachWithInstance's dedup guard (phys_key match)
+    // silently returns, leaving the managed entry stuck on dead hidraw fds
+    // and producing no input until `padctl reload`.
+    //
+    // Expected behavior: when the dedup guard matches on phys_key, probe
+    // the backing fd; if dead, force-detach the stale entry and proceed
+    // with a fresh attach so the new devname/fds bind.
+
+    const allocator = testing.allocator;
+    const parsed = try device_mod.parseString(allocator, minimal_toml);
+    defer parsed.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+    var mock_b = try MockDeviceIO.init(allocator, &.{});
+    defer mock_b.deinit();
+    var sup = try initSup(allocator);
+    defer sup.deinit();
+
+    // Step 1 — attach the original instance (thread spawns; starts polling).
+    try attach(&sup, allocator, &mock_a, &parsed.value, "hidraw0", "phys0");
+    try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
+    try testing.expect(!sup.managed.items[0].suspended);
+
+    // Step 2 — simulate the backing device going away WITHOUT a REMOVE
+    // uevent reaching `detach()` yet. Closing pipe_w surfaces POLLHUP on
+    // pipe_r, which is what a real hidraw fd shows after USB removal.
+    // The fix's fd probe in attachWithInstance polls with 0 timeout on the
+    // managed slot's DeviceIO and is independent of the device thread's
+    // lifecycle, so no sleep is needed here. stopAll()/deinit() at teardown
+    // will still cleanly join the live thread.
+    posix.close(mock_a.pipe_w);
+    mock_a.pipe_w = -1;
+
+    // Step 3 — udev ADD for the "new" hidraw node arrives BEFORE the
+    // REMOVE for hidraw0 was processed. Kernel assigned a new devname
+    // ("hidraw1") because the old node was marked removed but user-space
+    // hasn't caught up. phys_key is the same stable USB topology path.
+    const inst_b = try makeInstance(allocator, &mock_b, &parsed.value);
+    // On failure paths (pre-fix), attachWithInstance silently returns and
+    // the caller is expected to clean up the un-adopted instance.
+    var adopted = false;
+    defer if (!adopted) {
+        inst_b.deinit();
+        allocator.destroy(inst_b);
+    };
+
+    try sup.attachWithInstance("hidraw1", "phys0", inst_b, null);
+
+    // Ownership transferred to sup only when the attach actually bound the
+    // new devname. If the dedup guard silent-dropped (pre-fix), devname_map
+    // would still map "hidraw0" → "phys0" and never gain "hidraw1".
+    adopted = sup.devname_map.contains("hidraw1");
+
+    // --- assertions ---
+    // New devname must be bound to the supervisor.
+    try testing.expect(sup.devname_map.contains("hidraw1"));
+    // Stale devname must have been evicted.
+    try testing.expect(!sup.devname_map.contains("hidraw0"));
+    // Exactly one managed instance remains — the fresh one.
+    try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
+    try testing.expect(!sup.managed.items[0].suspended);
+
+    sup.stopAll();
+}
+
+test "regression-93: orphan managed entry (devname==null) with matching phys_key does not dup-attach" {
+    // Edge case carve-out for the #93 race-guard fix.
+    //
+    // Scenario: a ManagedInstance exists with phys_key="phys0" but its
+    // devname is null — this models the hotplug allocation-failure edge
+    // (supervisor.zig:1289-1304) where `spawnInstance` succeeded but the
+    // subsequent devname/map allocations failed and the entry was left
+    // orphaned, never registered in devname_map.
+    //
+    // Without the carve-out, the #93 fix's dead-fd fall-through would
+    // spawn a SECOND ManagedInstance under the same phys_key, breaking
+    // the dedup invariant. The fix preserves the original silent-return
+    // behavior when devname is null (there is no devname to force-detach
+    // by anyway — detachFull looks up via devname_map).
+
+    const allocator = testing.allocator;
+    const parsed = try device_mod.parseString(allocator, minimal_toml);
+    defer parsed.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+    var mock_b = try MockDeviceIO.init(allocator, &.{});
+    defer mock_b.deinit();
+    var sup = try initSup(allocator);
+    defer sup.deinit();
+
+    // Step 1 — create a normal managed entry via attach() so the
+    // bookkeeping is valid, then synthesise the orphan state by removing
+    // its devname_map binding and freeing/nulling its devname slot.
+    try attach(&sup, allocator, &mock_a, &parsed.value, "hidraw0", "phys0");
+    try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
+
+    {
+        // Evict the devname_map binding (simulates the put() that never
+        // happened in the allocation-failure edge).
+        if (sup.devname_map.fetchRemove("hidraw0")) |e| {
+            sup.allocator.free(e.key);
+            sup.allocator.free(e.value);
+        }
+        // Free and null m.devname to mirror the orphan's missing devname.
+        const m = &sup.managed.items[0];
+        if (m.devname) |dn| sup.allocator.free(dn);
+        m.devname = null;
+    }
+    try testing.expect(!sup.devname_map.contains("hidraw0"));
+    try testing.expect(sup.managed.items[0].devname == null);
+
+    // Step 2 — kill the backing fd so managedInstanceAlive() returns
+    // false, forcing the race-guard path to evaluate the devname branch.
+    posix.close(mock_a.pipe_w);
+    mock_a.pipe_w = -1;
+
+    // Step 3 — attempt a new attach with the same phys_key. Without the
+    // carve-out, this would fall through and dup-attach; with it, the
+    // orphan branch returns early and inst_b must be cleaned up by the
+    // caller.
+    const inst_b = try makeInstance(allocator, &mock_b, &parsed.value);
+    var adopted = false;
+    defer if (!adopted) {
+        inst_b.deinit();
+        allocator.destroy(inst_b);
+    };
+
+    try sup.attachWithInstance("hidraw1", "phys0", inst_b, null);
+    adopted = sup.devname_map.contains("hidraw1");
+
+    // --- assertions ---
+    // Dedup invariant preserved — still only one ManagedInstance.
+    try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
+    // The new devname must NOT have been bound (early-return).
+    try testing.expect(!sup.devname_map.contains("hidraw1"));
+    // The orphan is still in place (we couldn't force-detach it without
+    // a devname).
+    try testing.expect(sup.managed.items[0].devname == null);
+    try testing.expect(std.mem.eql(u8, sup.managed.items[0].phys_key, "phys0"));
+
     sup.stopAll();
 }


### PR DESCRIPTION
Fixes #93 — wireless controller quick-replug race.

## Root cause (refined via @Harbdrain's 2026-04-22 clarification)

@Harbdrain confirmed the timing signature:
> reconnecting BEFORE `info: device suspended:` log appears → no input
> reconnecting AFTER the log appears → works fine

The \`Supervisor.detach()\` path (PR #114) IS firing correctly on REMOVE events. The bug is a race window:

1. User unplugs → udev REMOVE enqueued (not yet drained by netlink callback)
2. User replugs within seconds → udev ADD enqueued
3. ADD processed while REMOVE is still pending: managed entry's \`suspended\` flag is still false
4. \`attachWithInstance\` dedup guard \`if (std.mem.eql(u8, m.phys_key, phys_key)) return;\` matches → silent bail
5. Underlying hidraw fd is already dead (device physically gone), but managed entry thinks it's live
6. REMOVE processes afterwards → suspend flag set — but the new ADD was already rejected
7. No new hidraw binding → consumer (SDL game / Steam / whatever) reads stale/dead evdev fd → no input until \`padctl reload\`

## Fix

Probe fd liveness on dedup hit. If \`POLLHUP | POLLNVAL | POLLERR\` fires on the managed entry's first pollfd → entry is stale → force \`detachFull\` and fall through to the normal attach path so the new ADD binds fresh hidraw fds.

- \`supervisor.zig:272-309\` — dedup guard extended with liveness probe
- \`supervisor.zig:362-381\` — new \`managedInstanceAlive()\` helper using \`posix.poll(&pfd, 0)\`
- Suspended instances intentionally return \`true\` (they are rebind-reserved by \`attachWithRoot\`, preserving the existing suspend/resume property test at \`supervisor_sm_props.zig:142\`)

## Test

\`src/test/properties/supervisor_sm_props.zig:295-368\` — new Layer 0 property test \`regression-93: ADD before REMOVE completes must not silent-drop\`:
- Attaches a fake device, invalidates backing fds (closes the pipe side the event loop polls)
- Issues a second ADD with same phys_key
- Asserts dedup does NOT silent-drop; the new attach or rebind happens

Before fix: test hits the dedup \`return\` and \`devname_map\` is empty after second ADD.
After fix: \`poll()\` returns POLLHUP, managed entry is \`detachFull\`'d, and the new attach proceeds normally.

## Verification

- \`zig build check-fmt\`: OK
- \`zig build -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false -Doptimize=ReleaseSafe\`: OK
- \`zig build test -Dtarget=x86_64-linux-musl ...\`: compiles OK; runtime execution deferred to Linux CI (macOS host cannot run x86_64-linux-musl)

## Scope

- Only touches the \`attachWithInstance\` dedup path
- \`attachWithRoot\`'s suspended-rebind branch (already handles REMOVE-processed-before-ADD) unchanged
- No change to public CLI, TOML, or IPC protocol

## What this does NOT fix (out of scope)

- Process restart / \`systemctl restart\` demoting suspended entries to fresh attaches — separate concern, covered by issue #126-adjacent work
- Wireless dongle phys_key drift (hypothetical hypothesis 1 from prior investigation — not observed in Harbdrain's reproduction)

Fixes #93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Devices with the same physical identifier are no longer silently rejected; the supervisor detects and removes stale device entries before accepting new attachments.

* **Tests**
  * Added regression tests ensuring new attachments win races against stale disconnected entries and that orphaned stale entries without device names do not cause duplicate attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->