### PR TITLE
fix(install): remove obsolete padctl-resume.service unit

### DIFF
--- a/contrib/aur/padctl-bin/PKGBUILD
+++ b/contrib/aur/padctl-bin/PKGBUILD
@@ -36,6 +36,10 @@ package() {
 
     install -Dm644 install/padctl.service \
         "${pkgdir}/usr/lib/systemd/user/padctl.service"
+    # padctl-resume.service was removed in issue #131 Problem B fix; the
+    # udev padctl-reconnect hook handles post-suspend reconnect. Kept the
+    # conditional guard so older tarballs still package cleanly, but new
+    # tarballs will not ship the file.
     [[ -f install/padctl-resume.service ]] && install -Dm644 install/padctl-resume.service \
         "${pkgdir}/usr/lib/systemd/user/padctl-resume.service"
     [[ -f install/padctl-reconnect ]] && install -Dm755 install/padctl-reconnect \

--- a/contrib/copr/padctl.spec
+++ b/contrib/copr/padctl.spec
@@ -44,25 +44,25 @@ systemd socket activation and udev integration.
 %{_bindir}/padctl-debug
 %{_bindir}/padctl-reconnect
 %{_unitdir}/padctl.service
-%{_unitdir}/padctl-resume.service
 %{_udevrulesdir}/60-padctl.rules
 %{_udevrulesdir}/61-padctl-driver-block.rules
 %{_datadir}/padctl/
 
 %post
-%systemd_post padctl.service padctl-resume.service
+%systemd_post padctl.service
 
 %preun
-%systemd_preun padctl.service padctl-resume.service
+%systemd_preun padctl.service
 
 %postun
-%systemd_postun_with_restart padctl.service padctl-resume.service
+%systemd_postun_with_restart padctl.service
 
 %changelog
 * Fri Apr 04 2026 padctl maintainers <maintainers@padctl.dev> - 0.1.0-1
 - Fix ExclusiveArch (was incorrectly BuildArch)
 - Update udev rules: 99-padctl.rules -> 60-padctl.rules + 61-padctl-driver-block.rules
-- Add padctl-debug, padctl-capture, padctl-reconnect, padctl-resume.service to %files
+- Add padctl-debug, padctl-capture, padctl-reconnect to %files
+- Drop padctl-resume.service (removed in issue #131 Problem B fix)
 - Use padctl install to generate all files instead of manual installs
 - Add Requires: systemd
 

--- a/contrib/deb/DEBIAN-BIN/prerm
+++ b/contrib/deb/DEBIAN-BIN/prerm
@@ -2,7 +2,9 @@
 set -e
 if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then
     if [ -d /run/systemd/system ]; then
-        systemctl stop padctl.service padctl-resume.service || true
-        systemctl disable padctl.service padctl-resume.service || true
+        # padctl-resume.service was removed in issue #131 Problem B fix;
+        # still attempt stop/disable to clean up upgrades from v0.1.2.
+        systemctl stop padctl.service padctl-resume.service 2>/dev/null || true
+        systemctl disable padctl.service padctl-resume.service 2>/dev/null || true
     fi
 fi

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -55,8 +55,7 @@ sudo ./zig-out/bin/padctl install --prefix /usr --destdir "$DESTDIR"
 
 `padctl install` also sets up the following on all systems:
 
-- **`padctl-resume.service`** — Restarts padctl after sleep/hibernate so USB devices reconnect cleanly.
-- **`padctl-reconnect`** — A hotplug script triggered by udev when a controller is plugged in. It starts the daemon if not running, restarts it if failed, and re-applies the active mapping.
+- **`padctl-reconnect`** — A hotplug script triggered by udev when a controller is plugged in. It starts the daemon if not running, restarts it if failed, and re-applies the active mapping. After suspend/resume the kernel re-emits udev events for re-enumerated devices, so the same hook handles post-wake reconnect — no separate resume unit is needed.
 - **Driver conflict rules** — Auto-generated udev rules that unbind conflicting kernel drivers (e.g., `xpad`) from devices that padctl manages. Configured per-device via `block_kernel_drivers` in device TOML configs.
 
 ### Install a Mapping

--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -343,10 +343,9 @@ else
     warn "Service: not running — check 'systemctl --user status padctl' and 'journalctl --user -u padctl -n 30'"
 fi
 
-# Check resume service
-if systemctl --user is-enabled padctl-resume.service &>/dev/null; then
-    ok "Resume service: enabled"
-fi
+# padctl-resume.service was removed in issue #131 Problem B fix —
+# the udev padctl-reconnect hook handles post-suspend reconnects.
+# Nothing to verify here.
 
 # Check udev rules
 for rules_file in 60-padctl.rules 61-padctl-driver-block.rules; do

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -2365,6 +2365,36 @@ test "install: parseYesNoDefaultYes non-y non-n input is treated as no" {
 // hotplug after suspend/resume. These tests lock in that the installer
 // neither writes the unit nor leaves legacy copies behind on upgrade.
 
+// Scoped fd-1 silencer for tests that drive run()/uninstall() directly.
+// Those functions emit user-facing progress on STDOUT_FILENO (fd 1).
+// Under `zig build test*`, fd 1 is the zig build-server binary protocol
+// channel (test_runner mainServer). Any bytes written by the test body
+// corrupt that stream; the build runner then parses ASCII as a message
+// header (~1.9 GB body) and blocks forever reading, while the test
+// runner sits in `anon_pipe_read` waiting for the next `run_test`
+// command — i.e., the deadlock observed as `zig build test-tsan` hang.
+// Redirecting fd 1 to /dev/null for the duration of the install/uninstall
+// call lets the test exercise real production code without touching the
+// protocol channel. Restore is mandatory so the subsequent
+// `serveTestResults` write reaches the build runner.
+const SilencedStdout = struct {
+    saved_fd: std.posix.fd_t,
+
+    fn begin() !SilencedStdout {
+        const saved = try std.posix.dup(std.posix.STDOUT_FILENO);
+        errdefer std.posix.close(saved);
+        const devnull = try std.posix.open("/dev/null", .{ .ACCMODE = .WRONLY }, 0);
+        defer std.posix.close(devnull);
+        try std.posix.dup2(devnull, std.posix.STDOUT_FILENO);
+        return .{ .saved_fd = saved };
+    }
+
+    fn end(self: *SilencedStdout) void {
+        std.posix.dup2(self.saved_fd, std.posix.STDOUT_FILENO) catch {};
+        std.posix.close(self.saved_fd);
+    }
+};
+
 test "install: resume service is NOT installed (system immutable)" {
     const testing = std.testing;
     const allocator = testing.allocator;
@@ -2382,6 +2412,8 @@ test "install: resume service is NOT installed (system immutable)" {
         .no_enable = true,
         .no_start = true,
     };
+    var silencer = try SilencedStdout.begin();
+    defer silencer.end();
     run(allocator, opts) catch |err| switch (err) {
         // Staging install legitimately fails late (e.g. devices source dir
         // not found in the test harness); we only care about the earlier
@@ -2436,7 +2468,11 @@ test "uninstall: legacy padctl-resume.service is removed (system immutable)" {
         .immutable = true,
         .user_service = false,
     };
-    try uninstall(allocator, opts);
+    {
+        var silencer = try SilencedStdout.begin();
+        defer silencer.end();
+        try uninstall(allocator, opts);
+    }
 
     if (std.fs.accessAbsolute(legacy_unit, .{})) |_| {
         std.debug.print("legacy resume unit not cleaned up: {s}\n", .{legacy_unit});
@@ -2472,7 +2508,11 @@ test "uninstall: legacy padctl-resume.service is removed (non-immutable)" {
         .immutable = false,
         .user_service = false,
     };
-    try uninstall(allocator, opts);
+    {
+        var silencer = try SilencedStdout.begin();
+        defer silencer.end();
+        try uninstall(allocator, opts);
+    }
 
     if (std.fs.accessAbsolute(legacy_unit, .{})) |_| {
         std.debug.print("legacy resume unit not cleaned up on non-immutable path: {s}\n", .{legacy_unit});

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -107,20 +107,16 @@ const immutable_dropin_content =
     \\
 ;
 
-const resume_service_content =
-    \\[Unit]
-    \\Description=Restart padctl after sleep/resume
-    \\After=suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target
-    \\
-    \\[Service]
-    \\Type=oneshot
-    \\ExecStartPre=/usr/bin/sleep 2
-    \\ExecStart=/usr/bin/systemctl restart padctl.service
-    \\
-    \\[Install]
-    \\WantedBy=suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target
-    \\
-;
+// padctl-resume.service was removed in the fix for issue #131 Problem B.
+// The unit was broken by design — never enabled, scope-mismatched on
+// immutable installs (WantedBy=suspend.target only resolves in system
+// scope but the file was written under /etc/systemd/user/), and the
+// ExecStart called `systemctl restart padctl.service` without --user,
+// which would target a nonexistent system-scope unit (padctl has been a
+// user service since PR #77 / ADR-014 Path B). Post-suspend reconnect is
+// handled by the udev `padctl-reconnect` hook: when the controller
+// replugs after wake, udev re-fires and the reconnect script re-applies
+// the mapping. See uninstall() for legacy cleanup of v0.1.2 installs.
 
 fn generateReconnectScript(allocator: std.mem.Allocator, prefix: []const u8) ![]const u8 {
     return std.fmt.allocPrint(allocator,
@@ -885,17 +881,9 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     // helper is a no-op when no legacy file is present.
     updateLegacySystemService(allocator, destdir, prefix);
 
-    // 2c. Write resume service (system installs only; user sessions handle sleep via logind)
-    if (!effective_user_service) {
-        const resume_path = try std.fmt.allocPrint(allocator, "{s}/padctl-resume.service", .{lib_systemd_dir});
-        defer allocator.free(resume_path);
-        var f = try std.fs.createFileAbsolute(resume_path, .{ .truncate = true });
-        defer f.close();
-        try f.writeAll(resume_service_content);
-        _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
-        _ = std.posix.write(std.posix.STDOUT_FILENO, resume_path) catch {};
-        _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
-    }
+    // 2c. (removed) padctl-resume.service — see comment at top of file.
+    // Post-suspend reconnect is handled by the udev padctl-reconnect hook
+    // below. Legacy cleanup for upgrades from v0.1.2 lives in uninstall().
 
     // 2d. Write reconnect script (all systems)
     {
@@ -1153,7 +1141,13 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         }
     }
 
-    // Standard prefix-based files (always removed)
+    // Standard prefix-based files (always removed).
+    // Legacy note: padctl-resume.service (removed in issue #131 Problem B
+    // fix) was written by v0.1.2 installs under either /lib/systemd/system/
+    // or /lib/systemd/user/ depending on prefix+scope — the old install
+    // code had no single canonical location, so cleanup lists both to
+    // catch every upgrade path.
+    _ = std.posix.write(std.posix.STDOUT_FILENO, "  info: removing legacy padctl-resume.service files if present\n") catch {};
     const files = [_][]const u8{
         "/bin/padctl",
         "/bin/padctl-capture",
@@ -1161,6 +1155,7 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         "/bin/padctl-reconnect",
         "/lib/systemd/system/padctl.service",
         "/lib/systemd/system/padctl-resume.service",
+        "/lib/systemd/user/padctl-resume.service",
         "/lib/udev/rules.d/60-padctl.rules",
         "/lib/udev/rules.d/61-padctl-driver-block.rules",
         "/lib/udev/rules.d/99-padctl.rules",
@@ -1178,13 +1173,21 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     // Remove user unit if applicable
     if (effective_user_service) {
         if (std.posix.getenv("HOME")) |home| {
-            const user_unit = try std.fmt.allocPrint(allocator, "{s}/.config/systemd/user/padctl.service", .{home});
-            defer allocator.free(user_unit);
-            if (std.fs.deleteFileAbsolute(user_unit)) |_| {
-                _ = std.posix.write(std.posix.STDOUT_FILENO, "  removed ") catch {};
-                _ = std.posix.write(std.posix.STDOUT_FILENO, user_unit) catch {};
-                _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
-            } else |_| {}
+            const user_units = [_][]const u8{
+                "/.config/systemd/user/padctl.service",
+                // Legacy v0.1.2 resume unit (issue #131 Problem B cleanup);
+                // harmless if absent on fresh installs.
+                "/.config/systemd/user/padctl-resume.service",
+            };
+            for (user_units) |suffix| {
+                const user_unit = try std.fmt.allocPrint(allocator, "{s}{s}", .{ home, suffix });
+                defer allocator.free(user_unit);
+                if (std.fs.deleteFileAbsolute(user_unit)) |_| {
+                    _ = std.posix.write(std.posix.STDOUT_FILENO, "  removed ") catch {};
+                    _ = std.posix.write(std.posix.STDOUT_FILENO, user_unit) catch {};
+                    _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
+                } else |_| {}
+            }
         }
     }
 
@@ -1202,11 +1205,16 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     defer allocator.free(share_dir);
     std.fs.deleteTreeAbsolute(share_dir) catch {};
 
-    // Immutable-specific files in /etc/ (auto-detected or explicit)
+    // Immutable-specific files in /etc/ (auto-detected or explicit).
+    // /etc/systemd/user/padctl-resume.service is where v0.1.2's buggy
+    // install path actually wrote the unit on immutable systems (the
+    // scope-mismatch root cause of issue #131 Problem B); keep both
+    // /etc/systemd/system/ and /etc/systemd/user/ entries for upgrade.
     if (effective_immutable) {
         const etc_files = [_][]const u8{
             "/etc/systemd/system/padctl.service",
             "/etc/systemd/system/padctl-resume.service",
+            "/etc/systemd/user/padctl-resume.service",
             "/etc/systemd/system/padctl.service.d/immutable.conf",
             "/etc/udev/rules.d/60-padctl.rules",
             "/etc/udev/rules.d/61-padctl-driver-block.rules",
@@ -2338,14 +2346,91 @@ test "install: parseYesNoDefaultYes non-y non-n input is treated as no" {
     try std.testing.expect(!parseYesNoDefaultYes("asdf"));
 }
 
-// --- Phase 3: resume service, reconnect script, hotplug rules ---
+// --- Phase 3: resume service cleanup, reconnect script, hotplug rules ---
 
-test "install: resume service content has required fields" {
+// issue #131 Problem B: padctl-resume.service was broken by design (never
+// enabled, scope-mismatched, ExecStart targeted a nonexistent system unit)
+// and is now removed. The udev reconnect hook (padctl-reconnect) handles
+// hotplug after suspend/resume. These tests lock in that the installer
+// neither writes the unit nor leaves legacy copies behind on upgrade.
+
+test "install: resume service is NOT installed (system immutable)" {
     const testing = std.testing;
-    try testing.expect(std.mem.indexOf(u8, resume_service_content, "suspend.target") != null);
-    try testing.expect(std.mem.indexOf(u8, resume_service_content, "Type=oneshot") != null);
-    try testing.expect(std.mem.indexOf(u8, resume_service_content, "ExecStartPre=/usr/bin/sleep 2") != null);
-    try testing.expect(std.mem.indexOf(u8, resume_service_content, "systemctl restart padctl.service") != null);
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const staging = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(staging);
+
+    const opts = InstallOptions{
+        .prefix = "/usr/local",
+        .destdir = staging,
+        .immutable = true,
+        .user_service = false,
+        .no_enable = true,
+        .no_start = true,
+    };
+    run(allocator, opts) catch |err| switch (err) {
+        // Staging install legitimately fails late (e.g. devices source dir
+        // not found in the test harness); we only care about the earlier
+        // resume-write step, so tolerate downstream errors.
+        error.MappingInstallFailed => {},
+        else => return err,
+    };
+
+    // Every plausible legacy install location must be empty.
+    const candidates = [_][]const u8{
+        "/usr/local/lib/systemd/user/padctl-resume.service",
+        "/usr/local/lib/systemd/system/padctl-resume.service",
+        "/etc/systemd/system/padctl-resume.service",
+        "/etc/systemd/user/padctl-resume.service",
+    };
+    for (candidates) |rel| {
+        const abs = try std.fmt.allocPrint(allocator, "{s}{s}", .{ staging, rel });
+        defer allocator.free(abs);
+        if (std.fs.accessAbsolute(abs, .{})) |_| {
+            std.debug.print("found leftover resume unit at {s}\n", .{abs});
+            return error.UnexpectedResumeUnitFound;
+        } else |_| {}
+    }
+}
+
+test "uninstall: legacy padctl-resume.service is removed (system immutable)" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const staging = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(staging);
+
+    // Seed a fake legacy resume unit at the immutable user-scope location
+    // — this is exactly where v0.1.2 installs wrote the unit on immutable
+    // systems (issue #131 Problem B scope-mismatch).
+    const legacy_dir = try std.fmt.allocPrint(allocator, "{s}/etc/systemd/user", .{staging});
+    defer allocator.free(legacy_dir);
+    try ensureDirAll(allocator, legacy_dir);
+    const legacy_unit = try std.fmt.allocPrint(allocator, "{s}/padctl-resume.service", .{legacy_dir});
+    defer allocator.free(legacy_unit);
+    {
+        var f = try std.fs.createFileAbsolute(legacy_unit, .{ .truncate = true });
+        defer f.close();
+        try f.writeAll("# legacy v0.1.2 resume unit — must be removed on upgrade\n");
+    }
+
+    const opts = InstallOptions{
+        .prefix = "/usr/local",
+        .destdir = staging,
+        .immutable = true,
+        .user_service = false,
+    };
+    try uninstall(allocator, opts);
+
+    if (std.fs.accessAbsolute(legacy_unit, .{})) |_| {
+        std.debug.print("legacy resume unit not cleaned up: {s}\n", .{legacy_unit});
+        return error.LegacyResumeUnitNotRemoved;
+    } else |_| {}
 }
 
 test "install: generateReconnectScript has required commands" {

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1205,16 +1205,27 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     defer allocator.free(share_dir);
     std.fs.deleteTreeAbsolute(share_dir) catch {};
 
+    // Unconditional: v0.1.2 resolveServiceDir fallback could write
+    // padctl-resume.service here on non-immutable, non-/usr prefixes too.
+    {
+        const legacy_resume = [_][]const u8{
+            "/etc/systemd/user/padctl-resume.service",
+            "/etc/systemd/system/padctl-resume.service",
+        };
+        for (legacy_resume) |suffix| {
+            const path = try std.fmt.allocPrint(allocator, "{s}{s}", .{ destdir, suffix });
+            defer allocator.free(path);
+            std.fs.deleteFileAbsolute(path) catch continue;
+            _ = std.posix.write(std.posix.STDOUT_FILENO, "  removed ") catch {};
+            _ = std.posix.write(std.posix.STDOUT_FILENO, path) catch {};
+            _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
+        }
+    }
+
     // Immutable-specific files in /etc/ (auto-detected or explicit).
-    // /etc/systemd/user/padctl-resume.service is where v0.1.2's buggy
-    // install path actually wrote the unit on immutable systems (the
-    // scope-mismatch root cause of issue #131 Problem B); keep both
-    // /etc/systemd/system/ and /etc/systemd/user/ entries for upgrade.
     if (effective_immutable) {
         const etc_files = [_][]const u8{
             "/etc/systemd/system/padctl.service",
-            "/etc/systemd/system/padctl-resume.service",
-            "/etc/systemd/user/padctl-resume.service",
             "/etc/systemd/system/padctl.service.d/immutable.conf",
             "/etc/udev/rules.d/60-padctl.rules",
             "/etc/udev/rules.d/61-padctl-driver-block.rules",
@@ -2429,6 +2440,42 @@ test "uninstall: legacy padctl-resume.service is removed (system immutable)" {
 
     if (std.fs.accessAbsolute(legacy_unit, .{})) |_| {
         std.debug.print("legacy resume unit not cleaned up: {s}\n", .{legacy_unit});
+        return error.LegacyResumeUnitNotRemoved;
+    } else |_| {}
+}
+
+// T-H1: non-immutable + non-/usr prefix must also clean /etc/systemd/user/
+// padctl-resume.service (issue #131-B uninstall gap — H1 fix).
+test "uninstall: legacy padctl-resume.service is removed (non-immutable)" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const staging = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(staging);
+
+    const legacy_dir = try std.fmt.allocPrint(allocator, "{s}/etc/systemd/user", .{staging});
+    defer allocator.free(legacy_dir);
+    try ensureDirAll(allocator, legacy_dir);
+    const legacy_unit = try std.fmt.allocPrint(allocator, "{s}/padctl-resume.service", .{legacy_dir});
+    defer allocator.free(legacy_unit);
+    {
+        var f = try std.fs.createFileAbsolute(legacy_unit, .{ .truncate = true });
+        defer f.close();
+        try f.writeAll("# legacy v0.1.2 resume unit\n");
+    }
+
+    const opts = InstallOptions{
+        .prefix = "/usr/local",
+        .destdir = staging,
+        .immutable = false,
+        .user_service = false,
+    };
+    try uninstall(allocator, opts);
+
+    if (std.fs.accessAbsolute(legacy_unit, .{})) |_| {
+        std.debug.print("legacy resume unit not cleaned up on non-immutable path: {s}\n", .{legacy_unit});
         return error.LegacyResumeUnitNotRemoved;
     } else |_| {}
 }


### PR DESCRIPTION
Fixes #131 (Problem B).

## Problem

\`padctl-resume.service\` was broken in three independent ways:

1. **Never enabled** — install.zig had no \`systemctl enable padctl-resume\` call; the file was written to disk but would never fire.
2. **Scope mismatch** — on immutable installs the unit went to \`/etc/systemd/user/\` (because \`resolveServiceDir\` routes everything to user-scope dirs), but its \`WantedBy=suspend.target\` resolves only in **system** scope; user-scope systemd cannot enable the unit.
3. **ExecStart broken** — \`systemctl restart padctl.service\` (no \`--user\`) would target a nonexistent system-scope unit since padctl has been a user service since PR #77.

Result: users on Bazzite saw the unit listed but in a disabled/failed state, and reinstall had no effect.

## Fix

Remove \`padctl-resume.service\` entirely. The udev reconnect hook (\`padctl-reconnect\`) already handles hotplug after suspend/resume: when the controller replugs post-wake, udev re-fires and the reconnect script re-applies mapping. The resume unit was redundant.

Changes:

- \`src/cli/install.zig\`: drop \`resume_service_content\` constant + the install-path write
- \`src/cli/install.zig\` uninstall paths: preserve legacy cleanup for all plausible v0.1.2 write locations (\`/lib/systemd/{system,user}/\`, \`/etc/systemd/{system,user}/\`, \`~/.config/systemd/user/\`) with an info log
- \`scripts/bazzite-setup.sh\`: remove the \`is-enabled padctl-resume.service\` verify probe
- \`docs/src/getting-started.md\`: drop the padctl-resume mention; update \`padctl-reconnect\` description
- \`contrib/copr/padctl.spec\`: drop from \`%files\` + systemd hooks
- \`contrib/deb/DEBIAN-BIN/prerm\`: kept stop/disable as best-effort legacy cleanup
- \`contrib/aur/padctl-bin/PKGBUILD\`: kept conditional-guarded install as legacy cleanup

## Tests

- New: \`install: resume service is NOT installed (system immutable)\` — runs install against a staging dir, asserts no \`padctl-resume.service\` file appears under any of 4 candidate paths
- New: \`uninstall: legacy padctl-resume.service is removed (system immutable)\` — seeds a legacy unit at \`/etc/systemd/user/\` (the actual buggy v0.1.2 location), runs uninstall, asserts cleanup
- Removed: \`install: resume service content has required fields\` (referenced the deleted constant)

## Verification

- [x] \`zig build check-fmt\` clean
- [x] \`zig build -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false -Doptimize=ReleaseSafe\` clean
- [ ] Linux CI
- [ ] Hardware smoke test on Steam Deck / Bazzite: \`sudo padctl install --immutable\` must produce no \`padctl-resume.service\` files and no "failed to enable" warnings

Fixes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed non-functional `padctl-resume.service` unit; post-suspend device handling is now managed by the reconnect udev hook.

* **Documentation**
  * Updated getting-started guide to reflect suspend/resume behavior is handled via the reconnect mechanism.

* **Chores**
  * Updated installation and packaging scripts to remove the deprecated resume service and clean up legacy installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->