### PR TITLE
fix(uhid): close 6 audit findings + implement descriptor-driven encoder + input-group permission fallback

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -243,6 +243,7 @@ fn generateSystemServiceContent(allocator: std.mem.Allocator, prefix: []const u8
         \\SupplementaryGroups=input
         \\DeviceAllow=/dev/hidraw* rw
         \\DeviceAllow=/dev/uinput rw
+        \\DeviceAllow=/dev/uhid rw
         \\DeviceAllow=char-input rw
         \\
         \\[Install]
@@ -1561,6 +1562,11 @@ fn generateUdevRulesFromEntries(allocator: std.mem.Allocator, entries: []const U
 
     try buf.appendSlice(allocator, "\n# uinput access for logged-in users\n");
     try buf.appendSlice(allocator, "SUBSYSTEM==\"misc\", KERNEL==\"uinput\", TAG+=\"uaccess\"\n");
+    // ADR-015 §Dependencies: UHID virtual-device creation mirrors uinput's
+    // permission model. padctl running as a user service needs write access
+    // to /dev/uhid to expose SDL-visible gamepads; uaccess grants this to
+    // the active login session without requiring CAP_SYS_ADMIN.
+    try buf.appendSlice(allocator, "SUBSYSTEM==\"misc\", KERNEL==\"uhid\", TAG+=\"uaccess\"\n");
 
     var f = try std.fs.createFileAbsolute(rules_path, .{ .truncate = true });
     defer f.close();
@@ -2205,6 +2211,9 @@ test "install: generateUdevRules produces valid output" {
     try testing.expect(std.mem.indexOf(u8, content, "TAG+=\"uaccess\"") != null); // hidraw rule
     try testing.expect(std.mem.indexOf(u8, content, "GROUP=\"input\", MODE=\"0660\"") != null);
     try testing.expect(std.mem.indexOf(u8, content, "KERNEL==\"uinput\"") != null);
+    // ADR-015: /dev/uhid must get uaccess so the user service can create
+    // virtual SDL-visible gamepads without CAP_SYS_ADMIN.
+    try testing.expect(std.mem.indexOf(u8, content, "KERNEL==\"uhid\"") != null);
 }
 
 test "install: findDevicesSourceDir discovers repo-root devices from zig-out/bin" {
@@ -2450,6 +2459,19 @@ test "install: generateSystemServiceContent uses StateDirectory (not LogsDirecto
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "StateDirectory=padctl") != null);
     try testing.expect(std.mem.indexOf(u8, content, "LogsDirectory") == null);
+}
+
+test "install: generateSystemServiceContent grants /dev/uhid DeviceAllow (ADR-015)" {
+    // ADR-015 §Dependencies: the UHID migration needs /dev/uhid access
+    // parallel to /dev/uinput. Pre-fix the template listed only hidraw,
+    // uinput, and char-input — UhidDevice.init would have failed with
+    // EACCES on a default install.
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const content = try generateSystemServiceContent(allocator, "/usr/local");
+    defer allocator.free(content);
+    try testing.expect(std.mem.indexOf(u8, content, "DeviceAllow=/dev/uhid rw") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "DeviceAllow=/dev/uinput rw") != null);
 }
 
 test "install: parseYesNoDefaultYes empty input is yes (default-yes)" {

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -259,6 +259,76 @@ fn resolveUdevDir(allocator: std.mem.Allocator, destdir: []const u8, prefix: []c
     return std.fmt.allocPrint(allocator, "{s}{s}/lib/udev/rules.d", .{ destdir, prefix });
 }
 
+const modules_load_content =
+    \\# padctl requires these kernel modules for virtual gamepad support
+    \\uhid
+    \\uinput
+    \\
+;
+
+fn writeModulesLoad(allocator: std.mem.Allocator, destdir: []const u8, prefix: []const u8, immutable: bool) void {
+    // Immutable systems use /etc; otherwise prefer prefix/lib/modules-load.d
+    const dir_path = if (immutable)
+        std.fmt.allocPrint(allocator, "{s}/etc/modules-load.d", .{destdir}) catch return
+    else
+        std.fmt.allocPrint(allocator, "{s}{s}/lib/modules-load.d", .{ destdir, prefix }) catch return;
+    defer allocator.free(dir_path);
+
+    ensureDirAll(allocator, dir_path) catch |err| {
+        var errbuf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(&errbuf, "warning: modules-load.d dir not created: {}\n", .{err}) catch "warning: modules-load.d dir error\n";
+        _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch {};
+        return;
+    };
+
+    const conf_path = std.fmt.allocPrint(allocator, "{s}/padctl.conf", .{dir_path}) catch return;
+    defer allocator.free(conf_path);
+
+    if (std.fs.createFileAbsolute(conf_path, .{ .truncate = true })) |f| {
+        defer f.close();
+        f.writeAll(modules_load_content) catch {};
+        _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
+        _ = std.posix.write(std.posix.STDOUT_FILENO, conf_path) catch {};
+        _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
+    } else |err| {
+        var errbuf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(&errbuf, "warning: modules-load.d not written: {}\n", .{err}) catch "warning: modules-load.d write error\n";
+        _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch {};
+    }
+}
+
+/// Returns the GID for the named group by parsing /etc/group, or null on failure.
+fn groupGid(name: []const u8) ?std.os.linux.gid_t {
+    const f = std.fs.openFileAbsolute("/etc/group", .{}) catch return null;
+    defer f.close();
+    var buf: [4096]u8 = undefined;
+    const n = f.readAll(&buf) catch return null;
+    var it = std.mem.splitScalar(u8, buf[0..n], '\n');
+    while (it.next()) |line| {
+        // Format: name:password:gid:members
+        var fields = std.mem.splitScalar(u8, line, ':');
+        const gname = fields.next() orelse continue;
+        _ = fields.next(); // password
+        const gid_str = fields.next() orelse continue;
+        if (!std.mem.eql(u8, gname, name)) continue;
+        return std.fmt.parseInt(std.os.linux.gid_t, gid_str, 10) catch null;
+    }
+    return null;
+}
+
+/// Returns true if the current process is a member of the named group.
+fn userInGroup(name: []const u8) bool {
+    const target_gid = groupGid(name) orelse return false;
+    if (std.os.linux.getegid() == target_gid) return true;
+    var gids: [64]std.os.linux.gid_t = undefined;
+    const ret = std.os.linux.getgroups(gids.len, &gids[0]);
+    if (ret > gids.len) return false;
+    for (gids[0..ret]) |g| {
+        if (g == target_gid) return true;
+    }
+    return false;
+}
+
 fn ensureDir(path: []const u8) !void {
     std.fs.makeDirAbsolute(path) catch |err| switch (err) {
         error.PathAlreadyExists => {},
@@ -1111,8 +1181,11 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         std.fs.deleteFileAbsolute(legacy_etc) catch {};
     }
 
-    // 4d. Install mapping configs (if --mapping specified, repeatable)
-    // Track per-mapping success so 4e only writes bindings for mappings
+    // 4d. Write modules-load.d so uhid and uinput are available at boot
+    writeModulesLoad(allocator, destdir, prefix, effective_immutable);
+
+    // 4e. Install mapping configs (if --mapping specified, repeatable)
+    // Track per-mapping success so 4f only writes bindings for mappings
     // that were actually installed (avoids a config.toml entry pointing
     // at a missing mapping file).
     var mapping_failed = false;
@@ -1140,10 +1213,10 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         }
     }
 
-    // 4e. Write device→mapping bindings to /etc/padctl/config.toml so the
+    // 4f. Write device→mapping bindings to /etc/padctl/config.toml so the
     //      daemon auto-applies the mapping at boot without a manual
     //      `padctl switch`. Only process mappings that were successfully
-    //      installed in 4d — writing a binding for a missing mapping file
+    //      installed in 4e — writing a binding for a missing mapping file
     //      would make reboot auto-apply point at nothing.
     if (installed_mappings.items.len > 0) {
         const devices_src = findDevicesSourceDir(allocator, self_dir, null) catch null;
@@ -1230,6 +1303,18 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     } else {
         _ = std.posix.write(std.posix.STDOUT_FILENO, "\nInstall complete.\n") catch {};
     }
+
+    if (!userInGroup("input")) {
+        _ = std.posix.write(std.posix.STDOUT_FILENO,
+            \\
+            \\[padctl] Note: /dev/uhid and /dev/uinput now grant rw to 'input' group members.
+            \\[padctl] For 0-sudo UHID access from SSH/headless/test sessions, add yourself:
+            \\[padctl]   sudo usermod -aG input $USER
+            \\[padctl]   (then re-login for group membership to take effect)
+            \\[padctl] Graphical desktop users do not need this — uaccess ACL handles it automatically.
+            \\
+        ) catch {};
+    }
 }
 
 pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
@@ -1290,6 +1375,7 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         "/lib/udev/rules.d/60-padctl.rules",
         "/lib/udev/rules.d/61-padctl-driver-block.rules",
         "/lib/udev/rules.d/99-padctl.rules",
+        "/lib/modules-load.d/padctl.conf",
     };
 
     for (files) |suffix| {
@@ -1361,6 +1447,7 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
             "/etc/udev/rules.d/60-padctl.rules",
             "/etc/udev/rules.d/61-padctl-driver-block.rules",
             "/etc/udev/rules.d/99-padctl.rules",
+            "/etc/modules-load.d/padctl.conf",
         };
         for (etc_files) |suffix| {
             const path = try std.fmt.allocPrint(allocator, "{s}{s}", .{ destdir, suffix });
@@ -1560,13 +1647,9 @@ fn generateUdevRulesFromEntries(allocator: std.mem.Allocator, entries: []const U
         try buf.appendSlice(allocator, hotplug_line);
     }
 
-    try buf.appendSlice(allocator, "\n# uinput access for logged-in users\n");
-    try buf.appendSlice(allocator, "SUBSYSTEM==\"misc\", KERNEL==\"uinput\", TAG+=\"uaccess\"\n");
-    // ADR-015 §Dependencies: UHID virtual-device creation mirrors uinput's
-    // permission model. padctl running as a user service needs write access
-    // to /dev/uhid to expose SDL-visible gamepads; uaccess grants this to
-    // the active login session without requiring CAP_SYS_ADMIN.
-    try buf.appendSlice(allocator, "SUBSYSTEM==\"misc\", KERNEL==\"uhid\", TAG+=\"uaccess\"\n");
+    // uaccess: graphical login ACL; GROUP+MODE: headless/SSH/test fallback via 'input' group
+    try buf.appendSlice(allocator, "\nSUBSYSTEM==\"misc\", KERNEL==\"uinput\", TAG+=\"uaccess\", GROUP=\"input\", MODE=\"0660\"\n");
+    try buf.appendSlice(allocator, "SUBSYSTEM==\"misc\", KERNEL==\"uhid\",   TAG+=\"uaccess\", GROUP=\"input\", MODE=\"0660\"\n");
 
     var f = try std.fs.createFileAbsolute(rules_path, .{ .truncate = true });
     defer f.close();
@@ -3902,4 +3985,37 @@ test "install: resolveTargetHomeFromFile falls back to /home/<user> on missing p
         try testing.expectEqualStrings(home_env, result);
     }
     // Root path with fallback is covered by integration / real-machine testing.
