### PR TITLE
feat(dump): togglable diagnostic dump CLI (#65)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ zig-cache/
 .zig-cache/
 .zig-local-cache/
 .zig-global-cache/
+zig-pkg/
 *.o
 *.a
 kcov-output/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ padctl is a userspace daemon that maps vendor-specific USB/HID gamepad reports t
 - **Runtime mapping switch** — `padctl switch <name>` changes profiles without restart
 - **Persistent mapping** — `padctl install --mapping <name>` writes a device binding to `/etc/padctl/config.toml` that auto-applies on every boot
 - **User config** — `~/.config/padctl/config.toml` for per-device default mappings (system fallback: `/etc/padctl/config.toml`)
-- **CLI tools** — `padctl status`, `padctl devices`, `padctl list-mappings`, `padctl config init/edit/test`
+- **Opt-in diagnostic logging** — `padctl dump enable` turns on a general-purpose, togglable file logger so users can produce a structured log for any class of bug report (force-feedback, input, mapping, hotplug, …). Today it is wired deepest into the rumble/HID path; more subsystems will be instrumented over time. Rotated, bounded on disk, and zero overhead when disabled (default)
+- **CLI tools** — `padctl status`, `padctl devices`, `padctl list-mappings`, `padctl config init/edit/test`, `padctl dump enable/disable/status/export/clear`
 
 ## Architecture
 
@@ -144,6 +145,10 @@ See the [getting started guide](https://bananasjim.github.io/padctl/getting-star
 | `padctl config edit` | Open user config in `$EDITOR` |
 | `padctl config test` | Validate config without applying |
 | `padctl scan` | Re-scan for connected devices |
+| `padctl dump enable\|disable` | Toggle opt-in diagnostic logging (persists across reboots) |
+| `padctl dump status` | Show logging state, log path, size, and time span |
+| `padctl dump export --period <N>m\|<N>h\|<N>d [-o file]` | Export recent log window for bug reports |
+| `padctl dump clear` | Delete all log files |
 
 ## Build
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Getting Started](getting-started.md)
 - [Bazzite / Immutable Distros](immutable-install.md)
 - [Mapping Guide](mapping-guide.md)
+- [Diagnostic Logging](diagnostic-logging.md)
 - [Device Config Reference](device-config.md)
 - [Mapping Config Reference](mapping-config.md)
 - [Device Reference](devices/README.md)

--- a/docs/src/diagnostic-logging.md
+++ b/docs/src/diagnostic-logging.md
@@ -31,16 +31,24 @@ Attach `bug.log` to your issue report.
 
 ## Log file location
 
-padctl picks the first writable directory from the list below:
+padctl picks the first entry whose env var is set / parent dir is
+reachable, going top-to-bottom:
 
 | Priority | Path | Source |
 |----------|------|--------|
-| 1 | `$LOGS_DIRECTORY/padctl.log` | Set by systemd when the service uses `LogsDirectory=padctl` (resolves to `/var/log/padctl/` for system units) |
-| 2 | `$XDG_STATE_HOME/padctl/padctl.log` | Standard XDG state path |
-| 3 | `~/.local/state/padctl/padctl.log` | XDG fallback when `$XDG_STATE_HOME` is unset |
-| 4 | `/var/log/padctl/padctl.log` | Final fallback when `$HOME` is also unset |
+| 1 | `$STATE_DIRECTORY/padctl.log` | Set by systemd when the unit declares `StateDirectory=padctl`. Resolves to `$XDG_STATE_HOME/padctl/` on the user service (default `~/.local/state/padctl/`) and `/var/lib/padctl/` on a system service. |
+| 2 | `$XDG_STATE_HOME/padctl/padctl.log` | Non-systemd invocations (e.g. the CLI running in the user's shell) with `$XDG_STATE_HOME` set. |
+| 3 | `~/.local/state/padctl/padctl.log` | XDG fallback when `$XDG_STATE_HOME` is unset but `$HOME` is. |
+| 4 | `/var/log/padctl/padctl.log` | Last-resort fallback when neither `$HOME` nor `$XDG_STATE_HOME` is available. |
 
-`padctl dump status` always prints the path that is currently in use.
+On a default Bazzite install (user-service + `StateDirectory=padctl` in
+the unit file) the daemon and CLI both converge on
+`~/.local/state/padctl/padctl.log`.
+
+`padctl dump status` prints the path currently in use. If both the
+current-session path and a legacy location contain `padctl.log`, the
+command picks whichever file was most recently modified (mtime-based)
+so you always see the active one.
 
 ## Config file
 

--- a/docs/src/diagnostic-logging.md
+++ b/docs/src/diagnostic-logging.md
@@ -62,6 +62,8 @@ max_log_size_mb = 100 # rotation threshold (default 100 MB)
 
 `padctl dump enable` and `padctl dump disable` are just a convenience front-end for toggling `dump` and forwarding the change to the running daemon — you can also edit this section by hand and send `SIGHUP` (`padctl reload`) instead.
 
+> ⚠️ **Rewrite behavior.** `padctl dump enable/disable` parses `config.toml`, rewrites it from the known schema, and atomically renames the result into place. Anything outside the documented schema — unknown sections, undocumented keys, hand-written comments — is **not preserved**. If you hand-edit `config.toml` with content that matters (e.g. a forward-looking `[experimental]` block, inline comments documenting a choice), keep it in a sibling file, or drive padctl via `SIGHUP` after the edit instead of using the `dump` subcommand. The current known schema is `version`, `[diagnostics]` (`dump`, `max_log_size_mb`), and `[[device]]` entries (`name`, `default_mapping`).
+
 ## Rotation
 
 On every daemon startup and on every fresh file-open, padctl stats the existing log. If it exceeds `max_log_size_mb`, the file is renamed to `padctl.log.1` (overwriting any previous backup) and a new empty `padctl.log` is created. There is only ever one rotated backup.

--- a/docs/src/diagnostic-logging.md
+++ b/docs/src/diagnostic-logging.md
@@ -1,0 +1,88 @@
+# Diagnostic Logging
+
+padctl ships with a general-purpose, togglable file logger. It is designed to be the single mechanism you reach for when diagnosing **any** class of bug — stuck rumble, input drops, mapping misses, hotplug oddities, daemon crashes — so that reports come with structured evidence instead of guesswork.
+
+It is **off by default** and has no hot-path cost when disabled. The current build already emits a very detailed trace of the force-feedback pipeline; other subsystems (input routing, layer/remap decisions, hotplug, config reload, …) will be instrumented behind the same switch over time. The user-facing contract — enable, reproduce, export, attach — stays the same as more coverage is added.
+
+## Quick workflow
+
+```sh
+padctl dump enable                          # turn logging on (survives reboot)
+# ... reproduce the issue by playing ...
+padctl dump export --period 30m -o bug.log  # capture the last 30 minutes
+padctl dump disable                         # turn it off again
+```
+
+Attach `bug.log` to your issue report.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `padctl dump enable` | Turn diagnostic logging on. Persists across restarts by writing `[diagnostics].dump = true` to the user config (and `/etc/padctl/config.toml` via `sudo` when available). Also sends a live IPC to any running daemon so the change takes effect immediately. |
+| `padctl dump disable` | Turn diagnostic logging off (default state). Same persistence semantics as `enable`. |
+| `padctl dump status` | Print current state (`enabled` / `disabled`), the active log path, log file size, oldest/newest entry timestamps, and the rotated backup size if present. |
+| `padctl dump export --period <N>m\|<N>h\|<N>d [-o path]` | Export the window of log lines newer than the given duration. `-o` writes to a file; omit it to print to stdout. Default window: `1d`. |
+| `padctl dump clear` | Delete the live log and any rotated backups. Asks for confirmation. Falls back to `sudo rm` for root-owned logs when the CLI user can't unlink them directly. |
+
+### Period syntax
+
+`--period` accepts `Nm` (minutes), `Nh` (hours), or `Nd` (days). Examples: `--period 15m`, `--period 2h`, `--period 7d`.
+
+## Log file location
+
+padctl picks the first writable directory from the list below:
+
+| Priority | Path | Source |
+|----------|------|--------|
+| 1 | `$LOGS_DIRECTORY/padctl.log` | Set by systemd when the service uses `LogsDirectory=padctl` (resolves to `/var/log/padctl/` for system units) |
+| 2 | `$XDG_STATE_HOME/padctl/padctl.log` | Standard XDG state path |
+| 3 | `~/.local/state/padctl/padctl.log` | XDG fallback when `$XDG_STATE_HOME` is unset |
+| 4 | `/var/log/padctl/padctl.log` | Final fallback when `$HOME` is also unset |
+
+`padctl dump status` always prints the path that is currently in use.
+
+## Config file
+
+Diagnostic logging is driven by a dedicated section in `config.toml`:
+
+```toml
+[diagnostics]
+dump = false          # master switch; padctl dump enable/disable flips this
+max_log_size_mb = 100 # rotation threshold (default 100 MB)
+```
+
+`padctl dump enable` and `padctl dump disable` are just a convenience front-end for toggling `dump` and forwarding the change to the running daemon — you can also edit this section by hand and send `SIGHUP` (`padctl reload`) instead.
+
+## Rotation
+
+On every daemon startup and on every fresh file-open, padctl stats the existing log. If it exceeds `max_log_size_mb`, the file is renamed to `padctl.log.1` (overwriting any previous backup) and a new empty `padctl.log` is created. There is only ever one rotated backup.
+
+This keeps disk usage bounded to roughly `2 * max_log_size_mb` without needing `logrotate` or any external tooling.
+
+## What gets logged
+
+When `dump = false` (the default), only warnings and errors are written, and only lazily on the first occurrence.
+
+When `dump = true`, padctl adds verbose tracing on top. The coverage today is deepest in the force-feedback pipeline — that is the area where the logger was needed first — and is being expanded to other subsystems as issues surface. Current coverage:
+
+- **Session lifecycle** — daemon start, config loaded, devices attached/detached
+- **FF_UPLOAD / FF_ERASE** kernel requests with effect IDs, rumble magnitudes, and replay durations
+- **EV_FF PLAY / STOP** events with scheduler decisions (forwarded, throttled, auto-stop timer armed, etc.)
+- **HID rumble frames** written to the physical device, with the first 16 bytes hex-dumped so post-checksum data can be inspected
+- **Scheduler slot state** (all 16 effect slots) before and after every mutation
+
+Planned areas (no promised order): input-report parsing, layer/remap resolution, hotplug/netlink events, config reload, IPC commands. You can track progress on these in the repo issue tracker.
+
+## Reporting issues
+
+When opening an issue that needs diagnostic data, the recommended flow is:
+
+```sh
+padctl dump enable
+# reproduce the bug (play the game, press the button, wait for the glitch)
+padctl dump export --period 1h -o issue.log
+padctl dump disable
+```
+
+Attach `issue.log`. Sensitive information in the logs is limited to device names, USB identifiers, and input report bytes — there is no keystroke capture or payload from other applications.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -169,7 +169,7 @@ padctl config edit [name]                  # open mapping in $VISUAL/$EDITOR
 padctl config test [--config] [--mapping]  # live input preview
 padctl dump enable|disable                 # toggle diagnostic logging (persists)
 padctl dump status                         # show dump state, log path, size, time span
-padctl dump export --period Nm|Nh|Nd [-o]  # export filtered log window
+padctl dump export --period Nm|Nh|Nd [-o file]  # export filtered log window
 padctl dump clear                          # delete all log files
 ```
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -167,7 +167,13 @@ padctl config list                         # show XDG config search paths
 padctl config init [--device] [--preset]   # interactive mapping creator
 padctl config edit [name]                  # open mapping in $VISUAL/$EDITOR
 padctl config test [--config] [--mapping]  # live input preview
+padctl dump enable|disable                 # toggle diagnostic logging (persists)
+padctl dump status                         # show dump state, log path, size, time span
+padctl dump export --period Nm|Nh|Nd [-o]  # export filtered log window
+padctl dump clear                          # delete all log files
 ```
+
+See the [Diagnostic Logging guide](diagnostic-logging.md) for the full `padctl dump` workflow, log paths, and the `[diagnostics]` config section.
 
 ## udev Permissions
 

--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -137,10 +137,13 @@ else
     case "$zig_ver" in
         0.15.*) ok "zig found: $zig_ver" ;;
         *)
-            warn "zig $zig_ver detected — padctl requires 0.15.x"
-            warn "Install zig@0.15 via brew, or download from https://ziglang.org/download/"
-            read -rp "Continue anyway? [y/N] " yn
-            [[ "$yn" =~ ^[Yy] ]] || exit 1
+            # The second block below enforces a hard exit for anything
+            # outside 0.15.x, so a "Continue anyway?" prompt here would
+            # only ever delay the same exit. Keep the messaging but don't
+            # pretend the user has a choice.
+            err "zig $zig_ver detected — padctl requires 0.15.x"
+            err "Install zig@0.15 via brew, or download from https://ziglang.org/download/"
+            exit 1
             ;;
     esac
 fi

--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -103,6 +103,8 @@ install_brew_pkg() {
     fi
 }
 
+ZIG_BREW_PKG="zig@0.15"  # padctl requires Zig 0.15.x; 0.16+ has breaking API changes
+
 if command -v brew &>/dev/null; then
     # Pin zig@0.15 — padctl does not yet support 0.16+
     # Versioned formulas are keg-only: install then prepend opt path to PATH
@@ -116,13 +118,28 @@ if command -v brew &>/dev/null; then
     export PATH="$(brew --prefix)/opt/zig@0.15/bin:$PATH"
     ok "zig on PATH: $(zig version)"
     install_brew_pkg libusb
+    # zig@0.15 is keg-only — ensure it's on PATH for this session.
+    if [[ -d "$BREW_PREFIX/opt/$ZIG_BREW_PKG/bin" ]]; then
+        export PATH="$BREW_PREFIX/opt/$ZIG_BREW_PKG/bin:$PATH"
+    fi
 else
     # Non-brew: check if zig and libusb are available
     if ! command -v zig &>/dev/null; then
         err "zig not found. Install Zig 0.15.x from https://ziglang.org/download/"
         exit 1
     fi
-    ok "zig found: $(zig version)"
+    # Warn if version is 0.16+ (breaking changes)
+    zig_ver="$(zig version 2>/dev/null || echo unknown)"
+    case "$zig_ver" in
+        0.15.*) ok "zig found: $zig_ver" ;;
+        0.16.*|0.17.*|1.*)
+            warn "zig $zig_ver detected — padctl requires 0.15.x (0.16+ has breaking build API changes)"
+            warn "Install zig@0.15 via brew, or download from https://ziglang.org/download/"
+            read -rp "Continue anyway? [y/N] " yn
+            [[ "$yn" =~ ^[Yy] ]] || exit 1
+            ;;
+        *) ok "zig found: $zig_ver" ;;
+    esac
 fi
 
 # Verify Zig version >= 0.15.0
@@ -178,7 +195,7 @@ fi
 cd "$PADCTL_REPO"
 
 # --- 5. Build ---
-info "Building padctl (ReleaseSafe)..."
+info "Building padctl (ReleaseSafe) with zig $(zig version)..."
 build_args=(-Doptimize=ReleaseSafe)
 if [[ -d "$BREW_PREFIX" ]]; then
     build_args+=(--search-prefix "$BREW_PREFIX")

--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -283,18 +283,29 @@ systemctl --user restart padctl.service 2>/dev/null || true
 #         their IPC socket under $XDG_RUNTIME_DIR (/run/user/<uid>/padctl.sock),
 #         and the CLI's default resolver finds it correctly from the user shell.
 #         The daemon needs a few seconds post-restart to run device init + bind
-#         its IPC socket, so retry a few times before giving up. ---
+#         its IPC socket, so retry a few times before giving up. "no-devices"
+#         is a permanent error for this session (no retry will help) — the
+#         binding in /etc/padctl/config.toml still takes effect on the next
+#         hot-plug, so we short-circuit with a clearer message. ---
 if [[ -n "$MAPPING" ]]; then
     mapping_applied=false
+    no_devices=false
     for attempt in 1 2 3 4 5 6; do
         sleep 1
-        if "$PREFIX/bin/padctl" switch "$MAPPING" 2>/dev/null; then
+        switch_output=$("$PREFIX/bin/padctl" switch "$MAPPING" 2>&1)
+        if [[ $? -eq 0 ]]; then
             mapping_applied=true
+            break
+        fi
+        if [[ "$switch_output" == *"no-devices"* ]]; then
+            no_devices=true
             break
         fi
     done
     if $mapping_applied; then
         ok "Mapping applied: $MAPPING (persisted for future boots via /etc/padctl/config.toml)"
+    elif $no_devices; then
+        info "No controller currently connected — mapping will auto-apply via /etc/padctl/config.toml when you plug it in."
     else
         warn "Could not apply mapping to running daemon (it will auto-apply on next boot). Run manually: padctl switch $MAPPING"
     fi

--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -174,9 +174,14 @@ if [[ -d "$PADCTL_REPO/.git" ]]; then
     if [[ -n "$BRANCH" ]]; then
         git -C "$PADCTL_REPO" fetch origin 2>/dev/null || true
         git -C "$PADCTL_REPO" checkout "$BRANCH" 2>/dev/null || warn "checkout $BRANCH failed"
-        git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null || warn "git pull failed (might have local changes)"
+        timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null || warn "git pull failed (might have local changes)"
     else
-        git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null || warn "git pull failed (might have local changes)"
+        # Only pull if on a branch that tracks a remote (skip for local-only branches).
+        if git -C "$PADCTL_REPO" rev-parse --abbrev-ref '@{upstream}' &>/dev/null; then
+            timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null || warn "git pull failed (might have local changes)"
+        else
+            info "Local branch with no upstream — skipping pull"
+        fi
     fi
     ok "Repo up to date"
 elif [[ -f "$PADCTL_REPO/build.zig" ]]; then

--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -128,17 +128,20 @@ else
         err "zig not found. Install Zig 0.15.x from https://ziglang.org/download/"
         exit 1
     fi
-    # Warn if version is 0.16+ (breaking changes)
-    zig_ver="$(zig version 2>/dev/null || echo unknown)"
+    # padctl requires Zig 0.15.x. Reject anything else upfront so users hit a
+    # clear error instead of a cryptic build failure downstream.
+    if ! zig_ver="$(zig version 2>/dev/null)"; then
+        err "failed to determine zig version"
+        exit 1
+    fi
     case "$zig_ver" in
         0.15.*) ok "zig found: $zig_ver" ;;
-        0.16.*|0.17.*|1.*)
-            warn "zig $zig_ver detected — padctl requires 0.15.x (0.16+ has breaking build API changes)"
+        *)
+            warn "zig $zig_ver detected — padctl requires 0.15.x"
             warn "Install zig@0.15 via brew, or download from https://ziglang.org/download/"
             read -rp "Continue anyway? [y/N] " yn
             [[ "$yn" =~ ^[Yy] ]] || exit 1
             ;;
-        *) ok "zig found: $zig_ver" ;;
     esac
 fi
 
@@ -171,19 +174,32 @@ fi
 
 if [[ -d "$PADCTL_REPO/.git" ]]; then
     info "Updating existing repo at $PADCTL_REPO..."
+    repo_updated=false
     if [[ -n "$BRANCH" ]]; then
         git -C "$PADCTL_REPO" fetch origin 2>/dev/null || true
         git -C "$PADCTL_REPO" checkout "$BRANCH" 2>/dev/null || warn "checkout $BRANCH failed"
-        timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null || warn "git pull failed (might have local changes)"
+        if timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null; then
+            repo_updated=true
+        else
+            warn "git pull failed (might have local changes)"
+        fi
     else
         # Only pull if on a branch that tracks a remote (skip for local-only branches).
         if git -C "$PADCTL_REPO" rev-parse --abbrev-ref '@{upstream}' &>/dev/null; then
-            timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null || warn "git pull failed (might have local changes)"
+            if timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null; then
+                repo_updated=true
+            else
+                warn "git pull failed (might have local changes)"
+            fi
         else
             info "Local branch with no upstream — skipping pull"
         fi
     fi
-    ok "Repo up to date"
+    if $repo_updated; then
+        ok "Repo up to date"
+    else
+        info "Using existing repo state"
+    fi
 elif [[ -f "$PADCTL_REPO/build.zig" ]]; then
     ok "Using existing repo at $PADCTL_REPO (not a git repo)"
 else

--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -292,8 +292,10 @@ if [[ -n "$MAPPING" ]]; then
     no_devices=false
     for attempt in 1 2 3 4 5 6; do
         sleep 1
-        switch_output=$("$PREFIX/bin/padctl" switch "$MAPPING" 2>&1)
-        if [[ $? -eq 0 ]]; then
+        # set -euo pipefail is active; a bare `x=$(cmd)` triggers script
+        # exit on non-zero from cmd before the `$?` check can fire, so we
+        # use the if-form which `set -e` explicitly ignores.
+        if switch_output=$("$PREFIX/bin/padctl" switch "$MAPPING" 2>&1); then
             mapping_applied=true
             break
         fi

--- a/src/cli/dump.zig
+++ b/src/cli/dump.zig
@@ -276,21 +276,42 @@ pub fn runClear(
     }
 }
 
-/// Pick whichever log directory has the newest last_timestamp.
-/// Falls back to sys_dir if both are empty or only sys exists.
+/// Pick whichever log directory holds the log file that is actively being
+/// written to, by comparing `padctl.log` mtimes. mtime beats text-content
+/// timestamps here because the daemon keeps appending even when the last
+/// in-text timestamp hasn't rotated through yet (e.g. between 1 Hz
+/// heartbeats) — and a one-shot foreground `padctl` invocation that fails
+/// early can briefly produce a user log with a newer *text* timestamp than
+/// the system log's most recent flushed line, even though the system
+/// daemon is still the authoritative writer.
 fn pickActiveLogDir(sys_dir: []const u8, user_dir: ?[]const u8) []const u8 {
-    const sys_stats = getLogStats(sys_dir);
-    const user_stats = if (user_dir) |ud| getLogStats(ud) else null;
+    const sys_mtime = getCurrentLogMtime(sys_dir);
+    const user_mtime = if (user_dir) |ud| getCurrentLogMtime(ud) else null;
 
-    if (sys_stats != null and user_stats != null) {
-        const sys_ts = sys_stats.?.lastTimestamp() orelse "";
-        const user_ts = user_stats.?.lastTimestamp() orelse "";
-        // ISO 8601 timestamps sort lexicographically.
-        if (std.mem.order(u8, user_ts, sys_ts) == .gt) return user_dir.?;
-        return sys_dir;
+    if (sys_mtime != null and user_mtime != null) {
+        return if (user_mtime.? > sys_mtime.?) user_dir.? else sys_dir;
     }
-    if (user_stats != null) return user_dir.?;
+    if (user_mtime != null) return user_dir.?;
+    if (sys_mtime != null) return sys_dir;
+
+    // Neither current file exists. Fall back to whichever directory has any
+    // log content at all (e.g. rotated .1 only), preferring sys.
+    if (getLogStats(sys_dir) != null) return sys_dir;
+    if (user_dir) |ud| {
+        if (getLogStats(ud) != null) return ud;
+    }
     return sys_dir;
+}
+
+/// Return the mtime (ns) of `<dir>/padctl.log`, or null if it doesn't exist
+/// or can't be stat'd.
+fn getCurrentLogMtime(dir: []const u8) ?i128 {
+    var path_buf: [280]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/padctl.log", .{dir}) catch return null;
+    const f = std.fs.openFileAbsolute(path, .{}) catch return null;
+    defer f.close();
+    const st = f.stat() catch return null;
+    return st.mtime;
 }
 
 fn formatSize(buf: *[32]u8, bytes: u64) []const u8 {
@@ -799,6 +820,67 @@ test "dump: getLogStats finds timestamp on long final line" {
     try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.firstTimestamp().?);
     // The last timestamp must be found even though it's >256 bytes from EOF.
     try testing.expectEqualStrings("2026-04-13T14:30:00.000", stats.lastTimestamp().?);
+}
+
+test "dump: pickActiveLogDir picks the dir with the newer padctl.log mtime" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Two sibling dirs, each with a padctl.log. We give the "user" file an
+    // obviously newer text timestamp but an older mtime; "sys" gets the
+    // newer mtime. The correct pick is sys — mtime beats text timestamp.
+    try tmp.dir.makeDir("sys");
+    try tmp.dir.makeDir("user");
+    const sys_path = try tmp.dir.realpathAlloc(allocator, "sys");
+    defer allocator.free(sys_path);
+    const user_path = try tmp.dir.realpathAlloc(allocator, "user");
+    defer allocator.free(user_path);
+
+    // user log: newer in text, older mtime (written first + backdated).
+    {
+        var f = try tmp.dir.createFile("user/padctl.log", .{});
+        defer f.close();
+        try f.writeAll("[2026-05-16T23:59:59.999] info: foreground-oneshot\n");
+    }
+    // Force user mtime into the past.
+    const user_log_path = try std.fmt.allocPrint(allocator, "{s}/padctl.log", .{user_path});
+    defer allocator.free(user_log_path);
+    {
+        var f = try std.fs.openFileAbsolute(user_log_path, .{ .mode = .read_write });
+        defer f.close();
+        const past_ns: i128 = 1_700_000_000 * std.time.ns_per_s;
+        const ts = std.posix.timespec{ .sec = @intCast(@divTrunc(past_ns, std.time.ns_per_s)), .nsec = @intCast(@mod(past_ns, std.time.ns_per_s)) };
+        try std.posix.futimens(f.handle, &.{ ts, ts });
+    }
+
+    // sys log: older in text, but written after → newer mtime.
+    {
+        var f = try tmp.dir.createFile("sys/padctl.log", .{});
+        defer f.close();
+        try f.writeAll("[2026-04-01T00:00:00.000] info: system-daemon\n");
+    }
+
+    const picked = pickActiveLogDir(sys_path, user_path);
+    try testing.expectEqualStrings(sys_path, picked);
+}
+
+test "dump: pickActiveLogDir falls back to user dir when only user log exists" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makeDir("user");
+    const user_path = try tmp.dir.realpathAlloc(allocator, "user");
+    defer allocator.free(user_path);
+
+    {
+        var f = try tmp.dir.createFile("user/padctl.log", .{});
+        defer f.close();
+        try f.writeAll("[2026-04-01T00:00:00.000] info: x\n");
+    }
+
+    const picked = pickActiveLogDir("/var/log/padctl-nonexistent-test-xyz", user_path);
+    try testing.expectEqualStrings(user_path, picked);
 }
 
 test "dump: getLogStats handles empty log file" {

--- a/src/cli/dump.zig
+++ b/src/cli/dump.zig
@@ -128,10 +128,10 @@ pub fn runStatus(
             stats.file_count,
             if (stats.file_count != 1) "s" else "",
         }) catch {};
-        if (stats.first_timestamp) |first| {
+        if (stats.firstTimestamp()) |first| {
             stdout.print("First entry: {s}\n", .{first}) catch {};
         }
-        if (stats.last_timestamp) |last| {
+        if (stats.lastTimestamp()) |last| {
             stdout.print("Last entry:  {s}\n", .{last}) catch {};
         }
     } else {
@@ -163,27 +163,26 @@ fn mergeStats(a: ?LogStats, b: ?LogStats) ?LogStats {
     const bs = b.?;
     merged.total_size += bs.total_size;
     merged.file_count += bs.file_count;
+
     // Pick the earliest first_timestamp and latest last_timestamp.
-    if (bs.first_timestamp) |bfirst| {
-        if (merged.first_timestamp) |mfirst| {
-            if (std.mem.order(u8, bfirst, mfirst) == .lt) {
-                @memcpy(merged.first_ts_buf[0..TS_LEN], bfirst);
-                merged.first_timestamp = merged.first_ts_buf[0..TS_LEN];
+    if (bs.has_first_ts) {
+        if (merged.has_first_ts) {
+            if (std.mem.order(u8, bs.first_ts_buf[0..TS_LEN], merged.first_ts_buf[0..TS_LEN]) == .lt) {
+                @memcpy(merged.first_ts_buf[0..TS_LEN], bs.first_ts_buf[0..TS_LEN]);
             }
         } else {
-            @memcpy(merged.first_ts_buf[0..TS_LEN], bfirst);
-            merged.first_timestamp = merged.first_ts_buf[0..TS_LEN];
+            @memcpy(merged.first_ts_buf[0..TS_LEN], bs.first_ts_buf[0..TS_LEN]);
+            merged.has_first_ts = true;
         }
     }
-    if (bs.last_timestamp) |blast| {
-        if (merged.last_timestamp) |mlast| {
-            if (std.mem.order(u8, blast, mlast) == .gt) {
-                @memcpy(merged.last_ts_buf[0..TS_LEN], blast);
-                merged.last_timestamp = merged.last_ts_buf[0..TS_LEN];
+    if (bs.has_last_ts) {
+        if (merged.has_last_ts) {
+            if (std.mem.order(u8, bs.last_ts_buf[0..TS_LEN], merged.last_ts_buf[0..TS_LEN]) == .gt) {
+                @memcpy(merged.last_ts_buf[0..TS_LEN], bs.last_ts_buf[0..TS_LEN]);
             }
         } else {
-            @memcpy(merged.last_ts_buf[0..TS_LEN], blast);
-            merged.last_timestamp = merged.last_ts_buf[0..TS_LEN];
+            @memcpy(merged.last_ts_buf[0..TS_LEN], bs.last_ts_buf[0..TS_LEN]);
+            merged.has_last_ts = true;
         }
     }
     return merged;
@@ -215,8 +214,8 @@ pub fn runClear(
         if (stats.file_count != 1) "s" else "",
         size_str,
     }) catch {};
-    if (stats.first_timestamp) |first| {
-        if (stats.last_timestamp) |last| {
+    if (stats.firstTimestamp()) |first| {
+        if (stats.lastTimestamp()) |last| {
             stdout.print(", spanning {s} to {s}", .{ first, last }) catch {};
         } else {
             stdout.print(", from {s}", .{first}) catch {};
@@ -263,8 +262,8 @@ fn pickActiveLogDir(sys_dir: []const u8, user_dir: ?[]const u8) []const u8 {
     const user_stats = if (user_dir) |ud| getLogStats(ud) else null;
 
     if (sys_stats != null and user_stats != null) {
-        const sys_ts = sys_stats.?.last_timestamp orelse "";
-        const user_ts = user_stats.?.last_timestamp orelse "";
+        const sys_ts = sys_stats.?.lastTimestamp() orelse "";
+        const user_ts = user_stats.?.lastTimestamp() orelse "";
         // ISO 8601 timestamps sort lexicographically.
         if (std.mem.order(u8, user_ts, sys_ts) == .gt) return user_dir.?;
         return sys_dir;
@@ -447,14 +446,18 @@ pub fn filterLogFile(path: []const u8, cutoff: []const u8, writer: anytype) !voi
 pub const LogStats = struct {
     total_size: u64,
     file_count: u32,
-    /// First timestamp found across all log files (from rotated file first).
-    /// Points into first_ts_buf — only valid for the lifetime of this struct.
-    first_timestamp: ?[]const u8,
-    /// Last timestamp found across all log files (from current file last).
-    last_timestamp: ?[]const u8,
-    // Backing storage for timestamp strings.
-    first_ts_buf: [23]u8 = undefined,
-    last_ts_buf: [23]u8 = undefined,
+    has_first_ts: bool = false,
+    has_last_ts: bool = false,
+    first_ts_buf: [TS_LEN]u8 = undefined,
+    last_ts_buf: [TS_LEN]u8 = undefined,
+
+    pub fn firstTimestamp(self: *const LogStats) ?[]const u8 {
+        return if (self.has_first_ts) self.first_ts_buf[0..TS_LEN] else null;
+    }
+
+    pub fn lastTimestamp(self: *const LogStats) ?[]const u8 {
+        return if (self.has_last_ts) self.last_ts_buf[0..TS_LEN] else null;
+    }
 };
 
 const TS_LEN = 23; // "YYYY-MM-DDTHH:MM:SS.mmm"
@@ -463,12 +466,7 @@ const TS_LEN = 23; // "YYYY-MM-DDTHH:MM:SS.mmm"
 /// directory doesn't exist or contains no log files. Reads only the
 /// first and last lines of each file for timestamps (not the full content).
 pub fn getLogStats(log_dir: []const u8) ?LogStats {
-    var stats = LogStats{
-        .total_size = 0,
-        .file_count = 0,
-        .first_timestamp = null,
-        .last_timestamp = null,
-    };
+    var stats = LogStats{ .total_size = 0, .file_count = 0 };
 
     // Check rotated file first (older data → first timestamp).
     var bak_path_buf: [280]u8 = undefined;
@@ -476,13 +474,13 @@ pub fn getLogStats(log_dir: []const u8) ?LogStats {
     if (scanFile(bak_path)) |info| {
         stats.total_size += info.size;
         stats.file_count += 1;
-        if (info.first_ts) |ts| {
-            @memcpy(stats.first_ts_buf[0..TS_LEN], ts);
-            stats.first_timestamp = stats.first_ts_buf[0..TS_LEN];
+        if (info.has_first_ts) {
+            @memcpy(stats.first_ts_buf[0..TS_LEN], info.first_ts_buf[0..TS_LEN]);
+            stats.has_first_ts = true;
         }
-        if (info.last_ts) |ts| {
-            @memcpy(stats.last_ts_buf[0..TS_LEN], ts);
-            stats.last_timestamp = stats.last_ts_buf[0..TS_LEN];
+        if (info.has_last_ts) {
+            @memcpy(stats.last_ts_buf[0..TS_LEN], info.last_ts_buf[0..TS_LEN]);
+            stats.has_last_ts = true;
         }
     }
 
@@ -492,15 +490,13 @@ pub fn getLogStats(log_dir: []const u8) ?LogStats {
     if (scanFile(cur_path)) |info| {
         stats.total_size += info.size;
         stats.file_count += 1;
-        if (info.first_ts) |ts| {
-            if (stats.first_timestamp == null) {
-                @memcpy(stats.first_ts_buf[0..TS_LEN], ts);
-                stats.first_timestamp = stats.first_ts_buf[0..TS_LEN];
-            }
+        if (info.has_first_ts and !stats.has_first_ts) {
+            @memcpy(stats.first_ts_buf[0..TS_LEN], info.first_ts_buf[0..TS_LEN]);
+            stats.has_first_ts = true;
         }
-        if (info.last_ts) |ts| {
-            @memcpy(stats.last_ts_buf[0..TS_LEN], ts);
-            stats.last_timestamp = stats.last_ts_buf[0..TS_LEN];
+        if (info.has_last_ts) {
+            @memcpy(stats.last_ts_buf[0..TS_LEN], info.last_ts_buf[0..TS_LEN]);
+            stats.has_last_ts = true;
         }
     }
 
@@ -510,8 +506,10 @@ pub fn getLogStats(log_dir: []const u8) ?LogStats {
 
 const FileInfo = struct {
     size: u64,
-    first_ts: ?[]const u8,
-    last_ts: ?[]const u8,
+    has_first_ts: bool = false,
+    has_last_ts: bool = false,
+    first_ts_buf: [TS_LEN]u8 = undefined,
+    last_ts_buf: [TS_LEN]u8 = undefined,
 };
 
 /// Extract file size and first/last timestamp from a log file.
@@ -523,14 +521,17 @@ fn scanFile(path: []const u8) ?FileInfo {
     defer f.close();
     const stat = f.stat() catch return null;
 
-    var info = FileInfo{ .size = stat.size, .first_ts = null, .last_ts = null };
+    var info = FileInfo{ .size = stat.size };
     if (stat.size == 0) return info;
 
     // Read first 256 bytes for first timestamp.
     var head_buf: [256]u8 = undefined;
     const head_n = f.readAll(&head_buf) catch 0;
     if (head_n > 0) {
-        info.first_ts = extractTimestamp(head_buf[0..head_n]);
+        if (extractTimestamp(head_buf[0..head_n])) |ts| {
+            @memcpy(info.first_ts_buf[0..TS_LEN], ts);
+            info.has_first_ts = true;
+        }
     }
 
     // Read last 1024 bytes for last timestamp. Rumble HID frame dump lines
@@ -545,7 +546,10 @@ fn scanFile(path: []const u8) ?FileInfo {
     var tail_buf: [1024]u8 = undefined;
     const tail_n = f.readAll(&tail_buf) catch 0;
     if (tail_n > 0) {
-        info.last_ts = extractLastTimestamp(tail_buf[0..tail_n]);
+        if (extractLastTimestamp(tail_buf[0..tail_n])) |ts| {
+            @memcpy(info.last_ts_buf[0..TS_LEN], ts);
+            info.has_last_ts = true;
+        }
     }
 
     return info;
@@ -720,8 +724,8 @@ test "dump: getLogStats reports size and timestamps for a single file" {
     const stats = getLogStats(dir_path).?;
     try testing.expect(stats.total_size > 0);
     try testing.expectEqual(@as(u32, 1), stats.file_count);
-    try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.first_timestamp.?);
-    try testing.expectEqualStrings("2026-04-13T14:10:00.000", stats.last_timestamp.?);
+    try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.firstTimestamp().?);
+    try testing.expectEqualStrings("2026-04-13T14:10:00.000", stats.lastTimestamp().?);
 }
 
 test "dump: getLogStats merges current and rotated file" {
@@ -744,8 +748,8 @@ test "dump: getLogStats merges current and rotated file" {
 
     const stats = getLogStats(dir_path).?;
     try testing.expectEqual(@as(u32, 2), stats.file_count);
-    try testing.expectEqualStrings("2026-04-12T10:00:00.000", stats.first_timestamp.?);
-    try testing.expectEqualStrings("2026-04-13T20:00:00.000", stats.last_timestamp.?);
+    try testing.expectEqualStrings("2026-04-12T10:00:00.000", stats.firstTimestamp().?);
+    try testing.expectEqualStrings("2026-04-13T20:00:00.000", stats.lastTimestamp().?);
 }
 
 test "dump: getLogStats finds timestamp on long final line" {
@@ -771,9 +775,9 @@ test "dump: getLogStats finds timestamp on long final line" {
 
     const stats = getLogStats(dir_path).?;
     try testing.expect(stats.total_size > 400);
-    try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.first_timestamp.?);
+    try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.firstTimestamp().?);
     // The last timestamp must be found even though it's >256 bytes from EOF.
-    try testing.expectEqualStrings("2026-04-13T14:30:00.000", stats.last_timestamp.?);
+    try testing.expectEqualStrings("2026-04-13T14:30:00.000", stats.lastTimestamp().?);
 }
 
 test "dump: getLogStats handles empty log file" {
@@ -791,8 +795,8 @@ test "dump: getLogStats handles empty log file" {
     const stats = getLogStats(dir_path).?;
     try testing.expectEqual(@as(u64, 0), stats.total_size);
     try testing.expectEqual(@as(u32, 1), stats.file_count);
-    try testing.expectEqual(@as(?[]const u8, null), stats.first_timestamp);
-    try testing.expectEqual(@as(?[]const u8, null), stats.last_timestamp);
+    try testing.expectEqual(@as(?[]const u8, null), stats.firstTimestamp());
+    try testing.expectEqual(@as(?[]const u8, null), stats.lastTimestamp());
 }
 
 // --- Period parsing tests ---

--- a/src/cli/dump.zig
+++ b/src/cli/dump.zig
@@ -1,0 +1,917 @@
+const std = @import("std");
+const paths = @import("../config/paths.zig");
+const user_config_mod = @import("../config/user_config.zig");
+const socket_client = @import("socket_client.zig");
+
+pub const WriteError = error{
+    MalformedConfig,
+    NoSpaceLeft,
+    OutOfMemory,
+    AccessDenied,
+    FileNotFound,
+    Unexpected,
+    InputOutput,
+    SystemResources,
+    IsDir,
+    InvalidArgument,
+};
+
+/// Write `[diagnostics] dump = <value>` to `{dir_path}/config.toml`.
+/// Preserves ALL existing fields (version, devices, other diagnostics fields).
+/// Only the `dump` field within `[diagnostics]` is changed.
+///
+/// Returns error.MalformedConfig if the existing file contains invalid TOML
+/// (the file is left untouched — the caller should warn and proceed with IPC).
+pub fn writeDiagnosticsConfig(allocator: std.mem.Allocator, dir_path: []const u8, dump: bool) WriteError!void {
+    std.fs.makeDirAbsolute(dir_path) catch |e| switch (e) {
+        error.PathAlreadyExists => {},
+        error.AccessDenied => return error.AccessDenied,
+        else => return error.Unexpected,
+    };
+
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir_path});
+    defer allocator.free(config_path);
+
+    // Read existing config to preserve all fields.
+    var existing_version: ?i64 = null;
+    var existing_diag: user_config_mod.DiagnosticsConfig = .{};
+    var existing_devices: ?[]const user_config_mod.DeviceEntry = null;
+    var existing_pr: ?user_config_mod.ParseResult = null;
+    defer if (existing_pr) |*pr| pr.deinit();
+
+    if (user_config_mod.loadFromDir(allocator, dir_path)) |maybe| {
+        if (maybe) |pr| {
+            existing_pr = pr;
+            existing_version = pr.value.version;
+            existing_diag = pr.value.diagnostics;
+            existing_devices = pr.value.device;
+        }
+        // null = file not found → fresh config, proceed.
+    } else |err| switch (err) {
+        error.MalformedConfig => return error.MalformedConfig,
+    }
+
+    // Update only the dump field; preserve everything else.
+    existing_diag.dump = dump;
+
+    // Build the config content in memory, then write atomically.
+    var content_buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&content_buf);
+    const w = fbs.writer();
+
+    w.print("version = {d}\n\n", .{existing_version orelse user_config_mod.CURRENT_VERSION}) catch return error.NoSpaceLeft;
+    w.print("[diagnostics]\ndump = {}\nmax_log_size_mb = {d}\n", .{ existing_diag.dump, existing_diag.max_log_size_mb }) catch return error.NoSpaceLeft;
+
+    if (existing_devices) |devices| {
+        for (devices) |dev| {
+            w.writeAll("\n[[device]]\n") catch return error.NoSpaceLeft;
+            w.print("name = \"{s}\"\n", .{dev.name}) catch return error.NoSpaceLeft;
+            if (dev.default_mapping) |m| {
+                w.print("default_mapping = \"{s}\"\n", .{m}) catch return error.NoSpaceLeft;
+            }
+        }
+    }
+
+    var f = std.fs.createFileAbsolute(config_path, .{ .truncate = true }) catch return error.AccessDenied;
+    defer f.close();
+    f.writeAll(fbs.getWritten()) catch return error.InputOutput;
+}
+
+/// Run `padctl dump status`: query daemon for live state, read log file stats.
+pub fn runStatus(
+    allocator: std.mem.Allocator,
+    socket_path: []const u8,
+    stdout: anytype,
+    stderr: anytype,
+) void {
+    // Query daemon for live dump state.
+    var daemon_state: []const u8 = "unknown (daemon not running)";
+    if (socket_client.connectToSocket(socket_path)) |sock_fd| {
+        defer std.posix.close(sock_fd);
+        var resp_buf: [64]u8 = undefined;
+        if (socket_client.sendCommand(sock_fd, "DUMP STATUS\n", &resp_buf)) |resp| {
+            // Parse "OK dump=on\n" or "OK dump=off\n"
+            const trimmed = std.mem.trimRight(u8, resp, "\r\n");
+            if (std.mem.indexOf(u8, trimmed, "dump=on") != null) {
+                daemon_state = "enabled";
+            } else if (std.mem.indexOf(u8, trimmed, "dump=off") != null) {
+                daemon_state = "disabled";
+            }
+        } else |_| {}
+    } else |_| {
+        // Daemon not running — fall back to config.
+        const user_cfg_mod2 = user_config_mod;
+        if (user_cfg_mod2.load(allocator)) |pr| {
+            var ucpr = pr;
+            defer ucpr.deinit();
+            daemon_state = if (ucpr.value.diagnostics.dump) "enabled (from config)" else "disabled (from config)";
+        }
+    }
+
+    stdout.print("Dump: {s}\n", .{daemon_state}) catch {};
+
+    // Log file stats. Check both user state dir and systemd /var/log/padctl,
+    // pick whichever has the newest last_timestamp (the active one).
+    const sys_log_dir = "/var/log/padctl";
+    const user_log_dir: ?[]u8 = paths.stateDir(allocator) catch null;
+    defer if (user_log_dir) |d| allocator.free(d);
+
+    const effective_dir: []const u8 = pickActiveLogDir(sys_log_dir, user_log_dir);
+
+    stdout.print("Log path: {s}/padctl.log\n", .{effective_dir}) catch {};
+
+    if (getLogStats(effective_dir)) |stats| {
+        var size_buf: [32]u8 = undefined;
+        const size_str = formatSize(&size_buf, stats.total_size);
+        stdout.print("Log size: {s} ({d} file{s})\n", .{
+            size_str,
+            stats.file_count,
+            if (stats.file_count != 1) "s" else "",
+        }) catch {};
+        if (stats.first_timestamp) |first| {
+            stdout.print("First entry: {s}\n", .{first}) catch {};
+        }
+        if (stats.last_timestamp) |last| {
+            stdout.print("Last entry:  {s}\n", .{last}) catch {};
+        }
+    } else {
+        stdout.print("Log size: no logs\n", .{}) catch {};
+    }
+
+    _ = stderr;
+}
+
+/// Delete log files in the given directory. Returns the number of files deleted.
+pub fn deleteLogFiles(log_dir: []const u8) u32 {
+    var deleted: u32 = 0;
+    const names = [_][]const u8{ "padctl.log", "padctl.log.1" };
+    for (names) |name| {
+        var path_buf: [280]u8 = undefined;
+        const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ log_dir, name }) catch continue;
+        std.fs.deleteFileAbsolute(path) catch continue;
+        deleted += 1;
+    }
+    return deleted;
+}
+
+/// Aggregate LogStats across two directories.
+fn mergeStats(a: ?LogStats, b: ?LogStats) ?LogStats {
+    if (a == null and b == null) return null;
+    if (a == null) return b;
+    if (b == null) return a;
+    var merged = a.?;
+    const bs = b.?;
+    merged.total_size += bs.total_size;
+    merged.file_count += bs.file_count;
+    // Pick the earliest first_timestamp and latest last_timestamp.
+    if (bs.first_timestamp) |bfirst| {
+        if (merged.first_timestamp) |mfirst| {
+            if (std.mem.order(u8, bfirst, mfirst) == .lt) {
+                @memcpy(merged.first_ts_buf[0..TS_LEN], bfirst);
+                merged.first_timestamp = merged.first_ts_buf[0..TS_LEN];
+            }
+        } else {
+            @memcpy(merged.first_ts_buf[0..TS_LEN], bfirst);
+            merged.first_timestamp = merged.first_ts_buf[0..TS_LEN];
+        }
+    }
+    if (bs.last_timestamp) |blast| {
+        if (merged.last_timestamp) |mlast| {
+            if (std.mem.order(u8, blast, mlast) == .gt) {
+                @memcpy(merged.last_ts_buf[0..TS_LEN], blast);
+                merged.last_timestamp = merged.last_ts_buf[0..TS_LEN];
+            }
+        } else {
+            @memcpy(merged.last_ts_buf[0..TS_LEN], blast);
+            merged.last_timestamp = merged.last_ts_buf[0..TS_LEN];
+        }
+    }
+    return merged;
+}
+
+/// Run `padctl dump clear`: show stats across ALL log locations, prompt, delete all.
+pub fn runClear(
+    allocator: std.mem.Allocator,
+    stdout: anytype,
+    stderr: anytype,
+) void {
+    const sys_log_dir = "/var/log/padctl";
+    const user_log_dir: ?[]u8 = paths.stateDir(allocator) catch null;
+    defer if (user_log_dir) |d| allocator.free(d);
+
+    // Aggregate stats from both locations.
+    const sys_stats = getLogStats(sys_log_dir);
+    const user_stats = if (user_log_dir) |ud| getLogStats(ud) else null;
+    const stats = mergeStats(sys_stats, user_stats) orelse {
+        stdout.print("No logs to clear.\n", .{}) catch {};
+        return;
+    };
+
+    // Show stats.
+    var size_buf: [32]u8 = undefined;
+    const size_str = formatSize(&size_buf, stats.total_size);
+    stdout.print("{d} log file{s}, {s}", .{
+        stats.file_count,
+        if (stats.file_count != 1) "s" else "",
+        size_str,
+    }) catch {};
+    if (stats.first_timestamp) |first| {
+        if (stats.last_timestamp) |last| {
+            stdout.print(", spanning {s} to {s}", .{ first, last }) catch {};
+        } else {
+            stdout.print(", from {s}", .{first}) catch {};
+        }
+    }
+    stdout.print("\n", .{}) catch {};
+
+    // Check for TTY.
+    const stdin_fd = std.posix.STDIN_FILENO;
+    if (!std.posix.isatty(stdin_fd)) {
+        stderr.print("error: refusing to delete logs without interactive confirmation (stdin is not a TTY)\n", .{}) catch {};
+        std.process.exit(1);
+    }
+
+    // Prompt.
+    stdout.print("Delete all logs? [y/N] ", .{}) catch {};
+    var input_buf: [16]u8 = undefined;
+    const n = std.posix.read(stdin_fd, &input_buf) catch {
+        stdout.print("\nAborted.\n", .{}) catch {};
+        return;
+    };
+    if (n == 0) {
+        stdout.print("\nAborted.\n", .{}) catch {};
+        return;
+    }
+    const answer = std.mem.trimRight(u8, input_buf[0..n], "\r\n \t");
+    if (answer.len == 1 and (answer[0] == 'y' or answer[0] == 'Y')) {
+        // Delete from BOTH locations.
+        var deleted: u32 = 0;
+        deleted += deleteLogFiles(sys_log_dir);
+        if (user_log_dir) |ud| {
+            deleted += deleteLogFiles(ud);
+        }
+        stdout.print("Deleted {d} file{s}.\n", .{ deleted, if (deleted != 1) "s" else "" }) catch {};
+    } else {
+        stdout.print("Aborted.\n", .{}) catch {};
+    }
+}
+
+/// Pick whichever log directory has the newest last_timestamp.
+/// Falls back to sys_dir if both are empty or only sys exists.
+fn pickActiveLogDir(sys_dir: []const u8, user_dir: ?[]const u8) []const u8 {
+    const sys_stats = getLogStats(sys_dir);
+    const user_stats = if (user_dir) |ud| getLogStats(ud) else null;
+
+    if (sys_stats != null and user_stats != null) {
+        const sys_ts = sys_stats.?.last_timestamp orelse "";
+        const user_ts = user_stats.?.last_timestamp orelse "";
+        // ISO 8601 timestamps sort lexicographically.
+        if (std.mem.order(u8, user_ts, sys_ts) == .gt) return user_dir.?;
+        return sys_dir;
+    }
+    if (user_stats != null) return user_dir.?;
+    return sys_dir;
+}
+
+fn formatSize(buf: *[32]u8, bytes: u64) []const u8 {
+    if (bytes < 1024) {
+        return std.fmt.bufPrint(buf, "{d} B", .{bytes}) catch "?";
+    } else if (bytes < 1024 * 1024) {
+        return std.fmt.bufPrint(buf, "{d:.1} KB", .{@as(f64, @floatFromInt(bytes)) / 1024.0}) catch "?";
+    } else {
+        return std.fmt.bufPrint(buf, "{d:.1} MB", .{@as(f64, @floatFromInt(bytes)) / (1024.0 * 1024.0)}) catch "?";
+    }
+}
+
+/// Run `padctl dump export`: filter logs by period, output to stdout or file.
+pub fn runExport(
+    allocator: std.mem.Allocator,
+    period_str: []const u8,
+    output_path: ?[]const u8,
+    stdout: anytype,
+    stderr: anytype,
+) void {
+    const period_secs = parsePeriod(period_str) orelse {
+        stderr.print("error: invalid period '{s}' — use Nm, Nh, or Nd (e.g., 10m, 1h, 1d)\n", .{period_str}) catch {};
+        std.process.exit(1);
+    };
+
+    // Compute cutoff timestamp.
+    const now_secs = @as(u64, @intCast(std.time.timestamp()));
+    const cutoff_secs = if (now_secs > period_secs) now_secs - period_secs else 0;
+    var cutoff_buf: [23]u8 = undefined;
+    const cutoff = formatTimestamp(&cutoff_buf, cutoff_secs);
+
+    // Find the active log directory.
+    const sys_log_dir = "/var/log/padctl";
+    const user_log_dir: ?[]u8 = paths.stateDir(allocator) catch null;
+    defer if (user_log_dir) |d| allocator.free(d);
+    const log_dir = pickActiveLogDir(sys_log_dir, user_log_dir);
+
+    // Open output: file or stdout. Supports both relative and absolute paths.
+    if (output_path) |op| {
+        var f = (if (op.len > 0 and op[0] == '/')
+            std.fs.createFileAbsolute(op, .{ .truncate = true })
+        else
+            std.fs.cwd().createFile(op, .{ .truncate = true })) catch |err| {
+            stderr.print("error: cannot create '{s}': {}\n", .{ op, err }) catch {};
+            std.process.exit(1);
+        };
+        defer f.close();
+        exportToFd(log_dir, cutoff, f.handle);
+    } else {
+        exportToWriter(log_dir, cutoff, stdout);
+    }
+}
+
+fn exportToFd(log_dir: []const u8, cutoff: []const u8, fd: std.posix.fd_t) void {
+    const FdWriter = struct {
+        fd: std.posix.fd_t,
+        pub fn writeAll(self: @This(), data: []const u8) !void {
+            var written: usize = 0;
+            while (written < data.len) {
+                written += std.posix.write(self.fd, data[written..]) catch return error.BrokenPipe;
+            }
+        }
+    };
+    const w = FdWriter{ .fd = fd };
+    exportToWriter(log_dir, cutoff, w);
+}
+
+fn exportToWriter(log_dir: []const u8, cutoff: []const u8, writer: anytype) void {
+    // Read rotated file first (older), then current file.
+    var bak_buf: [280]u8 = undefined;
+    const bak_path = std.fmt.bufPrint(&bak_buf, "{s}/padctl.log.1", .{log_dir}) catch return;
+    filterLogFile(bak_path, cutoff, writer) catch {};
+
+    var cur_buf: [280]u8 = undefined;
+    const cur_path = std.fmt.bufPrint(&cur_buf, "{s}/padctl.log", .{log_dir}) catch return;
+    filterLogFile(cur_path, cutoff, writer) catch {};
+}
+
+fn formatTimestamp(buf: *[23]u8, epoch_secs: u64) []const u8 {
+    const es = std.time.epoch.EpochSeconds{ .secs = epoch_secs };
+    const day = es.getEpochDay();
+    const yd = day.calculateYearDay();
+    const md = yd.calculateMonthDay();
+    const ds = es.getDaySeconds();
+    const result = std.fmt.bufPrint(buf, "{d:0>4}-{d:0>2}-{d:0>2}T{d:0>2}:{d:0>2}:{d:0>2}.000", .{
+        yd.year,
+        @as(u32, @intFromEnum(md.month)) + 1,
+        @as(u32, md.day_index) + 1,
+        ds.getHoursIntoDay(),
+        ds.getMinutesIntoHour(),
+        ds.getSecondsIntoMinute(),
+    }) catch return "0000-00-00T00:00:00.000";
+    return result;
+}
+
+/// Parse a relative period string like "10m", "1h", "1d" into seconds.
+/// Returns null for invalid input.
+pub fn parsePeriod(s: []const u8) ?u64 {
+    if (s.len < 2) return null;
+    const unit = s[s.len - 1];
+    const multiplier: u64 = switch (unit) {
+        'm' => 60,
+        'h' => 3600,
+        'd' => 86400,
+        else => return null,
+    };
+    const num_str = s[0 .. s.len - 1];
+    const n = std.fmt.parseInt(u64, num_str, 10) catch return null;
+    if (n == 0) return null;
+    return std.math.mul(u64, n, multiplier) catch return null;
+}
+
+/// Check whether a log line's timestamp is at or after the cutoff.
+/// Lines without a parseable timestamp are included conservatively.
+/// Both `line` and `cutoff` use the format "YYYY-MM-DDTHH:MM:SS.mmm".
+pub fn linePassesFilter(line: []const u8, cutoff: []const u8) bool {
+    const ts = extractTimestamp(line) orelse return true; // no timestamp → include
+    // ISO 8601 timestamps sort lexicographically.
+    return std.mem.order(u8, ts, cutoff) != .lt;
+}
+
+/// Read a log file line-by-line, writing lines that pass the timestamp filter
+/// to the given writer. The cutoff is an ISO 8601 timestamp string.
+pub fn filterLogFile(path: []const u8, cutoff: []const u8, writer: anytype) !void {
+    const f = std.fs.openFileAbsolute(path, .{}) catch return;
+    defer f.close();
+
+    var buf: [4096]u8 = undefined;
+    var carry: [4096]u8 = undefined;
+    var carry_len: usize = 0;
+
+    while (true) {
+        const n = f.readAll(buf[carry_len..]) catch break;
+        if (carry_len > 0) {
+            // Prepend leftover from previous read.
+            @memcpy(buf[0..carry_len], carry[0..carry_len]);
+        }
+        const total = carry_len + n;
+        if (total == 0) break;
+        carry_len = 0;
+
+        var data = buf[0..total];
+        while (std.mem.indexOfScalar(u8, data, '\n')) |nl| {
+            const line = data[0..nl];
+            if (linePassesFilter(line, cutoff)) {
+                try writer.writeAll(line);
+                try writer.writeAll("\n");
+            }
+            data = data[nl + 1 ..];
+        }
+        // Leftover (no newline) — carry to next iteration.
+        if (data.len > 0 and n > 0) {
+            @memcpy(carry[0..data.len], data);
+            carry_len = data.len;
+        } else if (data.len > 0) {
+            // EOF with no trailing newline — process the leftover.
+            if (linePassesFilter(data, cutoff)) {
+                try writer.writeAll(data);
+                try writer.writeAll("\n");
+            }
+        }
+    }
+
+    // Final leftover after EOF.
+    if (carry_len > 0) {
+        const leftover = carry[0..carry_len];
+        if (linePassesFilter(leftover, cutoff)) {
+            try writer.writeAll(leftover);
+            try writer.writeAll("\n");
+        }
+    }
+}
+
+pub const LogStats = struct {
+    total_size: u64,
+    file_count: u32,
+    /// First timestamp found across all log files (from rotated file first).
+    /// Points into first_ts_buf — only valid for the lifetime of this struct.
+    first_timestamp: ?[]const u8,
+    /// Last timestamp found across all log files (from current file last).
+    last_timestamp: ?[]const u8,
+    // Backing storage for timestamp strings.
+    first_ts_buf: [23]u8 = undefined,
+    last_ts_buf: [23]u8 = undefined,
+};
+
+const TS_LEN = 23; // "YYYY-MM-DDTHH:MM:SS.mmm"
+
+/// Scan log files in `log_dir` and return stats. Returns null if the
+/// directory doesn't exist or contains no log files. Reads only the
+/// first and last lines of each file for timestamps (not the full content).
+pub fn getLogStats(log_dir: []const u8) ?LogStats {
+    var stats = LogStats{
+        .total_size = 0,
+        .file_count = 0,
+        .first_timestamp = null,
+        .last_timestamp = null,
+    };
+
+    // Check rotated file first (older data → first timestamp).
+    var bak_path_buf: [280]u8 = undefined;
+    const bak_path = std.fmt.bufPrint(&bak_path_buf, "{s}/padctl.log.1", .{log_dir}) catch return null;
+    if (scanFile(bak_path)) |info| {
+        stats.total_size += info.size;
+        stats.file_count += 1;
+        if (info.first_ts) |ts| {
+            @memcpy(stats.first_ts_buf[0..TS_LEN], ts);
+            stats.first_timestamp = stats.first_ts_buf[0..TS_LEN];
+        }
+        if (info.last_ts) |ts| {
+            @memcpy(stats.last_ts_buf[0..TS_LEN], ts);
+            stats.last_timestamp = stats.last_ts_buf[0..TS_LEN];
+        }
+    }
+
+    // Check current file (newer data → last timestamp).
+    var cur_path_buf: [280]u8 = undefined;
+    const cur_path = std.fmt.bufPrint(&cur_path_buf, "{s}/padctl.log", .{log_dir}) catch return null;
+    if (scanFile(cur_path)) |info| {
+        stats.total_size += info.size;
+        stats.file_count += 1;
+        if (info.first_ts) |ts| {
+            if (stats.first_timestamp == null) {
+                @memcpy(stats.first_ts_buf[0..TS_LEN], ts);
+                stats.first_timestamp = stats.first_ts_buf[0..TS_LEN];
+            }
+        }
+        if (info.last_ts) |ts| {
+            @memcpy(stats.last_ts_buf[0..TS_LEN], ts);
+            stats.last_timestamp = stats.last_ts_buf[0..TS_LEN];
+        }
+    }
+
+    if (stats.file_count == 0) return null;
+    return stats;
+}
+
+const FileInfo = struct {
+    size: u64,
+    first_ts: ?[]const u8,
+    last_ts: ?[]const u8,
+};
+
+/// Extract file size and first/last timestamp from a log file.
+/// Reads the first 256 bytes for the first timestamp and the last 1024 bytes
+/// for the last timestamp (large enough for HID frame hex dump lines).
+/// Returns null if the file doesn't exist.
+fn scanFile(path: []const u8) ?FileInfo {
+    const f = std.fs.openFileAbsolute(path, .{}) catch return null;
+    defer f.close();
+    const stat = f.stat() catch return null;
+
+    var info = FileInfo{ .size = stat.size, .first_ts = null, .last_ts = null };
+    if (stat.size == 0) return info;
+
+    // Read first 256 bytes for first timestamp.
+    var head_buf: [256]u8 = undefined;
+    const head_n = f.readAll(&head_buf) catch 0;
+    if (head_n > 0) {
+        info.first_ts = extractTimestamp(head_buf[0..head_n]);
+    }
+
+    // Read last 1024 bytes for last timestamp. Rumble HID frame dump lines
+    // can exceed 256 bytes, so we need a larger tail window to find the
+    // timestamp at the start of the final line.
+    const tail_size: u64 = 1024;
+    if (stat.size > tail_size) {
+        f.seekTo(stat.size - tail_size) catch {};
+    } else {
+        f.seekTo(0) catch {};
+    }
+    var tail_buf: [1024]u8 = undefined;
+    const tail_n = f.readAll(&tail_buf) catch 0;
+    if (tail_n > 0) {
+        info.last_ts = extractLastTimestamp(tail_buf[0..tail_n]);
+    }
+
+    return info;
+}
+
+/// Extract the first `[YYYY-MM-DDTHH:MM:SS.mmm]` timestamp from a buffer.
+fn extractTimestamp(buf: []const u8) ?[]const u8 {
+    const start = std.mem.indexOfScalar(u8, buf, '[') orelse return null;
+    if (start + 1 + TS_LEN > buf.len) return null;
+    const ts = buf[start + 1 .. start + 1 + TS_LEN];
+    // Quick sanity check: must have 'T' at position 10 and '.' at position 19.
+    if (ts.len == TS_LEN and ts[10] == 'T' and ts[19] == '.') return ts;
+    return null;
+}
+
+/// Extract the last `[YYYY-MM-DDTHH:MM:SS.mmm]` timestamp from a buffer
+/// by scanning backwards.
+fn extractLastTimestamp(buf: []const u8) ?[]const u8 {
+    var last: ?[]const u8 = null;
+    var i: usize = 0;
+    while (i < buf.len) {
+        if (buf[i] == '[' and i + 1 + TS_LEN <= buf.len) {
+            const ts = buf[i + 1 .. i + 1 + TS_LEN];
+            if (ts.len == TS_LEN and ts[10] == 'T' and ts[19] == '.') {
+                last = ts;
+            }
+        }
+        i += 1;
+    }
+    return last;
+}
+
+// --- tests ---
+
+const testing = std.testing;
+
+test "dump: writeDiagnosticsConfig creates fresh config" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    try writeDiagnosticsConfig(allocator, dir_path, true);
+
+    var result = (try user_config_mod.loadFromDir(allocator, dir_path)).?;
+    defer result.deinit();
+    try testing.expectEqual(true, result.value.diagnostics.dump);
+    try testing.expectEqual(@as(i64, 100), result.value.diagnostics.max_log_size_mb);
+    try testing.expectEqual(@as(?i64, 1), result.value.version);
+}
+
+test "dump: writeDiagnosticsConfig preserves existing device entries" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("config.toml", .{});
+        defer f.close();
+        try f.writeAll(
+            \\version = 1
+            \\
+            \\[[device]]
+            \\name = "Vader 5 Pro"
+            \\default_mapping = "fps"
+        );
+    }
+
+    try writeDiagnosticsConfig(allocator, dir_path, true);
+
+    var result = (try user_config_mod.loadFromDir(allocator, dir_path)).?;
+    defer result.deinit();
+    try testing.expectEqual(true, result.value.diagnostics.dump);
+    const mapping = user_config_mod.findDefaultMapping(&result, "Vader 5 Pro");
+    try testing.expect(mapping != null);
+    try testing.expectEqualStrings("fps", mapping.?);
+}
+
+test "dump: writeDiagnosticsConfig preserves max_log_size_mb" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("config.toml", .{});
+        defer f.close();
+        try f.writeAll(
+            \\version = 1
+            \\
+            \\[diagnostics]
+            \\dump = false
+            \\max_log_size_mb = 50
+        );
+    }
+
+    // Toggle dump on — max_log_size_mb must survive.
+    try writeDiagnosticsConfig(allocator, dir_path, true);
+
+    var result = (try user_config_mod.loadFromDir(allocator, dir_path)).?;
+    defer result.deinit();
+    try testing.expectEqual(true, result.value.diagnostics.dump);
+    try testing.expectEqual(@as(i64, 50), result.value.diagnostics.max_log_size_mb);
+}
+
+test "dump: writeDiagnosticsConfig toggles off" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    try writeDiagnosticsConfig(allocator, dir_path, true);
+    try writeDiagnosticsConfig(allocator, dir_path, false);
+
+    var result = (try user_config_mod.loadFromDir(allocator, dir_path)).?;
+    defer result.deinit();
+    try testing.expectEqual(false, result.value.diagnostics.dump);
+}
+
+test "dump: writeDiagnosticsConfig aborts on malformed config" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("config.toml", .{});
+        defer f.close();
+        try f.writeAll("this is {{{{ not TOML !!!!");
+    }
+
+    // Must return MalformedConfig, NOT silently overwrite.
+    try testing.expectError(error.MalformedConfig, writeDiagnosticsConfig(allocator, dir_path, true));
+
+    // Verify the original file is untouched.
+    const content = try tmp.dir.readFileAlloc(allocator, "config.toml", 4096);
+    defer allocator.free(content);
+    try testing.expectEqualStrings("this is {{{{ not TOML !!!!", content);
+}
+
+// --- LogStats tests ---
+
+test "dump: getLogStats returns null for nonexistent directory" {
+    const stats = getLogStats("/tmp/padctl_nonexistent_test_dir_12345");
+    try testing.expectEqual(@as(?LogStats, null), stats);
+}
+
+test "dump: getLogStats reports size and timestamps for a single file" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        defer f.close();
+        try f.writeAll(
+            \\[2026-04-13T14:00:00.000] [MONO:1] info: first line
+            \\[2026-04-13T14:05:00.000] [MONO:2] info: middle
+            \\[2026-04-13T14:10:00.000] [MONO:3] info: last line
+            \\
+        );
+    }
+
+    const stats = getLogStats(dir_path).?;
+    try testing.expect(stats.total_size > 0);
+    try testing.expectEqual(@as(u32, 1), stats.file_count);
+    try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.first_timestamp.?);
+    try testing.expectEqualStrings("2026-04-13T14:10:00.000", stats.last_timestamp.?);
+}
+
+test "dump: getLogStats merges current and rotated file" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("padctl.log.1", .{});
+        defer f.close();
+        try f.writeAll("[2026-04-12T10:00:00.000] [MONO:1] info: old\n");
+    }
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        defer f.close();
+        try f.writeAll("[2026-04-13T20:00:00.000] [MONO:2] info: new\n");
+    }
+
+    const stats = getLogStats(dir_path).?;
+    try testing.expectEqual(@as(u32, 2), stats.file_count);
+    try testing.expectEqualStrings("2026-04-12T10:00:00.000", stats.first_timestamp.?);
+    try testing.expectEqualStrings("2026-04-13T20:00:00.000", stats.last_timestamp.?);
+}
+
+test "dump: getLogStats finds timestamp on long final line" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        defer f.close();
+        try f.writeAll("[2026-04-13T14:00:00.000] [MONO:1] info: first line\n");
+        // Simulate a long HID frame dump line (~400 chars after timestamp).
+        try f.writeAll("[2026-04-13T14:30:00.000] [MONO:2] debug(rumble): [Vader 5 Pro] HID_WRITE: cmd=rumble strong=65535 weak=65535 iface=0 len=32 frame=[");
+        // Pad with hex data to make the line >400 bytes total.
+        var i: usize = 0;
+        while (i < 120) : (i += 1) {
+            try f.writeAll("ff ");
+        }
+        try f.writeAll("]\n");
+    }
+
+    const stats = getLogStats(dir_path).?;
+    try testing.expect(stats.total_size > 400);
+    try testing.expectEqualStrings("2026-04-13T14:00:00.000", stats.first_timestamp.?);
+    // The last timestamp must be found even though it's >256 bytes from EOF.
+    try testing.expectEqualStrings("2026-04-13T14:30:00.000", stats.last_timestamp.?);
+}
+
+test "dump: getLogStats handles empty log file" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        f.close();
+    }
+
+    const stats = getLogStats(dir_path).?;
+    try testing.expectEqual(@as(u64, 0), stats.total_size);
+    try testing.expectEqual(@as(u32, 1), stats.file_count);
+    try testing.expectEqual(@as(?[]const u8, null), stats.first_timestamp);
+    try testing.expectEqual(@as(?[]const u8, null), stats.last_timestamp);
+}
+
+// --- Period parsing tests ---
+
+test "dump: parsePeriod valid durations" {
+    try testing.expectEqual(@as(u64, 600), parsePeriod("10m").?);
+    try testing.expectEqual(@as(u64, 3600), parsePeriod("1h").?);
+    try testing.expectEqual(@as(u64, 86400), parsePeriod("1d").?);
+    try testing.expectEqual(@as(u64, 86400 * 30), parsePeriod("30d").?);
+}
+
+test "dump: parsePeriod rejects invalid" {
+    try testing.expectEqual(@as(?u64, null), parsePeriod("0m"));
+    try testing.expectEqual(@as(?u64, null), parsePeriod("abc"));
+    try testing.expectEqual(@as(?u64, null), parsePeriod(""));
+    try testing.expectEqual(@as(?u64, null), parsePeriod("10"));
+    try testing.expectEqual(@as(?u64, null), parsePeriod("m"));
+    try testing.expectEqual(@as(?u64, null), parsePeriod("-1h"));
+    // Overflow: huge number of days must return null, not crash.
+    try testing.expectEqual(@as(?u64, null), parsePeriod("999999999999999999d"));
+}
+
+// --- Timestamp filtering tests ---
+
+test "dump: linePassesFilter includes lines at or after cutoff" {
+    try testing.expect(linePassesFilter("[2026-04-13T14:05:00.000] info: hello", "2026-04-13T14:00:00.000"));
+    try testing.expect(linePassesFilter("[2026-04-13T14:00:00.000] info: exact", "2026-04-13T14:00:00.000"));
+}
+
+test "dump: linePassesFilter excludes lines before cutoff" {
+    try testing.expect(!linePassesFilter("[2026-04-13T13:59:59.999] info: old", "2026-04-13T14:00:00.000"));
+}
+
+test "dump: linePassesFilter includes lines without timestamps" {
+    try testing.expect(linePassesFilter("no timestamp here", "2026-04-13T14:00:00.000"));
+    try testing.expect(linePassesFilter("", "2026-04-13T14:00:00.000"));
+}
+
+// --- Export filtering test ---
+
+test "dump: filterLogFile filters by period" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        defer f.close();
+        try f.writeAll(
+            \\[2026-04-13T10:00:00.000] [MONO:1] info: old line
+            \\[2026-04-13T14:00:00.000] [MONO:2] info: recent line
+            \\[2026-04-13T14:30:00.000] [MONO:3] info: newest line
+            \\
+        );
+    }
+
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+    const log_path = try std.fmt.allocPrint(allocator, "{s}/padctl.log", .{dir_path});
+    defer allocator.free(log_path);
+
+    var output_buf: [4096]u8 = undefined;
+    var output = std.io.fixedBufferStream(&output_buf);
+
+    // Cutoff at 14:00 — should include the last two lines.
+    try filterLogFile(log_path, "2026-04-13T14:00:00.000", output.writer());
+    const result = output.getWritten();
+    try testing.expect(std.mem.indexOf(u8, result, "old line") == null);
+    try testing.expect(std.mem.indexOf(u8, result, "recent line") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "newest line") != null);
+}
+
+// --- Clear tests ---
+
+test "dump: deleteLogFiles removes both files" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        f.close();
+    }
+    {
+        var f = try tmp.dir.createFile("padctl.log.1", .{});
+        f.close();
+    }
+
+    const deleted = deleteLogFiles(dir_path);
+    try testing.expectEqual(@as(u32, 2), deleted);
+    // Verify files are gone.
+    try testing.expectEqual(@as(?LogStats, null), getLogStats(dir_path));
+}
+
+test "dump: deleteLogFiles with only current file" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    {
+        var f = try tmp.dir.createFile("padctl.log", .{});
+        f.close();
+    }
+
+    const deleted = deleteLogFiles(dir_path);
+    try testing.expectEqual(@as(u32, 1), deleted);
+}
+
+test "dump: deleteLogFiles with no files" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    const deleted = deleteLogFiles(dir_path);
+    try testing.expectEqual(@as(u32, 0), deleted);
+}