+}
+
+test "install: udev rule grants input group and uaccess tag to uhid and uinput" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    const devices_dir = try std.fmt.allocPrint(allocator, "{s}/devices", .{tmp_path});
+    defer allocator.free(devices_dir);
+    try ensureDirAll(allocator, devices_dir);
+
+    const rules_path = try std.fmt.allocPrint(allocator, "{s}/60-padctl.rules", .{tmp_path});
+    defer allocator.free(rules_path);
+    try generateUdevRules(allocator, devices_dir, rules_path, "/usr");
+
+    var file = try std.fs.openFileAbsolute(rules_path, .{});
+    defer file.close();
+    const content = try file.readToEndAlloc(allocator, 4096);
+    defer allocator.free(content);
+
+    try testing.expect(std.mem.indexOf(u8, content, "KERNEL==\"uinput\", TAG+=\"uaccess\", GROUP=\"input\", MODE=\"0660\"") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "KERNEL==\"uhid\",   TAG+=\"uaccess\", GROUP=\"input\", MODE=\"0660\"") != null);
+}
+
+test "install: modules-load.d content includes uhid and uinput" {
+    const testing = std.testing;
+    try testing.expect(std.mem.indexOf(u8, modules_load_content, "uhid") != null);
+    try testing.expect(std.mem.indexOf(u8, modules_load_content, "uinput") != null);
 }

--- a/src/io/ioctl_constants.zig
+++ b/src/io/ioctl_constants.zig
@@ -13,8 +13,23 @@ pub const HIDIOCGRAWPHYS = blk: {
     break :blk @as(u32, @bitCast(req));
 };
 
+/// Dynamic-size ioctl: caller picks the user buffer length. Kernel copies
+/// up to `len` bytes of the `uniq` sysfs attribute (NUL-terminated) into it.
+pub fn HIDIOCGRAWUNIQ(len: u16) u32 {
+    const req = IOCTL.Request{ .dir = 2, .io_type = 'H', .nr = 0x08, .size = len };
+    return @bitCast(req);
+}
+
 // evdev
 pub const EVIOCGRAB = IOCTL.IOW('E', 0x90, c_int);
+
+/// Dynamic-size evdev ioctl: kernel copies up to `len` bytes of the device's
+/// uniq attribute (NUL-terminated) into the user buffer. SDL reads this to
+/// pair main-pad and IMU nodes — see ADR-015 §Stage 1 AC.
+pub fn EVIOCGUNIQ(len: u16) u32 {
+    const req = IOCTL.Request{ .dir = 2, .io_type = 'E', .nr = 0x08, .size = len };
+    return @bitCast(req);
+}
 
 // uinput
 pub const UI_DEV_CREATE = IOCTL.IO('U', 1);

--- a/src/io/ioctl_constants.zig
+++ b/src/io/ioctl_constants.zig
@@ -15,7 +15,7 @@ pub const HIDIOCGRAWPHYS = blk: {
 
 /// Dynamic-size ioctl: caller picks the user buffer length. Kernel copies
 /// up to `len` bytes of the `uniq` sysfs attribute (NUL-terminated) into it.
-pub fn HIDIOCGRAWUNIQ(len: u16) u32 {
+pub fn HIDIOCGRAWUNIQ(len: u14) u32 {
     const req = IOCTL.Request{ .dir = 2, .io_type = 'H', .nr = 0x08, .size = len };
     return @bitCast(req);
 }
@@ -26,7 +26,7 @@ pub const EVIOCGRAB = IOCTL.IOW('E', 0x90, c_int);
 /// Dynamic-size evdev ioctl: kernel copies up to `len` bytes of the device's
 /// uniq attribute (NUL-terminated) into the user buffer. SDL reads this to
 /// pair main-pad and IMU nodes — see ADR-015 §Stage 1 AC.
-pub fn EVIOCGUNIQ(len: u16) u32 {
+pub fn EVIOCGUNIQ(len: u14) u32 {
     const req = IOCTL.Request{ .dir = 2, .io_type = 'E', .nr = 0x08, .size = len };
     return @bitCast(req);
 }

--- a/src/io/uhid.zig
+++ b/src/io/uhid.zig
@@ -428,13 +428,52 @@ test "uhid: axisToU8 clamps and centres" {
     try testing.expectEqual(@as(u8, 127), UhidDevice.axisToU8(-1));
 }
 
-test "uhid: UhidDevice vtable signature matches OutputDevice" {
-    // Compile-time guardrail: if UinputDevice's vtable ever evolves (say, to
-    // add a new member), this test forces UhidDevice to be updated in
-    // lockstep before the code base can even compile its tests.
-    const uhid_vt = std.meta.fieldInfo(@TypeOf(UhidDevice.vtable), .emit).type;
-    const uinput_vt = std.meta.fieldInfo(uinput.OutputDevice.VTable, .emit).type;
-    try testing.expectEqual(uinput_vt, uhid_vt);
+test "uhid: outputDevice().emit routes through UhidDevice.emit (not a stub)" {
+    // The prior revision compared UhidDevice.vtable.emit's type to
+    // OutputDevice.VTable.emit's type — a tautology since vtable is declared
+    // as `uinput.OutputDevice.VTable{ ... }`. This replacement asserts that a
+    // vtable-routed emit call reaches the real implementation by observing
+    // the bytes written to the backing fd change with the input state.
+    if (@import("builtin").os.tag != .linux) return error.SkipZigTest;
+
+    const alloc = testing.allocator;
+    var fds: [2]posix.fd_t = undefined;
+    fds = try posix.pipe();
+    defer posix.close(fds[0]);
+
+    const cfg = Config{
+        .vid = 0xFADE,
+        .pid = 0xCAFE,
+        .name = "padctl-vtable-dispatch",
+        .descriptor = &[_]u8{ 0x05, 0x01, 0xC0 },
+    };
+    const dev = try UhidDevice.initWithFd(alloc, fds[1], cfg);
+    defer alloc.destroy(dev);
+
+    const out = dev.outputDevice();
+    // Emit a non-zero state — axisToU8 shifts away from the 128 centre.
+    try out.emit(.{ .ax = 32767, .ay = -32768, .rx = 0, .ry = 0 });
+
+    var buf: [UHID_EVENT_SIZE]u8 = undefined;
+    _ = try posix.read(fds[0], &buf);
+    try testing.expectEqual(UHID_INPUT2, std.mem.readInt(u32, buf[0..4], .little));
+    // Bytes 6..10 are the stick payload after the u16 size field at offset 4.
+    try testing.expectEqual(@as(u8, 255), buf[6]); // ax full positive
+    try testing.expectEqual(@as(u8, 0), buf[7]); // ay full negative
+    try testing.expectEqual(@as(u8, 128), buf[8]); // rx centre
+    try testing.expectEqual(@as(u8, 128), buf[9]); // ry centre
+
+    // A second emit with the opposite state must produce different bytes —
+    // proves the call routed into the live UhidDevice.emit each time rather
+    // than capturing the first invocation's state.
+    try out.emit(.{ .ax = -32768, .ay = 32767, .rx = 0, .ry = 0 });
+    _ = try posix.read(fds[0], &buf);
+    try testing.expectEqual(@as(u8, 0), buf[6]);
+    try testing.expectEqual(@as(u8, 255), buf[7]);
+
+    out.close();
+    var scratch: [UHID_EVENT_SIZE]u8 = undefined;
+    _ = try posix.read(fds[0], &scratch);
 }
 
 test "uhid: init rejects empty name" {

--- a/src/io/uhid.zig
+++ b/src/io/uhid.zig
@@ -123,8 +123,14 @@ pub fn uhidCreate(
     _ = try posix.write(fd, &buf);
 }
 
-/// Send a `UHID_INPUT2` event carrying an input report payload.
+/// Send a `UHID_INPUT2` event carrying an input report payload. Rejects
+/// payloads larger than `UHID_DATA_MAX` — the kernel's `uhid_input2_req.data`
+/// is a fixed `[4096]u8` and `uhid_input2_req.size` is a `u16`, so anything
+/// beyond 4096 bytes would both overrun the payload array (panic in safe
+/// builds, silent corruption in release) and truncate in the `size` field.
 pub fn uhidInput(fd: posix.fd_t, data: []const u8) !void {
+    if (data.len > UHID_DATA_MAX) return error.PayloadTooLong;
+
     var ev = std.mem.zeroes(UhidInput2Event);
     ev.type = UHID_INPUT2;
     ev.payload.size = @intCast(data.len);
@@ -614,6 +620,67 @@ test "uhid: initWithFd rejects negative fd" {
     // round-trips cleanly. Use a `var` so @as survives the const inference.
     const bogus_fd: posix.fd_t = -1;
     try testing.expectError(error.InvalidFd, UhidDevice.initWithFd(alloc, bogus_fd, cfg));
+}
+
+test "uhid: uhidInput rejects oversized payload (regression H4)" {
+    // Pre-fix: uhidInput blindly `@memcpy`'d `data` into the fixed 4096-byte
+    // payload array, which panics in safe builds and corrupts adjacent
+    // memory in release. Assert a slice larger than UHID_DATA_MAX now
+    // returns error.PayloadTooLong before touching the buffer.
+    if (@import("builtin").os.tag != .linux) return error.SkipZigTest;
+
+    var fds: [2]posix.fd_t = undefined;
+    fds = try posix.pipe();
+    defer posix.close(fds[0]);
+    defer posix.close(fds[1]);
+
+    const oversized = try testing.allocator.alloc(u8, UHID_DATA_MAX + 1);
+    defer testing.allocator.free(oversized);
+    @memset(oversized, 0xAA);
+
+    try testing.expectError(error.PayloadTooLong, uhidInput(fds[1], oversized));
+
+    // A boundary-case payload of exactly UHID_DATA_MAX must pass.
+    const ok_size = try testing.allocator.alloc(u8, UHID_DATA_MAX);
+    defer testing.allocator.free(ok_size);
+    @memset(ok_size, 0x55);
+    try uhidInput(fds[1], ok_size);
+
+    // Drain to keep the pipe clean for later tests.
+    var scratch: [UHID_EVENT_SIZE]u8 = undefined;
+    _ = try posix.read(fds[0], &scratch);
+}
+
+test "uhid: emitRaw maps PayloadTooLong to WriteFailed (vtable error stability)" {
+    // `emitRaw` returns `uinput.EmitError` which is `{ WriteFailed, DeviceGone }`
+    // — adding a new variant would ripple across every vtable call site. Map
+    // oversized payloads to `WriteFailed` so the new guard stays inside the
+    // existing error set.
+    if (@import("builtin").os.tag != .linux) return error.SkipZigTest;
+
+    const alloc = testing.allocator;
+    var fds: [2]posix.fd_t = undefined;
+    fds = try posix.pipe();
+    defer posix.close(fds[0]);
+
+    const cfg = Config{
+        .vid = 0xFADE,
+        .pid = 0xCAFE,
+        .name = "padctl-payload-guard",
+        .descriptor = &[_]u8{ 0x05, 0x01, 0xC0 },
+    };
+    const dev = try UhidDevice.initWithFd(alloc, fds[1], cfg);
+    defer alloc.destroy(dev);
+
+    const oversized = try alloc.alloc(u8, UHID_DATA_MAX + 512);
+    defer alloc.free(oversized);
+    @memset(oversized, 0x42);
+
+    try testing.expectError(error.WriteFailed, dev.emitRaw(oversized));
+
+    dev.close();
+    var scratch: [UHID_EVENT_SIZE]u8 = undefined;
+    _ = posix.read(fds[0], &scratch) catch {};
 }
 
 test "uhid: close() is idempotent (second call is a no-op)" {

--- a/src/io/uhid.zig
+++ b/src/io/uhid.zig
@@ -21,6 +21,8 @@ const std = @import("std");
 const posix = std.posix;
 const state = @import("../core/state.zig");
 const uinput = @import("uinput.zig");
+const device_cfg = @import("../config/device.zig");
+const descriptor = @import("uhid_descriptor.zig");
 
 // --- Kernel protocol constants ---------------------------------------------
 
@@ -188,6 +190,12 @@ pub const Config = struct {
     version: u32 = 0,
     /// HID country code. 0 = "not localized" which matches most gamepads.
     country: u32 = 0,
+    /// Optional `[output]` section the descriptor was built from. When set,
+    /// `emit()` packs HID reports via `uhid_descriptor.encodeReport` so the
+    /// bytes on the wire match the declared layout. When null, `emit()`
+    /// falls back to a raw 4-byte stick stub (legacy tests that pass a hand
+    /// -written descriptor without a matching `OutputConfig` still work).
+    output: ?device_cfg.OutputConfig = null,
 };
 
 /// A UHID-backed output device implementing the shared `OutputDevice` vtable.
@@ -211,6 +219,9 @@ pub const UhidDevice = struct {
     /// stores the backing TOML allocator; CI tests use string literals.
     name: []const u8,
     uniq: []const u8,
+    /// Optional `OutputConfig` — when set, `emit()` dispatches to the
+    /// descriptor-driven encoder. See `Config.output`.
+    output: ?device_cfg.OutputConfig,
 
     /// Construct a `UhidDevice` against a real `/dev/uhid` fd. Opens the
     /// kernel node, populates a `UhidCreate2Req`, and writes it.
@@ -244,6 +255,7 @@ pub const UhidDevice = struct {
             .pid = cfg.pid,
             .name = cfg.name,
             .uniq = cfg.uniq,
+            .output = cfg.output,
         };
         return self;
     }
@@ -276,6 +288,7 @@ pub const UhidDevice = struct {
             .pid = cfg.pid,
             .name = cfg.name,
             .uniq = cfg.uniq,
+            .output = cfg.output,
         };
         return self;
     }
@@ -335,22 +348,33 @@ pub const UhidDevice = struct {
         self.close();
     }
 
-    /// Emit a `UHID_INPUT2` event carrying a Wave-1 stub payload derived from
-    /// `s`. The payload is 4 bytes of stick axes mapped into the 0..255 HID
-    /// logical range — enough to exercise the vtable contract and the
-    /// `UhidSimulator` consumer harness. Wave 2 replaces this with the real
-    /// descriptor-driven encoder.
+    /// Emit a `UHID_INPUT2` event carrying an input report derived from `s`.
+    /// When `Config.output` was supplied, bytes are packed by
+    /// `uhid_descriptor.encodeReport` against the exact layout declared by
+    /// the descriptor (Report ID + buttons + hat + sticks + triggers +
+    /// touchpad). When `output` is null, a 4-byte stick-only stub is sent —
+    /// retained for tests that bring a hand-written descriptor without a
+    /// matching `OutputConfig`.
     pub fn emit(self: *UhidDevice, s: state.GamepadState) uinput.EmitError!void {
-        var payload: [4]u8 = undefined;
-        payload[0] = axisToU8(s.ax);
-        payload[1] = axisToU8(s.ay);
-        payload[2] = axisToU8(s.rx);
-        payload[3] = axisToU8(s.ry);
-
-        uhidInput(self.fd, &payload) catch |err| switch (err) {
-            error.BrokenPipe, error.ConnectionResetByPeer => return error.DeviceGone,
-            else => return error.WriteFailed,
-        };
+        if (self.output) |out| {
+            var report_buf: [descriptor.MAX_REPORT_BYTES]u8 = undefined;
+            const bytes = descriptor.encodeReport(out, s, &report_buf) catch
+                return error.WriteFailed;
+            uhidInput(self.fd, bytes) catch |err| switch (err) {
+                error.BrokenPipe, error.ConnectionResetByPeer => return error.DeviceGone,
+                else => return error.WriteFailed,
+            };
+        } else {
+            var payload: [4]u8 = undefined;
+            payload[0] = axisToU8(s.ax);
+            payload[1] = axisToU8(s.ay);
+            payload[2] = axisToU8(s.rx);
+            payload[3] = axisToU8(s.ry);
+            uhidInput(self.fd, &payload) catch |err| switch (err) {
+                error.BrokenPipe, error.ConnectionResetByPeer => return error.DeviceGone,
+                else => return error.WriteFailed,
+            };
+        }
 
         self.state_snapshot = s;
     }

--- a/src/io/uhid_descriptor.zig
+++ b/src/io/uhid_descriptor.zig
@@ -49,6 +49,7 @@
 const std = @import("std");
 const uhid = @import("uhid.zig");
 const device = @import("../config/device.zig");
+const state_mod = @import("../core/state.zig");
 
 pub const BuildError = std.mem.Allocator.Error || error{
     DescriptorTooLarge,
@@ -384,6 +385,167 @@ pub const UhidDescriptorBuilder = struct {
         return buf.toOwnedSlice(allocator);
     }
 };
+
+// ---------------------------------------------------------------------------
+// Input report encoder — mirrors the descriptor layout byte-for-byte.
+// ---------------------------------------------------------------------------
+
+/// Max bytes `encodeReport` will ever emit. Sized to cover an input report ID
+/// byte + 64-bit button bitmap (cap in `buildFromOutput`) + 1-byte hat + four
+/// i16 sticks + two u8 triggers + two 5-byte touch contacts. 32 bytes is
+/// comfortably larger than any baseline gamepad the builder accepts; the
+/// boundary is pinned by a descriptor-driven unit test.
+pub const MAX_REPORT_BYTES: usize = 32;
+
+pub const EncodeError = error{ReportTooLong};
+
+/// Stable HID-bit-index → `state_mod.ButtonId` assignment. The builder's
+/// button pass emits `Usage Minimum 1, Usage Maximum button_count`; the
+/// encoder walks `ButtonId` in declaration order and packs a 1-bit entry for
+/// each id that appears in `cfg.buttons`. Determinism matters: SDL assumes
+/// a stable ordering between descriptor enumeration and report payload.
+fn buttonIdSlot(cfg: device.OutputConfig, bit_idx: u8) ?state_mod.ButtonId {
+    const buttons = cfg.buttons orelse return null;
+    var slot: u8 = 0;
+    inline for (@typeInfo(state_mod.ButtonId).@"enum".fields) |f| {
+        if (buttons.map.contains(f.name)) {
+            if (slot == bit_idx) return @enumFromInt(f.value);
+            slot += 1;
+        }
+    }
+    return null;
+}
+
+/// Number of buttons the builder declares — mirrors the `map.count()` +
+/// 64-cap path in `buildFromOutput` so encoder and descriptor stay in sync.
+fn buttonCount(cfg: device.OutputConfig) u8 {
+    const buttons = cfg.buttons orelse return 0;
+    const n = buttons.map.count();
+    return if (n > 64) 64 else @intCast(n);
+}
+
+fn axisWithCode(cfg: device.OutputConfig, code: []const u8) ?device.AxisConfig {
+    const axes = cfg.axes orelse return null;
+    var it = axes.map.iterator();
+    while (it.next()) |entry| {
+        if (std.mem.eql(u8, entry.value_ptr.code, code)) return entry.value_ptr.*;
+    }
+    return null;
+}
+
+/// Translate (dpad_x, dpad_y) into a 4-bit hat value matching the descriptor's
+/// Logical Maximum 7 (N, NE, E, SE, S, SW, W, NW; neutral = 8).
+fn hatValue(gs: state_mod.GamepadState) u4 {
+    const x = gs.dpad_x;
+    const y = gs.dpad_y;
+    if (x == 0 and y == -1) return 0;
+    if (x == 1 and y == -1) return 1;
+    if (x == 1 and y == 0) return 2;
+    if (x == 1 and y == 1) return 3;
+    if (x == 0 and y == 1) return 4;
+    if (x == -1 and y == 1) return 5;
+    if (x == -1 and y == 0) return 6;
+    if (x == -1 and y == -1) return 7;
+    return 8;
+}
+
+/// Encode a `GamepadState` into a wire-format HID input report matching the
+/// bytes the descriptor produced by `UhidDescriptorBuilder.buildFromOutput`
+/// describes. First byte is always `INPUT_REPORT_ID`. Layout follows the
+/// same section order as the descriptor: buttons → hat → sticks → triggers
+/// → touchpad. Sections absent from `cfg` are simply skipped — the resulting
+/// byte length is the sum of declared section widths.
+///
+/// Owned by the caller. `buf` must have capacity >= `MAX_REPORT_BYTES`.
+/// Returns the slice of `buf` that was populated.
+pub fn encodeReport(
+    cfg: device.OutputConfig,
+    gs: state_mod.GamepadState,
+    buf: []u8,
+) EncodeError![]u8 {
+    if (buf.len < MAX_REPORT_BYTES) return error.ReportTooLong;
+    @memset(buf, 0);
+
+    var pos: usize = 0;
+    buf[pos] = INPUT_REPORT_ID;
+    pos += 1;
+
+    // --- Button bitmap ---
+    const btn_count = buttonCount(cfg);
+    if (btn_count > 0) {
+        const btn_bytes: usize = (@as(usize, btn_count) + 7) / 8;
+        var i: u8 = 0;
+        while (i < btn_count) : (i += 1) {
+            const slot = buttonIdSlot(cfg, i) orelse continue;
+            const mask: u64 = @as(u64, 1) << @intFromEnum(slot);
+            if ((gs.buttons & mask) != 0) {
+                const byte_idx = pos + (@as(usize, i) / 8);
+                const bit_pos: u3 = @intCast(i % 8);
+                buf[byte_idx] |= @as(u8, 1) << bit_pos;
+            }
+        }
+        pos += btn_bytes;
+    }
+
+    // --- Hat (4-bit + 4-bit padding packed into one byte) ---
+    const has_hat: bool = if (cfg.dpad) |d| std.mem.eql(u8, d.type, "hat") else false;
+    if (has_hat) {
+        buf[pos] = @as(u8, hatValue(gs)) & 0x0F;
+        pos += 1;
+    }
+
+    // --- Sticks (fixed order) ---
+    const stick_order = [_]struct { code: []const u8, field: enum { ax, ay, rx, ry } }{
+        .{ .code = "ABS_X", .field = .ax },
+        .{ .code = "ABS_Y", .field = .ay },
+        .{ .code = "ABS_RX", .field = .rx },
+        .{ .code = "ABS_RY", .field = .ry },
+    };
+    for (stick_order) |s| {
+        if (axisWithCode(cfg, s.code) == null) continue;
+        const v: i16 = switch (s.field) {
+            .ax => gs.ax,
+            .ay => gs.ay,
+            .rx => gs.rx,
+            .ry => gs.ry,
+        };
+        std.mem.writeInt(i16, buf[pos..][0..2], v, .little);
+        pos += 2;
+    }
+
+    // --- Triggers (fixed order) ---
+    const trigger_order = [_]struct { code: []const u8, field: enum { lt, rt } }{
+        .{ .code = "ABS_Z", .field = .lt },
+        .{ .code = "ABS_RZ", .field = .rt },
+    };
+    for (trigger_order) |t| {
+        if (axisWithCode(cfg, t.code) == null) continue;
+        buf[pos] = switch (t.field) {
+            .lt => gs.lt,
+            .rt => gs.rt,
+        };
+        pos += 1;
+    }
+
+    // --- Touchpad (per-finger tip + X + Y) ---
+    if (cfg.touchpad) |_| {
+        const finger0 = [_]struct { active: bool, x: i16, y: i16 }{
+            .{ .active = gs.touch0_active, .x = gs.touch0_x, .y = gs.touch0_y },
+            .{ .active = gs.touch1_active, .x = gs.touch1_x, .y = gs.touch1_y },
+        };
+        for (finger0) |f| {
+            if (pos + 5 > buf.len) return error.ReportTooLong;
+            buf[pos] = if (f.active) 1 else 0;
+            pos += 1;
+            std.mem.writeInt(i16, buf[pos..][0..2], f.x, .little);
+            pos += 2;
+            std.mem.writeInt(i16, buf[pos..][0..2], f.y, .little);
+            pos += 2;
+        }
+    }
+
+    return buf[0..pos];
+}
 
 // ---------------------------------------------------------------------------
 // Tests — kept in-module so new contributors reading `uhid_descriptor.zig`
@@ -818,4 +980,235 @@ test "descriptor: FFB-only output (no input buttons/axes) produces a valid descr
         }
     }
     try testing.expect(found);
+}
+
+// --- encodeReport tests (H3 regression) ------------------------------------
+
+test "encodeReport: buttons + stick pair + triggers pack in declared order" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const axes = try makeAxesMap(a, &.{
+        .{ .name = "left_x", .cfg = .{ .code = "ABS_X", .min = -32768, .max = 32767 } },
+        .{ .name = "left_y", .cfg = .{ .code = "ABS_Y", .min = -32768, .max = 32767 } },
+        .{ .name = "lt", .cfg = .{ .code = "ABS_Z", .min = 0, .max = 255 } },
+        .{ .name = "rt", .cfg = .{ .code = "ABS_RZ", .min = 0, .max = 255 } },
+    });
+    const buttons = try makeButtonsMap(a, &.{
+        .{ .name = "A", .code = "BTN_SOUTH" },
+        .{ .name = "B", .code = "BTN_EAST" },
+        .{ .name = "X", .code = "BTN_WEST" },
+    });
+    const out = device.OutputConfig{
+        .name = "layout-test",
+        .axes = axes,
+        .buttons = buttons,
+    };
+
+    // Build descriptor to measure the declared input report width and sanity
+    // -check the encoder stays within it.
+    const desc = try UhidDescriptorBuilder.buildFromOutput(testing.allocator, out);
+    defer testing.allocator.free(desc);
+
+    // Press A (bit 0) and X (bit 2); lt=100, rt=200, ax=1234, ay=-1.
+    var gs = state_mod.GamepadState{};
+    gs.buttons = (@as(u64, 1) << @intFromEnum(state_mod.ButtonId.A)) |
+        (@as(u64, 1) << @intFromEnum(state_mod.ButtonId.X));
+    gs.ax = 1234;
+    gs.ay = -1;
+    gs.lt = 100;
+    gs.rt = 200;
+
+    var report_buf: [MAX_REPORT_BYTES]u8 = undefined;
+    const report = try encodeReport(out, gs, &report_buf);
+
+    // Layout: [ReportID=1][buttons=1 byte for 3 buttons][ax lo][ax hi][ay lo][ay hi][lt][rt]
+    try testing.expectEqual(@as(usize, 8), report.len);
+    try testing.expectEqual(@as(u8, INPUT_REPORT_ID), report[0]);
+    // A = bit 0, B = bit 1, X = bit 2. Pressed: A + X → 0b0000_0101 = 0x05.
+    try testing.expectEqual(@as(u8, 0x05), report[1]);
+    try testing.expectEqual(@as(i16, 1234), std.mem.readInt(i16, report[2..4], .little));
+    try testing.expectEqual(@as(i16, -1), std.mem.readInt(i16, report[4..6], .little));
+    try testing.expectEqual(@as(u8, 100), report[6]);
+    try testing.expectEqual(@as(u8, 200), report[7]);
+}
+
+test "encodeReport: hat packs cardinal/diagonal and neutral correctly" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const axes = try makeAxesMap(a, &.{
+        .{ .name = "left_x", .cfg = .{ .code = "ABS_X", .min = -32768, .max = 32767 } },
+    });
+    const out = device.OutputConfig{
+        .name = "hat-test",
+        .axes = axes,
+        .dpad = .{ .type = "hat" },
+    };
+
+    const cases = [_]struct { dx: i8, dy: i8, expect: u8 }{
+        .{ .dx = 0, .dy = -1, .expect = 0 }, // N
+        .{ .dx = 1, .dy = -1, .expect = 1 }, // NE
+        .{ .dx = 1, .dy = 0, .expect = 2 }, // E
+        .{ .dx = 1, .dy = 1, .expect = 3 }, // SE
+        .{ .dx = 0, .dy = 1, .expect = 4 }, // S
+        .{ .dx = -1, .dy = 1, .expect = 5 }, // SW
+        .{ .dx = -1, .dy = 0, .expect = 6 }, // W
+        .{ .dx = -1, .dy = -1, .expect = 7 }, // NW
+        .{ .dx = 0, .dy = 0, .expect = 8 }, // neutral
+    };
+    for (cases) |tc| {
+        var gs = state_mod.GamepadState{};
+        gs.dpad_x = tc.dx;
+        gs.dpad_y = tc.dy;
+        var buf: [MAX_REPORT_BYTES]u8 = undefined;
+        const r = try encodeReport(out, gs, &buf);
+        // Layout: [ID=1][hat][ax lo][ax hi]
+        try testing.expectEqual(@as(u8, tc.expect), r[1] & 0x0F);
+        try testing.expectEqual(@as(usize, 4), r.len);
+    }
+}
+
+test "encodeReport: Steam Deck TOML produces a non-empty report with correct ID" {
+    const alloc = testing.allocator;
+    const parsed = try device.parseFile(alloc, "devices/valve/steam-deck.toml");
+    defer parsed.deinit();
+    const out = parsed.value.output orelse return error.MissingOutputSection;
+
+    var gs = state_mod.GamepadState{};
+    gs.ax = 100;
+    gs.ay = -100;
+    gs.rx = 50;
+    gs.ry = -50;
+    gs.lt = 128;
+    gs.rt = 64;
+
+    var buf: [MAX_REPORT_BYTES]u8 = undefined;
+    const r = try encodeReport(out, gs, &buf);
+
+    try testing.expectEqual(@as(u8, INPUT_REPORT_ID), r[0]);
+    // Steam Deck layout: ID(1) + buttons(17→3 bytes after pad) + hat(1) +
+    // sticks(4×2=8) + triggers(2) + touchpad(2 fingers × 5=10) = 25.
+    try testing.expect(r.len > 1);
+    try testing.expect(r.len <= MAX_REPORT_BYTES);
+}
+
+test "encodeReport: empty config is rejected by descriptor builder, encoder never sees it" {
+    // encodeReport is only called after buildFromOutput succeeded, so an
+    // empty config path cannot occur in production. Assert the guard to
+    // document the invariant.
+    const out = device.OutputConfig{ .name = "empty" };
+    try testing.expectError(error.InvalidOutputConfig, UhidDescriptorBuilder.buildFromOutput(testing.allocator, out));
+}
+
+test "encodeReport: buffer smaller than MAX_REPORT_BYTES returns ReportTooLong" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const axes = try makeAxesMap(a, &.{
+        .{ .name = "left_x", .cfg = .{ .code = "ABS_X", .min = -32768, .max = 32767 } },
+    });
+    const out = device.OutputConfig{ .name = "small", .axes = axes };
+    var tiny: [4]u8 = undefined;
+    try testing.expectError(error.ReportTooLong, encodeReport(out, .{}, &tiny));
+}
+
+// --- Structural invariants on the Steam Deck golden fixture (H5) -----------
+//
+// The golden .bin is the builder's own output, so a byte-exact match is
+// tautological. Instead we *parse* the bytes as HID 1.11 short items and
+// assert global structure invariants that would catch any builder-level
+// corruption (wrong report ID, unbalanced collections, byte alignment).
+
+fn hidItemSize(prefix: u8) u8 {
+    // HID 1.11 §6.2.2.2 short item: bSize lives in the low 2 bits of the
+    // prefix byte. Encoding: 0=0 bytes, 1=1 byte, 2=2 bytes, 3=4 bytes.
+    return switch (prefix & 0b11) {
+        0 => 0,
+        1 => 1,
+        2 => 2,
+        3 => 4,
+        else => unreachable,
+    };
+}
+
+test "golden invariants: Steam Deck HID descriptor parses as balanced HID 1.11 item stream" {
+    const alloc = testing.allocator;
+    const bytes = try std.fs.cwd().readFileAlloc(
+        alloc,
+        "src/test/fixtures/golden/steam_deck_hid_descriptor.bin",
+        65536,
+    );
+    defer alloc.free(bytes);
+
+    // Prologue: Usage Page (Generic Desktop) 0x05 0x01, Usage (Game Pad)
+    // 0x09 0x05, Collection (Application) 0xA1 0x01.
+    try testing.expectEqual(@as(u8, 0x05), bytes[0]);
+    try testing.expectEqual(@as(u8, 0x01), bytes[1]);
+    try testing.expectEqual(@as(u8, 0x09), bytes[2]);
+    try testing.expectEqual(@as(u8, 0x05), bytes[3]);
+    try testing.expectEqual(@as(u8, 0xA1), bytes[4]);
+    try testing.expectEqual(@as(u8, 0x01), bytes[5]);
+
+    var collection_depth: i32 = 0;
+    var max_depth: i32 = 0;
+    var collection_opens: u32 = 0;
+    var collection_closes: u32 = 0;
+    var report_ids_seen: u32 = 0;
+    var total_input_bits: u64 = 0;
+    var cur_report_size: u32 = 0;
+    var cur_report_count: u32 = 0;
+
+    var i: usize = 0;
+    while (i < bytes.len) {
+        const prefix = bytes[i];
+        const size = hidItemSize(prefix);
+        i += 1;
+        if (i + size > bytes.len) return error.TruncatedItem;
+
+        const tag = prefix & 0xF0;
+        const btype = (prefix >> 2) & 0b11; // 0=main, 1=global, 2=local
+        const payload = bytes[i..][0..size];
+
+        switch (prefix) {
+            0xA1 => { // Collection
+                collection_opens += 1;
+                collection_depth += 1;
+                if (collection_depth > max_depth) max_depth = collection_depth;
+            },
+            0xC0 => { // End Collection
+                collection_closes += 1;
+                collection_depth -= 1;
+            },
+            0x85 => { // Report ID (global)
+                report_ids_seen += 1;
+            },
+            else => {},
+        }
+
+        // Track Report Size / Report Count to verify byte alignment on Input
+        // items.
+        if (prefix == 0x75 and size == 1) cur_report_size = payload[0];
+        if (prefix == 0x95 and size == 1) cur_report_count = payload[0];
+
+        // Main input item (tag 1000, btype 0) — 0x80 family. 0x81 <data> is
+        // "Input".
+        if (tag == 0x80 and btype == 0) {
+            total_input_bits += @as(u64, cur_report_size) * @as(u64, cur_report_count);
+        }
+
+        i += size;
+    }
+
+    try testing.expectEqual(collection_opens, collection_closes);
+    try testing.expectEqual(@as(i32, 0), collection_depth);
+    try testing.expect(max_depth >= 1); // at least the application collection
+    try testing.expectEqual(@as(u32, 1), report_ids_seen);
+    // Steam Deck descriptor declares >= 1 input bit (buttons + hat + axes).
+    try testing.expect(total_input_bits > 0);
+    // The sum of Report Size × Report Count across Input items must be a
+    // multiple of 8 — the kernel rejects unaligned Input aggregates.
+    try testing.expectEqual(@as(u64, 0), total_input_bits % 8);
 }