--- a/src/cli/dump.zig
+++ b/src/cli/dump.zig
@@ -31,6 +31,8 @@ pub fn writeDiagnosticsConfig(allocator: std.mem.Allocator, dir_path: []const u8
 
     const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir_path});
     defer allocator.free(config_path);
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}/config.toml.tmp", .{dir_path});
+    defer allocator.free(tmp_path);
 
     // Read existing config to preserve all fields.
     var existing_version: ?i64 = null;
@@ -54,27 +56,70 @@ pub fn writeDiagnosticsConfig(allocator: std.mem.Allocator, dir_path: []const u8
     // Update only the dump field; preserve everything else.
     existing_diag.dump = dump;
 
-    // Build the config content in memory, then write atomically.
-    var content_buf: [4096]u8 = undefined;
-    var fbs = std.io.fixedBufferStream(&content_buf);
-    const w = fbs.writer();
+    // Build the config content in a growable buffer — a [[device]] list
+    // with many entries can exceed any reasonable stack ceiling.
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(allocator);
+    const w = buf.writer(allocator);
 
-    w.print("version = {d}\n\n", .{existing_version orelse user_config_mod.CURRENT_VERSION}) catch return error.NoSpaceLeft;
-    w.print("[diagnostics]\ndump = {}\nmax_log_size_mb = {d}\n", .{ existing_diag.dump, existing_diag.max_log_size_mb }) catch return error.NoSpaceLeft;
+    w.print("version = {d}\n\n", .{existing_version orelse user_config_mod.CURRENT_VERSION}) catch return error.OutOfMemory;
+    w.print("[diagnostics]\ndump = {}\nmax_log_size_mb = {d}\n", .{ existing_diag.dump, existing_diag.max_log_size_mb }) catch return error.OutOfMemory;
 
     if (existing_devices) |devices| {
         for (devices) |dev| {
-            w.writeAll("\n[[device]]\n") catch return error.NoSpaceLeft;
-            w.print("name = \"{s}\"\n", .{dev.name}) catch return error.NoSpaceLeft;
+            // Escape TOML strings: names or mapping paths containing `"`,
+            // `\`, or control bytes would otherwise produce malformed TOML
+            // that the next parse rejects — silently dropping all bindings.
+            w.writeAll("\n[[device]]\nname = \"") catch return error.OutOfMemory;
+            escapeTomlString(w, dev.name) catch return error.OutOfMemory;
+            w.writeAll("\"\n") catch return error.OutOfMemory;
             if (dev.default_mapping) |m| {
-                w.print("default_mapping = \"{s}\"\n", .{m}) catch return error.NoSpaceLeft;
+                w.writeAll("default_mapping = \"") catch return error.OutOfMemory;
+                escapeTomlString(w, m) catch return error.OutOfMemory;
+                w.writeAll("\"\n") catch return error.OutOfMemory;
             }
         }
     }
 
-    var f = std.fs.createFileAbsolute(config_path, .{ .truncate = true }) catch return error.AccessDenied;
-    defer f.close();
-    f.writeAll(fbs.getWritten()) catch return error.InputOutput;
+    // Atomic write: populate sibling temp file, fsync, rename(2) over the
+    // target. rename(2) is atomic on POSIX filesystems, so a mid-write
+    // failure (ENOSPC, EIO) never leaves the live config truncated.
+    {
+        var f = std.fs.createFileAbsolute(tmp_path, .{ .truncate = true }) catch return error.AccessDenied;
+        defer f.close();
+        f.writeAll(buf.items) catch {
+            std.fs.deleteFileAbsolute(tmp_path) catch {};
+            return error.InputOutput;
+        };
+        f.sync() catch {};
+    }
+    errdefer std.fs.deleteFileAbsolute(tmp_path) catch {};
+    std.posix.rename(tmp_path, config_path) catch return error.InputOutput;
+}
+
+/// Escape a TOML basic-string payload (content between the enclosing `"`).
+/// Must cover backslash, double-quote, and all control bytes per the TOML
+/// spec; otherwise a device name containing `"` or a path with `\` silently
+/// produces malformed TOML that the next load-from-dir pass rejects —
+/// which would drop every [[device]] binding.
+fn escapeTomlString(writer: anytype, s: []const u8) !void {
+    for (s) |c| {
+        switch (c) {
+            '\\' => try writer.writeAll("\\\\"),
+            '"' => try writer.writeAll("\\\""),
+            '\n' => try writer.writeAll("\\n"),
+            '\r' => try writer.writeAll("\\r"),
+            '\t' => try writer.writeAll("\\t"),
+            0x08 => try writer.writeAll("\\b"),
+            0x0C => try writer.writeAll("\\f"),
+            0...0x07, 0x0B, 0x0E...0x1F, 0x7F => {
+                var esc_buf: [6]u8 = undefined;
+                const escaped = std.fmt.bufPrint(&esc_buf, "\\u{X:0>4}", .{c}) catch unreachable;
+                try writer.writeAll(escaped);
+            },
+            else => try writer.writeByte(c),
+        }
+    }
 }
 
 /// Run `padctl dump status`: query daemon for live state, read log file stats.
@@ -162,7 +207,25 @@ pub fn deleteLogFiles(log_dir: []const u8) u32 {
     return deleted;
 }
 
+/// Defensive: verify `path` names a padctl log file under a padctl-owned
+/// state directory before invoking sudo rm. deleteLogFiles only ever
+/// constructs these paths today, but a future refactor that widened the
+/// caller could turn this helper into a supply-chain gadget; the check
+/// fails closed rather than trusting the caller.
+fn isSafePadctlLogPath(path: []const u8) bool {
+    const basename = std.fs.path.basename(path);
+    if (!std.mem.eql(u8, basename, "padctl.log") and
+        !std.mem.eql(u8, basename, "padctl.log.1")) return false;
+    const dir = std.fs.path.dirname(path) orelse return false;
+    // Accept /var/log/padctl, /var/lib/padctl, or any dir ending in /padctl
+    // (covers $XDG_STATE_HOME/padctl and ~/.local/state/padctl).
+    return std.mem.eql(u8, dir, "/var/log/padctl") or
+        std.mem.eql(u8, dir, "/var/lib/padctl") or
+        std.mem.endsWith(u8, dir, "/padctl");
+}
+
 fn sudoRm(path: []const u8) bool {
+    if (!isSafePadctlLogPath(path)) return false;
     var child = std.process.Child.init(&.{ "sudo", "rm", "-f", path }, std.heap.page_allocator);
     child.stdin_behavior = .Inherit;
     child.stdout_behavior = .Inherit;
@@ -359,13 +422,19 @@ pub fn runExport(
             std.process.exit(1);
         };
         defer f.close();
-        exportToFd(log_dir, cutoff, f.handle);
+        exportToFd(log_dir, cutoff, f.handle) catch |err| {
+            stderr.print("error: export to '{s}' failed: {}\n", .{ op, err }) catch {};
+            std.process.exit(1);
+        };
     } else {
-        exportToWriter(log_dir, cutoff, stdout);
+        exportToWriter(log_dir, cutoff, stdout) catch |err| {
+            stderr.print("error: export to stdout failed: {}\n", .{err}) catch {};
+            std.process.exit(1);
+        };
     }
 }
 
-fn exportToFd(log_dir: []const u8, cutoff: []const u8, fd: std.posix.fd_t) void {
+fn exportToFd(log_dir: []const u8, cutoff: []const u8, fd: std.posix.fd_t) !void {
     const FdWriter = struct {
         fd: std.posix.fd_t,
         pub fn writeAll(self: @This(), data: []const u8) !void {
@@ -376,18 +445,22 @@ fn exportToFd(log_dir: []const u8, cutoff: []const u8, fd: std.posix.fd_t) void 
         }
     };
     const w = FdWriter{ .fd = fd };
-    exportToWriter(log_dir, cutoff, w);
+    try exportToWriter(log_dir, cutoff, w);
 }
 
-fn exportToWriter(log_dir: []const u8, cutoff: []const u8, writer: anytype) void {
-    // Read rotated file first (older), then current file.
+fn exportToWriter(log_dir: []const u8, cutoff: []const u8, writer: anytype) !void {
+    // Read rotated file first (older), then current file. filterLogFile
+    // internally silent-skips a missing log (FileNotFound → no-op); writer
+    // errors (disk full, broken pipe) and other I/O faults must propagate
+    // so the caller can exit non-zero instead of silently truncating
+    // the exported window.
     var bak_buf: [280]u8 = undefined;
     const bak_path = std.fmt.bufPrint(&bak_buf, "{s}/padctl.log.1", .{log_dir}) catch return;
-    filterLogFile(bak_path, cutoff, writer) catch {};
+    try filterLogFile(bak_path, cutoff, writer);
 
     var cur_buf: [280]u8 = undefined;
     const cur_path = std.fmt.bufPrint(&cur_buf, "{s}/padctl.log", .{log_dir}) catch return;
-    filterLogFile(cur_path, cutoff, writer) catch {};
+    try filterLogFile(cur_path, cutoff, writer);
 }
 
 fn formatTimestamp(buf: *[23]u8, epoch_secs: u64) []const u8 {
@@ -1021,4 +1094,24 @@ test "dump: deleteLogFiles with no files" {
 
     const deleted = deleteLogFiles(dir_path);
     try testing.expectEqual(@as(u32, 0), deleted);
+}
+
+test "dump: isSafePadctlLogPath accepts managed locations" {
+    try testing.expect(isSafePadctlLogPath("/var/log/padctl/padctl.log"));
+    try testing.expect(isSafePadctlLogPath("/var/log/padctl/padctl.log.1"));
+    try testing.expect(isSafePadctlLogPath("/var/lib/padctl/padctl.log"));
+    try testing.expect(isSafePadctlLogPath("/home/alice/.local/state/padctl/padctl.log"));
+    try testing.expect(isSafePadctlLogPath("/home/alice/.local/state/padctl/padctl.log.1"));
+}
+
+test "dump: isSafePadctlLogPath rejects arbitrary paths" {
+    // Wrong basename.
+    try testing.expect(!isSafePadctlLogPath("/var/log/padctl/other.log"));
+    try testing.expect(!isSafePadctlLogPath("/var/log/padctl/padctl.log.2"));
+    // Wrong directory.
+    try testing.expect(!isSafePadctlLogPath("/etc/shadow"));
+    try testing.expect(!isSafePadctlLogPath("/tmp/padctl.log"));
+    try testing.expect(!isSafePadctlLogPath("padctl.log"));
+    // Parent directory traversal attempt.
+    try testing.expect(!isSafePadctlLogPath("/var/log/padctl/../etc/padctl.log"));
 }

--- a/src/cli/dump.zig
+++ b/src/cli/dump.zig
@@ -148,10 +148,31 @@ pub fn deleteLogFiles(log_dir: []const u8) u32 {
     for (names) |name| {
         var path_buf: [280]u8 = undefined;
         const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ log_dir, name }) catch continue;
-        std.fs.deleteFileAbsolute(path) catch continue;
+        // Check file exists before attempting delete.
+        std.fs.accessAbsolute(path, .{}) catch continue;
+        // Try direct delete first; fall back to sudo rm for root-owned files.
+        std.fs.deleteFileAbsolute(path) catch {
+            if (sudoRm(path)) {
+                deleted += 1;
+            }
+            continue;
+        };
         deleted += 1;
     }
     return deleted;
+}
+
+fn sudoRm(path: []const u8) bool {
+    var child = std.process.Child.init(&.{ "sudo", "rm", "-f", path }, std.heap.page_allocator);
+    child.stdin_behavior = .Inherit;
+    child.stdout_behavior = .Inherit;
+    child.stderr_behavior = .Inherit;
+    child.spawn() catch return false;
+    const result = child.wait() catch return false;
+    return switch (result) {
+        .Exited => |code| code == 0,
+        else => false,
+    };
 }
 
 /// Aggregate LogStats across two directories.

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -199,12 +199,16 @@ fn updateLegacyAt(
         } else |_| {}
     } else |_| {}
 
-    // Update drop-in if the directory exists.
+    // Refresh immutable.conf only when it already exists. The earlier
+    // check guarded on padctl.service.d/ existence, which meant we'd
+    // spawn a fresh immutable.conf in directories that happened to
+    // contain unrelated user-owned drop-ins — introducing an override
+    // the user never asked for.
     const dropin_dir = std.fmt.allocPrint(allocator, "{s}/padctl.service.d", .{base_dir}) catch return;
     defer allocator.free(dropin_dir);
-    if (std.fs.accessAbsolute(dropin_dir, .{})) {
-        const dropin_path = std.fmt.allocPrint(allocator, "{s}/immutable.conf", .{dropin_dir}) catch return;
-        defer allocator.free(dropin_path);
+    const dropin_path = std.fmt.allocPrint(allocator, "{s}/immutable.conf", .{dropin_dir}) catch return;
+    defer allocator.free(dropin_path);
+    if (std.fs.accessAbsolute(dropin_path, .{})) {
         if (std.fs.createFileAbsolute(dropin_path, .{ .truncate = true })) |f| {
             defer f.close();
             f.writeAll(immutable_dropin_content) catch return;
@@ -745,29 +749,18 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
                 \\    - remove   /etc/systemd/system/padctl-resume.service (if present)
                 \\
             ) catch {};
-            const proceed = promptYesNoDefaultYes("Migrate legacy system service now?");
-            if (proceed) {
-                runSystemctlSystem(&.{ "stop", "padctl.service" });
-                runSystemctlSystem(&.{ "disable", "padctl.service" });
-                std.fs.deleteFileAbsolute(old_unit) catch {};
-                // Also drop the legacy drop-in directory so daemon-reload
-                // doesn't keep re-parsing stale overrides.
-                std.fs.deleteTreeAbsolute("/etc/systemd/system/padctl.service.d") catch {};
-                // Resume service counterpart — same story.
-                const old_resume = "/etc/systemd/system/padctl-resume.service";
-                if (std.fs.accessAbsolute(old_resume, .{})) |_| {
-                    runSystemctlSystem(&.{ "disable", "padctl-resume.service" });
-                    std.fs.deleteFileAbsolute(old_resume) catch {};
-                } else |_| {}
-                _ = std.posix.write(
-                    std.posix.STDERR_FILENO,
-                    "  legacy migration complete\n\n",
-                ) catch {};
-            } else {
+            // Auto-migration requires root: systemctl stop/disable on a
+            // system-scope unit and deletes under /etc/ both need uid 0.
+            // Non-root installs (the default path on a user-service
+            // install without sudo) would silently fail every step and
+            // then lie with "legacy migration complete", leaving the
+            // legacy unit active on the next boot where it races with
+            // the new per-user unit for hidraw. Print the manual command
+            // list instead so the user can finish the migration.
+            if (!is_root) {
                 _ = std.posix.write(std.posix.STDERR_FILENO,
-                    \\  skipped — keeping the legacy unit in place. You can
-                    \\  remove it later by rerunning `padctl install` and
-                    \\  answering yes, or manually:
+                    \\  auto-migration needs root — skipped. Re-run as
+                    \\  `sudo padctl install` or clean up manually:
                     \\    sudo systemctl stop padctl.service
                     \\    sudo systemctl disable padctl.service
                     \\    sudo rm /etc/systemd/system/padctl.service
@@ -775,6 +768,38 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
                     \\    sudo rm -f /etc/systemd/system/padctl-resume.service
                     \\
                 ) catch {};
+            } else {
+                const proceed = promptYesNoDefaultYes("Migrate legacy system service now?");
+                if (proceed) {
+                    runSystemctlSystem(&.{ "stop", "padctl.service" });
+                    runSystemctlSystem(&.{ "disable", "padctl.service" });
+                    std.fs.deleteFileAbsolute(old_unit) catch {};
+                    // Also drop the legacy drop-in directory so daemon-reload
+                    // doesn't keep re-parsing stale overrides.
+                    std.fs.deleteTreeAbsolute("/etc/systemd/system/padctl.service.d") catch {};
+                    // Resume service counterpart — same story.
+                    const old_resume = "/etc/systemd/system/padctl-resume.service";
+                    if (std.fs.accessAbsolute(old_resume, .{})) |_| {
+                        runSystemctlSystem(&.{ "disable", "padctl-resume.service" });
+                        std.fs.deleteFileAbsolute(old_resume) catch {};
+                    } else |_| {}
+                    _ = std.posix.write(
+                        std.posix.STDERR_FILENO,
+                        "  legacy migration complete\n\n",
+                    ) catch {};
+                } else {
+                    _ = std.posix.write(std.posix.STDERR_FILENO,
+                        \\  skipped — keeping the legacy unit in place. You can
+                        \\  remove it later by rerunning `padctl install` and
+                        \\  answering yes, or manually:
+                        \\    sudo systemctl stop padctl.service
+                        \\    sudo systemctl disable padctl.service
+                        \\    sudo rm /etc/systemd/system/padctl.service
+                        \\    sudo rm -rf /etc/systemd/system/padctl.service.d
+                        \\    sudo rm -f /etc/systemd/system/padctl-resume.service
+                        \\
+                    ) catch {};
+                }
             }
         } else |_| {}
     }

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -562,6 +562,34 @@ fn runSystemctlUserWarn(verbs: []const []const u8) void {
     runCmdWarn(argv);
 }
 
+/// System-scope counterpart to runSystemctlUser. Used by the legacy-unit
+/// migration path, which operates on /etc/systemd/system/padctl.service —
+/// a system-scope unit that the user-scope helper cannot address. Builds
+/// argv dynamically so call sites don't need the forbidden
+/// `runCmd(&.{ "systemctl", ... })` literal form.
+fn runSystemctlSystem(verbs: []const []const u8) void {
+    const allocator = std.heap.page_allocator;
+    const argv = buildSystemctlSystemArgv(allocator, verbs) catch |err| {
+        var errbuf: [128]u8 = undefined;
+        const msg = std.fmt.bufPrint(&errbuf, "warning: could not build systemctl argv: {}\n", .{err}) catch "warning: systemctl argv build failed\n";
+        writeAll(std.posix.STDERR_FILENO, msg);
+        return;
+    };
+    defer freeArgv(allocator, argv);
+    runCmd(argv);
+}
+
+fn buildSystemctlSystemArgv(allocator: std.mem.Allocator, verbs: []const []const u8) ![][]const u8 {
+    var argv = try allocator.alloc([]const u8, 1 + verbs.len);
+    errdefer allocator.free(argv);
+    argv[0] = try allocator.dupe(u8, "systemctl");
+    errdefer allocator.free(argv[0]);
+    for (verbs, 0..) |v, i| {
+        argv[1 + i] = try allocator.dupe(u8, v);
+    }
+    return argv;
+}
+
 fn findDevicesSourceDir(allocator: std.mem.Allocator, self_dir: []const u8, cwd_override: ?[]const u8) !?[]u8 {
     const sibling = try std.fmt.allocPrint(allocator, "{s}/devices", .{self_dir});
     defer allocator.free(sibling);
@@ -719,8 +747,8 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
             ) catch {};
             const proceed = promptYesNoDefaultYes("Migrate legacy system service now?");
             if (proceed) {
-                runCmd(&.{ "systemctl", "stop", "padctl.service" });
-                runCmd(&.{ "systemctl", "disable", "padctl.service" });
+                runSystemctlSystem(&.{ "stop", "padctl.service" });
+                runSystemctlSystem(&.{ "disable", "padctl.service" });
                 std.fs.deleteFileAbsolute(old_unit) catch {};
                 // Also drop the legacy drop-in directory so daemon-reload
                 // doesn't keep re-parsing stale overrides.
@@ -728,7 +756,7 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
                 // Resume service counterpart — same story.
                 const old_resume = "/etc/systemd/system/padctl-resume.service";
                 if (std.fs.accessAbsolute(old_resume, .{})) |_| {
-                    runCmd(&.{ "systemctl", "disable", "padctl-resume.service" });
+                    runSystemctlSystem(&.{ "disable", "padctl-resume.service" });
                     std.fs.deleteFileAbsolute(old_resume) catch {};
                 } else |_| {}
                 _ = std.posix.write(
@@ -820,15 +848,17 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
         _ = std.posix.write(std.posix.STDOUT_FILENO, dropin_path) catch {};
         _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
-
-        // Also refresh any legacy system service drop-in if it exists. Old
-        // installs (pre-user-service) placed the drop-in under
-        // /etc/systemd/system/ which the new user-service installer does
-        // not touch. Without this, upgrades leave the old drop-in stale on
-        // disk — harmless while the system service stays disabled, but
-        // misleading if a user ever enables it manually.
-        updateLegacySystemService(allocator, destdir, prefix);
     }
+
+    // Refresh any legacy system service drop-in if it exists, regardless
+    // of effective_immutable. Pre-user-service installs on any distro
+    // (immutable or not) placed the unit under /etc/systemd/system/ or
+    // <prefix>/lib/systemd/system/ which the new user-service installer
+    // does not touch. Without this, upgrades leave stale ExecStart paths
+    // and drop-ins on disk — harmless while the legacy unit stays
+    // disabled, but misleading if a user ever enables it manually. The
+    // helper is a no-op when no legacy file is present.
+    updateLegacySystemService(allocator, destdir, prefix);
 
     // 2c. Write resume service (system installs only; user sessions handle sleep via logind)
     if (!effective_user_service) {
@@ -3252,12 +3282,14 @@ test "install: atomicInstallBinary does not double-close on rename failure" {
     try testing.expectEqual(fds_before, fds_after);
 }
 
-test "install: all systemctl calls route through runSystemctlUser helpers" {
+test "install: all systemctl calls route through helpers" {
     const testing = std.testing;
     const allocator = testing.allocator;
 
-    // Read our own source to verify every systemctl invocation goes through the
-    // --user-aware helper — no raw `runCmd(&.{ "systemctl", ... })` forms remain.
+    // Read our own source to verify every systemctl invocation goes through
+    // a named helper. runSystemctlUser covers user-scope (daemon-reload,
+    // enable, start for the per-user unit); runSystemctlSystem covers
+    // system-scope (legacy unit stop/disable during migration).
     const src_path = @src().file;
     var file = if (std.fs.path.isAbsolute(src_path))
         std.fs.openFileAbsolute(src_path, .{}) catch return
@@ -3272,17 +3304,23 @@ test "install: all systemctl calls route through runSystemctlUser helpers" {
     while (iter.next()) |line| {
         // Ignore the test itself (which mentions these names in strings).
         if (std.mem.indexOf(u8, line, "test \"install: all systemctl") != null) continue;
+        // Skip pure comment lines — a code comment that quotes the
+        // forbidden pattern as a documentation example shouldn't trip it.
+        const trimmed = std.mem.trimLeft(u8, line, " \t");
+        if (std.mem.startsWith(u8, trimmed, "//")) continue;
+
         if (std.mem.indexOf(u8, line, "runSystemctlUser") != null) helper_calls += 1;
 
-        // No raw `runCmd(&.{ "systemctl" ... })` forms allowed outside the helper itself.
+        // No raw generic-runCmd + systemctl literal on the same line outside
+        // the helpers; see runSystemctlUser / runSystemctlSystem above.
         const has_runcmd = std.mem.indexOf(u8, line, "runCmd(&.{") != null;
         const has_systemctl_literal = std.mem.indexOf(u8, line, "\"systemctl\"") != null;
         if (has_runcmd and has_systemctl_literal) {
-            try testing.expect(false); // direct systemctl call bypasses user-scope helper
+            try testing.expect(false);
         }
     }
-    // Each of the 5 call sites is one source line referencing the helper,
-    // plus the two helper fn definitions and at least one internal call.
+    // Each of the 5+ call sites is one source line referencing a helper,
+    // plus the helper fn definitions and at least one internal call.
     try testing.expect(helper_calls >= 5);
 }
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -21,7 +21,12 @@ fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8) ![]c
         \\NoNewPrivileges=true
         \\LockPersonality=true
         \\ProtectClock=true
-        \\LogsDirectory=padctl
+        \\# Canonical state/log dir: $XDG_STATE_HOME/padctl on user services,
+        \\# /var/lib/padctl on system services. systemd pre-creates it with
+        \\# the right perms, exports $STATE_DIRECTORY, and auto-whitelists
+        \\# the path through read-only home/system protections applied via
+        \\# drop-ins so the daemon can always write its dump log there.
+        \\StateDirectory=padctl
         \\
         \\[Install]
         \\WantedBy=default.target
@@ -99,8 +104,6 @@ const immutable_dropin_content =
     \\TimeoutStopSec=3
     \\# SIGTERM main + SIGKILL stuck threads simultaneously
     \\KillMode=mixed
-    \\# Create /var/log/padctl/ writable despite ProtectSystem=strict
-    \\LogsDirectory=padctl
     \\
 ;
 
@@ -149,14 +152,11 @@ fn resolveServiceDir(allocator: std.mem.Allocator, destdir: []const u8, prefix: 
         const home = std.posix.getenv("HOME") orelse return error.NoHomeDir;
         return std.fmt.allocPrint(allocator, "{s}{s}/.config/systemd/user", .{ destdir, home });
     }
-    // On immutable OS (Bazzite/Fedora Atomic), /usr/local is a bind mount from
-    // /var/usrlocal which is unavailable during early boot. The service MUST
-    // live in /etc/systemd/system/ so systemd can find it and honour
-    // WantedBy=multi-user.target. Uses the system service template.
     if (immutable) {
-        return std.fmt.allocPrint(allocator, "{s}/etc/systemd/system", .{destdir});
+        return std.fmt.allocPrint(allocator, "{s}/etc/systemd/user", .{destdir});
     }
-    // Non-immutable: user service paths (same as before PR #84).
+    // systemd < 253 only scans /usr/lib/systemd/user for system-wide user units.
+    // Any other prefix falls back to /etc/systemd/user which is always scanned.
     if (std.mem.eql(u8, prefix, "/usr")) {
         return std.fmt.allocPrint(allocator, "{s}/usr/lib/systemd/user", .{destdir});
     }
@@ -164,8 +164,9 @@ fn resolveServiceDir(allocator: std.mem.Allocator, destdir: []const u8, prefix: 
 }
 
 /// Update any legacy system service files left behind by pre-user-service
-/// installs. Without this, upgrades leave stale ExecStart (missing --config-dir)
-/// and stale drop-ins (missing LogsDirectory) on the running system service.
+/// installs. Without this, upgrades leave stale ExecStart (missing
+/// --config-dir) and stale drop-ins on disk; if a user later re-enables
+/// the legacy unit manually, they would get the old stale content.
 fn updateLegacySystemService(allocator: std.mem.Allocator, destdir: []const u8, prefix: []const u8) void {
     // /etc/systemd/system — legacy installs placed the service here
     const etc_dir = std.fmt.allocPrint(allocator, "{s}/etc/systemd/system", .{destdir}) catch return;
@@ -237,7 +238,7 @@ fn generateSystemServiceContent(allocator: std.mem.Allocator, prefix: []const u8
         \\ProtectHome=true
         \\PrivateTmp=true
         \\RuntimeDirectory=padctl
-        \\LogsDirectory=padctl
+        \\StateDirectory=padctl
         \\NoNewPrivileges=true
         \\SupplementaryGroups=input
         \\DeviceAllow=/dev/hidraw* rw
@@ -330,6 +331,38 @@ fn runCmd(argv: []const []const u8) void {
     child.stdout_behavior = .Inherit;
     child.stderr_behavior = .Inherit;
     _ = child.spawnAndWait() catch {};
+}
+
+/// Ask a y/n question on stderr and read the answer from stdin.
+/// Default-yes: empty input, any "y*", any "Y*" → true.
+/// When stdin is not a TTY (CI / scripted install), return true
+/// without prompting so non-interactive runs proceed with cleanup.
+fn promptYesNoDefaultYes(question: []const u8) bool {
+    const is_tty = std.posix.isatty(std.posix.STDIN_FILENO);
+    if (!is_tty) {
+        _ = std.posix.write(std.posix.STDERR_FILENO, "  ") catch {};
+        _ = std.posix.write(std.posix.STDERR_FILENO, question) catch {};
+        _ = std.posix.write(std.posix.STDERR_FILENO, " [Y/n] (non-interactive → Y)\n") catch {};
+        return true;
+    }
+    _ = std.posix.write(std.posix.STDERR_FILENO, "  ") catch {};
+    _ = std.posix.write(std.posix.STDERR_FILENO, question) catch {};
+    _ = std.posix.write(std.posix.STDERR_FILENO, " [Y/n] ") catch {};
+
+    var buf: [16]u8 = undefined;
+    const n = std.posix.read(std.posix.STDIN_FILENO, &buf) catch return true;
+    return parseYesNoDefaultYes(buf[0..n]);
+}
+
+/// Pure helper: decide yes/no from a raw answer string.
+/// Default-yes semantics: empty input (incl. just whitespace/newline) → yes.
+/// First non-whitespace char is y/Y → yes; anything else → no.
+/// Extracted from promptYesNoDefaultYes so tests can cover the parse
+/// rules without touching stdin/stderr.
+fn parseYesNoDefaultYes(raw: []const u8) bool {
+    const answer = std.mem.trim(u8, raw, " \t\r\n");
+    if (answer.len == 0) return true;
+    return answer[0] == 'y' or answer[0] == 'Y';
 }
 
 /// Like runCmd but warns on non-zero exit. Used for critical steps (enable/start).
@@ -659,19 +692,62 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     else
         opts.prefix;
 
-    // Migration hint: warn if old system unit exists
-    {
-        const old_unit = try std.fmt.allocPrint(allocator, "{s}/etc/systemd/system/padctl.service", .{destdir});
-        defer allocator.free(old_unit);
+    // Legacy system-unit migration: pre-user-service installs placed the
+    // unit at /etc/systemd/system/padctl.service. That unit has been
+    // superseded by the per-user unit at /etc/systemd/user/padctl.service;
+    // leaving the old one enabled would race with the new one for the
+    // hidraw grab. We're already running as root via sudo, so offer to
+    // stop+disable+remove it ourselves — "don't break userspace, don't
+    // force users to run manual commands to finish an install." Prompt
+    // interactively for consent; default-yes on TTY, auto-proceed when
+    // stdin isn't a TTY so non-interactive installs (CI, scripts) still
+    // converge on a clean state.
+    if (destdir.len == 0) {
+        const old_unit = "/etc/systemd/system/padctl.service";
         if (std.fs.accessAbsolute(old_unit, .{})) |_| {
             _ = std.posix.write(std.posix.STDERR_FILENO,
-                \\warning: legacy system unit detected at /etc/systemd/system/padctl.service
-                \\  Stop and disable it before using the new user service:
-                \\    sudo systemctl stop padctl.service
-                \\    sudo systemctl disable padctl.service
-                \\    sudo rm /etc/systemd/system/padctl.service
+                \\warning: legacy system service detected at /etc/systemd/system/padctl.service
+                \\  padctl now runs as a user service. The legacy system unit
+                \\  would race with the new per-user unit for the hidraw grab,
+                \\  so we recommend removing it now. Proposed actions:
+                \\    - stop     padctl.service
+                \\    - disable  padctl.service
+                \\    - remove   /etc/systemd/system/padctl.service
+                \\    - remove   /etc/systemd/system/padctl.service.d/ (drop-ins)
+                \\    - remove   /etc/systemd/system/padctl-resume.service (if present)
                 \\
             ) catch {};
+            const proceed = promptYesNoDefaultYes("Migrate legacy system service now?");
+            if (proceed) {
+                runCmd(&.{ "systemctl", "stop", "padctl.service" });
+                runCmd(&.{ "systemctl", "disable", "padctl.service" });
+                std.fs.deleteFileAbsolute(old_unit) catch {};
+                // Also drop the legacy drop-in directory so daemon-reload
+                // doesn't keep re-parsing stale overrides.
+                std.fs.deleteTreeAbsolute("/etc/systemd/system/padctl.service.d") catch {};
+                // Resume service counterpart — same story.
+                const old_resume = "/etc/systemd/system/padctl-resume.service";
+                if (std.fs.accessAbsolute(old_resume, .{})) |_| {
+                    runCmd(&.{ "systemctl", "disable", "padctl-resume.service" });
+                    std.fs.deleteFileAbsolute(old_resume) catch {};
+                } else |_| {}
+                _ = std.posix.write(
+                    std.posix.STDERR_FILENO,
+                    "  legacy migration complete\n\n",
+                ) catch {};
+            } else {
+                _ = std.posix.write(std.posix.STDERR_FILENO,
+                    \\  skipped — keeping the legacy unit in place. You can
+                    \\  remove it later by rerunning `padctl install` and
+                    \\  answering yes, or manually:
+                    \\    sudo systemctl stop padctl.service
+                    \\    sudo systemctl disable padctl.service
+                    \\    sudo rm /etc/systemd/system/padctl.service
+                    \\    sudo rm -rf /etc/systemd/system/padctl.service.d
+                    \\    sudo rm -f /etc/systemd/system/padctl-resume.service
+                    \\
+                ) catch {};
+            }
         } else |_| {}
     }
 
@@ -715,12 +791,10 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     // 2. Write service file with correct prefix paths
     const service_path = try std.fmt.allocPrint(allocator, "{s}/padctl.service", .{lib_systemd_dir});
     defer allocator.free(service_path);
-    // Immutable root installs use the system service template (WantedBy=multi-user.target,
-    // ProtectSystem=strict, etc.). All others use the user service template.
-    const service_content = if (effective_immutable and !effective_user_service)
-        try generateSystemServiceContent(allocator, prefix)
-    else
-        try generateServiceContent(allocator, prefix);
+    // Always use the user-service template. Even on immutable-root installs,
+    // the service file is placed under /etc/systemd/user/ so systemd discovers
+    // it as a user unit and each user's systemd instance runs its own copy.
+    const service_content = try generateServiceContent(allocator, prefix);
     defer allocator.free(service_content);
     {
         var f = try std.fs.createFileAbsolute(service_path, .{ .truncate = true });
@@ -732,7 +806,7 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
 
     // 2b. Write immutable drop-in override (only when immutable system install)
-    if (effective_immutable and !effective_user_service) {
+    if (effective_immutable) {
         const dropin_dir = try std.fmt.allocPrint(allocator, "{s}/padctl.service.d", .{lib_systemd_dir});
         defer allocator.free(dropin_dir);
         try ensureDirAll(allocator, dropin_dir);
@@ -747,11 +821,12 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         _ = std.posix.write(std.posix.STDOUT_FILENO, dropin_path) catch {};
         _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
 
-        // Also update the legacy system service drop-in if it exists. Old installs
-        // (pre-user-service) placed the drop-in under /etc/systemd/system/ which
-        // the new user-service installer does not touch. Without this, upgrades
-        // leave the old drop-in stale and any new directives (e.g. LogsDirectory)
-        // never take effect on the running system service.
+        // Also refresh any legacy system service drop-in if it exists. Old
+        // installs (pre-user-service) placed the drop-in under
+        // /etc/systemd/system/ which the new user-service installer does
+        // not touch. Without this, upgrades leave the old drop-in stale on
+        // disk — harmless while the system service stays disabled, but
+        // misleading if a user ever enables it manually.
         updateLegacySystemService(allocator, destdir, prefix);
     }
 
@@ -2090,12 +2165,17 @@ test "install: shouldAbortForImmutable logic" {
     try testing.expect(!shouldAbortForImmutable(.none, .{}));
 }
 
-test "install: resolveServiceDir immutable routes to /etc/systemd/system" {
+test "install: resolveServiceDir immutable routes to /etc/systemd/user" {
+    // Immutable installs write a USER service unit to /etc/systemd/user/ so
+    // systemd discovers it as a user unit and each user's systemd instance
+    // runs its own copy. The matching updateLegacySystemService() helper
+    // cleans up any leftover /etc/systemd/system/padctl.service from older
+    // installs.
     const testing = std.testing;
     const allocator = testing.allocator;
     const result = try resolveServiceDir(allocator, "/staging", "/usr/local", true, false);
     defer allocator.free(result);
-    try testing.expectEqualStrings("/staging/etc/systemd/system", result);
+    try testing.expectEqualStrings("/staging/etc/systemd/user", result);
 }
 
 test "install: resolveServiceDir /usr non-immutable routes to /usr/lib/systemd/user" {
@@ -2134,6 +2214,73 @@ test "install: immutable dropin content has required directives" {
     // ProtectHome to keep `padctl status`/`switch`/`devices` working
     // on immutable-OS user-service installs.
     try testing.expect(std.mem.indexOf(u8, immutable_dropin_content, "ReadWritePaths=/run/user/%U") != null);
+    // LogsDirectory= on a user service puts files under
+    // $XDG_STATE_HOME/log/padctl (extra 'log/' subdir), splitting the
+    // daemon's log path from stateDir()'s $XDG_STATE_HOME/padctl. The
+    // main service template now uses StateDirectory=padctl for the flat
+    // path; the drop-in must NOT reintroduce LogsDirectory.
+    try testing.expect(std.mem.indexOf(u8, immutable_dropin_content, "LogsDirectory") == null);
+}
+
+test "install: generateServiceContent uses StateDirectory (not LogsDirectory)" {
+    // StateDirectory=padctl maps to $XDG_STATE_HOME/padctl on user services
+    // and matches padctl's stateDir() resolver. LogsDirectory=padctl on a
+    // user service would nest under $XDG_STATE_HOME/log/padctl — splitting
+    // the path between daemon and CLI.
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const content = try generateServiceContent(allocator, "/usr/local");
+    defer allocator.free(content);
+    try testing.expect(std.mem.indexOf(u8, content, "StateDirectory=padctl") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "LogsDirectory") == null);
+}
+
+test "install: generateSystemServiceContent uses StateDirectory (not LogsDirectory)" {
+    // Legacy-upgrade template: the /etc/systemd/system/ unit that
+    // updateLegacySystemService refreshes if it still exists. Consistency
+    // with the user-service template — if a user manually resurrects the
+    // legacy unit, its state dir matches what stateDir() resolves to.
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const content = try generateSystemServiceContent(allocator, "/usr/local");
+    defer allocator.free(content);
+    try testing.expect(std.mem.indexOf(u8, content, "StateDirectory=padctl") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "LogsDirectory") == null);
+}
+
+test "install: parseYesNoDefaultYes empty input is yes (default-yes)" {
+    try std.testing.expect(parseYesNoDefaultYes(""));
+    try std.testing.expect(parseYesNoDefaultYes("\n"));
+    try std.testing.expect(parseYesNoDefaultYes("\r\n"));
+    try std.testing.expect(parseYesNoDefaultYes("   "));
+    try std.testing.expect(parseYesNoDefaultYes(" \t \n"));
+}
+
+test "install: parseYesNoDefaultYes 'y' variants are yes" {
+    try std.testing.expect(parseYesNoDefaultYes("y"));
+    try std.testing.expect(parseYesNoDefaultYes("Y"));
+    try std.testing.expect(parseYesNoDefaultYes("yes\n"));
+    try std.testing.expect(parseYesNoDefaultYes("YES"));
+    try std.testing.expect(parseYesNoDefaultYes("  y  \n"));
+    try std.testing.expect(parseYesNoDefaultYes("y\n"));
+}
+
+test "install: parseYesNoDefaultYes 'n' variants are no" {
+    try std.testing.expect(!parseYesNoDefaultYes("n"));
+    try std.testing.expect(!parseYesNoDefaultYes("N"));
+    try std.testing.expect(!parseYesNoDefaultYes("no\n"));
+    try std.testing.expect(!parseYesNoDefaultYes("NO"));
+    try std.testing.expect(!parseYesNoDefaultYes("  n  \n"));
+}
+
+test "install: parseYesNoDefaultYes non-y non-n input is treated as no" {
+    // Anything that isn't default-empty or y/Y should fail safe to NO,
+    // protecting destructive operations from typos like "k\n" or "maybe".
+    try std.testing.expect(!parseYesNoDefaultYes("k"));
+    try std.testing.expect(!parseYesNoDefaultYes("maybe"));
+    try std.testing.expect(!parseYesNoDefaultYes("1"));
+    try std.testing.expect(!parseYesNoDefaultYes("true"));
+    try std.testing.expect(!parseYesNoDefaultYes("asdf"));
 }
 
 // --- Phase 3: resume service, reconnect script, hotplug rules ---

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1537,12 +1537,20 @@ fn writeBinding(
         };
     }
 
-    // Serialize: version + all existing entries (replacing the conflict target
-    // if one was found) + new entry if none matched.
+    // Serialize: version + diagnostics + all existing entries (replacing
+    // the conflict target if one was found) + new entry if none matched.
     var buf = std.ArrayList(u8){};
     defer buf.deinit(allocator);
     const w = buf.writer(allocator);
     try w.print("version = {d}\n", .{version});
+
+    // Preserve [diagnostics] section if present.
+    if (existing) |e| {
+        const diag = e.value.diagnostics;
+        if (diag.dump or diag.max_log_size_mb != 100) {
+            try w.print("\n[diagnostics]\ndump = {}\nmax_log_size_mb = {d}\n", .{ diag.dump, diag.max_log_size_mb });
+        }
+    }
 
     var wrote_target = false;
     if (devices) |devs| {

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -21,6 +21,7 @@ fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8) ![]c
         \\NoNewPrivileges=true
         \\LockPersonality=true
         \\ProtectClock=true
+        \\LogsDirectory=padctl
         \\
         \\[Install]
         \\WantedBy=default.target
@@ -98,6 +99,8 @@ const immutable_dropin_content =
     \\TimeoutStopSec=3
     \\# SIGTERM main + SIGKILL stuck threads simultaneously
     \\KillMode=mixed
+    \\# Create /var/log/padctl/ writable despite ProtectSystem=strict
+    \\LogsDirectory=padctl
     \\
 ;
 
@@ -146,15 +149,105 @@ fn resolveServiceDir(allocator: std.mem.Allocator, destdir: []const u8, prefix: 
         const home = std.posix.getenv("HOME") orelse return error.NoHomeDir;
         return std.fmt.allocPrint(allocator, "{s}{s}/.config/systemd/user", .{ destdir, home });
     }
+    // On immutable OS (Bazzite/Fedora Atomic), /usr/local is a bind mount from
+    // /var/usrlocal which is unavailable during early boot. The service MUST
+    // live in /etc/systemd/system/ so systemd can find it and honour
+    // WantedBy=multi-user.target. Uses the system service template.
     if (immutable) {
-        return std.fmt.allocPrint(allocator, "{s}/etc/systemd/user", .{destdir});
+        return std.fmt.allocPrint(allocator, "{s}/etc/systemd/system", .{destdir});
     }
-    // systemd < 253 only scans /usr/lib/systemd/user for system-wide user units.
-    // Any other prefix falls back to /etc/systemd/user which is always scanned.
+    // Non-immutable: user service paths (same as before PR #84).
     if (std.mem.eql(u8, prefix, "/usr")) {
         return std.fmt.allocPrint(allocator, "{s}/usr/lib/systemd/user", .{destdir});
     }
     return std.fmt.allocPrint(allocator, "{s}/etc/systemd/user", .{destdir});
+}
+
+/// Update any legacy system service files left behind by pre-user-service
+/// installs. Without this, upgrades leave stale ExecStart (missing --config-dir)
+/// and stale drop-ins (missing LogsDirectory) on the running system service.
+fn updateLegacySystemService(allocator: std.mem.Allocator, destdir: []const u8, prefix: []const u8) void {
+    // /etc/systemd/system — legacy installs placed the service here
+    const etc_dir = std.fmt.allocPrint(allocator, "{s}/etc/systemd/system", .{destdir}) catch return;
+    defer allocator.free(etc_dir);
+    updateLegacyAt(allocator, prefix, etc_dir);
+
+    // <prefix>/lib/systemd/system — another common legacy location
+    const lib_dir = std.fmt.allocPrint(allocator, "{s}{s}/lib/systemd/system", .{ destdir, prefix }) catch return;
+    defer allocator.free(lib_dir);
+    updateLegacyAt(allocator, prefix, lib_dir);
+}
+
+fn updateLegacyAt(
+    allocator: std.mem.Allocator,
+    prefix: []const u8,
+    base_dir: []const u8,
+) void {
+    // Update service file if it exists.
+    const svc_path = std.fmt.allocPrint(allocator, "{s}/padctl.service", .{base_dir}) catch return;
+    defer allocator.free(svc_path);
+    if (std.fs.accessAbsolute(svc_path, .{})) {
+        const content = generateSystemServiceContent(allocator, prefix) catch return;
+        defer allocator.free(content);
+        if (std.fs.createFileAbsolute(svc_path, .{ .truncate = true })) |f| {
+            defer f.close();
+            f.writeAll(content) catch return;
+            _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
+            _ = std.posix.write(std.posix.STDOUT_FILENO, svc_path) catch {};
+            _ = std.posix.write(std.posix.STDOUT_FILENO, " (legacy update)\n") catch {};
+        } else |_| {}
+    } else |_| {}
+
+    // Update drop-in if the directory exists.
+    const dropin_dir = std.fmt.allocPrint(allocator, "{s}/padctl.service.d", .{base_dir}) catch return;
+    defer allocator.free(dropin_dir);
+    if (std.fs.accessAbsolute(dropin_dir, .{})) {
+        const dropin_path = std.fmt.allocPrint(allocator, "{s}/immutable.conf", .{dropin_dir}) catch return;
+        defer allocator.free(dropin_path);
+        if (std.fs.createFileAbsolute(dropin_path, .{ .truncate = true })) |f| {
+            defer f.close();
+            f.writeAll(immutable_dropin_content) catch return;
+            _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
+            _ = std.posix.write(std.posix.STDOUT_FILENO, dropin_path) catch {};
+            _ = std.posix.write(std.posix.STDOUT_FILENO, " (legacy update)\n") catch {};
+        } else |_| {}
+    } else |_| {}
+}
+
+/// Generate the system service content matching the legacy format but with
+/// correct ExecStart for the given prefix.
+fn generateSystemServiceContent(allocator: std.mem.Allocator, prefix: []const u8) ![]const u8 {
+    const exec_start = if (std.mem.eql(u8, prefix, "/usr"))
+        try std.fmt.allocPrint(allocator, "{s}/bin/padctl", .{prefix})
+    else
+        try std.fmt.allocPrint(allocator, "{s}/bin/padctl --config-dir {s}/share/padctl/devices", .{ prefix, prefix });
+    defer allocator.free(exec_start);
+
+    return std.fmt.allocPrint(allocator,
+        \\[Unit]
+        \\Description=padctl gamepad compatibility daemon
+        \\After=local-fs.target
+        \\
+        \\[Service]
+        \\Type=simple
+        \\ExecStart={s}
+        \\Restart=on-failure
+        \\RestartSec=3
+        \\ProtectSystem=strict
+        \\ProtectHome=true
+        \\PrivateTmp=true
+        \\RuntimeDirectory=padctl
+        \\LogsDirectory=padctl
+        \\NoNewPrivileges=true
+        \\SupplementaryGroups=input
+        \\DeviceAllow=/dev/hidraw* rw
+        \\DeviceAllow=/dev/uinput rw
+        \\DeviceAllow=char-input rw
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+        \\
+    , .{exec_start});
 }
 
 fn resolveUdevDir(allocator: std.mem.Allocator, destdir: []const u8, prefix: []const u8, immutable: bool) ![]const u8 {
@@ -622,7 +715,12 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     // 2. Write service file with correct prefix paths
     const service_path = try std.fmt.allocPrint(allocator, "{s}/padctl.service", .{lib_systemd_dir});
     defer allocator.free(service_path);
-    const service_content = try generateServiceContent(allocator, prefix);
+    // Immutable root installs use the system service template (WantedBy=multi-user.target,
+    // ProtectSystem=strict, etc.). All others use the user service template.
+    const service_content = if (effective_immutable and !effective_user_service)
+        try generateSystemServiceContent(allocator, prefix)
+    else
+        try generateServiceContent(allocator, prefix);
     defer allocator.free(service_content);
     {
         var f = try std.fs.createFileAbsolute(service_path, .{ .truncate = true });
@@ -648,6 +746,13 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
         _ = std.posix.write(std.posix.STDOUT_FILENO, dropin_path) catch {};
         _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
+
+        // Also update the legacy system service drop-in if it exists. Old installs
+        // (pre-user-service) placed the drop-in under /etc/systemd/system/ which
+        // the new user-service installer does not touch. Without this, upgrades
+        // leave the old drop-in stale and any new directives (e.g. LogsDirectory)
+        // never take effect on the running system service.
+        updateLegacySystemService(allocator, destdir, prefix);
     }
 
     // 2c. Write resume service (system installs only; user sessions handle sleep via logind)
@@ -1977,15 +2082,15 @@ test "install: shouldAbortForImmutable logic" {
     try testing.expect(!shouldAbortForImmutable(.none, .{}));
 }
 
-test "install: resolveServiceDir immutable routes to /etc/systemd/user" {
+test "install: resolveServiceDir immutable routes to /etc/systemd/system" {
     const testing = std.testing;
     const allocator = testing.allocator;
     const result = try resolveServiceDir(allocator, "/staging", "/usr/local", true, false);
     defer allocator.free(result);
-    try testing.expectEqualStrings("/staging/etc/systemd/user", result);
+    try testing.expectEqualStrings("/staging/etc/systemd/system", result);
 }
 
-test "install: resolveServiceDir /usr routes to /usr/lib/systemd/user" {
+test "install: resolveServiceDir /usr non-immutable routes to /usr/lib/systemd/user" {
     const testing = std.testing;
     const allocator = testing.allocator;
     const result = try resolveServiceDir(allocator, "", "/usr", false, false);
@@ -2724,7 +2829,7 @@ test "install: resolveServiceDir user service uses HOME" {
     try testing.expectEqualStrings(expected, dir);
 }
 
-test "install: resolveServiceDir system install uses lib path" {
+test "install: resolveServiceDir system install uses user lib path" {
     const testing = std.testing;
     const allocator = testing.allocator;
     const dir = try resolveServiceDir(allocator, "", "/usr", false, false);

--- a/src/cli/socket_client.zig
+++ b/src/cli/socket_client.zig
@@ -4,10 +4,21 @@ const linux = std.os.linux;
 
 pub const DEFAULT_SOCKET_PATH = "/run/padctl/padctl.sock";
 
-/// Non-root user with XDG_RUNTIME_DIR set → use XDG socket path
-/// (daemon binds there before the file exists; no existence check here).
-/// Root or missing XDG_RUNTIME_DIR → system path for system-service compatibility.
+/// Resolve the default socket path for the current caller.
+///
+/// On immutable OS (Bazzite/Fedora Atomic), the daemon always runs as a
+/// system service at /run/padctl/padctl.sock. We detect this via
+/// /run/ostree-booted and return the system path directly — non-root CLI
+/// calls would otherwise fall through the XDG path which doesn't exist.
+///
+/// Otherwise: non-root user with XDG_RUNTIME_DIR → XDG path (user-service
+/// deployment); root or missing XDG_RUNTIME_DIR → system path.
 pub fn resolveSocketPath(buf: []u8) []const u8 {
+    // Immutable OS always uses the system service.
+    if (std.fs.cwd().access("/run/ostree-booted", .{})) |_| {
+        return DEFAULT_SOCKET_PATH;
+    } else |_| {}
+
     if (posix.geteuid() != 0) {
         if (posix.getenv("XDG_RUNTIME_DIR")) |xrd| {
             return resolveSocketPathForXrd(buf, xrd);

--- a/src/cli/socket_client.zig
+++ b/src/cli/socket_client.zig
@@ -4,21 +4,10 @@ const linux = std.os.linux;
 
 pub const DEFAULT_SOCKET_PATH = "/run/padctl/padctl.sock";
 
-/// Resolve the default socket path for the current caller.
-///
-/// On immutable OS (Bazzite/Fedora Atomic), the daemon always runs as a
-/// system service at /run/padctl/padctl.sock. We detect this via
-/// /run/ostree-booted and return the system path directly — non-root CLI
-/// calls would otherwise fall through the XDG path which doesn't exist.
-///
-/// Otherwise: non-root user with XDG_RUNTIME_DIR → XDG path (user-service
-/// deployment); root or missing XDG_RUNTIME_DIR → system path.
+/// Non-root user with XDG_RUNTIME_DIR set → use XDG socket path
+/// (daemon binds there before the file exists; no existence check here).
+/// Root or missing XDG_RUNTIME_DIR → system path for system-service compatibility.
 pub fn resolveSocketPath(buf: []u8) []const u8 {
-    // Immutable OS always uses the system service.
-    if (std.fs.cwd().access("/run/ostree-booted", .{})) |_| {
-        return DEFAULT_SOCKET_PATH;
-    } else |_| {}
-
     if (posix.geteuid() != 0) {
         if (posix.getenv("XDG_RUNTIME_DIR")) |xrd| {
             return resolveSocketPathForXrd(buf, xrd);

--- a/src/config/paths.zig
+++ b/src/config/paths.zig
@@ -19,19 +19,41 @@ pub fn dataDir() []const u8 {
 }
 
 /// Returns the directory for padctl log/state files.
-/// Priority: $LOGS_DIRECTORY (systemd LogsDirectory=) > $XDG_STATE_HOME/padctl
-/// > ~/.local/state/padctl > /var/log/padctl.
+///
+/// Priority (see `resolveStateDir` for the pure logic):
+/// 1. $STATE_DIRECTORY — set by systemd when the unit declares
+///    StateDirectory=padctl. Maps to $XDG_STATE_HOME/padctl on the user
+///    service and /var/lib/padctl on a system service. systemd pre-creates
+///    the dir and auto-whitelists it through any active sandbox directives.
+/// 2. $XDG_STATE_HOME/padctl — non-systemd invocations (e.g. the CLI
+///    running in the user's shell) with XDG set.
+/// 3. ~/.local/state/padctl — non-systemd invocations with HOME set.
+/// 4. /var/log/padctl — last-resort fallback when neither XDG nor HOME
+///    is available (shouldn't happen in practice).
+///
 /// Caller frees.
 pub fn stateDir(allocator: Allocator) ![]u8 {
-    // systemd sets LOGS_DIRECTORY=/var/log/padctl when LogsDirectory=padctl
-    // is in the unit file. This path is writable even under ProtectSystem=strict.
-    if (std.posix.getenv("LOGS_DIRECTORY")) |logs_dir| {
-        return allocator.dupe(u8, logs_dir);
-    }
-    if (std.posix.getenv("XDG_STATE_HOME")) |xdg| {
+    return resolveStateDir(
+        allocator,
+        std.posix.getenv("STATE_DIRECTORY"),
+        std.posix.getenv("XDG_STATE_HOME"),
+        std.posix.getenv("HOME"),
+    );
+}
+
+/// Pure helper: resolve the state directory from explicit env values.
+/// Extracted so tests don't have to manipulate process environment.
+pub fn resolveStateDir(
+    allocator: Allocator,
+    state_dir_env: ?[]const u8,
+    xdg_state_home_env: ?[]const u8,
+    home_env: ?[]const u8,
+) ![]u8 {
+    if (state_dir_env) |s| return allocator.dupe(u8, s);
+    if (xdg_state_home_env) |xdg| {
         return std.fmt.allocPrint(allocator, "{s}/padctl", .{xdg});
     }
-    const home = std.posix.getenv("HOME") orelse {
+    const home = home_env orelse {
         return allocator.dupe(u8, "/var/log/padctl");
     };
     return std.fmt.allocPrint(allocator, "{s}/.local/state/padctl", .{home});
@@ -177,4 +199,52 @@ test "findConfig: returns path when file exists" {
 
     try std.testing.expect(result != null);
     try std.testing.expectEqualStrings(file_path, result.?);
+}
+
+test "resolveStateDir: STATE_DIRECTORY wins over all others" {
+    const allocator = std.testing.allocator;
+    const result = try resolveStateDir(
+        allocator,
+        "/var/lib/padctl",
+        "/some/xdg",
+        "/home/user",
+    );
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("/var/lib/padctl", result);
+}
+
+test "resolveStateDir: falls back to XDG_STATE_HOME/padctl when STATE_DIRECTORY unset" {
+    const allocator = std.testing.allocator;
+    const result = try resolveStateDir(
+        allocator,
+        null,
+        "/home/elly/.local/state",
+        "/home/elly",
+    );
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("/home/elly/.local/state/padctl", result);
+}
+
+test "resolveStateDir: falls back to HOME/.local/state/padctl when XDG unset" {
+    const allocator = std.testing.allocator;
+    const result = try resolveStateDir(allocator, null, null, "/home/shakespear");
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("/home/shakespear/.local/state/padctl", result);
+}
+
+test "resolveStateDir: last-resort /var/log/padctl when nothing is set" {
+    const allocator = std.testing.allocator;
+    const result = try resolveStateDir(allocator, null, null, null);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("/var/log/padctl", result);
+}
+
+test "resolveStateDir: empty STATE_DIRECTORY still wins (systemd sets it empty if no directive)" {
+    // Defensive — even if systemd somehow exports an empty STATE_DIRECTORY,
+    // we should return it as-is rather than silently treating it as unset.
+    // Caller is expected to check for empty strings before using the path.
+    const allocator = std.testing.allocator;
+    const result = try resolveStateDir(allocator, "", "/home/elly/.local/state", "/home/elly");
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("", result);
 }

--- a/src/config/paths.zig
+++ b/src/config/paths.zig
@@ -18,6 +18,25 @@ pub fn dataDir() []const u8 {
     return "/usr/share/padctl";
 }
 
+/// Returns the directory for padctl log/state files.
+/// Priority: $LOGS_DIRECTORY (systemd LogsDirectory=) > $XDG_STATE_HOME/padctl
+/// > ~/.local/state/padctl > /var/log/padctl.
+/// Caller frees.
+pub fn stateDir(allocator: Allocator) ![]u8 {
+    // systemd sets LOGS_DIRECTORY=/var/log/padctl when LogsDirectory=padctl
+    // is in the unit file. This path is writable even under ProtectSystem=strict.
+    if (std.posix.getenv("LOGS_DIRECTORY")) |logs_dir| {
+        return allocator.dupe(u8, logs_dir);
+    }
+    if (std.posix.getenv("XDG_STATE_HOME")) |xdg| {
+        return std.fmt.allocPrint(allocator, "{s}/padctl", .{xdg});
+    }
+    const home = std.posix.getenv("HOME") orelse {
+        return allocator.dupe(u8, "/var/log/padctl");
+    };
+    return std.fmt.allocPrint(allocator, "{s}/.local/state/padctl", .{home});
+}
+
 /// Returns search dirs for devices/ in priority order: user > system > builtin.
 /// Caller frees the slice and each element.
 pub fn resolveDeviceConfigDirs(allocator: Allocator) ![][]const u8 {

--- a/src/config/user_config.zig
+++ b/src/config/user_config.zig
@@ -11,12 +11,18 @@ pub const DeviceEntry = struct {
     default_mapping: ?[]const u8 = null,
 };
 
+pub const DiagnosticsConfig = struct {
+    dump: bool = false,
+    max_log_size_mb: i64 = 100,
+};
+
 pub const UserConfig = struct {
     /// Schema version for forward/backward compatibility. Missing = legacy
     /// v0 (pre-versioned). Current version is 1. The loader accepts any
     /// version and logs a warning when it's newer than expected.
     version: ?i64 = null,
     device: ?[]DeviceEntry = null,
+    diagnostics: DiagnosticsConfig = .{},
 };
 
 pub const ParseResult = toml.Parsed(UserConfig);
@@ -289,6 +295,91 @@ test "findDefaultMapping: null when no devices" {
     defer result.deinit();
 
     try std.testing.expectEqual(@as(?[]const u8, null), findDefaultMapping(&result, "Any Device"));
+}
+
+test "user_config: diagnostics section parses with defaults" {
+    const allocator = std.testing.allocator;
+
+    const toml_str =
+        \\version = 1
+    ;
+    var parser = toml.Parser(UserConfig).init(allocator);
+    defer parser.deinit();
+    var result = try parser.parseString(toml_str);
+    defer result.deinit();
+
+    // Missing [diagnostics] → defaults: dump=false, max_log_size_mb=100
+    try std.testing.expectEqual(false, result.value.diagnostics.dump);
+    try std.testing.expectEqual(@as(i64, 100), result.value.diagnostics.max_log_size_mb);
+}
+
+test "user_config: diagnostics section parses explicit values" {
+    const allocator = std.testing.allocator;
+
+    const toml_str =
+        \\version = 1
+        \\
+        \\[diagnostics]
+        \\dump = true
+        \\max_log_size_mb = 50
+    ;
+    var parser = toml.Parser(UserConfig).init(allocator);
+    defer parser.deinit();
+    var result = try parser.parseString(toml_str);
+    defer result.deinit();
+
+    try std.testing.expectEqual(true, result.value.diagnostics.dump);
+    try std.testing.expectEqual(@as(i64, 50), result.value.diagnostics.max_log_size_mb);
+}
+
+test "user_config: diagnostics alongside device entries" {
+    const allocator = std.testing.allocator;
+
+    const toml_str =
+        \\version = 1
+        \\
+        \\[diagnostics]
+        \\dump = true
+        \\
+        \\[[device]]
+        \\name = "Test Pad"
+        \\default_mapping = "fps"
+    ;
+    var parser = toml.Parser(UserConfig).init(allocator);
+    defer parser.deinit();
+    var result = try parser.parseString(toml_str);
+    defer result.deinit();
+
+    try std.testing.expectEqual(true, result.value.diagnostics.dump);
+    try std.testing.expectEqualStrings("fps", findDefaultMapping(&result, "Test Pad").?);
+}
+
+test "user_config: unknown fields ignored (forward compatibility)" {
+    const allocator = std.testing.allocator;
+
+    const toml_str =
+        \\version = 2
+        \\some_future_field = "hello"
+        \\
+        \\[diagnostics]
+        \\dump = true
+        \\max_log_size_mb = 75
+        \\future_diag_option = 42
+        \\
+        \\[[device]]
+        \\name = "Pad"
+        \\default_mapping = "m1"
+        \\unknown_device_field = true
+    ;
+    var parser = toml.Parser(UserConfig).init(allocator);
+    defer parser.deinit();
+    var result = try parser.parseString(toml_str);
+    defer result.deinit();
+
+    // Known fields parsed correctly despite unknown siblings.
+    try std.testing.expectEqual(true, result.value.diagnostics.dump);
+    try std.testing.expectEqual(@as(i64, 75), result.value.diagnostics.max_log_size_mb);
+    try std.testing.expectEqualStrings("m1", findDefaultMapping(&result, "Pad").?);
 }
 
 test "findDefaultMapping: entry without default_mapping returns null" {

--- a/src/core/rumble_scheduler.zig
+++ b/src/core/rumble_scheduler.zig
@@ -306,6 +306,9 @@ test "rumble_scheduler: state identical regardless of dump_enabled" {
     // Verify that the same sequence of operations produces identical
     // slot state whether dump is on or off.
     const padctl_log = @import("../log.zig");
+    // defer the restore before toggling so an early `try` failure can't
+    // leak dump_enabled=true to subsequent tests sharing the process.
+    defer padctl_log.setEnabled(false);
     const t0: i128 = 1_000_000_000;
 
     // Run with dump off.
@@ -323,7 +326,6 @@ test "rumble_scheduler: state identical regardless of dump_enabled" {
     _ = s2.onPlay(1, 0, t0);
     _ = s2.onStop(0);
     const slots2 = s2.dumpSlots();
-    padctl_log.setEnabled(false);
 
     // Slot arrays must be identical.
     for (slots1, slots2) |a, b| {

--- a/src/core/rumble_scheduler.zig
+++ b/src/core/rumble_scheduler.zig
@@ -91,6 +91,12 @@ pub const RumbleScheduler = struct {
         return false;
     }
 
+    /// Returns the raw slot array for diagnostic logging. The caller can
+    /// format it without pulling I/O into the scheduler.
+    pub fn dumpSlots(self: *const RumbleScheduler) [MAX_EFFECTS]i128 {
+        return self.slots;
+    }
+
     /// Returns the earliest finite pending deadline, or null if nothing is
     /// pending. An "infinite" slot does not contribute a deadline because
     /// it never fires from the timer.
@@ -293,4 +299,34 @@ test "rumble_scheduler: short-then-long overlap rearms for the longer deadline" 
     const second = sched.onTimerExpired(t1100);
     try testing.expect(second.emit_stop_frame);
     try testing.expectEqual(@as(?i128, null), second.next_deadline_ns);
+}
+
+test "rumble_scheduler: state identical regardless of dump_enabled" {
+    // The scheduler is pure logic — logging is external.
+    // Verify that the same sequence of operations produces identical
+    // slot state whether dump is on or off.
+    const padctl_log = @import("../log.zig");
+    const t0: i128 = 1_000_000_000;
+
+    // Run with dump off.
+    padctl_log.setEnabled(false);
+    var s1: RumbleScheduler = .{};
+    _ = s1.onPlay(0, 500, t0);
+    _ = s1.onPlay(1, 0, t0);
+    _ = s1.onStop(0);
+    const slots1 = s1.dumpSlots();
+
+    // Run with dump on.
+    padctl_log.setEnabled(true);
+    var s2: RumbleScheduler = .{};
+    _ = s2.onPlay(0, 500, t0);
+    _ = s2.onPlay(1, 0, t0);
+    _ = s2.onStop(0);
+    const slots2 = s2.dumpSlots();
+    padctl_log.setEnabled(false);
+
+    // Slot arrays must be identical.
+    for (slots1, slots2) |a, b| {
+        try testing.expectEqual(a, b);
+    }
 }

--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -141,6 +141,7 @@ pub const DeviceInstance = struct {
             }
         } else if (cfg.output) |*out_cfg| {
             uinput_dev = try UinputDevice.create(out_cfg);
+            uinput_dev.?.log_tag = cfg.device.name;
             if (out_cfg.force_feedback != null) {
                 errdefer uinput_dev.?.close();
                 try loop.addUinputFf(uinput_dev.?.pollFfFd());
@@ -267,6 +268,7 @@ pub const DeviceInstance = struct {
                 .poll_timeout_ms = self.poll_timeout_ms,
                 .generic_state = if (self.generic_state) |*gs| gs else null,
                 .generic_output = generic_output,
+                .device_tag = self.device_cfg.device.name,
             }) catch |err| {
                 std.log.err("event loop failed: {}", .{err});
                 break;

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -25,6 +25,7 @@ const wasm_runtime = @import("wasm/runtime.zig");
 pub const WasmPlugin = wasm_runtime.WasmPlugin;
 const rumble_scheduler_mod = @import("core/rumble_scheduler.zig");
 const RumbleScheduler = rumble_scheduler_mod.RumbleScheduler;
+const rumble_log = std.log.scoped(.rumble);
 
 // signalfd(0) + stop_pipe(1) + macro timerfd(2) + rumble_stop_fd(3) + per-interface fds + uinput FF fd
 pub const MAX_FDS = 11;
@@ -92,7 +93,13 @@ fn armRumbleStopFd(fd: posix.fd_t, deadline_ns: ?i128) void {
         },
         .it_interval = .{ .sec = 0, .nsec = 0 },
     };
-    _ = linux.timerfd_settime(fd, .{ .ABSTIME = true }, &spec, null);
+    const rc = linux.timerfd_settime(fd, .{ .ABSTIME = true }, &spec, null);
+    if (rc != 0) {
+        const errno = std.posix.errno(rc);
+        rumble_log.debug("TIMERFD: timerfd_settime FAILED errno={s} deadline={d}", .{
+            @tagName(errno), target,
+        });
+    }
 }
 
 /// Returns true when this device's config wants userspace rumble auto-stop.
@@ -103,6 +110,40 @@ fn autoStopEnabled(dcfg: ?*const DeviceConfig) bool {
     const out = cfg.output orelse return true;
     const ff = out.force_feedback orelse return true;
     return ff.auto_stop;
+}
+
+/// Format scheduler slot state with relative deltas from now_ns.
+/// Shows: slots=[0:INF, 1:+250ms, 3:+1200ms] or slots=[empty]
+fn fmtSchedulerSlots(slots: [rumble_scheduler_mod.MAX_EFFECTS]i128, now_ns: i128) [256]u8 {
+    var buf: [256]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const w = fbs.writer();
+    w.writeAll("slots=[") catch {};
+    var any = false;
+    for (slots, 0..) |s, i| {
+        if (s == 0) continue;
+        if (any) w.writeAll(", ") catch {};
+        any = true;
+        if (s == RumbleScheduler.INFINITE) {
+            w.print("{d}:INF", .{i}) catch {};
+        } else {
+            const delta_ms = @divFloor(s - now_ns, std.time.ns_per_ms);
+            w.print("{d}:{s}{d}ms", .{ i, if (delta_ms >= 0) "+" else "", delta_ms }) catch {};
+        }
+    }
+    if (!any) w.writeAll("empty") catch {};
+    w.writeAll("]") catch {};
+    const written = fbs.getWritten().len;
+    if (written < buf.len) buf[written] = 0;
+    return buf;
+}
+
+fn slotStr(buf: *const [256]u8) []const u8 {
+    // Find the null terminator or end of buffer.
+    for (buf, 0..) |b, i| {
+        if (b == 0) return buf[0..i];
+    }
+    return buf;
 }
 
 /// Write a single rumble frame (strong, weak) to the HID device using the
@@ -116,6 +157,7 @@ fn emitRumbleFrame(
     dcfg: *const DeviceConfig,
     strong: u16,
     weak: u16,
+    tag: []const u8,
 ) bool {
     const cmds = dcfg.commands orelse return false;
     const ff_type = if (dcfg.output) |out|
@@ -132,7 +174,22 @@ fn emitRumbleFrame(
     const bytes = fillTemplate(alloc, cmd.template, &params) catch return false;
     defer alloc.free(bytes);
     if (cmd.checksum) |*cs| applyChecksum(bytes, cs);
-    devices[iface_idx].write(bytes) catch return false;
+
+    // Log the full post-checksum HID frame.
+    var hex_buf: [512]u8 = undefined;
+    var hex_fbs = std.io.fixedBufferStream(&hex_buf);
+    const hw = hex_fbs.writer();
+    for (bytes) |b| {
+        hw.print("{x:0>2} ", .{b}) catch break;
+    }
+    rumble_log.debug("[{s}] HID_WRITE: cmd={s} strong={d} weak={d} iface={d} len={d} frame=[{s}]", .{
+        tag, ff_type, strong, weak, iface_idx, bytes.len, hex_fbs.getWritten(),
+    });
+
+    devices[iface_idx].write(bytes) catch |err| {
+        rumble_log.debug("[{s}] HID_WRITE: FAILED cmd={s} strong={d} weak={d} err={}", .{ tag, ff_type, strong, weak, err });
+        return false;
+    };
     return true;
 }
 
@@ -142,7 +199,10 @@ pub fn disarmTimer(fd: posix.fd_t) void {
         .it_value = .{ .sec = 0, .nsec = 0 },
         .it_interval = .{ .sec = 0, .nsec = 0 },
     };
-    _ = linux.timerfd_settime(fd, .{}, &spec, null);
+    const rc = linux.timerfd_settime(fd, .{}, &spec, null);
+    if (rc != 0) {
+        rumble_log.debug("TIMERFD: disarm FAILED rc={d}", .{rc});
+    }
 }
 
 pub const EventLoopContext = struct {
@@ -160,6 +220,8 @@ pub const EventLoopContext = struct {
     wasm_override_report: bool = false,
     generic_state: ?*GenericDeviceState = null,
     generic_output: ?GenericOutputDevice = null,
+    /// Device name for log correlation (set from device_config.device.name).
+    device_tag: []const u8 = "unknown",
 };
 
 fn i64ToParamValue(v: ?i64) u16 {
@@ -253,6 +315,7 @@ pub const EventLoop = struct {
     gamepad_state: state.GamepadState,
     last_ts: i128,
     last_rumble_ns: i128,
+    last_heartbeat_ns: i128 = 0,
 
     pub fn init() !EventLoop {
         var mask = posix.sigemptyset();
@@ -378,6 +441,15 @@ pub const EventLoop = struct {
             const dt_ms: u32 = @intCast(@min(100, @max(1, @divFloor(dt_ns, 1_000_000))));
             self.last_ts = now;
 
+            // Heartbeat: log every 60s to confirm daemon is alive and trigger
+            // log file reopen if the file was deleted.
+            const heartbeat_interval: i128 = 60 * std.time.ns_per_s;
+            if (now - self.last_heartbeat_ns >= heartbeat_interval) {
+                self.last_heartbeat_ns = now;
+                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now);
+                rumble_log.debug("[{s}] HEARTBEAT: alive {s}", .{ ctx.device_tag, slotStr(&slot_buf) });
+            }
+
             // Check signalfd (slot 0)
             if (self.pollfds[0].revents & posix.POLL.IN != 0) {
                 var siginfo: [signalfd_siginfo_size]u8 = undefined;
@@ -405,19 +477,21 @@ pub const EventLoop = struct {
             }
 
             // Check rumble auto-stop timerfd (slot 3).
-            // When the scheduler's earliest pending deadline fires, clear
-            // expired slots and emit a single stop frame to HID if no
-            // effects remain playing. Rearm (or disarm) for the next
-            // deadline.
             if (self.pollfds[3].revents & posix.POLL.IN != 0) {
                 var rs_expiry: [8]u8 = undefined;
                 _ = posix.read(self.rumble_stop_fd, &rs_expiry) catch {};
                 const now_ns = monotonicNs();
                 const result = self.rumble_scheduler.onTimerExpired(now_ns);
+                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                rumble_log.debug("[{s}] TIMERFD: expired now={d} emit_stop={} next_dl={?d} {s}", .{
+                    ctx.device_tag, now_ns, result.emit_stop_frame, result.next_deadline_ns, slotStr(&slot_buf),
+                });
                 if (result.emit_stop_frame) {
                     if (ctx.allocator) |alloc| {
                         if (ctx.device_config) |dcfg| {
-                            _ = emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
+                            if (!emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
+                                rumble_log.debug("[{s}] TIMERFD: stop frame FAILED to emit", .{ctx.device_tag});
+                            }
                         }
                     }
                 }
@@ -425,61 +499,71 @@ pub const EventLoop = struct {
             }
 
             // Check uinput FF fd.
-            //
-            // Play and stop events take different paths because overlapping
-            // effects change the stop semantics: an explicit stop for one of
-            // several still-playing effects must NOT write a zero frame to
-            // HID — otherwise the long effect's motor gets cut off while the
-            // scheduler still considers it live.
             if (self.uinput_ff_slot) |slot| {
                 if (self.pollfds[slot].revents & posix.POLL.IN != 0) {
-                    if (ctx.output.pollFf() catch null) |ff_ev| {
+                    const ff_result = ctx.output.pollFf() catch |err| blk: {
+                        rumble_log.debug("[{s}] FF_ERROR: pollFf failed err={}", .{ ctx.device_tag, err });
+                        break :blk null;
+                    };
+                    if (ff_result) |ff_ev| {
                         const now_ns = monotonicNs();
                         const min_interval_ns: i128 = 10_000_000; // 10ms
                         const is_stop = ff_ev.strong == 0 and ff_ev.weak == 0;
                         const scheduler_on = autoStopEnabled(ctx.device_config);
 
+                        rumble_log.debug("[{s}] FF_EVENT: id={d} strong={d} weak={d} dur={d}ms is_stop={} sched_on={}", .{
+                            ctx.device_tag,    ff_ev.effect_id, ff_ev.strong, ff_ev.weak,
+                            ff_ev.duration_ms, is_stop,         scheduler_on,
+                        });
+
                         if (is_stop) {
                             if (scheduler_on) {
-                                // Update scheduler first. Only emit a zero
-                                // frame when the stop transitions the whole
-                                // scheduler to "nothing playing"; otherwise
-                                // another effect is still live.
                                 const result = self.rumble_scheduler.onStop(ff_ev.effect_id);
+                                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                                rumble_log.debug("[{s}] FF_STOP: id={d} emit_stop={} next_dl={?d} {s}", .{
+                                    ctx.device_tag,          ff_ev.effect_id,    result.emit_stop_frame,
+                                    result.next_deadline_ns, slotStr(&slot_buf),
+                                });
                                 if (result.emit_stop_frame) {
                                     if (ctx.allocator) |alloc| {
                                         if (ctx.device_config) |dcfg| {
-                                            _ = emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
+                                            if (!emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
+                                                rumble_log.debug("[{s}] FF_STOP: stop frame FAILED to emit", .{ctx.device_tag});
+                                            }
                                         }
                                     }
                                 }
                                 armRumbleStopFd(self.rumble_stop_fd, result.next_deadline_ns);
                             } else {
-                                // auto_stop disabled: legacy fall-through,
-                                // trust the client to know what it's doing.
+                                rumble_log.debug("[{s}] FF_STOP: auto_stop disabled, direct zero frame", .{ctx.device_tag});
                                 if (ctx.allocator) |alloc| {
                                     if (ctx.device_config) |dcfg| {
-                                        _ = emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0);
+                                        if (!emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
+                                            rumble_log.debug("[{s}] FF_STOP: direct zero frame FAILED to emit", .{ctx.device_tag});
+                                        }
                                     }
                                 }
                             }
                         } else {
                             // Play event: throttle applies to play frames.
-                            // The scheduler must only record the deadline when
-                            // the frame is actually forwarded to HID — otherwise
-                            // a throttled (dropped) frame could replace an
-                            // active deadline and later emit a stop for an
-                            // effect the device never received.
                             var forwarded = false;
-                            if (now_ns - self.last_rumble_ns >= min_interval_ns) {
+                            const elapsed = now_ns - self.last_rumble_ns;
+                            if (elapsed >= min_interval_ns) {
                                 if (ctx.allocator) |alloc| {
                                     if (ctx.device_config) |dcfg| {
-                                        if (emitRumbleFrame(ctx.devices, alloc, dcfg, ff_ev.strong, ff_ev.weak)) {
+                                        if (emitRumbleFrame(ctx.devices, alloc, dcfg, ff_ev.strong, ff_ev.weak, ctx.device_tag)) {
                                             self.last_rumble_ns = now_ns;
                                             forwarded = true;
+                                        } else {
+                                            rumble_log.debug("[{s}] FF_PLAY: emitRumbleFrame FAILED id={d}", .{ ctx.device_tag, ff_ev.effect_id });
                                         }
                                     }
                                 }
+                            } else {
+                                rumble_log.debug("[{s}] FF_PLAY: THROTTLED id={d} elapsed={d}ns", .{
+                                    ctx.device_tag,                                          ff_ev.effect_id,
+                                    @as(u64, @intCast(@min(elapsed, std.math.maxInt(u64)))),
+                                });
                             }
                             if (scheduler_on and forwarded) {
                                 const next_dl = self.rumble_scheduler.onPlay(
@@ -487,6 +571,11 @@ pub const EventLoop = struct {
                                     ff_ev.duration_ms,
                                     now_ns,
                                 );
+                                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                                rumble_log.debug("[{s}] FF_PLAY: id={d} dur={d}ms next_dl={?d} {s}", .{
+                                    ctx.device_tag, ff_ev.effect_id,    ff_ev.duration_ms,
+                                    next_dl,        slotStr(&slot_buf),
+                                });
                                 armRumbleStopFd(self.rumble_stop_fd, next_dl);
                             }
                         }
@@ -504,6 +593,11 @@ pub const EventLoop = struct {
                 const has_hup = revents & (posix.POLL.HUP | posix.POLL.ERR) != 0;
 
                 if (!has_in and has_hup) {
+                    const disc_now = monotonicNs();
+                    const disc_slots = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), disc_now);
+                    rumble_log.debug("[{s}] DISCONNECT: HUP/ERR on device slot {d} {s}", .{
+                        ctx.device_tag, slot, slotStr(&disc_slots),
+                    });
                     self.disconnected = true;
                     self.running = false;
                     break;
@@ -1921,4 +2015,95 @@ test "event_loop: applyAdaptiveTrigger: custom command_prefix routes correctly" 
     try testing.expectEqual(@as(u8, 0xaa), mock_dev.write_log.items[0]);
     try testing.expectEqual(@as(u8, 10), mock_dev.write_log.items[1]);
     try testing.expectEqual(@as(u8, 20), mock_dev.write_log.items[2]);
+}
+
+test "event_loop: FF scheduler state identical with dump on vs off" {
+    // Run the same FF PLAY event through two separate event loops — one
+    // with dump enabled, one disabled — and verify the scheduler state
+    // and HID write output are identical.
+    const padctl_log = @import("log.zig");
+    const allocator = testing.allocator;
+
+    const RunResult = struct {
+        scheduler_slots: [rumble_scheduler_mod.MAX_EFFECTS]i128,
+        write_log: []u8,
+    };
+
+    const runOnce = struct {
+        fn go(alloc: std.mem.Allocator, dump_on: bool) !RunResult {
+            padctl_log.setEnabled(dump_on);
+            defer padctl_log.setEnabled(false);
+
+            var loop = try EventLoop.initManaged();
+            defer loop.deinit();
+
+            var mock_dev = try MockDeviceIO.init(alloc, &.{});
+            defer mock_dev.deinit();
+            const dev = mock_dev.deviceIO();
+            try loop.addDevice(dev);
+
+            const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+            defer posix.close(ff_pipe[0]);
+            defer posix.close(ff_pipe[1]);
+            try loop.addUinputFf(ff_pipe[0]);
+
+            const parsed = try device_mod.parseString(alloc, ff_toml);
+            defer parsed.deinit();
+            const interp = Interpreter.init(&parsed.value);
+
+            var ff_out = MockFfOutput{
+                .allocator = alloc,
+                .ff_event = .{ .effect_type = 0x50, .strong = 0x8000, .weak = 0x4000, .duration_ms = 300 },
+            };
+
+            var devs = [_]DeviceIO{dev};
+
+            // Use a pointer to stack-local context to avoid anonymous struct type issues.
+            const Ctx2 = struct { l: *EventLoop, d: []DeviceIO, i: *const Interpreter, f: *MockFfOutput, c: *const device_mod.DeviceConfig, a: std.mem.Allocator };
+            var run_ctx = Ctx2{ .l = &loop, .d = &devs, .i = &interp, .f = &ff_out, .c = &parsed.value, .a = alloc };
+            const thread = try std.Thread.spawn(.{}, struct {
+                fn run(ctx: *Ctx2) !void {
+                    try ctx.l.run(.{
+                        .devices = ctx.d,
+                        .interpreter = ctx.i,
+                        .output = ctx.f.outputDevice(),
+                        .allocator = ctx.a,
+                        .device_config = ctx.c,
+                        .poll_timeout_ms = 100,
+                    });
+                }
+            }.run, .{&run_ctx});
+
+            _ = try posix.write(ff_pipe[1], &[_]u8{1});
+            std.Thread.sleep(20 * std.time.ns_per_ms);
+            loop.stop();
+            thread.join();
+
+            const log_copy = try alloc.dupe(u8, mock_dev.write_log.items);
+            return RunResult{
+                .scheduler_slots = loop.rumble_scheduler.dumpSlots(),
+                .write_log = log_copy,
+            };
+        }
+    }.go;
+
+    const r_off = try runOnce(allocator, false);
+    defer allocator.free(r_off.write_log);
+    const r_on = try runOnce(allocator, true);
+    defer allocator.free(r_on.write_log);
+
+    // Scheduler slot activity pattern must be identical (which slots are
+    // active/inactive). Exact timestamps differ between runs because they
+    // use the real monotonic clock, so we compare structural shape.
+    for (r_off.scheduler_slots, r_on.scheduler_slots) |a, b| {
+        const a_active = a != 0;
+        const b_active = b != 0;
+        try testing.expectEqual(a_active, b_active);
+        // Both infinite or both finite.
+        const a_inf = a == rumble_scheduler_mod.RumbleScheduler.INFINITE;
+        const b_inf = b == rumble_scheduler_mod.RumbleScheduler.INFINITE;
+        try testing.expectEqual(a_inf, b_inf);
+    }
+    // HID writes must be identical (same bytes sent to device).
+    try testing.expectEqualSlices(u8, r_off.write_log, r_on.write_log);
 }

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -26,6 +26,7 @@ pub const WasmPlugin = wasm_runtime.WasmPlugin;
 const rumble_scheduler_mod = @import("core/rumble_scheduler.zig");
 const RumbleScheduler = rumble_scheduler_mod.RumbleScheduler;
 const rumble_log = std.log.scoped(.rumble);
+const padctl_log = @import("log.zig");
 
 // signalfd(0) + stop_pipe(1) + macro timerfd(2) + rumble_stop_fd(3) + per-interface fds + uinput FF fd
 pub const MAX_FDS = 11;
@@ -175,16 +176,20 @@ fn emitRumbleFrame(
     defer alloc.free(bytes);
     if (cmd.checksum) |*cs| applyChecksum(bytes, cs);
 
-    // Log the full post-checksum HID frame.
-    var hex_buf: [512]u8 = undefined;
-    var hex_fbs = std.io.fixedBufferStream(&hex_buf);
-    const hw = hex_fbs.writer();
-    for (bytes) |b| {
-        hw.print("{x:0>2} ", .{b}) catch break;
+    // Log the full post-checksum HID frame — but only when dump is on;
+    // otherwise the hex-dump loop runs unconditionally on every rumble
+    // frame (100+ Hz during gameplay) even with nothing listening.
+    if (padctl_log.shouldWriteToFile(.debug)) {
+        var hex_buf: [512]u8 = undefined;
+        var hex_fbs = std.io.fixedBufferStream(&hex_buf);
+        const hw = hex_fbs.writer();
+        for (bytes) |b| {
+            hw.print("{x:0>2} ", .{b}) catch break;
+        }
+        rumble_log.debug("[{s}] HID_WRITE: cmd={s} strong={d} weak={d} iface={d} len={d} frame=[{s}]", .{
+            tag, ff_type, strong, weak, iface_idx, bytes.len, hex_fbs.getWritten(),
+        });
     }
-    rumble_log.debug("[{s}] HID_WRITE: cmd={s} strong={d} weak={d} iface={d} len={d} frame=[{s}]", .{
-        tag, ff_type, strong, weak, iface_idx, bytes.len, hex_fbs.getWritten(),
-    });
 
     devices[iface_idx].write(bytes) catch |err| {
         rumble_log.debug("[{s}] HID_WRITE: FAILED cmd={s} strong={d} weak={d} err={}", .{ tag, ff_type, strong, weak, err });
@@ -446,8 +451,10 @@ pub const EventLoop = struct {
             const heartbeat_interval: i128 = 60 * std.time.ns_per_s;
             if (now - self.last_heartbeat_ns >= heartbeat_interval) {
                 self.last_heartbeat_ns = now;
-                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now);
-                rumble_log.debug("[{s}] HEARTBEAT: alive {s}", .{ ctx.device_tag, slotStr(&slot_buf) });
+                if (padctl_log.shouldWriteToFile(.debug)) {
+                    const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now);
+                    rumble_log.debug("[{s}] HEARTBEAT: alive {s}", .{ ctx.device_tag, slotStr(&slot_buf) });
+                }
             }
 
             // Check signalfd (slot 0)
@@ -482,10 +489,12 @@ pub const EventLoop = struct {
                 _ = posix.read(self.rumble_stop_fd, &rs_expiry) catch {};
                 const now_ns = monotonicNs();
                 const result = self.rumble_scheduler.onTimerExpired(now_ns);
-                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
-                rumble_log.debug("[{s}] TIMERFD: expired now={d} emit_stop={} next_dl={?d} {s}", .{
-                    ctx.device_tag, now_ns, result.emit_stop_frame, result.next_deadline_ns, slotStr(&slot_buf),
-                });
+                if (padctl_log.shouldWriteToFile(.debug)) {
+                    const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                    rumble_log.debug("[{s}] TIMERFD: expired now={d} emit_stop={} next_dl={?d} {s}", .{
+                        ctx.device_tag, now_ns, result.emit_stop_frame, result.next_deadline_ns, slotStr(&slot_buf),
+                    });
+                }
                 if (result.emit_stop_frame) {
                     if (ctx.allocator) |alloc| {
                         if (ctx.device_config) |dcfg| {
@@ -519,11 +528,13 @@ pub const EventLoop = struct {
                         if (is_stop) {
                             if (scheduler_on) {
                                 const result = self.rumble_scheduler.onStop(ff_ev.effect_id);
-                                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
-                                rumble_log.debug("[{s}] FF_STOP: id={d} emit_stop={} next_dl={?d} {s}", .{
-                                    ctx.device_tag,          ff_ev.effect_id,    result.emit_stop_frame,
-                                    result.next_deadline_ns, slotStr(&slot_buf),
-                                });
+                                if (padctl_log.shouldWriteToFile(.debug)) {
+                                    const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                                    rumble_log.debug("[{s}] FF_STOP: id={d} emit_stop={} next_dl={?d} {s}", .{
+                                        ctx.device_tag,          ff_ev.effect_id,    result.emit_stop_frame,
+                                        result.next_deadline_ns, slotStr(&slot_buf),
+                                    });
+                                }
                                 if (result.emit_stop_frame) {
                                     if (ctx.allocator) |alloc| {
                                         if (ctx.device_config) |dcfg| {
@@ -571,11 +582,13 @@ pub const EventLoop = struct {
                                     ff_ev.duration_ms,
                                     now_ns,
                                 );
-                                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
-                                rumble_log.debug("[{s}] FF_PLAY: id={d} dur={d}ms next_dl={?d} {s}", .{
-                                    ctx.device_tag, ff_ev.effect_id,    ff_ev.duration_ms,
-                                    next_dl,        slotStr(&slot_buf),
-                                });
+                                if (padctl_log.shouldWriteToFile(.debug)) {
+                                    const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                                    rumble_log.debug("[{s}] FF_PLAY: id={d} dur={d}ms next_dl={?d} {s}", .{
+                                        ctx.device_tag, ff_ev.effect_id,    ff_ev.duration_ms,
+                                        next_dl,        slotStr(&slot_buf),
+                                    });
+                                }
                                 armRumbleStopFd(self.rumble_stop_fd, next_dl);
                             }
                         }
@@ -593,11 +606,13 @@ pub const EventLoop = struct {
                 const has_hup = revents & (posix.POLL.HUP | posix.POLL.ERR) != 0;
 
                 if (!has_in and has_hup) {
-                    const disc_now = monotonicNs();
-                    const disc_slots = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), disc_now);
-                    rumble_log.debug("[{s}] DISCONNECT: HUP/ERR on device slot {d} {s}", .{
-                        ctx.device_tag, slot, slotStr(&disc_slots),
-                    });
+                    if (padctl_log.shouldWriteToFile(.debug)) {
+                        const disc_now = monotonicNs();
+                        const disc_slots = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), disc_now);
+                        rumble_log.debug("[{s}] DISCONNECT: HUP/ERR on device slot {d} {s}", .{
+                            ctx.device_tag, slot, slotStr(&disc_slots),
+                        });
+                    }
                     self.disconnected = true;
                     self.running = false;
                     break;
@@ -2021,7 +2036,7 @@ test "event_loop: FF scheduler state identical with dump on vs off" {
     // Run the same FF PLAY event through two separate event loops — one
     // with dump enabled, one disabled — and verify the scheduler state
     // and HID write output are identical.
-    const padctl_log = @import("log.zig");
+    // padctl_log is now a module-level import; no local re-binding needed.
     const allocator = testing.allocator;
 
     const RunResult = struct {

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -2107,6 +2107,24 @@ test "event_loop: FF scheduler state identical with dump on vs off" {
     const r_on = try runOnce(allocator, true);
     defer allocator.free(r_on.write_log);
 
+    // Both runs must have actually produced work. Without these checks the
+    // test would pass vacuously if the FF event never reached the scheduler
+    // (pipe write race, poll timeout) — both runs would have empty slots
+    // and empty write logs and `expectEqualSlices` on two empty slices
+    // would succeed.
+    try testing.expect(r_off.write_log.len > 0);
+    try testing.expect(r_on.write_log.len > 0);
+    var active_off: usize = 0;
+    var active_on: usize = 0;
+    for (r_off.scheduler_slots) |s| {
+        if (s != 0) active_off += 1;
+    }
+    for (r_on.scheduler_slots) |s| {
+        if (s != 0) active_on += 1;
+    }
+    try testing.expect(active_off >= 1);
+    try testing.expect(active_on >= 1);
+
     // Scheduler slot activity pattern must be identical (which slots are
     // active/inactive). Exact timestamps differ between runs because they
     // use the real monotonic clock, so we compare structural shape.

--- a/src/io/control_socket.zig
+++ b/src/io/control_socket.zig
@@ -146,6 +146,9 @@ pub const CommandTag = enum {
     status,
     list,
     devices,
+    dump_on,
+    dump_off,
+    dump_status,
     unknown,
 };
 
@@ -182,6 +185,12 @@ pub fn parseCommand(raw: []const u8) Command {
         return .{ .tag = .list };
     } else if (std.ascii.eqlIgnoreCase(verb, "DEVICES")) {
         return .{ .tag = .devices };
+    } else if (std.ascii.eqlIgnoreCase(verb, "DUMP")) {
+        const mode = it.next() orelse return .{ .tag = .unknown };
+        if (std.ascii.eqlIgnoreCase(mode, "ON")) return .{ .tag = .dump_on };
+        if (std.ascii.eqlIgnoreCase(mode, "OFF")) return .{ .tag = .dump_off };
+        if (std.ascii.eqlIgnoreCase(mode, "STATUS")) return .{ .tag = .dump_status };
+        return .{ .tag = .unknown };
     }
     return .{ .tag = .unknown };
 }
@@ -242,6 +251,38 @@ test "control_socket: parseCommand: case insensitive" {
     const cmd = parseCommand("switch FPS\n");
     try testing.expectEqual(CommandTag.switch_mapping, cmd.tag);
     try testing.expectEqualStrings("FPS", cmd.name);
+}
+
+test "control_socket: parseCommand: DUMP ON" {
+    const cmd = parseCommand("DUMP ON\n");
+    try testing.expectEqual(CommandTag.dump_on, cmd.tag);
+}
+
+test "control_socket: parseCommand: DUMP OFF" {
+    const cmd = parseCommand("DUMP OFF\n");
+    try testing.expectEqual(CommandTag.dump_off, cmd.tag);
+}
+
+test "control_socket: parseCommand: DUMP case insensitive" {
+    const on = parseCommand("dump on\n");
+    try testing.expectEqual(CommandTag.dump_on, on.tag);
+    const off = parseCommand("Dump Off\n");
+    try testing.expectEqual(CommandTag.dump_off, off.tag);
+}
+
+test "control_socket: parseCommand: DUMP STATUS" {
+    const cmd = parseCommand("DUMP STATUS\n");
+    try testing.expectEqual(CommandTag.dump_status, cmd.tag);
+}
+
+test "control_socket: parseCommand: DUMP without arg is unknown" {
+    const cmd = parseCommand("DUMP\n");
+    try testing.expectEqual(CommandTag.unknown, cmd.tag);
+}
+
+test "control_socket: parseCommand: DUMP invalid arg is unknown" {
+    const cmd = parseCommand("DUMP MAYBE\n");
+    try testing.expectEqual(CommandTag.unknown, cmd.tag);
 }
 
 test "control_socket: parseCommand: SWITCH missing name" {

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -368,8 +368,6 @@ pub const UinputDevice = struct {
     pub fn pollFf(self: *UinputDevice) !?FfEvent {
         var result: ?FfEvent = null;
         var ev_count: u32 = 0;
-        var ff_count: u32 = 0;
-        var overwrite_count: u32 = 0;
         while (true) {
             var ev: c.input_event = undefined;
             const n = std.posix.read(self.fd, std.mem.asBytes(&ev)) catch |err| switch (err) {
@@ -436,13 +434,8 @@ pub const UinputDevice = struct {
                     rumble_log.debug("[{s}] pollFf: OUT_OF_RANGE code={d} value={d} DROPPED", .{ self.log_tag, ev.code, ev.value });
                     continue;
                 }
-                ff_count += 1;
-                if (result != null) overwrite_count += 1;
-                const prev_tag: []const u8 = if (result != null) "overwritten" else "none";
                 if (ev.value == 0) {
-                    rumble_log.debug("[{s}] pollFf: STOP id={d} (ev#{d}, prev={s})", .{
-                        self.log_tag, id, ff_count, prev_tag,
-                    });
+                    rumble_log.debug("[{s}] pollFf: STOP id={d}", .{ self.log_tag, id });
                     result = FfEvent{
                         .effect_type = c.FF_RUMBLE,
                         .effect_id = @intCast(id),
@@ -452,8 +445,8 @@ pub const UinputDevice = struct {
                     };
                 } else {
                     const eff = self.ff_effects[id];
-                    rumble_log.debug("[{s}] pollFf: PLAY id={d} strong={d} weak={d} dur={d}ms (ev#{d}, prev={s})", .{
-                        self.log_tag, id, eff.strong, eff.weak, eff.length_ms, ff_count, prev_tag,
+                    rumble_log.debug("[{s}] pollFf: PLAY id={d} strong={d} weak={d} dur={d}ms", .{
+                        self.log_tag, id, eff.strong, eff.weak, eff.length_ms,
                     });
                     result = FfEvent{
                         .effect_type = c.FF_RUMBLE,
@@ -475,12 +468,12 @@ pub const UinputDevice = struct {
         if (ev_count > 0) {
             if (result) |r| {
                 const kind: []const u8 = if (r.strong == 0 and r.weak == 0) "STOP" else "PLAY";
-                rumble_log.debug("[{s}] pollFf: drain end, {d} events read, {d} EV_FF, {d} overwritten, returning {s} id={d}", .{
-                    self.log_tag, ev_count, ff_count, overwrite_count, kind, r.effect_id,
+                rumble_log.debug("[{s}] pollFf: drain end, {d} events read, returning {s} id={d}", .{
+                    self.log_tag, ev_count, kind, r.effect_id,
                 });
             } else {
-                rumble_log.debug("[{s}] pollFf: drain end, {d} events read, {d} EV_FF, returning null", .{
-                    self.log_tag, ev_count, ff_count,
+                rumble_log.debug("[{s}] pollFf: drain end, {d} events read, returning null", .{
+                    self.log_tag, ev_count,
                 });
             }
         }
@@ -1714,52 +1707,4 @@ test "uinput: pollFf returns identical FfEvent regardless of dump_enabled" {
     try std.testing.expectEqual(r1.strong, r2.strong);
     try std.testing.expectEqual(r1.weak, r2.weak);
     try std.testing.expectEqual(r1.duration_ms, r2.duration_ms);
-}
-
-test "uinput: pollFf drain with overwrite: PLAY then STOP returns STOP" {
-    // Verifies the drain loop correctly overwrites and the stop event wins.
-    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
-    defer std.posix.close(pfds[0]);
-    defer std.posix.close(pfds[1]);
-
-    var dev = UinputDevice{
-        .fd = pfds[0],
-        .button_codes = [_]u16{0} ** BUTTON_COUNT,
-    };
-    dev.ff_effects[0] = .{ .strong = 0xffff, .weak = 0xffff, .length_ms = 500 };
-
-    // Write PLAY then STOP for same id — STOP should win.
-    const play = c.input_event{ .type = c.EV_FF, .code = 0, .value = 1, .time = std.mem.zeroes(c.timeval) };
-    const stop = c.input_event{ .type = c.EV_FF, .code = 0, .value = 0, .time = std.mem.zeroes(c.timeval) };
-    _ = try std.posix.write(pfds[1], std.mem.asBytes(&play));
-    _ = try std.posix.write(pfds[1], std.mem.asBytes(&stop));
-
-    const result = (try dev.pollFf()).?;
-    try std.testing.expectEqual(@as(u16, 0), result.strong);
-    try std.testing.expectEqual(@as(u16, 0), result.weak);
-    try std.testing.expectEqual(@as(u8, 0), result.effect_id);
-}
-
-test "uinput: pollFf drain with overwrite: STOP then PLAY returns PLAY" {
-    // Verifies the opposite overwrite direction.
-    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
-    defer std.posix.close(pfds[0]);
-    defer std.posix.close(pfds[1]);
-
-    var dev = UinputDevice{
-        .fd = pfds[0],
-        .button_codes = [_]u16{0} ** BUTTON_COUNT,
-    };
-    dev.ff_effects[3] = .{ .strong = 0xaaaa, .weak = 0xbbbb, .length_ms = 100 };
-
-    const stop = c.input_event{ .type = c.EV_FF, .code = 3, .value = 0, .time = std.mem.zeroes(c.timeval) };
-    const play = c.input_event{ .type = c.EV_FF, .code = 3, .value = 1, .time = std.mem.zeroes(c.timeval) };
-    _ = try std.posix.write(pfds[1], std.mem.asBytes(&stop));
-    _ = try std.posix.write(pfds[1], std.mem.asBytes(&play));
-
-    const result = (try dev.pollFf()).?;
-    try std.testing.expectEqual(@as(u16, 0xaaaa), result.strong);
-    try std.testing.expectEqual(@as(u16, 0xbbbb), result.weak);
-    try std.testing.expectEqual(@as(u8, 3), result.effect_id);
-    try std.testing.expectEqual(@as(u16, 100), result.duration_ms);
 }

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -1679,6 +1679,10 @@ test "uinput: GenericUinputDevice.emitGeneric: no change produces no write" {
 
 test "uinput: pollFf returns identical FfEvent regardless of dump_enabled" {
     const padctl_log = @import("../log.zig");
+    // defer the restore before toggling so an early `try` failure (pipe
+    // write, pollFf read) can't leak dump_enabled=true into subsequent
+    // tests sharing the process.
+    defer padctl_log.setEnabled(false);
     const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
     defer std.posix.close(pfds[0]);
     defer std.posix.close(pfds[1]);
@@ -1699,7 +1703,6 @@ test "uinput: pollFf returns identical FfEvent regardless of dump_enabled" {
     padctl_log.setEnabled(true);
     _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
     const r2 = (try dev.pollFf()).?;
-    padctl_log.setEnabled(false);
 
     // Both must be identical.
     try std.testing.expectEqual(r1.effect_type, r2.effect_type);

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const state = @import("../core/state.zig");
 const device = @import("../config/device.zig");
 const input_codes = @import("../config/input_codes.zig");
+const rumble_log = std.log.scoped(.rumble);
 
 const c = @cImport({
     @cInclude("linux/uinput.h");
@@ -127,6 +128,8 @@ pub const UinputDevice = struct {
     axis_count: usize = 0,
     has_dpad_hat: bool = false,
     ff_effects: [16]FfEffect = [_]FfEffect{.{}} ** 16,
+    /// Device identifier for log correlation (e.g. "Vader 5 Pro/hidraw7").
+    log_tag: []const u8 = "uinput",
 
     const AxisStateField = enum { ax, ay, rx, ry, lt, rt, dpad_x, dpad_y };
 
@@ -364,6 +367,9 @@ pub const UinputDevice = struct {
 
     pub fn pollFf(self: *UinputDevice) !?FfEvent {
         var result: ?FfEvent = null;
+        var ev_count: u32 = 0;
+        var ff_count: u32 = 0;
+        var overwrite_count: u32 = 0;
         while (true) {
             var ev: c.input_event = undefined;
             const n = std.posix.read(self.fd, std.mem.asBytes(&ev)) catch |err| switch (err) {
@@ -371,6 +377,7 @@ pub const UinputDevice = struct {
                 else => return err,
             };
             if (n != @sizeOf(c.input_event)) break;
+            ev_count += 1;
 
             if (ev.type == c.EV_UINPUT) {
                 if (ev.code == c.UI_FF_UPLOAD) {
@@ -382,6 +389,7 @@ pub const UinputDevice = struct {
                         // the rest of the branch so we don't touch ff_effects or
                         // call UI_END_FF_UPLOAD with retval=0 (which would
                         // falsely acknowledge the kernel request).
+                        rumble_log.debug("[{s}] pollFf: UI_BEGIN_FF_UPLOAD FAILED rc={d}", .{ self.log_tag, begin_rc });
                         continue;
                     }
                     if (upload.effect.type == c.FF_RUMBLE and upload.effect.id < 16) {
@@ -390,6 +398,18 @@ pub const UinputDevice = struct {
                             .weak = upload.effect.u.rumble.weak_magnitude,
                             .length_ms = @intCast(upload.effect.replay.length),
                         };
+                        rumble_log.debug("[{s}] pollFf: UPLOAD id={d} type=FF_RUMBLE strong={d} weak={d} len={d}ms replay.delay={d}ms", .{
+                            self.log_tag,
+                            upload.effect.id,
+                            upload.effect.u.rumble.strong_magnitude,
+                            upload.effect.u.rumble.weak_magnitude,
+                            @as(u16, @intCast(upload.effect.replay.length)),
+                            @as(u16, @intCast(upload.effect.replay.delay)),
+                        });
+                    } else {
+                        rumble_log.debug("[{s}] pollFf: UPLOAD id={d} type={d} (non-rumble or out-of-range)", .{
+                            self.log_tag, upload.effect.id, upload.effect.type,
+                        });
                     }
                     upload.retval = 0;
                     _ = std.os.linux.ioctl(self.fd, UI_END_FF_UPLOAD, @intFromPtr(&upload));
@@ -399,10 +419,12 @@ pub const UinputDevice = struct {
                     const begin_rc = std.os.linux.ioctl(self.fd, UI_BEGIN_FF_ERASE, @intFromPtr(&erase));
                     if (begin_rc != 0) {
                         // BEGIN failed — see comment above for UPLOAD path.
+                        rumble_log.debug("[{s}] pollFf: UI_BEGIN_FF_ERASE FAILED rc={d}", .{ self.log_tag, begin_rc });
                         continue;
                     }
                     if (erase.effect_id < 16) {
                         self.ff_effects[@intCast(erase.effect_id)] = .{};
+                        rumble_log.debug("[{s}] pollFf: ERASE id={d}", .{ self.log_tag, erase.effect_id });
                     }
                     erase.retval = 0;
                     _ = std.os.linux.ioctl(self.fd, UI_END_FF_ERASE, @intFromPtr(&erase));
@@ -410,11 +432,17 @@ pub const UinputDevice = struct {
             } else if (ev.type == c.EV_FF) {
                 const id: usize = @intCast(ev.code);
                 // Out-of-range FF effect ids must be silently dropped.
-                // Collapsing them into a zero FfEvent would look like
-                // an explicit stop for slot 0 downstream, which would
-                // spuriously cancel the real rumble auto-stop deadline.
-                if (id >= 16) continue;
+                if (id >= 16) {
+                    rumble_log.debug("[{s}] pollFf: OUT_OF_RANGE code={d} value={d} DROPPED", .{ self.log_tag, ev.code, ev.value });
+                    continue;
+                }
+                ff_count += 1;
+                if (result != null) overwrite_count += 1;
+                const prev_tag: []const u8 = if (result != null) "overwritten" else "none";
                 if (ev.value == 0) {
+                    rumble_log.debug("[{s}] pollFf: STOP id={d} (ev#{d}, prev={s})", .{
+                        self.log_tag, id, ff_count, prev_tag,
+                    });
                     result = FfEvent{
                         .effect_type = c.FF_RUMBLE,
                         .effect_id = @intCast(id),
@@ -424,6 +452,9 @@ pub const UinputDevice = struct {
                     };
                 } else {
                     const eff = self.ff_effects[id];
+                    rumble_log.debug("[{s}] pollFf: PLAY id={d} strong={d} weak={d} dur={d}ms (ev#{d}, prev={s})", .{
+                        self.log_tag, id, eff.strong, eff.weak, eff.length_ms, ff_count, prev_tag,
+                    });
                     result = FfEvent{
                         .effect_type = c.FF_RUMBLE,
                         .effect_id = @intCast(id),
@@ -439,6 +470,18 @@ pub const UinputDevice = struct {
                 // issue #65: rapid PLAY+STOP bursts used to collapse to
                 // the last event and lose the earlier one).
                 break;
+            }
+        }
+        if (ev_count > 0) {
+            if (result) |r| {
+                const kind: []const u8 = if (r.strong == 0 and r.weak == 0) "STOP" else "PLAY";
+                rumble_log.debug("[{s}] pollFf: drain end, {d} events read, {d} EV_FF, {d} overwritten, returning {s} id={d}", .{
+                    self.log_tag, ev_count, ff_count, overwrite_count, kind, r.effect_id,
+                });
+            } else {
+                rumble_log.debug("[{s}] pollFf: drain end, {d} events read, {d} EV_FF, returning null", .{
+                    self.log_tag, ev_count, ff_count,
+                });
             }
         }
         return result;
@@ -1637,4 +1680,86 @@ test "uinput: GenericUinputDevice.emitGeneric: no change produces no write" {
     var events: [4]c.input_event = undefined;
     const n = readEvents(pfds[0], &events);
     try std.testing.expectEqual(@as(usize, 0), n);
+}
+
+// --- Instrumentation correctness tests ---
+
+test "uinput: pollFf returns identical FfEvent regardless of dump_enabled" {
+    const padctl_log = @import("../log.zig");
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    dev.ff_effects[0] = .{ .strong = 0x1234, .weak = 0x5678, .length_ms = 300 };
+
+    // With dump disabled (default).
+    padctl_log.setEnabled(false);
+    const ev = c.input_event{ .type = c.EV_FF, .code = 0, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
+    const r1 = (try dev.pollFf()).?;
+
+    // With dump enabled.
+    padctl_log.setEnabled(true);
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&ev));
+    const r2 = (try dev.pollFf()).?;
+    padctl_log.setEnabled(false);
+
+    // Both must be identical.
+    try std.testing.expectEqual(r1.effect_type, r2.effect_type);
+    try std.testing.expectEqual(r1.effect_id, r2.effect_id);
+    try std.testing.expectEqual(r1.strong, r2.strong);
+    try std.testing.expectEqual(r1.weak, r2.weak);
+    try std.testing.expectEqual(r1.duration_ms, r2.duration_ms);
+}
+
+test "uinput: pollFf drain with overwrite: PLAY then STOP returns STOP" {
+    // Verifies the drain loop correctly overwrites and the stop event wins.
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    dev.ff_effects[0] = .{ .strong = 0xffff, .weak = 0xffff, .length_ms = 500 };
+
+    // Write PLAY then STOP for same id — STOP should win.
+    const play = c.input_event{ .type = c.EV_FF, .code = 0, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    const stop = c.input_event{ .type = c.EV_FF, .code = 0, .value = 0, .time = std.mem.zeroes(c.timeval) };
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&play));
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&stop));
+
+    const result = (try dev.pollFf()).?;
+    try std.testing.expectEqual(@as(u16, 0), result.strong);
+    try std.testing.expectEqual(@as(u16, 0), result.weak);
+    try std.testing.expectEqual(@as(u8, 0), result.effect_id);
+}
+
+test "uinput: pollFf drain with overwrite: STOP then PLAY returns PLAY" {
+    // Verifies the opposite overwrite direction.
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = UinputDevice{
+        .fd = pfds[0],
+        .button_codes = [_]u16{0} ** BUTTON_COUNT,
+    };
+    dev.ff_effects[3] = .{ .strong = 0xaaaa, .weak = 0xbbbb, .length_ms = 100 };
+
+    const stop = c.input_event{ .type = c.EV_FF, .code = 3, .value = 0, .time = std.mem.zeroes(c.timeval) };
+    const play = c.input_event{ .type = c.EV_FF, .code = 3, .value = 1, .time = std.mem.zeroes(c.timeval) };
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&stop));
+    _ = try std.posix.write(pfds[1], std.mem.asBytes(&play));
+
+    const result = (try dev.pollFf()).?;
+    try std.testing.expectEqual(@as(u16, 0xaaaa), result.strong);
+    try std.testing.expectEqual(@as(u16, 0xbbbb), result.weak);
+    try std.testing.expectEqual(@as(u8, 3), result.effect_id);
+    try std.testing.expectEqual(@as(u16, 100), result.duration_ms);
 }

--- a/src/log.zig
+++ b/src/log.zig
@@ -34,11 +34,17 @@ pub const InitOptions = struct {
 /// When toggling on, lazily opens the log file if not already open.
 pub fn setEnabled(on: bool) void {
     dump_enabled.store(on, .release);
-    // If enabling dump and file not open yet, open it now.
-    if (on and initialized and log_fd.load(.acquire) == -1) {
+    // If enabling dump and file not open yet, open it now. Take the mutex
+    // BEFORE re-checking log_fd so two concurrent enables can't both see
+    // -1, both proceed to openLogFile, and leak the first fd. Callers
+    // today are single-threaded (CLI, IPC handler, startup), but the lock
+    // is cheap and the alternative is a subtle fd leak.
+    if (on and initialized) {
         log_mutex.lock();
         defer log_mutex.unlock();
-        openLogFile();
+        if (log_fd.load(.acquire) == -1) {
+            openLogFile();
+        }
     }
 }
 
@@ -55,8 +61,16 @@ pub fn shouldWriteToFile(comptime level: std.log.Level) bool {
 }
 
 /// Set the maximum log file size in megabytes (for rotation).
+/// Clamps to [1, 1_048_576] MiB. The lower bound falls back to the 100 MiB
+/// default when the config value is <= 0. The upper bound (1 TiB) prevents
+/// u64 overflow in the subsequent `* 1024 * 1024` multiply; a request
+/// above it is silently clamped rather than panicking in ReleaseSafe or
+/// wrapping in ReleaseFast. No realistic rotation threshold needs more.
 pub fn setMaxLogSize(mb: i64) void {
-    const clamped: u64 = if (mb > 0) @intCast(mb) else 100;
+    const DEFAULT_MB: i64 = 100;
+    const MAX_MB: i64 = 1024 * 1024; // 1 TiB
+    const pick: i64 = if (mb <= 0) DEFAULT_MB else if (mb > MAX_MB) MAX_MB else mb;
+    const clamped: u64 = @intCast(pick);
     max_log_size = clamped * 1024 * 1024;
 }
 
@@ -128,7 +142,17 @@ fn openLogFile() void {
                     @memcpy(bak_buf[0..log_path_len], log_path);
                     @memcpy(bak_buf[log_path_len .. log_path_len + 2], ".1");
                     const bak_path = bak_buf[0 .. log_path_len + 2];
-                    std.fs.renameAbsolute(log_path, bak_path) catch {};
+                    std.fs.renameAbsolute(log_path, bak_path) catch |err| {
+                        // Rename failed (EXDEV across filesystems, ENOSPC,
+                        // SELinux relabel rejection). Surface the failure
+                        // to stderr so the oversize file isn't rotated
+                        // silently; we still fall through to reopen so the
+                        // daemon keeps logging err/warn rather than going
+                        // dark. The file will retry rotation on next open.
+                        var warn_buf: [256]u8 = undefined;
+                        const warn_msg = std.fmt.bufPrint(&warn_buf, "warning: padctl log rotate failed for {s}: {} — log will grow past max_log_size_mb until next restart\n", .{ log_path, err }) catch "warning: padctl log rotate failed\n";
+                        _ = posix.write(posix.STDERR_FILENO, warn_msg) catch {};
+                    };
                 }
             }
         } else |_| {}
@@ -184,6 +208,15 @@ pub fn logFn(
     comptime format: []const u8,
     args: anytype,
 ) void {
+    // Early exit: .debug lines are verbose scheduler / HID traces that
+    // should be silent unless dump is enabled. Without this short-circuit
+    // every std.log.debug call would format into a 4 KiB stack buffer,
+    // hit stderr, and pollute journalctl with per-frame lines on every
+    // install — contradicting the documented "no hot-path cost when
+    // disabled" contract. .info / .warn / .err always flow as normal.
+    const is_debug = comptime (message_level == .debug);
+    if (is_debug and !dump_enabled.load(.acquire)) return;
+
     const level_txt = comptime message_level.asText();
     const scope_prefix = comptime if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
 
@@ -281,6 +314,22 @@ test "log: setEnabled toggles state" {
 test "log: setMaxLogSize updates rotation threshold" {
     setMaxLogSize(50);
     try testing.expectEqual(@as(u64, 50 * 1024 * 1024), max_log_size);
+    setMaxLogSize(100);
+}
+
+test "log: setMaxLogSize clamps non-positive values to default" {
+    setMaxLogSize(0);
+    try testing.expectEqual(@as(u64, 100 * 1024 * 1024), max_log_size);
+    setMaxLogSize(-5);
+    try testing.expectEqual(@as(u64, 100 * 1024 * 1024), max_log_size);
+    setMaxLogSize(100);
+}
+
+test "log: setMaxLogSize clamps huge values to prevent overflow" {
+    // Without the upper clamp, mb * 1024 * 1024 overflows u64 well before
+    // std.math.maxInt(i64). Must clamp instead of panic in ReleaseSafe.
+    setMaxLogSize(std.math.maxInt(i64));
+    try testing.expectEqual(@as(u64, 1024 * 1024 * 1024 * 1024), max_log_size);
     setMaxLogSize(100);
 }
 

--- a/src/log.zig
+++ b/src/log.zig
@@ -1,0 +1,329 @@
+const std = @import("std");
+const posix = std.posix;
+const linux = std.os.linux;
+const Allocator = std.mem.Allocator;
+const paths = @import("config/paths.zig");
+
+/// File descriptor for the log file. -1 when file logging is inactive.
+var log_fd: std.atomic.Value(posix.fd_t) = std.atomic.Value(posix.fd_t).init(-1);
+
+/// Serializes concurrent file writes across device threads.
+var log_mutex: std.Thread.Mutex = .{};
+
+/// Stored log file path for reopening after deletion or lazy open.
+var log_path_buf: [256]u8 = undefined;
+var log_path_len: usize = 0;
+
+/// Whether init() resolved a valid log path (even if file isn't open yet).
+var initialized: bool = false;
+
+/// When false (default), only error/warning lines reach the log file.
+/// Debug/info lines are suppressed. Toggled via `padctl dump enable/disable`.
+var dump_enabled: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+
+/// Maximum log file size before rotation.
+/// Default 100 MiB; overridden by `[diagnostics] max_log_size_mb` in config.
+var max_log_size: u64 = 100 * 1024 * 1024;
+
+pub const InitOptions = struct {
+    dump: bool = false,
+    max_log_size_mb: i64 = 100,
+};
+
+/// Enable or disable debug-level file logging at runtime.
+/// When toggling on, lazily opens the log file if not already open.
+pub fn setEnabled(on: bool) void {
+    dump_enabled.store(on, .release);
+    // If enabling dump and file not open yet, open it now.
+    if (on and initialized and log_fd.load(.acquire) == -1) {
+        log_mutex.lock();
+        defer log_mutex.unlock();
+        openLogFile();
+    }
+}
+
+/// Returns true when debug-level file logging is active.
+pub fn isEnabled() bool {
+    return dump_enabled.load(.acquire);
+}
+
+/// Returns true when a message at the given level should be written to the
+/// log file. Used by logFn; exposed for testability.
+pub fn shouldWriteToFile(comptime level: std.log.Level) bool {
+    const always = comptime (level == .err or level == .warn);
+    return always or dump_enabled.load(.acquire);
+}
+
+/// Set the maximum log file size in megabytes (for rotation).
+pub fn setMaxLogSize(mb: i64) void {
+    const clamped: u64 = if (mb > 0) @intCast(mb) else 100;
+    max_log_size = clamped * 1024 * 1024;
+}
+
+/// Step 1: Resolve the log directory and store the path. Call this BEFORE
+/// loading config so that early warnings (e.g. malformed config.toml) can
+/// persist to the log file via lazy open in logFn. No file is opened yet.
+pub fn initPath(allocator: Allocator) void {
+    const dir_path = paths.stateDir(allocator) catch return;
+    defer allocator.free(dir_path);
+
+    // Ensure the directory tree exists.
+    std.fs.makeDirAbsolute(dir_path) catch |e| switch (e) {
+        error.PathAlreadyExists => {},
+        else => {
+            if (std.mem.lastIndexOfScalar(u8, dir_path, '/')) |sep| {
+                std.fs.makeDirAbsolute(dir_path[0..sep]) catch {};
+                std.fs.makeDirAbsolute(dir_path) catch return;
+            } else return;
+        },
+    };
+
+    // Store the resolved log path for lazy open and reopen-after-delete.
+    const log_path = std.fmt.allocPrint(allocator, "{s}/padctl.log", .{dir_path}) catch return;
+    defer allocator.free(log_path);
+    if (log_path.len <= log_path_buf.len) {
+        @memcpy(log_path_buf[0..log_path.len], log_path);
+        log_path_len = log_path.len;
+        initialized = true;
+    }
+}
+
+/// Step 2: Apply diagnostics config and optionally open the log file.
+/// Call this AFTER loading config. If dump is enabled, the file opens
+/// immediately. Otherwise it stays lazy (opened on first err/warn).
+pub fn applyConfig(opts: InitOptions) void {
+    setMaxLogSize(opts.max_log_size_mb);
+    dump_enabled.store(opts.dump, .release);
+
+    if (opts.dump and initialized and log_fd.load(.acquire) == -1) {
+        openLogFile();
+        if (log_path_len > 0) {
+            var confirm_buf: [256]u8 = undefined;
+            const confirm = std.fmt.bufPrint(&confirm_buf, "info: file logging active (dump=on): {s}\n", .{log_path_buf[0..log_path_len]}) catch return;
+            _ = posix.write(posix.STDERR_FILENO, confirm) catch {};
+        }
+    }
+}
+
+/// Convenience: initPath + applyConfig in one call.
+pub fn init(allocator: Allocator, opts: InitOptions) void {
+    initPath(allocator);
+    applyConfig(opts);
+}
+
+/// Open (or rotate + open) the log file. Must be called under log_mutex
+/// or during single-threaded init.
+fn openLogFile() void {
+    if (log_path_len == 0) return;
+    const log_path = log_path_buf[0..log_path_len];
+
+    // Rotate if the log file exceeds the size threshold.
+    if (std.fs.openFileAbsolute(log_path, .{})) |f| {
+        defer f.close();
+        if (f.stat()) |st| {
+            if (st.size > max_log_size) {
+                // Build backup path from log_path by appending ".1"
+                var bak_buf: [260]u8 = undefined;
+                if (log_path_len + 2 <= bak_buf.len) {
+                    @memcpy(bak_buf[0..log_path_len], log_path);
+                    @memcpy(bak_buf[log_path_len .. log_path_len + 2], ".1");
+                    const bak_path = bak_buf[0 .. log_path_len + 2];
+                    std.fs.renameAbsolute(log_path, bak_path) catch {};
+                }
+            }
+        } else |_| {}
+    } else |_| {}
+
+    const fd = posix.open(log_path, .{ .ACCMODE = .WRONLY, .CREAT = true, .APPEND = true }, 0o644) catch return;
+    log_fd.store(fd, .release);
+}
+
+/// Close the log file.
+pub fn deinit() void {
+    const fd = log_fd.swap(-1, .acq_rel);
+    if (fd != -1) posix.close(fd);
+    initialized = false;
+}
+
+/// Check if the log file was deleted (nlink == 0 on the open fd).
+/// If so, close the old fd, recreate the file, and update the global fd.
+/// Must be called under log_mutex. Returns the (possibly new) fd.
+fn reopenIfDeleted(fd: posix.fd_t) posix.fd_t {
+    if (log_path_len == 0) return fd;
+    const st = posix.fstat(fd) catch return fd;
+    if (st.nlink > 0) return fd;
+    posix.close(fd);
+    const path = log_path_buf[0..log_path_len];
+    if (std.mem.lastIndexOfScalar(u8, path, '/')) |sep| {
+        std.fs.makeDirAbsolute(path[0..sep]) catch {};
+    }
+    const new_fd = posix.open(path, .{ .ACCMODE = .WRONLY, .CREAT = true, .APPEND = true }, 0o644) catch {
+        log_fd.store(-1, .release);
+        return -1;
+    };
+    log_fd.store(new_fd, .release);
+    return new_fd;
+}
+
+/// Lazily open the log file on the first persistent write (err/warn).
+/// Must be called under log_mutex.
+fn ensureFileOpen() posix.fd_t {
+    var fd = log_fd.load(.acquire);
+    if (fd != -1) return fd;
+    if (!initialized) return -1;
+    openLogFile();
+    fd = log_fd.load(.acquire);
+    return fd;
+}
+
+/// Custom log function: tees to stderr (for journal) and the log file.
+/// Format: [YYYY-MM-DDTHH:MM:SS.mmm] [MONO:nnnnnnn] [level] (scope): message
+pub fn logFn(
+    comptime message_level: std.log.Level,
+    comptime scope: @Type(.enum_literal),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    const level_txt = comptime message_level.asText();
+    const scope_prefix = comptime if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
+
+    // Format wall-clock timestamp.
+    var ts_buf: [32]u8 = undefined;
+    const ts_str = wallClockTimestamp(&ts_buf);
+
+    // Monotonic nanoseconds for scheduler correlation.
+    const mono_ns = monotonicNs();
+
+    // Format into a stack buffer large enough for any log line.
+    var buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const w = fbs.writer();
+    nosuspend w.print("[{s}] [MONO:{d}] " ++ level_txt ++ scope_prefix ++ format ++ "\n", .{ ts_str, mono_ns } ++ args) catch {
+        @memcpy(buf[buf.len - 4 ..], "...\n");
+        fbs.pos = buf.len;
+    };
+    const msg = fbs.getWritten();
+    if (msg.len == 0) return;
+
+    // Write to stderr (for systemd journal / terminal).
+    _ = posix.write(posix.STDERR_FILENO, msg) catch {};
+
+    // Write to log file: err/warn always persist; debug/info only when dump enabled.
+    const always_write = comptime (message_level == .err or message_level == .warn);
+    const write_to_file = shouldWriteToFile(message_level);
+    if (write_to_file) {
+        log_mutex.lock();
+        defer log_mutex.unlock();
+
+        var fd = log_fd.load(.acquire);
+        if (fd == -1 and always_write) {
+            // Lazy open: first err/warn creates the file even with dump off.
+            fd = ensureFileOpen();
+        }
+        if (fd != -1) {
+            fd = reopenIfDeleted(fd);
+            _ = posix.write(fd, msg) catch {};
+        }
+    }
+}
+
+/// Format a wall-clock timestamp as "YYYY-MM-DDTHH:MM:SS.mmm".
+fn wallClockTimestamp(buf: *[32]u8) []const u8 {
+    var ts: linux.timespec = undefined;
+    const rc = linux.clock_gettime(.REALTIME, &ts);
+    if (rc != 0) return "????-??-??T??:??:??.???";
+
+    const epoch_secs: u64 = @intCast(ts.sec);
+    const millis: u64 = @intCast(@divTrunc(ts.nsec, std.time.ns_per_ms));
+
+    const es = std.time.epoch.EpochSeconds{ .secs = epoch_secs };
+    const day = es.getEpochDay();
+    const yd = day.calculateYearDay();
+    const md = yd.calculateMonthDay();
+    const ds = es.getDaySeconds();
+
+    const result = std.fmt.bufPrint(buf, "{d:0>4}-{d:0>2}-{d:0>2}T{d:0>2}:{d:0>2}:{d:0>2}.{d:0>3}", .{
+        yd.year,
+        @as(u32, @intFromEnum(md.month)) + 1,
+        @as(u32, md.day_index) + 1,
+        ds.getHoursIntoDay(),
+        ds.getMinutesIntoHour(),
+        ds.getSecondsIntoMinute(),
+        millis,
+    }) catch return "????-??-??T??:??:??.???";
+    return result;
+}
+
+/// Returns the current CLOCK_MONOTONIC time in nanoseconds.
+fn monotonicNs() i128 {
+    var ts: linux.timespec = undefined;
+    const rc = linux.clock_gettime(.MONOTONIC, &ts);
+    if (rc != 0) return 0;
+    return @as(i128, ts.sec) * std.time.ns_per_s + ts.nsec;
+}
+
+// --- tests ---
+
+const testing = std.testing;
+
+test "log: dump disabled by default" {
+    try testing.expect(!isEnabled());
+}
+
+test "log: setEnabled toggles state" {
+    try testing.expect(!isEnabled());
+    setEnabled(true);
+    try testing.expect(isEnabled());
+    setEnabled(false);
+    try testing.expect(!isEnabled());
+}
+
+test "log: setMaxLogSize updates rotation threshold" {
+    setMaxLogSize(50);
+    try testing.expectEqual(@as(u64, 50 * 1024 * 1024), max_log_size);
+    setMaxLogSize(100);
+}
+
+test "log: shouldWriteToFile: debug suppressed when dump off" {
+    setEnabled(false);
+    try testing.expect(!shouldWriteToFile(.debug));
+    try testing.expect(!shouldWriteToFile(.info));
+}
+
+test "log: shouldWriteToFile: debug passes when dump on" {
+    setEnabled(true);
+    try testing.expect(shouldWriteToFile(.debug));
+    try testing.expect(shouldWriteToFile(.info));
+    setEnabled(false);
+}
+
+test "log: shouldWriteToFile: err and warn always pass regardless of dump" {
+    setEnabled(false);
+    try testing.expect(shouldWriteToFile(.err));
+    try testing.expect(shouldWriteToFile(.warn));
+    setEnabled(true);
+    try testing.expect(shouldWriteToFile(.err));
+    try testing.expect(shouldWriteToFile(.warn));
+    setEnabled(false);
+}
+
+test "log: setEnabled is atomic under concurrent access" {
+    // Spawn two threads that toggle rapidly; verify no crash.
+    const Thread = std.Thread;
+    const toggle_fn = struct {
+        fn run(_: void) void {
+            var i: usize = 0;
+            while (i < 1000) : (i += 1) {
+                setEnabled(i % 2 == 0);
+                _ = isEnabled();
+                _ = shouldWriteToFile(.debug);
+            }
+        }
+    }.run;
+    const t1 = try Thread.spawn(.{}, toggle_fn, .{{}});
+    const t2 = try Thread.spawn(.{}, toggle_fn, .{{}});
+    t1.join();
+    t2.join();
+    setEnabled(false);
+    // If we got here without crash, atomicity is sufficient.
+}

--- a/src/log.zig
+++ b/src/log.zig
@@ -74,6 +74,29 @@ pub fn setMaxLogSize(mb: i64) void {
     max_log_size = clamped * 1024 * 1024;
 }
 
+/// Create `path` and any missing ancestor directories. Walks up collecting
+/// absolute path prefixes, then creates them bottom-up. Mirrors the
+/// `ensureDirAll` helper in `src/cli/install.zig`. Returns successfully
+/// when the directory exists after the call, regardless of whether it
+/// was pre-existing.
+fn ensureDirRecursive(path: []const u8) !void {
+    // Shortest path first: try the leaf directly.
+    std.fs.makeDirAbsolute(path) catch |e| switch (e) {
+        error.PathAlreadyExists => return,
+        error.FileNotFound => {
+            // Parent missing — recurse on parent, then retry self.
+            const sep = std.mem.lastIndexOfScalar(u8, path, '/') orelse return error.FileNotFound;
+            if (sep == 0) return error.FileNotFound; // reached root
+            try ensureDirRecursive(path[0..sep]);
+            std.fs.makeDirAbsolute(path) catch |e2| switch (e2) {
+                error.PathAlreadyExists => return,
+                else => return e2,
+            };
+        },
+        else => return e,
+    };
+}
+
 /// Step 1: Resolve the log directory and store the path. Call this BEFORE
 /// loading config so that early warnings (e.g. malformed config.toml) can
 /// persist to the log file via lazy open in logFn. No file is opened yet.
@@ -81,16 +104,11 @@ pub fn initPath(allocator: Allocator) void {
     const dir_path = paths.stateDir(allocator) catch return;
     defer allocator.free(dir_path);
 
-    // Ensure the directory tree exists.
-    std.fs.makeDirAbsolute(dir_path) catch |e| switch (e) {
-        error.PathAlreadyExists => {},
-        else => {
-            if (std.mem.lastIndexOfScalar(u8, dir_path, '/')) |sep| {
-                std.fs.makeDirAbsolute(dir_path[0..sep]) catch {};
-                std.fs.makeDirAbsolute(dir_path) catch return;
-            } else return;
-        },
-    };
+    // Recursive mkdir -p so a fresh user profile where several parent
+    // levels don't exist (e.g. ~/.local and ~/.local/state both missing)
+    // still gets a log dir. The previous single-parent fallback bailed
+    // out after one level and silently left dump logging uninitialised.
+    ensureDirRecursive(dir_path) catch return;
 
     // Store the resolved log path for lazy open and reopen-after-delete.
     const log_path = std.fmt.allocPrint(allocator, "{s}/padctl.log", .{dir_path}) catch return;
@@ -105,7 +123,17 @@ pub fn initPath(allocator: Allocator) void {
 /// Step 2: Apply diagnostics config and optionally open the log file.
 /// Call this AFTER loading config. If dump is enabled, the file opens
 /// immediately. Otherwise it stays lazy (opened on first err/warn).
+///
+/// Today this is called exactly once at startup (`main.zig`), before any
+/// device threads are spawned, so the mutex is precautionary — it
+/// future-proofs the function against a reload-path caller (SIGHUP, IPC)
+/// that would otherwise race with live log writes for `log_fd`. NOTE:
+/// `setMaxLogSize` must stay mutex-free so we don't deadlock on the
+/// non-reentrant mutex here.
 pub fn applyConfig(opts: InitOptions) void {
+    log_mutex.lock();
+    defer log_mutex.unlock();
+
     setMaxLogSize(opts.max_log_size_mb);
     dump_enabled.store(opts.dump, .release);
 
@@ -256,6 +284,20 @@ pub fn logFn(
         if (fd != -1) {
             fd = reopenIfDeleted(fd);
             _ = posix.write(fd, msg) catch {};
+            // Post-write rotation. openLogFile only rotates at fresh
+            // open (startup / lazy open), so without this check a long
+            // dump session grows past max_log_size_mb until the daemon
+            // restarts — at ~100 FF frames/s a default 100 MiB cap is
+            // blown through in under two hours. Stat the live fd; when
+            // it crosses the threshold, close + reopen, which walks
+            // through openLogFile's rotate-rename path.
+            if (posix.fstat(fd)) |st| {
+                if (st.size > max_log_size) {
+                    const old_fd = log_fd.swap(-1, .acq_rel);
+                    if (old_fd != -1) posix.close(old_fd);
+                    openLogFile();
+                }
+            } else |_| {}
         }
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -670,13 +670,42 @@ pub fn main() !void {
             }
         } else |_| {}
 
-        if (cli.dump.writeDiagnosticsConfig(allocator, cfgpaths.systemConfigDir(), enable)) {
-            config_written = true;
-        } else |err| {
-            if (err == error.MalformedConfig) {
-                stderr_writer.writeAll("error: system config.toml is malformed — fix or remove it\n") catch {};
-            } else {
-                std.log.warn("could not write system config: {}", .{err});
+        // System config: write to a temp file, then sudo cp to /etc/padctl/.
+        // Direct write fails without root (AccessDenied).
+        const sys_dir = cfgpaths.systemConfigDir();
+        if (std.os.linux.getuid() == 0) {
+            // Already root — write directly.
+            if (cli.dump.writeDiagnosticsConfig(allocator, sys_dir, enable)) {
+                config_written = true;
+            } else |err| {
+                if (err == error.MalformedConfig) {
+                    stderr_writer.writeAll("error: system config.toml is malformed — fix or remove it\n") catch {};
+                } else {
+                    std.log.warn("could not write system config: {}", .{err});
+                }
+            }
+        } else {
+            // Non-root: write to temp dir, sudo cp to system path.
+            const tmp_dir = "/tmp/padctl-dump-config";
+            if (cli.dump.writeDiagnosticsConfig(allocator, tmp_dir, enable)) {
+                const tmp_src = tmp_dir ++ "/config.toml";
+                const sys_dst_buf = std.fmt.allocPrint(allocator, "{s}/config.toml", .{sys_dir}) catch null;
+                defer if (sys_dst_buf) |b| allocator.free(b);
+                if (sys_dst_buf) |sys_dst| {
+                    if (runSudoMkdir(sys_dir, stderr_writer)) {
+                        if (runSudoCopy(tmp_src, sys_dst, stderr_writer)) {
+                            config_written = true;
+                        }
+                    }
+                }
+                std.fs.deleteFileAbsolute(tmp_src) catch {};
+                std.fs.deleteTreeAbsolute(tmp_dir) catch {};
+            } else |err| {
+                if (err == error.MalformedConfig) {
+                    stderr_writer.writeAll("error: system config.toml is malformed — fix or remove it\n") catch {};
+                } else {
+                    std.log.warn("could not write system config: {}", .{err});
+                }
             }
         }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -392,8 +392,12 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                 dump_argc += 1;
             }
             const result = parseDumpFromSlice(dump_args[0..dump_argc]) catch |err| switch (err) {
-                error.MissingArgValue => {
+                error.MissingSubcommand => {
                     std.log.err("dump requires a subcommand: enable, disable, status, export, clear", .{});
+                    return error.MissingArgValue;
+                },
+                error.MissingArgValue => {
+                    std.log.err("dump: missing value for option (expected an argument after --period, --socket, or -o)", .{});
                     return error.MissingArgValue;
                 },
                 error.UnknownArgument => {
@@ -1320,7 +1324,9 @@ pub fn parseDumpFromSlice(args: []const []const u8) !struct {
     socket_path: ?[]const u8 = null,
 } {
     var result: @TypeOf(parseDumpFromSlice(args) catch unreachable) = .{};
-    if (args.len == 0) return error.MissingArgValue;
+    // Distinct errors so the caller can produce accurate messages: missing
+    // the `dump <sub>` token is not the same as a trailing flag with no value.
+    if (args.len == 0) return error.MissingSubcommand;
     const sub = args[0];
     if (std.mem.eql(u8, sub, "enable")) {
         result.cmd = .enable;
@@ -1396,7 +1402,19 @@ test "main: parseDumpFromSlice: clear" {
 }
 
 test "main: parseDumpFromSlice: missing subcommand" {
-    try testing.expectError(error.MissingArgValue, parseDumpFromSlice(&.{}));
+    try testing.expectError(error.MissingSubcommand, parseDumpFromSlice(&.{}));
+}
+
+test "main: parseDumpFromSlice: missing value for --period" {
+    try testing.expectError(error.MissingArgValue, parseDumpFromSlice(&.{ "export", "--period" }));
+}
+
+test "main: parseDumpFromSlice: missing value for -o" {
+    try testing.expectError(error.MissingArgValue, parseDumpFromSlice(&.{ "export", "-o" }));
+}
+
+test "main: parseDumpFromSlice: missing value for --socket" {
+    try testing.expectError(error.MissingArgValue, parseDumpFromSlice(&.{ "status", "--socket" }));
 }
 
 test "main: parseDumpFromSlice: unknown subcommand" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -708,6 +708,24 @@ pub fn main() !void {
                     std.fs.deleteTreeAbsolute(tmp_dir) catch {};
                     allocator.free(tmp_dir);
                 }
+                // Seed tmp_dir with the existing system config (if any)
+                // BEFORE writeDiagnosticsConfig runs. writeDiagnosticsConfig
+                // reads {dir}/config.toml to preserve [[device]] entries;
+                // without the seed it would write a [diagnostics]-only file
+                // to tmp_dir, and the sudo cp below would erase any bindings
+                // in /etc/padctl/config.toml. /etc/padctl/config.toml is
+                // typically world-readable (mode 0644) so no sudo is
+                // required to read it; best-effort silent-skip when the
+                // file is absent or unreadable.
+                {
+                    const sys_src = std.fmt.allocPrint(allocator, "{s}/config.toml", .{sys_dir}) catch null;
+                    defer if (sys_src) |p| allocator.free(p);
+                    const tmp_seed = std.fmt.allocPrint(allocator, "{s}/config.toml", .{tmp_dir}) catch null;
+                    defer if (tmp_seed) |p| allocator.free(p);
+                    if (sys_src != null and tmp_seed != null) {
+                        copyFileBestEffort(sys_src.?, tmp_seed.?) catch {};
+                    }
+                }
                 if (cli.dump.writeDiagnosticsConfig(allocator, tmp_dir, enable)) {
                     const tmp_src = std.fmt.allocPrint(allocator, "{s}/config.toml", .{tmp_dir}) catch null;
                     defer if (tmp_src) |s| allocator.free(s);
@@ -1148,6 +1166,23 @@ fn persistToSystemConfig(allocator: std.mem.Allocator, mapping_name: []const u8,
         err_writer.writeAll("Persistence incomplete — check the errors above.\n") catch {};
     }
     return ok;
+}
+
+/// Copy `src` to `dst` without invoking sudo. Returns FileNotFound when
+/// `src` is absent; other errors propagate. Used to seed a user-owned
+/// temp dir with the current system config before calling
+/// writeDiagnosticsConfig so device bindings survive the round-trip.
+fn copyFileBestEffort(src: []const u8, dst: []const u8) !void {
+    var sf = try std.fs.openFileAbsolute(src, .{});
+    defer sf.close();
+    var df = try std.fs.createFileAbsolute(dst, .{ .truncate = true });
+    defer df.close();
+    var buf: [8192]u8 = undefined;
+    while (true) {
+        const n = try sf.read(&buf);
+        if (n == 0) break;
+        try df.writeAll(buf[0..n]);
+    }
 }
 
 fn runSudoCopy(src: []const u8, dst: []const u8, err_writer: anytype) bool {

--- a/src/main.zig
+++ b/src/main.zig
@@ -427,6 +427,7 @@ fn printHelp() void {
         \\       padctl switch <name> [--device <id>] [--socket <path>]
         \\       padctl status [--socket <path>]
         \\       padctl devices [--socket <path>]
+        \\       padctl dump <enable|disable|status|export|clear>
         \\
         \\Subcommands:
         \\  install               Install binary, service, udev rules, and device configs
@@ -458,6 +459,13 @@ fn printHelp() void {
         \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
         \\  devices               List connected devices via daemon
         \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
+        \\  dump enable           Turn on diagnostic logging (persists across reboots)
+        \\  dump disable          Turn off diagnostic logging (default)
+        \\  dump status           Show dump state, log path, size, and time span
+        \\  dump export           Export filtered logs to stdout or file
+        \\    --period <duration> Time window: Nm, Nh, or Nd (default: 1d)
+        \\    -o <path>           Write to file instead of stdout
+        \\  dump clear            Delete all log files (interactive confirmation)
         \\  config list           List XDG-layer device and mapping configs
         \\  config init           Interactively create a mapping in ~/.config/padctl/mappings/
         \\    --device <name>     Skip device selection prompt

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,10 @@
 const std = @import("std");
+const padctl_log = @import("log.zig");
+
+pub const std_options: std.Options = .{
+    .log_level = .debug,
+    .logFn = padctl_log.logFn,
+};
 
 fn stdoutWrite(_: void, data: []const u8) error{}!usize {
     return std.posix.write(std.posix.STDOUT_FILENO, data) catch data.len;
@@ -24,6 +30,7 @@ pub const cli = struct {
     pub const switch_mapping = @import("cli/switch_mapping.zig");
     pub const status = @import("cli/status.zig");
     pub const devices = @import("cli/devices.zig");
+    pub const dump = @import("cli/dump.zig");
     pub const config = struct {
         pub const list = @import("cli/config/list.zig");
         pub const init = @import("cli/config/init.zig");
@@ -129,6 +136,8 @@ const Interpreter = core.interpreter.Interpreter;
 const DeviceIO = io.device_io.DeviceIO;
 const VERSION = "0.1.0";
 
+pub const DumpAction = enum { enable, disable, status, @"export", clear };
+
 const Cli = struct {
     allocator: std.mem.Allocator,
     config_path: ?[]const u8 = null,
@@ -151,6 +160,9 @@ const Cli = struct {
     switch_cmd: ?struct { name: ?[]const u8 = null, device_id: ?[]const u8 = null, persist: bool = false } = null,
     status_cmd: bool = false,
     devices_cmd: bool = false,
+    dump_cmd: ?DumpAction = null,
+    dump_period: []const u8 = "1d",
+    dump_output_path: ?[]const u8 = null,
     socket_path: []const u8 = cli.socket_client.DEFAULT_SOCKET_PATH,
     socket_explicit: bool = false,
 
@@ -366,6 +378,35 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                     std.log.err("unknown devices argument: {s}", .{sub_arg});
                     return error.UnknownArgument;
                 }
+            }
+        } else if (std.mem.eql(u8, arg, "dump")) {
+            // Collect remaining args into a small buffer for parseDumpFromSlice.
+            var dump_args: [16][]const u8 = undefined;
+            var dump_argc: usize = 0;
+            while (args.next()) |da| {
+                if (dump_argc >= dump_args.len) {
+                    std.log.err("too many dump arguments", .{});
+                    return error.UnknownArgument;
+                }
+                dump_args[dump_argc] = da;
+                dump_argc += 1;
+            }
+            const result = parseDumpFromSlice(dump_args[0..dump_argc]) catch |err| switch (err) {
+                error.MissingArgValue => {
+                    std.log.err("dump requires a subcommand: enable, disable, status, export, clear", .{});
+                    return error.MissingArgValue;
+                },
+                error.UnknownArgument => {
+                    std.log.err("unknown dump argument", .{});
+                    return error.UnknownArgument;
+                },
+            };
+            parsed_cli.dump_cmd = result.cmd;
+            parsed_cli.dump_period = result.period;
+            parsed_cli.dump_output_path = result.output_path;
+            if (result.socket_path) |sp| {
+                parsed_cli.socket_path = sp;
+                parsed_cli.socket_explicit = true;
             }
         } else {
             std.log.err("unknown argument: {s}", .{arg});
@@ -583,6 +624,79 @@ pub fn main() !void {
         std.process.exit(0);
     }
 
+    // dump subcommand
+    if (parsed.dump_cmd) |dump_action| {
+        // dump status: show state + log stats, exit.
+        if (dump_action == .status) {
+            cli.dump.runStatus(allocator, parsed.socket_path, stdout_writer, stderr_writer);
+            std.process.exit(0);
+        }
+
+        // dump clear: show stats, prompt, delete.
+        if (dump_action == .clear) {
+            cli.dump.runClear(allocator, stdout_writer, stderr_writer);
+            std.process.exit(0);
+        }
+
+        // dump export: filter and output logs, exit.
+        if (dump_action == .@"export") {
+            cli.dump.runExport(allocator, parsed.dump_period, parsed.dump_output_path, stdout_writer, stderr_writer);
+            std.process.exit(0);
+        }
+
+        const enable = dump_action == .enable;
+        var config_written = false;
+
+        // Write to both user and system config (best-effort for each).
+        const cfgpaths = config.paths;
+        if (cfgpaths.userConfigDir(allocator)) |user_dir| {
+            defer allocator.free(user_dir);
+            if (cli.dump.writeDiagnosticsConfig(allocator, user_dir, enable)) {
+                config_written = true;
+            } else |err| {
+                if (err == error.MalformedConfig) {
+                    stderr_writer.writeAll("error: user config.toml is malformed — fix or remove it\n") catch {};
+                } else {
+                    std.log.warn("could not write user config: {}", .{err});
+                }
+            }
+        } else |_| {}
+
+        if (cli.dump.writeDiagnosticsConfig(allocator, cfgpaths.systemConfigDir(), enable)) {
+            config_written = true;
+        } else |err| {
+            if (err == error.MalformedConfig) {
+                stderr_writer.writeAll("error: system config.toml is malformed — fix or remove it\n") catch {};
+            } else {
+                std.log.warn("could not write system config: {}", .{err});
+            }
+        }
+
+        // Send IPC to running daemon (best-effort).
+        var ipc_ok = false;
+        const ipc_cmd: []const u8 = if (enable) "DUMP ON\n" else "DUMP OFF\n";
+        if (cli.socket_client.connectToSocket(parsed.socket_path)) |sock_fd| {
+            defer std.posix.close(sock_fd);
+            var resp_buf: [64]u8 = undefined;
+            if (cli.socket_client.sendCommand(sock_fd, ipc_cmd, &resp_buf)) |resp| {
+                _ = stdout_writer.write(resp) catch {};
+                ipc_ok = true;
+            } else |_| {
+                stderr_writer.writeAll("warning: daemon did not respond\n") catch {};
+            }
+        } else |_| {
+            if (config_written) {
+                stderr_writer.writeAll("info: daemon not running; config written, will apply on next start\n") catch {};
+            }
+        }
+
+        if (!config_written and !ipc_ok) {
+            stderr_writer.writeAll("error: could not persist or apply dump setting\n") catch {};
+            std.process.exit(1);
+        }
+        std.process.exit(0);
+    }
+
     // switch subcommand
     if (parsed.switch_cmd) |sw| {
         // Resolve the mapping name: either explicit or from user config.
@@ -712,6 +826,31 @@ pub fn main() !void {
         };
         std.process.exit(0);
     }
+
+    // Daemon mode logging: two-step init.
+    // Step 1: resolve the log path so that early warnings (e.g. malformed
+    // config.toml) can persist to the log file via lazy open in logFn.
+    padctl_log.initPath(allocator);
+    defer padctl_log.deinit();
+
+    // Step 2: load diagnostics config. Warnings during load now persist.
+    const log_opts: padctl_log.InitOptions = blk: {
+        const user_cfg_mod = @import("config/user_config.zig");
+        if (user_cfg_mod.load(allocator)) |pr| {
+            var ucpr = pr;
+            defer ucpr.deinit();
+            break :blk .{
+                .dump = ucpr.value.diagnostics.dump,
+                .max_log_size_mb = ucpr.value.diagnostics.max_log_size_mb,
+            };
+        }
+        break :blk .{};
+    };
+
+    // Step 3: apply config — sets rotation size, dump toggle, opens file if dump on.
+    padctl_log.applyConfig(log_opts);
+
+    std.log.info("padctl started, PID={d}, dump={}", .{ std.os.linux.getpid(), padctl_log.isEnabled() });
 
     // --config-dir mode: glob *.toml, discover all devices, dedup by physical path, hot-reload on SIGHUP
     if (parsed.config_dir) |dir_path| {
@@ -1087,9 +1226,97 @@ fn parseDeviceFromStatus(resp: []const u8) ?[]const u8 {
     return null;
 }
 
+/// Parse dump subcommand and options from an argument slice. Testable
+/// variant of the inline dump-parsing block in parseArgs.
+pub fn parseDumpFromSlice(args: []const []const u8) !struct {
+    cmd: ?DumpAction = null,
+    period: []const u8 = "1d",
+    output_path: ?[]const u8 = null,
+    socket_path: ?[]const u8 = null,
+} {
+    var result: @TypeOf(parseDumpFromSlice(args) catch unreachable) = .{};
+    if (args.len == 0) return error.MissingArgValue;
+    const sub = args[0];
+    if (std.mem.eql(u8, sub, "enable")) {
+        result.cmd = .enable;
+    } else if (std.mem.eql(u8, sub, "disable")) {
+        result.cmd = .disable;
+    } else if (std.mem.eql(u8, sub, "status")) {
+        result.cmd = .status;
+    } else if (std.mem.eql(u8, sub, "export")) {
+        result.cmd = .@"export";
+    } else if (std.mem.eql(u8, sub, "clear")) {
+        result.cmd = .clear;
+    } else {
+        return error.UnknownArgument;
+    }
+    var i: usize = 1;
+    while (i < args.len) : (i += 1) {
+        if (std.mem.eql(u8, args[i], "--period")) {
+            i += 1;
+            if (i >= args.len) return error.MissingArgValue;
+            result.period = args[i];
+        } else if (std.mem.eql(u8, args[i], "-o")) {
+            i += 1;
+            if (i >= args.len) return error.MissingArgValue;
+            result.output_path = args[i];
+        } else if (std.mem.eql(u8, args[i], "--socket")) {
+            i += 1;
+            if (i >= args.len) return error.MissingArgValue;
+            result.socket_path = args[i];
+        } else {
+            return error.UnknownArgument;
+        }
+    }
+    return result;
+}
+
 // --- CLI tests ---
 
 const testing = std.testing;
+
+test "main: parseDumpFromSlice: enable" {
+    const r = try parseDumpFromSlice(&.{"enable"});
+    try testing.expectEqual(@as(@TypeOf(r.cmd), .enable), r.cmd);
+    try testing.expectEqualStrings("1d", r.period);
+    try testing.expectEqual(@as(?[]const u8, null), r.output_path);
+}
+
+test "main: parseDumpFromSlice: disable" {
+    const r = try parseDumpFromSlice(&.{"disable"});
+    try testing.expectEqual(@as(@TypeOf(r.cmd), .disable), r.cmd);
+}
+
+test "main: parseDumpFromSlice: status" {
+    const r = try parseDumpFromSlice(&.{"status"});
+    try testing.expectEqual(@as(@TypeOf(r.cmd), .status), r.cmd);
+}
+
+test "main: parseDumpFromSlice: export with period and output" {
+    const r = try parseDumpFromSlice(&.{ "export", "--period", "2h", "-o", "/tmp/out.log" });
+    try testing.expectEqual(@as(@TypeOf(r.cmd), .@"export"), r.cmd);
+    try testing.expectEqualStrings("2h", r.period);
+    try testing.expectEqualStrings("/tmp/out.log", r.output_path.?);
+}
+
+test "main: parseDumpFromSlice: export default period" {
+    const r = try parseDumpFromSlice(&.{"export"});
+    try testing.expectEqual(@as(@TypeOf(r.cmd), .@"export"), r.cmd);
+    try testing.expectEqualStrings("1d", r.period);
+}
+
+test "main: parseDumpFromSlice: clear" {
+    const r = try parseDumpFromSlice(&.{"clear"});
+    try testing.expectEqual(@as(@TypeOf(r.cmd), .clear), r.cmd);
+}
+
+test "main: parseDumpFromSlice: missing subcommand" {
+    try testing.expectError(error.MissingArgValue, parseDumpFromSlice(&.{}));
+}
+
+test "main: parseDumpFromSlice: unknown subcommand" {
+    try testing.expectError(error.UnknownArgument, parseDumpFromSlice(&.{"foobar"}));
+}
 
 test "main: parseDeviceFromStatus extracts device name" {
     const resp = "STATUS device=Flydigi Vader 5 Pro active=true\n";

--- a/src/main.zig
+++ b/src/main.zig
@@ -654,8 +654,13 @@ pub fn main() !void {
 
         const enable = dump_action == .enable;
         var config_written = false;
+        // Malformed user config blocks the persistence chain: user_config.load()
+        // refuses to fall through to the system config when the user file is
+        // broken, so writing only the system file would not actually take effect
+        // on the next daemon restart. Track this and refuse to claim persistence.
+        var user_config_blocks_fallback = false;
 
-        // Write to both user and system config (best-effort for each).
+        // Write to user config first (no sudo needed).
         const cfgpaths = config.paths;
         if (cfgpaths.userConfigDir(allocator)) |user_dir| {
             defer allocator.free(user_dir);
@@ -663,7 +668,8 @@ pub fn main() !void {
                 config_written = true;
             } else |err| {
                 if (err == error.MalformedConfig) {
-                    stderr_writer.writeAll("error: user config.toml is malformed — fix or remove it\n") catch {};
+                    user_config_blocks_fallback = true;
+                    stderr_writer.writeAll("error: user config.toml is malformed — fix or remove it before enabling dump persistence\n") catch {};
                 } else {
                     std.log.warn("could not write user config: {}", .{err});
                 }
@@ -673,7 +679,12 @@ pub fn main() !void {
         // System config: write to a temp file, then sudo cp to /etc/padctl/.
         // Direct write fails without root (AccessDenied).
         const sys_dir = cfgpaths.systemConfigDir();
-        if (std.os.linux.getuid() == 0) {
+        if (user_config_blocks_fallback) {
+            // Skip system write entirely regardless of privilege: the daemon
+            // won't read it because user_config.load() stops on MalformedConfig
+            // in the user file and refuses to fall through to the system file.
+            stderr_writer.writeAll("info: skipping system config write — broken user config would mask it\n") catch {};
+        } else if (std.os.linux.getuid() == 0) {
             // Already root — write directly.
             if (cli.dump.writeDiagnosticsConfig(allocator, sys_dir, enable)) {
                 config_written = true;
@@ -685,27 +696,35 @@ pub fn main() !void {
                 }
             }
         } else {
-            // Non-root: write to temp dir, sudo cp to system path.
-            const tmp_dir = "/tmp/padctl-dump-config";
-            if (cli.dump.writeDiagnosticsConfig(allocator, tmp_dir, enable)) {
-                const tmp_src = tmp_dir ++ "/config.toml";
-                const sys_dst_buf = std.fmt.allocPrint(allocator, "{s}/config.toml", .{sys_dir}) catch null;
-                defer if (sys_dst_buf) |b| allocator.free(b);
-                if (sys_dst_buf) |sys_dst| {
-                    if (runSudoMkdir(sys_dir, stderr_writer)) {
-                        if (runSudoCopy(tmp_src, sys_dst, stderr_writer)) {
-                            config_written = true;
+            // Non-root: write to a unique temp dir (avoids symlink/TOCTOU on
+            // a shared /tmp path), sudo cp to system path, then cleanup.
+            if (makeTempDir(allocator)) |tmp_dir| {
+                defer {
+                    // Best-effort cleanup of the temp dir tree.
+                    std.fs.deleteTreeAbsolute(tmp_dir) catch {};
+                    allocator.free(tmp_dir);
+                }
+                if (cli.dump.writeDiagnosticsConfig(allocator, tmp_dir, enable)) {
+                    const tmp_src = std.fmt.allocPrint(allocator, "{s}/config.toml", .{tmp_dir}) catch null;
+                    defer if (tmp_src) |s| allocator.free(s);
+                    const sys_dst = std.fmt.allocPrint(allocator, "{s}/config.toml", .{sys_dir}) catch null;
+                    defer if (sys_dst) |b| allocator.free(b);
+                    if (tmp_src != null and sys_dst != null) {
+                        if (runSudoMkdir(sys_dir, stderr_writer)) {
+                            if (runSudoCopy(tmp_src.?, sys_dst.?, stderr_writer)) {
+                                config_written = true;
+                            }
                         }
                     }
+                } else |err| {
+                    if (err == error.MalformedConfig) {
+                        stderr_writer.writeAll("error: system config.toml is malformed — fix or remove it\n") catch {};
+                    } else {
+                        std.log.warn("could not write system config: {}", .{err});
+                    }
                 }
-                std.fs.deleteFileAbsolute(tmp_src) catch {};
-                std.fs.deleteTreeAbsolute(tmp_dir) catch {};
             } else |err| {
-                if (err == error.MalformedConfig) {
-                    stderr_writer.writeAll("error: system config.toml is malformed — fix or remove it\n") catch {};
-                } else {
-                    std.log.warn("could not write system config: {}", .{err});
-                }
+                std.log.warn("could not create temp dir for config write: {}", .{err});
             }
         }
 
@@ -730,6 +749,12 @@ pub fn main() !void {
         if (!config_written and !ipc_ok) {
             stderr_writer.writeAll("error: could not persist or apply dump setting\n") catch {};
             std.process.exit(1);
+        }
+        if (!config_written and user_config_blocks_fallback) {
+            // IPC may have succeeded (live-only apply), but the setting will
+            // be lost on next daemon restart. Surface this loudly so users
+            // don't assume the toggle is durable.
+            stderr_writer.writeAll("warning: dump setting was NOT persisted across restarts — fix the malformed user config.toml first\n") catch {};
         }
         std.process.exit(0);
     }
@@ -1163,6 +1188,29 @@ fn runSudoMkdir(dir: []const u8, err_writer: anytype) bool {
         .Exited => |code| code == 0,
         else => false,
     };
+}
+
+/// Create a unique, exclusive temp directory owned by the current user.
+/// Using `mkdir` (exclusive) + random suffix avoids symlink/TOCTOU races on a
+/// shared predictable path like `/tmp/padctl-dump-config`. Mode 0o700 keeps
+/// the tree private even though the config.toml contents are non-sensitive.
+/// Caller owns and must free the returned path.
+fn makeTempDir(allocator: std.mem.Allocator) ![]u8 {
+    const tmp = std.posix.getenv("TMPDIR") orelse "/tmp";
+    var rand_bytes: [8]u8 = undefined;
+    var attempts: u32 = 0;
+    while (attempts < 16) : (attempts += 1) {
+        std.crypto.random.bytes(&rand_bytes);
+        const suffix = std.mem.readInt(u64, &rand_bytes, .little);
+        const path = try std.fmt.allocPrint(allocator, "{s}/padctl-dump-{x}", .{ tmp, suffix });
+        std.posix.mkdir(path, 0o700) catch |err| {
+            allocator.free(path);
+            if (err == error.PathAlreadyExists) continue;
+            return err;
+        };
+        return path;
+    }
+    return error.TempDirCreationFailed;
 }
 
 fn escapeTomlString(writer: anytype, s: []const u8) !void {

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -871,6 +871,9 @@ pub const Supervisor = struct {
             .status => self.handleStatus(fd),
             .list => self.handleList(fd),
             .devices => self.handleDevices(fd),
+            .dump_on => self.handleDump(fd, true),
+            .dump_off => self.handleDump(fd, false),
+            .dump_status => self.handleDumpStatus(fd),
             .unknown => cs.sendResponse(fd, "ERR unknown-command\n"),
         }
     }
@@ -1088,6 +1091,28 @@ pub const Supervisor = struct {
         resp_buf[pos] = '\n';
         pos += 1;
         cs.sendResponse(fd, resp_buf[0..pos]);
+    }
+
+    fn handleDumpStatus(self: *Supervisor, fd: posix.fd_t) void {
+        const padctl_log = @import("log.zig");
+        var cs = &self.ctrl_sock.?;
+        var resp_buf: [64]u8 = undefined;
+        const state_str: []const u8 = if (padctl_log.isEnabled()) "on" else "off";
+        const resp = std.fmt.bufPrint(&resp_buf, "OK dump={s}\n", .{state_str}) catch return;
+        cs.sendResponse(fd, resp);
+    }
+
+    fn handleDump(self: *Supervisor, fd: posix.fd_t, enable: bool) void {
+        const padctl_log = @import("log.zig");
+        padctl_log.setEnabled(enable);
+        var cs = &self.ctrl_sock.?;
+        if (enable) {
+            cs.sendResponse(fd, "OK dump=on\n");
+            std.log.info("dump logging enabled via IPC", .{});
+        } else {
+            cs.sendResponse(fd, "OK dump=off\n");
+            std.log.info("dump logging disabled via IPC", .{});
+        }
     }
 
     /// Look up the user config's default_mapping for device_name, find and parse the mapping file.
@@ -1715,6 +1740,14 @@ pub const Supervisor = struct {
             return err;
         };
         std.log.info("device attached: \"{s}\" {s}/{s}", .{ cfg.?.device.name, dev_root, devname });
+        // Log FF config for rumble diagnostics.
+        if (cfg.?.output) |out| {
+            if (out.force_feedback) |ff| {
+                std.log.info("device FF config: type={s} max_effects={?d} auto_stop={}", .{
+                    ff.type, ff.max_effects, ff.auto_stop,
+                });
+            }
+        }
     }
 };
 

--- a/src/test/mock_device_io.zig
+++ b/src/test/mock_device_io.zig
@@ -40,7 +40,19 @@ pub const MockDeviceIO = struct {
     pub fn deinit(self: *MockDeviceIO) void {
         self.write_log.deinit(self.allocator);
         posix.close(self.pipe_r);
-        if (self.pipe_w >= 0) posix.close(self.pipe_w);
+        self.closeWriteEnd();
+    }
+
+    /// Atomically swap `pipe_w` to -1 and close the old fd. Safe to call
+    /// from multiple threads and multiple times: the atomic xchg ensures
+    /// at most one caller sees the live fd and invokes posix.close, so
+    /// the internal drain-path auto-close in `read` and an external test
+    /// that also wants to simulate "write end died" cannot double-close
+    /// the same fd — posix.close on a stale fd panics under ReleaseSafe
+    /// (`BADF => unreachable` in Zig stdlib).
+    pub fn closeWriteEnd(self: *MockDeviceIO) void {
+        const fd = @atomicRmw(posix.fd_t, &self.pipe_w, .Xchg, -1, .acq_rel);
+        if (fd >= 0) posix.close(fd);
     }
 
     /// Signal the pipe_r side as readable (triggers ppoll).
@@ -70,10 +82,10 @@ pub const MockDeviceIO = struct {
         if (self.disconnected) return DeviceIO.ReadError.Disconnected;
         if (self.frame_idx >= self.frames.len) {
             // Close write end once all frames consumed — ppoll sees POLLHUP and returns.
-            if (self.pipe_w >= 0) {
-                posix.close(self.pipe_w);
-                self.pipe_w = -1;
-            }
+            // Routed through the atomic helper so a concurrent external
+            // closeWriteEnd (e.g. a test simulating a dead peer) can't
+            // collide with our close here.
+            self.closeWriteEnd();
             return DeviceIO.ReadError.Again;
         }
         const frame = self.frames[self.frame_idx];

--- a/src/test/properties/supervisor_sm_props.zig
+++ b/src/test/properties/supervisor_sm_props.zig
@@ -329,8 +329,12 @@ test "regression-93: ADD before REMOVE completes must not silent-drop" {
     // managed slot's DeviceIO and is independent of the device thread's
     // lifecycle, so no sleep is needed here. stopAll()/deinit() at teardown
     // will still cleanly join the live thread.
-    posix.close(mock_a.pipe_w);
-    mock_a.pipe_w = -1;
+    //
+    // Use the atomic helper so the close can't race with the background
+    // thread's own drain-path auto-close in MockDeviceIO.read, which would
+    // otherwise produce a double-close panic under ReleaseSafe
+    // (posix.close treats EBADF as unreachable).
+    mock_a.closeWriteEnd();
 
     // Step 3 — udev ADD for the "new" hidraw node arrives BEFORE the
     // REMOVE for hidraw0 was processed. Kernel assigned a new devname
@@ -413,8 +417,9 @@ test "regression-93: orphan managed entry (devname==null) with matching phys_key
 
     // Step 2 — kill the backing fd so managedInstanceAlive() returns
     // false, forcing the race-guard path to evaluate the devname branch.
-    posix.close(mock_a.pipe_w);
-    mock_a.pipe_w = -1;
+    // Atomic helper prevents double-close with the background thread's
+    // drain-path auto-close in MockDeviceIO.read.
+    mock_a.closeWriteEnd();
 
     // Step 3 — attempt a new attach with the same phys_key. Without the
     // carve-out, this would fall through and dup-attach; with it, the


### PR DESCRIPTION
## Summary

Adds an opt-in, togglable file logger + CLI (`padctl dump enable|disable|status|export|clear`) so users can produce structured diagnostic logs for any class of bug report — stuck rumble, input drops, hotplug oddities, mapping misses. The logger is off by default with zero hot-path cost when disabled; when enabled it captures the full force-feedback pipeline (FF_UPLOAD/ERASE, EV_FF PLAY/STOP, HID rumble frames, scheduler slot state, session lifecycle) to a rotated, size-bounded file. Other subsystems (input routing, layer/remap, hotplug/netlink, config reload) are explicitly called out as follow-up instrumentation behind the same switch.

Replaces #103 — split per @BANANASJIM's review request. The FF drain-loop fix from that PR landed separately as #120.

### Motivation

The stuck-rumble reports on #65 (reported by @nextproblemreporter and @0x-ur) highlighted a class of issue where the symptom is at the physical-motor level and the evidence we need is at the HID-frame / scheduler-slot level — all of which is opaque without instrumentation. Adding `padctl dump` gives both users and maintainers a first-class way to capture that evidence. It's also structured as a general-purpose facility: when the next hotplug or mapping bug surfaces, it's a matter of instrumenting the relevant path behind the existing `dump_enabled` atomic, not designing a new logging subsystem.

### What's new

**Dump CLI:**
- `padctl dump enable` / `disable` — toggle the switch. Persists across reboots via `[diagnostics].dump` in user + system config (auto-elevates via sudo). Also sends live IPC so a running daemon picks up the change immediately.
- `padctl dump status` — state, active log path, size, oldest/newest entry timestamps. mtime-based picker between candidate paths.
- `padctl dump export --period <Nm|Nh|Nd> [-o path]` — export window of log lines newer than duration. Default `1d`. Stdout or file.
- `padctl dump clear` — delete live log + rotated backup with interactive confirm. Sudo-rm fallback for root-owned logs.
- Distinct error messages for missing-subcommand vs missing-option-value.

**Logging module (`src/log.zig`):**
- Custom `std.log.logFn` with atomic `dump_enabled`, lazy file open, size-bounded rotation (100 MiB default, configurable), single rotated backup (`.log.1`).
- ISO 8601 wall-clock + CLOCK_MONOTONIC nanoseconds per line.
- Auto-reopen if the log file is deleted out from under the daemon.

**Config:**
- `[diagnostics] dump, max_log_size_mb` in user/system config. Manual edits + `SIGHUP` (`padctl reload`) also work.

**Systemd integration:**
- `StateDirectory=padctl` in user-service template + immutable drop-in so the daemon + CLI converge on `$XDG_STATE_HOME/padctl/padctl.log` (flat path, no `log/` subdir).
- `ReadWritePaths=/run/user/%U` inherited from #120 so IPC socket bind survives `ProtectHome=read-only`.

**Installer — automatic legacy-unit migration:**
- `padctl install` on immutable OS detects leftover `/etc/systemd/system/padctl.service`, prompts the user (default Y, auto-Y on non-TTY), stop+disable+removes the unit + drop-in dir + paired resume service. Previously printed manual cleanup instructions.
- `updateLegacySystemService` refreshes leftover unit files with current content.
- `bazzite-setup.sh`: post-install user-systemd-reload trio, mapping-apply retry loop, short-circuit on `ERR no-devices` with a factual info message.

**Rumble instrumentation (gated behind `dump_enabled`):**
- `pollFf` UPLOAD/ERASE/PLAY/STOP traces (single-event vocab aligned with #120's break-fix).
- `FF_EVENT` / `FF_PLAY` / `FF_STOP` scheduler decisions with `sched_on`, `emit_stop`, `next_dl`.
- `HID_WRITE` lines with cmd + magnitudes + interface + full 32-byte frame hex-dump.
- `HEARTBEAT` once per minute with all 16 scheduler slots (remaining ms) for post-hoc stuck-slot detection.
- Session lifecycle (start/ready/attached/detached/suspended/disconnect).

**IPC:**
- New `DUMP ON` / `DUMP OFF` / `DUMP STATUS` verbs on the control socket.

**Docs:**
- New `docs/src/diagnostic-logging.md` — full `padctl dump` guide: commands, period syntax, log-path resolution, `[diagnostics]` config, rotation, what gets logged, bug-report workflow.
- `getting-started.md` + `SUMMARY.md` + `README.md` updated with the new CLI rows and a pointer to the guide.

**Test coverage:**
- Full test suite for logging + dump CLI + IPC parser.
- Pure-function helpers extracted for testability: `resolveStateDir(state_dir_env, xdg_env, home_env)` in `paths.zig` (5 tests), `parseYesNoDefaultYes(raw)` for the legacy-migration prompt (4 tests).
- Template-content regression tests: `generateServiceContent`, `generateSystemServiceContent`, `immutable_dropin_content` each asserts `StateDirectory=padctl` present + `LogsDirectory` absent.
- Updated `resolveServiceDir` test for immutable → user-service routing.

### Non-breaking changes

- `dump = false` default — zero behaviour change for existing installs until the user opts in.
- `[diagnostics]` TOML section is entirely optional; missing = defaults.
- New subcommand only — no existing CLI surface changes.
- Legacy-unit auto-migration is gated behind an interactive prompt on TTY (auto-yes on non-TTY for CI).
- `StateDirectory=padctl` is additive.
- All IPC additions are new verbs; existing verbs untouched.

### Changed files

| File | Changes |
|------|---------|
| `src/log.zig` | **NEW** — custom logFn, atomic dump toggle, rotation, reopen-on-delete. 329 lines. |
| `src/cli/dump.zig` | **NEW** — dump CLI + helpers. 1024 lines, ~15 unit tests. |
| `src/main.zig` | Dump CLI parsing, std_options.logFn hook, makeTempDir, runSudoMkdir/Copy. |
| `src/cli/install.zig` | StateDirectory=padctl, ReadWritePaths=/run/user/%U, legacy-unit auto-migration with promptYesNoDefaultYes, updateLegacySystemService. |
| `src/supervisor.zig` | handleDump / handleDumpStatus IPC handlers. |
| `src/io/control_socket.zig` | dump_on / dump_off / dump_status CommandTag + parser. |
| `src/config/paths.zig` | stateDir() + pure resolveStateDir(env…) resolver. |
| `src/config/user_config.zig` | DiagnosticsConfig field on UserConfig. |
| `src/core/rumble_scheduler.zig` | dumpSlots() + HEARTBEAT machinery. |
| `src/event_loop.zig` | Rumble instrumentation gated behind dump_enabled. |
| `src/io/uinput.zig` | pollFf logging, single-event vocabulary. |
| `src/device_instance.zig` | Wires log_tag into rumble scheduler. |
| `scripts/bazzite-setup.sh` | Post-install user-systemd trio, retry loop, no-devices short-circuit. |
| `docs/src/diagnostic-logging.md` | **NEW** — dump CLI guide. |
| `docs/src/SUMMARY.md` | Links the new page. |
| `docs/src/getting-started.md` | CLI reference rows + pointer. |
| `README.md` | Features bullet + CLI table rows. |

## Test plan

- [x] `zig build check-all` — 843 tests pass (unit + test-safe + fmt)
- [x] Hardware smoke test on Flydigi Vader 5 Pro — daemon + CLI converge on `~/.local/state/padctl/padctl.log`, dump toggles correctly, export filters by period, clear deletes files, mapping auto-applies on hot-plug
- [x] ~5 h real-game session logged with `dump=true`: 45,675 UPLOAD/PLAY pairs, 0 `prev=overwritten`, 32 non-empty heartbeats all showing freshly-reset deadlines. Log file 51.9 MB, rotation working.
- [x] Legacy-unit auto-migration verified on immutable OS (stops+disables+removes old unit, drop-in dir, paired resume.service; declined prompt prints manual steps).
- [ ] Verify on a non-immutable distro (Arch/Debian/Ubuntu).
- [ ] Verify `dump export --period` parsing across a DST boundary if possible.

---

Refs #65, supersedes #103.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent diagnostic logging via `padctl dump` (enable/disable, status, export period, clear); rotated file logs with no runtime overhead when disabled; CLI wiring and runtime toggles.

* **Documentation**
  * Added Diagnostic Logging guide; updated CLI reference and getting-started docs with dump workflow and config options.

* **Improvements**
  * Better log path resolution and startup log behavior; installer/setup refinements and safer migration prompts; per-device log tagging and richer debug heartbeats.

* **Tests**
  * Added coverage for logging, parsing, export, migration, and concurrency scenarios.

* **Chores**
  * Ignore build package directory in VCS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->