--- a/src/io/uhid_descriptor.zig
+++ b/src/io/uhid_descriptor.zig
@@ -556,10 +556,13 @@ pub fn encodeReport(
 const testing = std.testing;
 const toml = @import("toml");
 
-fn makeAxesMap(allocator: std.mem.Allocator, entries: []const struct {
-    name: []const u8,
-    cfg: device.AxisConfig,
-}) !toml.HashMap(device.AxisConfig) {
+// Named helper types so multiple test sites can pass literals without
+// tripping Zig's anonymous-struct nominal typing (two anonymous structs
+// with the same shape but different declaration sites are distinct types).
+const AxisEntry = struct { name: []const u8, cfg: device.AxisConfig };
+const ButtonEntry = struct { name: []const u8, code: []const u8 };
+
+fn makeAxesMap(allocator: std.mem.Allocator, entries: []const AxisEntry) !toml.HashMap(device.AxisConfig) {
     var map = std.StringHashMap(device.AxisConfig).init(allocator);
     errdefer map.deinit();
     for (entries) |e| {
@@ -569,10 +572,7 @@ fn makeAxesMap(allocator: std.mem.Allocator, entries: []const struct {
     return .{ .map = map };
 }
 
-fn makeButtonsMap(allocator: std.mem.Allocator, entries: []const struct {
-    name: []const u8,
-    code: []const u8,
-}) !toml.HashMap([]const u8) {
+fn makeButtonsMap(allocator: std.mem.Allocator, entries: []const ButtonEntry) !toml.HashMap([]const u8) {
     var map = std.StringHashMap([]const u8).init(allocator);
     errdefer map.deinit();
     for (entries) |e| {
@@ -860,7 +860,7 @@ test "descriptor: reject > UHID_DATA_MAX via excessive button count is capped to
     const a = arena.allocator();
 
     // Create 100 button entries; builder should cap at 64.
-    var entries: [100]struct { name: []const u8, code: []const u8 } = undefined;
+    var entries: [100]ButtonEntry = undefined;
     var name_buf: [100][16]u8 = undefined;
     for (&entries, 0..) |*e, i| {
         const n = std.fmt.bufPrint(&name_buf[i], "B{d}", .{i}) catch unreachable;

--- a/src/io/uhid_descriptor.zig
+++ b/src/io/uhid_descriptor.zig
@@ -1205,7 +1205,9 @@ test "golden invariants: Steam Deck HID descriptor parses as balanced HID 1.11 i
     try testing.expectEqual(collection_opens, collection_closes);
     try testing.expectEqual(@as(i32, 0), collection_depth);
     try testing.expect(max_depth >= 1); // at least the application collection
-    try testing.expectEqual(@as(u32, 1), report_ids_seen);
+    // The Steam Deck descriptor declares exactly two Report IDs — one for
+    // the main input stream (ID 1) and one for the rumble output (ID 2).
+    try testing.expectEqual(@as(u32, 2), report_ids_seen);
     // Steam Deck descriptor declares >= 1 input bit (buttons + hat + axes).
     try testing.expect(total_input_bits > 0);
     // The sum of Report Size × Report Count across Input items must be a

--- a/src/main.zig
+++ b/src/main.zig
@@ -1024,6 +1024,7 @@ test {
     std.testing.refAllDecls(@This());
     _ = @import("core/rumble_scheduler.zig");
     _ = @import("test/bugfix_regression_test.zig");
+    _ = @import("test/uhid_uniq_pairing_test.zig");
     _ = @import("test/properties/config_props.zig");
     _ = @import("test/properties/contract_props.zig");
     _ = @import("test/properties/device_specific_props.zig");

--- a/src/test/fixtures/README.md
+++ b/src/test/fixtures/README.md
@@ -1,0 +1,67 @@
+# `src/test/fixtures/`
+
+Test-time fixtures that exercise the production code. Each fixture either:
+
+- pins a byte-exact binary payload the production code must emit or parse, OR
+- provides a parameterised generator (`.zig`) that drives repeatable test scenarios.
+
+## Fixtures
+
+### `golden/steam_deck_hid_descriptor.bin`
+
+HID 1.11 report descriptor bytes that `UhidDescriptorBuilder.buildFromOutput`
+must produce when fed `devices/valve/steam-deck.toml`.
+
+**Caveat — self-reference risk**: the .bin was originally emitted by the
+builder itself and checked in. A byte-exact golden-file test against it is
+therefore a tautology: the builder compared to its own output. This is
+disclosed in the audit's H5 finding.
+
+**Guardrails that defeat the tautology**:
+
+1. `steam_deck_hid_descriptor.annotated.txt` — human-auditable byte-by-byte
+   decomposition into HID 1.11 items. A reviewer can manually cross-check
+   every byte against the spec without trusting the builder.
+
+2. Structural invariant test in `src/io/uhid_descriptor.zig`:
+   `golden invariants: Steam Deck HID descriptor parses as balanced HID 1.11
+   item stream` — parses the .bin as short items and asserts:
+   - Prologue is `Usage Page (Generic Desktop) + Usage (Game Pad) + Collection (Application)`
+   - Collection opens match Collection closes (balanced `A1 ... C0`)
+   - Exactly two Report IDs appear (input = 1, rumble output = 2)
+   - Sum of `Report Size × Report Count` across Input items is a multiple of 8
+     (byte-aligned aggregate — kernel rejects unaligned)
+
+   These invariants would catch any builder corruption that drifted from
+   the HID spec (unbalanced collections, missing report ID, unaligned
+   aggregates) even if the golden .bin itself were wrong.
+
+### `steam_deck_reports.zig`
+
+Synthetic Steam Deck 0x09 input-report generator. Drives end-to-end tests
+against `devices/valve/steam-deck.toml` with a lizard-mode state machine
+that mirrors the firmware-suppressed pre-unlock behaviour.
+
+The vendor/product IDs used here (`DECK_VID` / `DECK_PID`) are **synthetic**,
+not Valve's real `0x28de/0x1205`. This prevents the test harness from
+accidentally picking up a real Steam Deck plugged into the developer's
+machine — see the audit's H6 finding.
+
+## How to regenerate `steam_deck_hid_descriptor.bin`
+
+Do **not** regenerate by running the builder — that re-introduces the
+tautology. If the descriptor needs to change legitimately (TOML schema
+update, new field, bug fix), the correct procedure is:
+
+1. Update the builder and/or TOML.
+2. Update `steam_deck_hid_descriptor.annotated.txt` **by hand** with the
+   new expected items, reading the HID 1.11 spec.
+3. Write out the new .bin by copying the annotated bytes — the .txt is
+   the source of truth, the .bin is derived.
+4. Run `zig build test`; the structural invariant test must still pass,
+   and `descriptor: matches golden fixture for Steam Deck output` will
+   catch a builder/.bin mismatch.
+
+An alternative reference source would be a `hidrd-decode` round-trip of
+a real Steam Deck descriptor captured from `sysfs` — this is a valuable
+cross-check to add in a later audit pass but out of scope for H5.

--- a/src/test/fixtures/golden/steam_deck_hid_descriptor.annotated.txt
+++ b/src/test/fixtures/golden/steam_deck_hid_descriptor.annotated.txt
@@ -1,0 +1,193 @@
+Steam Deck HID report descriptor — byte-level annotation
+=========================================================
+
+Source: src/test/fixtures/golden/steam_deck_hid_descriptor.bin
+Generator: UhidDescriptorBuilder.buildFromOutput(devices/valve/steam-deck.toml)
+Reference: USB HID Usage Tables 1.11, Appendix A (Device Class Definition §6.2.2.4)
+
+Purpose: a human-auditable reference that allows a reviewer to verify the
+builder's output against HID spec without trusting the builder. Pair it with
+`golden invariants: Steam Deck HID descriptor parses as balanced HID 1.11
+item stream` in `src/io/uhid_descriptor.zig` — the test parses the .bin as
+HID 1.11 short items and asserts collection balance, report-id uniqueness,
+and byte alignment.
+
+Each line: `offset | bytes | HID item | notes`
+
+offset | bytes          | item
+--------------------------------------------------------------------------
+                                 === Prologue ===
+0x0000 | 05 01          | Usage Page (Generic Desktop)
+0x0002 | 09 05          | Usage (Game Pad)
+0x0004 | A1 01          | Collection (Application)
+0x0006 | 85 01          | Report ID (1) — main input report
+
+                                 === 1. Buttons (Button Page) ===
+0x0008 | 05 09          | Usage Page (Button)
+0x000A | 19 01          | Usage Minimum (Button 1)
+0x000C | 29 11          | Usage Maximum (Button 17)
+0x000E | 15 00          | Logical Minimum (0)
+0x0010 | 25 01          | Logical Maximum (1)
+0x0012 | 75 01          | Report Size (1 bit)
+0x0014 | 95 11          | Report Count (17 bits) — matches steam-deck.toml [output.buttons] count
+0x0016 | 81 02          | Input (Data, Var, Abs) — the button bitmap
+0x0018 | 75 01          | Report Size (1 bit)
+0x001A | 95 07          | Report Count (7 bits) — padding to realign to byte boundary (17 + 7 = 24 = 3 bytes)
+0x001C | 81 03          | Input (Const, Var, Abs) — padding
+
+                                 === 2. Hat switch (dpad) ===
+0x001E | 05 01          | Usage Page (Generic Desktop)
+0x0020 | 09 39          | Usage (Hat switch)
+0x0022 | 15 00          | Logical Minimum (0)
+0x0024 | 25 07          | Logical Maximum (7) — 8 directions, 8 = null
+0x0026 | 35 00          | Physical Minimum (0)
+0x0028 | 46 3B 01       | Physical Maximum (315 degrees)
+0x002B | 65 14          | Unit (Eng Rot: Degrees)
+0x002D | 75 04          | Report Size (4 bits)
+0x002F | 95 01          | Report Count (1)
+0x0031 | 81 42          | Input (Data, Var, Abs, Null) — 0x42: Null bit set, allows invalid=8
+0x0033 | 65 00          | Unit (None) — reset unit scope so following axes aren't degrees
+0x0035 | 75 04          | Report Size (4 bits)
+0x0037 | 95 01          | Report Count (1)
+0x0039 | 81 03          | Input (Const, Var, Abs) — 4-bit padding to realign to byte boundary
+
+                                 === 3. Left stick X ===
+0x003B | 05 01          | Usage Page (Generic Desktop)
+0x003D | 09 30          | Usage (X)
+0x003F | 16 00 80       | Logical Minimum (-32768)
+0x0042 | 26 FF 7F       | Logical Maximum (32767)
+0x0045 | 75 10          | Report Size (16 bits)
+0x0047 | 95 01          | Report Count (1)
+0x0049 | 81 02          | Input (Data, Var, Abs)
+
+                                 === 4. Left stick Y ===
+0x004B | 05 01          | Usage Page (Generic Desktop)
+0x004D | 09 31          | Usage (Y)
+0x004F | 16 00 80       | Logical Minimum (-32768)
+0x0052 | 26 FF 7F       | Logical Maximum (32767)
+0x0055 | 75 10          | Report Size (16 bits)
+0x0057 | 95 01          | Report Count (1)
+0x0059 | 81 02          | Input (Data, Var, Abs)
+
+                                 === 5. Right stick X ===
+0x005B | 05 01          | Usage Page (Generic Desktop)
+0x005D | 09 33          | Usage (Rx)
+0x005F | 16 00 80       | Logical Minimum (-32768)
+0x0062 | 26 FF 7F       | Logical Maximum (32767)
+0x0065 | 75 10          | Report Size (16 bits)
+0x0067 | 95 01          | Report Count (1)
+0x0069 | 81 02          | Input (Data, Var, Abs)
+
+                                 === 6. Right stick Y ===
+0x006B | 05 01          | Usage Page (Generic Desktop)
+0x006D | 09 34          | Usage (Ry)
+0x006F | 16 00 80       | Logical Minimum (-32768)
+0x0072 | 26 FF 7F       | Logical Maximum (32767)
+0x0075 | 75 10          | Report Size (16 bits)
+0x0077 | 95 01          | Report Count (1)
+0x0079 | 81 02          | Input (Data, Var, Abs)
+
+                                 === 7. Left trigger (Z) ===
+0x007B | 05 01          | Usage Page (Generic Desktop)
+0x007D | 09 32          | Usage (Z)
+0x007F | 15 00          | Logical Minimum (0)
+0x0081 | 26 FF 00       | Logical Maximum (255)
+0x0084 | 75 08          | Report Size (8 bits)
+0x0086 | 95 01          | Report Count (1)
+0x0088 | 81 02          | Input (Data, Var, Abs)
+
+                                 === 8. Right trigger (Rz) ===
+0x008A | 05 01          | Usage Page (Generic Desktop)
+0x008C | 09 35          | Usage (Rz)
+0x008E | 15 00          | Logical Minimum (0)
+0x0090 | 26 FF 00       | Logical Maximum (255)
+0x0093 | 75 08          | Report Size (8 bits)
+0x0095 | 95 01          | Report Count (1)
+0x0097 | 81 02          | Input (Data, Var, Abs)
+
+                                 === 9. Touchpad (Logical Collection, two fingers) ===
+0x0099 | 05 0D          | Usage Page (Digitizer)
+0x009B | 09 05          | Usage (Touch Pad)
+0x009D | A1 02          | Collection (Logical)
+
+                                 === Finger 0 ===
+0x009F | 09 22          | Usage (Finger)
+0x00A1 | A1 02          | Collection (Logical)
+0x00A3 | 09 42          | Usage (Tip Switch)
+0x00A5 | 15 00          | Logical Minimum (0)
+0x00A7 | 25 01          | Logical Maximum (1)
+0x00A9 | 75 01          | Report Size (1 bit)
+0x00AB | 95 01          | Report Count (1)
+0x00AD | 81 02          | Input (Data, Var, Abs) — tip switch (contact state)
+0x00AF | 75 07          | Report Size (7 bits)
+0x00B1 | 95 01          | Report Count (1)
+0x00B3 | 81 03          | Input (Const, Var, Abs) — padding
+0x00B5 | 05 01          | Usage Page (Generic Desktop)
+0x00B7 | 09 30          | Usage (X)
+0x00B9 | 16 00 80       | Logical Minimum (-32768)
+0x00BC | 26 FF 7F       | Logical Maximum (32767)
+0x00BF | 75 10          | Report Size (16 bits)
+0x00C1 | 95 01          | Report Count (1)
+0x00C3 | 81 02          | Input (Data, Var, Abs)
+0x00C5 | 09 31          | Usage (Y)
+0x00C7 | 16 00 80       | Logical Minimum (-32768)
+0x00CA | 26 FF 7F       | Logical Maximum (32767)
+0x00CD | 75 10          | Report Size (16 bits)
+0x00CF | 95 01          | Report Count (1)
+0x00D1 | 81 02          | Input (Data, Var, Abs)
+0x00D3 | 05 0D          | Usage Page (Digitizer)
+0x00D5 | C0             | End Collection (Finger 0)
+
+                                 === Finger 1 ===
+0x00D6 | 09 22          | Usage (Finger)
+0x00D8 | A1 02          | Collection (Logical)
+0x00DA | 09 42          | Usage (Tip Switch)
+0x00DC | 15 00          | Logical Minimum (0)
+0x00DE | 25 01          | Logical Maximum (1)
+0x00E0 | 75 01          | Report Size (1 bit)
+0x00E2 | 95 01          | Report Count (1)
+0x00E4 | 81 02          | Input (Data, Var, Abs)
+0x00E6 | 75 07          | Report Size (7 bits)
+0x00E8 | 95 01          | Report Count (1)
+0x00EA | 81 03          | Input (Const, Var, Abs) — padding
+0x00EC | 05 01          | Usage Page (Generic Desktop)
+0x00EE | 09 30          | Usage (X)
+0x00F0 | 16 00 80       | Logical Minimum (-32768)
+0x00F3 | 26 FF 7F       | Logical Maximum (32767)
+0x00F6 | 75 10          | Report Size (16 bits)
+0x00F8 | 95 01          | Report Count (1)
+0x00FA | 81 02          | Input (Data, Var, Abs)
+0x00FC | 09 31          | Usage (Y)
+0x00FE | 16 00 80       | Logical Minimum (-32768)
+0x0101 | 26 FF 7F       | Logical Maximum (32767)
+0x0104 | 75 10          | Report Size (16 bits)
+0x0106 | 95 01          | Report Count (1)
+0x0108 | 81 02          | Input (Data, Var, Abs)
+0x010A | 05 0D          | Usage Page (Digitizer)
+0x010C | C0             | End Collection (Finger 1)
+0x010D | C0             | End Collection (Touch Pad)
+
+                                 === 10. Rumble output report (Vendor-Defined) ===
+0x010E | 06 00 FF       | Usage Page (Vendor-Defined 0xFF00)
+0x0111 | 85 02          | Report ID (2) — rumble output report
+0x0113 | 09 01          | Usage (Vendor Usage 1)
+0x0115 | 15 00          | Logical Minimum (0)
+0x0117 | 26 FF 00       | Logical Maximum (255)
+0x011A | 75 08          | Report Size (8 bits)
+0x011C | 95 02          | Report Count (2) — strong + weak magnitudes
+0x011E | 91 02          | Output (Data, Var, Abs)
+
+                                 === End Application Collection ===
+0x0120 | C0             | End Collection
+
+--------------------------------------------------------------------------
+Total bytes: 0x121 = 289
+
+Invariants validated by the structural test:
+  * Collection opens == closes (each A1 has a matching C0)
+  * Exactly one Report ID appears on the input side (0x85 0x01) — the
+    0x85 0x02 at 0x0111 names the rumble OUTPUT report and is expected.
+  * Prologue is Usage Page (Generic Desktop) + Usage (Game Pad) +
+    Collection (Application).
+  * Sum of Report Size × Report Count across all Input items is a
+    multiple of 8 (byte-aligned aggregate).

--- a/src/test/fixtures/steam_deck_reports.zig
+++ b/src/test/fixtures/steam_deck_reports.zig
@@ -33,9 +33,15 @@ const std = @import("std");
 
 pub const ReportSize: usize = 64;
 
-/// Canonical Valve Steam Deck vendor / product IDs.
-pub const DECK_VID: u16 = 0x28de;
-pub const DECK_PID: u16 = 0x1205;
+/// Synthetic VID/PID used by the test harness — **not** Valve's real IDs.
+/// A developer running these tests on a machine with a real Steam Deck
+/// attached would otherwise see `UhidSimulator.findHidrawPath` alias to the
+/// real hardware node (same 0x28de:0x1205 match), corrupting both the test
+/// harness and potentially the real device's input stream. Picking a value
+/// outside any known vendor range (0xFADE is not assigned by USB-IF) ensures
+/// the virtual device we create is the only match.
+pub const DECK_VID: u16 = 0xFADE;
+pub const DECK_PID: u16 = 0xD00D;
 
 /// Subset of `ButtonId` relevant to Deck digital buttons. Enum values are the
 /// bit indices inside the 64-bit `button_group` field that starts at byte 8.

--- a/src/test/harness/uhid_simulator.zig
+++ b/src/test/harness/uhid_simulator.zig
@@ -96,11 +96,13 @@ pub const UhidSimulator = struct {
 
         // Bounded poll for the hidraw node. Real kernels take ~20-100ms to
         // wire the hidraw class device up. We deliberately exceed the test
-        // timeout by a small factor so slow CI doesn't flap.
+        // timeout by a small factor so slow CI doesn't flap. The optional
+        // uniq filter excludes real hardware sharing our synthetic VID/PID
+        // — belt-and-braces defence against vendor-ID collisions.
         const start = std.time.milliTimestamp();
         const deadline = start + @as(i64, @intCast(opts.hidraw_timeout_ms));
         while (std.time.milliTimestamp() < deadline) {
-            if (try findHidrawPath(opts.vid, opts.pid)) |entry| {
+            if (try findHidrawPath(opts.vid, opts.pid, opts.uniq)) |entry| {
                 @memcpy(self.hidraw_path_buf[0..entry.len], entry.slice());
                 self.hidraw_path_buf[entry.len] = 0;
                 self.hidraw_path_len = entry.len;
@@ -183,7 +185,12 @@ const HidrawEntry = struct {
     }
 };
 
-fn findHidrawPath(vid: u16, pid: u16) !?HidrawEntry {
+/// Find a /dev/hidrawN whose VID/PID match and — when `expect_uniq` is
+/// non-empty — whose `HIDIOCGRAWUNIQ` attribute matches exactly. The uniq
+/// filter prevents aliasing a real device that happens to share the
+/// synthetic test VID/PID; when `expect_uniq` is empty the legacy
+/// VID/PID-only match applies.
+fn findHidrawPath(vid: u16, pid: u16, expect_uniq: []const u8) !?HidrawEntry {
     const linux = std.os.linux;
     var i: u8 = 0;
     while (i < 64) : (i += 1) {
@@ -196,11 +203,19 @@ fn findHidrawPath(vid: u16, pid: u16) !?HidrawEntry {
         if (rc != 0) continue;
         const dev_vid: u16 = @bitCast(info.vendor);
         const dev_pid: u16 = @bitCast(info.product);
-        if (dev_vid == vid and dev_pid == pid) {
-            var out = HidrawEntry{ .storage = undefined, .len = path.len };
-            @memcpy(out.storage[0..path.len], path);
-            return out;
+        if (dev_vid != vid or dev_pid != pid) continue;
+
+        if (expect_uniq.len != 0) {
+            var uniq_buf: [64]u8 = std.mem.zeroes([64]u8);
+            const uniq_rc = linux.ioctl(fd, ioctl_constants.HIDIOCGRAWUNIQ(uniq_buf.len), @intFromPtr(&uniq_buf));
+            if (uniq_rc < 0) continue;
+            const nul = std.mem.indexOfScalar(u8, &uniq_buf, 0) orelse uniq_buf.len;
+            if (!std.mem.eql(u8, uniq_buf[0..nul], expect_uniq)) continue;
         }
+
+        var out = HidrawEntry{ .storage = undefined, .len = path.len };
+        @memcpy(out.storage[0..path.len], path);
+        return out;
     }
     return null;
 }

--- a/src/test/uhid_uniq_pairing_test.zig
+++ b/src/test/uhid_uniq_pairing_test.zig
@@ -1,0 +1,202 @@
+//! ADR-015 Stage 1 acceptance-criterion test: verify that two UHID-backed
+//! evdev nodes created with the same `uniq` string return byte-identical
+//! values from `EVIOCGUNIQ`. SDL's `GetSensor()` pairs main-pad and IMU by
+//! strcmp-equal uniq strings, so this is the CI-equivalent signal for the
+//! Stage 1 exit condition.
+//!
+//! ## Runtime behaviour
+//!
+//! - On non-Linux hosts: returns `error.SkipZigTest` (standard practice).
+//! - On Linux hosts *without* `/dev/uhid` access (root-only CI runners,
+//!   unprivileged containers): logs an explicit warning so the absence is
+//!   visible in CI output, then behaves one of two ways:
+//!     * Default: returns `error.SkipZigTest` — test suite stays green on
+//!       CI while making the gap audible.
+//!     * When `PADCTL_TEST_REQUIRE_UHID=1` is set: returns
+//!       `error.UhidAccessRequired` — fails the test so an environment
+//!       that's meant to have /dev/uhid access but doesn't surfaces the
+//!       breakage immediately. Used by post-install verification and
+//!       ADR-015-compliant CI runners.
+//!
+//! ## Why this can't just silently SkipZigTest
+//!
+//! The audit flagged H2 — the Stage 1 AC was unmet because no production
+//! code imported `EVIOCGUNIQ` at all. A plain `error.SkipZigTest` on
+//! missing /dev/uhid would recreate that silent failure mode. The warning
+//! log + opt-in hard fail preserves the CI signal without making local dev
+//! environments red by default.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const posix = std.posix;
+const linux = std.os.linux;
+const testing = std.testing;
+
+const uhid = @import("../io/uhid.zig");
+const ioctl_constants = @import("../io/ioctl_constants.zig");
+
+const SHARED_UNIQ = "padctl/uniq-pair-test-0";
+
+fn requireUhid() bool {
+    const v = std.posix.getenv("PADCTL_TEST_REQUIRE_UHID") orelse return false;
+    return std.mem.eql(u8, v, "1") or std.mem.eql(u8, v, "true");
+}
+
+fn reportMissingUhid(reason: []const u8) error{ SkipZigTest, UhidAccessRequired } {
+    std.log.warn(
+        "uhid_uniq_pairing_test: /dev/uhid unavailable ({s}) — ADR-015 Stage 1 CI signal is SILENT. " ++
+            "Install udev rules via 'sudo ./zig-out/bin/padctl install' and reload udev, " ++
+            "or set PADCTL_TEST_REQUIRE_UHID=1 to turn this into a hard failure.",
+        .{reason},
+    );
+    if (requireUhid()) return error.UhidAccessRequired;
+    return error.SkipZigTest;
+}
+
+fn waitForEvdevNode(vid: u16, pid: u16, uniq: []const u8, timeout_ms: u32) !?[64]u8 {
+    const start = std.time.milliTimestamp();
+    const deadline = start + @as(i64, @intCast(timeout_ms));
+    while (std.time.milliTimestamp() < deadline) {
+        if (try findEvdevByUniq(vid, pid, uniq)) |path| return path;
+        std.Thread.sleep(20 * std.time.ns_per_ms);
+    }
+    return null;
+}
+
+fn findEvdevByUniq(vid: u16, pid: u16, expect_uniq: []const u8) !?[64]u8 {
+    var i: u8 = 0;
+    while (i < 64) : (i += 1) {
+        var path_buf: [64]u8 = undefined;
+        const path = std.fmt.bufPrint(&path_buf, "/dev/input/event{d}", .{i}) catch continue;
+        const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch continue;
+        defer posix.close(fd);
+
+        var id: [4]u16 = std.mem.zeroes([4]u16); // bustype, vendor, product, version
+        const rc_id = linux.ioctl(fd, 0x80084502, @intFromPtr(&id)); // EVIOCGID
+        if (rc_id != 0) continue;
+        if (id[1] != vid or id[2] != pid) continue;
+
+        var uniq_buf: [64]u8 = std.mem.zeroes([64]u8);
+        const rc = linux.ioctl(fd, ioctl_constants.EVIOCGUNIQ(uniq_buf.len), @intFromPtr(&uniq_buf));
+        if (rc < 0) continue;
+        const nul = std.mem.indexOfScalar(u8, &uniq_buf, 0) orelse uniq_buf.len;
+        if (!std.mem.eql(u8, uniq_buf[0..nul], expect_uniq)) continue;
+
+        var result: [64]u8 = std.mem.zeroes([64]u8);
+        @memcpy(result[0..path.len], path);
+        return result;
+    }
+    return null;
+}
+
+fn readUniqFromEvdevPath(path: []const u8) ![]u8 {
+    const fd = try posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0);
+    defer posix.close(fd);
+
+    var buf: [64]u8 = std.mem.zeroes([64]u8);
+    const rc = linux.ioctl(fd, ioctl_constants.EVIOCGUNIQ(buf.len), @intFromPtr(&buf));
+    if (rc < 0) return error.EvdevIoctlFailed;
+    const nul = std.mem.indexOfScalar(u8, &buf, 0) orelse buf.len;
+    const out = try testing.allocator.alloc(u8, nul);
+    @memcpy(out, buf[0..nul]);
+    return out;
+}
+
+const MINIMAL_DESCRIPTOR = [_]u8{
+    0x05, 0x01, // Usage Page (Generic Desktop)
+    0x09, 0x05, // Usage (Game Pad)
+    0xA1, 0x01, // Collection (Application)
+    0x09, 0x30, // Usage (X)
+    0x15, 0x00, 0x26, 0xFF, 0x00, // Logical Min/Max 0..255
+    0x75, 0x08, 0x95, 0x01, // Report Size/Count 8/1
+    0x81, 0x02, // Input (Data, Var, Abs)
+    0xC0, // End Collection
+};
+
+test "uhid: EVIOCGUNIQ returns identical strings on a paired main-pad + IMU (ADR-015 Stage 1 AC)" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+
+    // Probe /dev/uhid accessibility — if the test host lacks permission,
+    // emit a loud warning so the gap is visible in logs rather than
+    // silently passing.
+    const probe = uhid.openUhid() catch |err| switch (err) {
+        error.SkipZigTest => return reportMissingUhid("openUhid returned SkipZigTest"),
+        else => |e| return e,
+    };
+    posix.close(probe);
+
+    const MAIN_VID: u16 = 0xFADE;
+    const MAIN_PID: u16 = 0xC001;
+    const IMU_VID: u16 = 0xFADE;
+    const IMU_PID: u16 = 0xC002;
+
+    // Create two UHID devices sharing the same uniq.
+    const main_fd = try uhid.openUhid();
+    defer {
+        uhid.uhidDestroy(main_fd);
+        posix.close(main_fd);
+    }
+    try sendCreateWithUniq(main_fd, MAIN_VID, MAIN_PID, "padctl-main", SHARED_UNIQ);
+
+    const imu_fd = try uhid.openUhid();
+    defer {
+        uhid.uhidDestroy(imu_fd);
+        posix.close(imu_fd);
+    }
+    try sendCreateWithUniq(imu_fd, IMU_VID, IMU_PID, "padctl-imu", SHARED_UNIQ);
+
+    // Wait for evdev nodes to appear.
+    const main_path = (try waitForEvdevNode(MAIN_VID, MAIN_PID, SHARED_UNIQ, 2000)) orelse
+        return reportMissingUhid("main-pad evdev node did not appear (input subsystem denied?)");
+    const imu_path = (try waitForEvdevNode(IMU_VID, IMU_PID, SHARED_UNIQ, 2000)) orelse
+        return reportMissingUhid("imu evdev node did not appear");
+
+    const main_path_len = std.mem.indexOfScalar(u8, &main_path, 0) orelse main_path.len;
+    const imu_path_len = std.mem.indexOfScalar(u8, &imu_path, 0) orelse imu_path.len;
+
+    const main_uniq = try readUniqFromEvdevPath(main_path[0..main_path_len]);
+    defer testing.allocator.free(main_uniq);
+    const imu_uniq = try readUniqFromEvdevPath(imu_path[0..imu_path_len]);
+    defer testing.allocator.free(imu_uniq);
+
+    // The actual contract — what SDL strcmp tests for.
+    try testing.expectEqualStrings(SHARED_UNIQ, main_uniq);
+    try testing.expectEqualStrings(SHARED_UNIQ, imu_uniq);
+    try testing.expectEqualSlices(u8, main_uniq, imu_uniq);
+}
+
+fn sendCreateWithUniq(fd: posix.fd_t, vid: u16, pid: u16, name: []const u8, uniq: []const u8) !void {
+    var ev = std.mem.zeroes(uhid.UhidCreate2Event);
+    ev.type = uhid.UHID_CREATE2;
+    const name_copy = @min(name.len, ev.payload.name.len - 1);
+    @memcpy(ev.payload.name[0..name_copy], name[0..name_copy]);
+    const uniq_copy = @min(uniq.len, ev.payload.uniq.len - 1);
+    @memcpy(ev.payload.uniq[0..uniq_copy], uniq[0..uniq_copy]);
+    ev.payload.rd_size = @intCast(MINIMAL_DESCRIPTOR.len);
+    ev.payload.bus = uhid.BUS_USB;
+    ev.payload.vendor = vid;
+    ev.payload.product = pid;
+    @memcpy(ev.payload.rd_data[0..MINIMAL_DESCRIPTOR.len], &MINIMAL_DESCRIPTOR);
+
+    const bytes = std.mem.asBytes(&ev);
+    var buf: [uhid.UHID_EVENT_SIZE]u8 = std.mem.zeroes([uhid.UHID_EVENT_SIZE]u8);
+    const copy_len = @min(bytes.len, uhid.UHID_EVENT_SIZE);
+    @memcpy(buf[0..copy_len], bytes[0..copy_len]);
+    _ = try posix.write(fd, &buf);
+}
+
+test "uhid: EVIOCGUNIQ ioctl constructor round-trips the size field" {
+    // Defensive unit test — if the IOCTL.Request layout ever drifts, this
+    // catches it before the hardware-gated test above.
+    const r = ioctl_constants.EVIOCGUNIQ(64);
+    // Direction = _IOC_READ = 2; io_type = 'E' (0x45); nr = 0x08; size = 64.
+    // Kernel layout (from linux/ioctl.h):
+    //   bits 0..7   = nr
+    //   bits 8..15  = type
+    //   bits 16..29 = size
+    //   bits 30..31 = dir
+    try testing.expectEqual(@as(u32, 0x08), r & 0xFF);
+    try testing.expectEqual(@as(u32, 'E'), (r >> 8) & 0xFF);
+    try testing.expectEqual(@as(u32, 64), (r >> 16) & 0x3FFF);
+    try testing.expectEqual(@as(u32, 2), (r >> 30) & 0x3);
+}


### PR DESCRIPTION
## Summary

Addresses all 6 HIGH findings from a strict independent UHID audit of `main` (Wave 1+2 merged via #127/#132), closes the ADR-015 Stage 1 CI acceptance criterion, implements the Wave-3 descriptor-driven encoder, and fixes the udev permission model so SSH / headless / test scenarios can access `/dev/uhid` (and `/dev/uinput`) without sudo at runtime.

## What changed

### UHID audit findings (6 HIGH → 0)

- **H1** — `test "uhid: UhidDevice vtable signature matches OutputDevice"` was a tautology (comparing `OutputDevice.VTable.emit` to itself). Replaced with a real dispatch test that pipes contrasting `GamepadState` inputs through `outputDevice().emit()` and asserts bytes on the backing fd. Proves dispatch reaches the live implementation.
- **H2** — ADR-015 Stage 1 CI AC required an `EVIOCGUNIQ` test pairing main-pad + IMU uniq. None existed. Added `src/test/uhid_uniq_pairing_test.zig`: creates two UHID devices with the same uniq, reads back via `EVIOCGUNIQ`, asserts byte-identical. Default skip when `/dev/uhid` inaccessible with loud `std.log.warn`; `PADCTL_TEST_REQUIRE_UHID=1` env var upgrades to hard fail for gated CI.
- **H3** — `UhidDevice.emit()` stub sent 4 raw `u8` axes with no Report ID, incompatible with the descriptor produced by `UhidDescriptorBuilder` (declares Report ID 1 + i16 sticks). Wave-3 encoder implemented: `encodeReport(cfg, state, buf)` packs bytes in the exact layout the builder declares — Report ID | buttons (LSB-first, byte-padded) | hat (4+4) | sticks (i16 LE × 4) | triggers (u8 × 2) | touchpad (tip + X i16 + Y i16 per finger). `emit()` now routes through `encodeReport` when `Config.output` is set.
- **H4** — `uhidInput` / `emitRaw` had no length guard against `UHID_DATA_MAX` (4096), safe-mode panic or release-mode OOB on oversized payload. Added `error.PayloadTooLong` return; `emitRaw` maps to `EmitError.WriteFailed` for vtable stability.
- **H5** — `steam_deck_hid_descriptor.bin` golden was the builder's own output (tautology). Added `steam_deck_hid_descriptor.annotated.txt` with byte-by-byte HID 1.11 item decomposition and `src/test/fixtures/README.md` documenting regeneration procedure. New test parses the golden as HID items and asserts structural invariants (balanced collections, exactly 2 Report IDs, input bit total multiple of 8) — catches builder regressions even if the golden is edited incorrectly.
- **H6** — `steam_deck_uhid_e2e_test` used Valve's real Steam Deck VID/PID (`0x28de:0x1205`); developers with real hardware would alias it. Switched to synthetic `0xFADE:0xD00D` + added uniq filter in `UhidSimulator.findHidrawPath` as secondary disambiguation.

### ADR-015 §Dependencies (install permissions)

- **DeviceAllow** `/dev/uhid rw` added to systemd user service (alongside existing `/dev/uinput`)
- **udev rule** `SUBSYSTEM=="misc", KERNEL=="uhid", TAG+="uaccess", GROUP="input", MODE="0660"` (and the same for `uinput`) — dual-path access: graphical-login users get uaccess ACL automatically; SSH / headless / test users get permission via `input` group membership. The `input` group fallback also addresses the same-root-cause regression hitting `/dev/input/event*` since `SupplementaryGroups=input` was dropped.
- **modules-load.d** `/usr/lib/modules-load.d/padctl.conf` writes `uhid` and `uinput` so both kernel modules load at boot (was a latent ordering issue — install relied on them being already loaded)
- **Install hint** — prints `sudo usermod -aG input $USER` remediation when current user is not in the `input` group

## Tests

All new code ships with regression tests. Independent verification on this machine:

```
zig build test        → exit 0 in 6s (891 pass, 3 hardware-gated skips)
zig build test-tsan   → exit 0 in 7s
zig build test-safe   → exit 0
```

With `/dev/uhid` accessible (post-install + `input` group membership + fresh session):

```
PADCTL_TEST_REQUIRE_UHID=1 zig build test  → exit 0 (H2 uniq pairing test runs end-to-end)
```

Without `/dev/uhid` access (the default CI environment):

```
PADCTL_TEST_REQUIRE_UHID=1 zig build test  → exit 1 (intentional — makes the CI-signal gap audible instead of silent)
```

## Commits

- `edb8edd` fix(uhid): replace tautological vtable test with real dispatch test
- `63750da` fix(uhid): guard uhidInput against oversized payload
- `b61bd08` feat(uhid): implement encodeReport driven by descriptor layout
- `5a94e19` test(uhid): add annotated golden reference and structural invariants
- `16f1ab7` fix(uhid): use synthetic VID/PID in e2e tests and add uniq filter
- `6fefef8` test(uhid): add EVIOCGUNIQ uniq-pairing test for ADR-015 Stage 1 AC
- `514bb15` feat(install): grant /dev/uhid DeviceAllow and uaccess tag (ADR-015)
- `3e53694` feat(install): add input group fallback to uhid/uinput udev rules

## Notes for reviewers

- No breaking API changes; `UhidDevice.Config.output` is optional, existing raw-descriptor test paths continue to work.
- The `encodeReport` layout ordering is fixed (`{ABS_X, ABS_Y, ABS_RX, ABS_RY}` sticks, `{ABS_Z, ABS_RZ}` triggers) rather than TOML insertion order, which is non-deterministic from `StringHashMap`.
- install.zig writes to `/usr/lib/modules-load.d/` on standard prefix or `/etc/modules-load.d/` on immutable systems; uninstall removes both locations to cover prior installs.
- `sg input -c '<cmd>'` or `newgrp input` is enough to pick up the new group in an existing SSH session without logout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Installer now configures kernel module loading and device access for both UHID and UINPUT; system service and udev rules updated accordingly.
  - Device output can emit descriptor-shaped HID reports when configured; oversized payloads are now rejected with clear errors.
  - CLI prints post-install guidance to join the input group when needed.

* **Bug Fixes**
  - Uninstall reliably removes generated module config files.

* **Tests**
  - Added integration and unit tests for UHID/evdev uniq pairing, ioctl helpers, report encoder, and installation artifacts.

* **Documentation**
  - Added fixture README and annotated HID descriptor reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->