### PR TITLE
fix(supervisor): rebuild aux device caps on padctl switch

### DIFF
--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const posix = std.posix;
 
 const DeviceIO = @import("io/device_io.zig").DeviceIO;
@@ -88,6 +89,10 @@ pub const DeviceInstance = struct {
     pending_mapping: ?*MappingConfig,
     stopped: bool,
     poll_timeout_ms: ?u32 = null,
+    // Test-only observability hook for issue #142 regression: counts
+    // rebuildAuxIfChanged invocations so tests can verify the switch path
+    // actually rebuilds aux caps without relying on /dev/uinput.
+    rebuild_aux_calls: if (builtin.is_test) usize else void = if (builtin.is_test) 0 else {},
 
     /// Open all interfaces, run init handshake, create EventLoop/Interpreter/Output.
     /// init_mapping: optional MappingConfig used to auto-derive aux capabilities when
@@ -280,6 +285,7 @@ pub const DeviceInstance = struct {
     /// Rebuild AuxDevice if caps changed after a mapping swap. old_mcfg may be null
     /// if there was no prior mapping. Called from run() after pending_mapping swap.
     pub fn rebuildAuxIfChanged(self: *DeviceInstance, new_mcfg: *const MappingConfig, old_mcfg: ?*const MappingConfig) !void {
+        if (builtin.is_test) self.rebuild_aux_calls += 1;
         if (self.device_cfg.output == null) return;
         const new_caps = mapping_mod.deriveAuxFromMapping(new_mcfg);
         const old_caps: mapping_mod.DerivedAuxCaps = if (old_mcfg) |m|

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -760,6 +760,15 @@ pub const Supervisor = struct {
         m.instance.mapper = tx.new_mapper.?;
         tx.new_mapper = null;
         m.instance.mapping_cfg = &tx.parsed_ptr.?.value;
+        // issue #142: rebuild AuxDevice when switching mappings so newly
+        // required KEY_* or REL_* capabilities become available. Warn rather
+        // than propagate on failure, matching the reload path (~line 676).
+        m.instance.rebuildAuxIfChanged(
+            &tx.parsed_ptr.?.value,
+            tx.old_mapping_cfg,
+        ) catch |err| {
+            std.log.warn("rebuildAuxIfChanged during switch: {}", .{err});
+        };
         restartManagedThread(m) catch |err| {
             if (m.instance.mapper) |*cur| {
                 cur.deinit();
@@ -2174,6 +2183,92 @@ test "supervisor: Supervisor: global SWITCH rolls back all devices on failure" {
     try testing.expect(sup.managed.items[1].switch_mapping == null);
     try testing.expectEqual(false, @atomicLoad(bool, &sup.managed.items[0].instance.stopped, .acquire));
     try testing.expectEqual(false, @atomicLoad(bool, &sup.managed.items[1].instance.stopped, .acquire));
+}
+
+test "supervisor: switch to mapping with new aux KEY_* rebuilds aux caps (issue #142)" {
+    // Regression for issue #142: before the fix, commitSwitchTarget swapped
+    // mapper and mapping_cfg but never called rebuildAuxIfChanged. If the
+    // default_mapping loaded at daemon start did not need aux (needs_keyboard
+    // false, no mouse/rel), AuxDevice was created with zero KEY_* caps; then
+    // `padctl switch` to a mapping containing KEY_* remaps left the aux_dev
+    // caps stale and the kernel silently rejected KEY_G emissions.
+    //
+    // This test uses a device config with no [output] section so
+    // rebuildAuxIfChanged short-circuits without touching /dev/uinput, and
+    // observes the call via the test-only rebuild_aux_calls counter on
+    // DeviceInstance. If the rebuildAuxIfChanged line in commitSwitchTarget
+    // is removed, the counter stays 0 and this test fails.
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+
+    const base_dir = "/tmp/padctl_supervisor_test_switch_issue142";
+    std.fs.deleteTreeAbsolute(base_dir) catch {};
+    try std.fs.makeDirAbsolute(base_dir);
+    defer std.fs.deleteTreeAbsolute(base_dir) catch {};
+
+    const mappings_dir = try std.fmt.allocPrint(allocator, "{s}/mappings", .{base_dir});
+    defer allocator.free(mappings_dir);
+    try std.fs.makeDirAbsolute(mappings_dir);
+    const mapping_path = try std.fmt.allocPrint(allocator, "{s}/keys.toml", .{mappings_dir});
+    defer allocator.free(mapping_path);
+    {
+        const f = try std.fs.createFileAbsolute(mapping_path, .{});
+        defer f.close();
+        // Mapping that triggers needs_keyboard=true (C -> KEY_G). The bug
+        // manifested precisely when switching INTO such a mapping.
+        try f.writeAll("[remap]\nC = \"KEY_G\"\n");
+    }
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.ctrl_sock = null;
+        sup.deinit();
+    }
+
+    sup.ctrl_sock = .{
+        .listen_fd = -1,
+        .client_fds = .{ -1, -1, -1, -1 },
+        .client_count = 0,
+        .path = "",
+        .allocator = allocator,
+    };
+
+    const resp_fds = try testSocketpair();
+    defer posix.close(resp_fds[0]);
+    defer posix.close(resp_fds[1]);
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+
+    const inst = try makeTestInstance(allocator, &mock, &parsed_dev.value);
+    try sup.spawnInstance("usb-1-1", inst, null);
+
+    // Baseline: the spawn path does not call rebuildAuxIfChanged; pre-switch
+    // counter must be 0 so any post-switch observation is attributable to
+    // commitSwitchTarget.
+    try testing.expectEqual(@as(usize, 0), sup.managed.items[0].instance.rebuild_aux_calls);
+
+    sup.test_switch_mapping_override = try allocator.dupe(u8, mapping_path);
+
+    sup.handleSwitch(resp_fds[0], "keys", null);
+
+    var resp_buf: [64]u8 = undefined;
+    const n = try posix.read(resp_fds[1], &resp_buf);
+    try testing.expectEqualStrings("OK keys\n", resp_buf[0..n]);
+
+    // Primary assertion: commitSwitchTarget must invoke rebuildAuxIfChanged
+    // exactly once for this device. Removing the fix drops this to 0.
+    try testing.expectEqual(@as(usize, 1), sup.managed.items[0].instance.rebuild_aux_calls);
+
+    // Secondary sanity checks: the swap itself still happened.
+    try testing.expect(sup.managed.items[0].instance.mapper != null);
+    try testing.expect(sup.managed.items[0].instance.mapping_cfg != null);
+    const new_mcfg = sup.managed.items[0].instance.mapping_cfg.?;
+    const caps = mapping_mod.deriveAuxFromMapping(new_mcfg);
+    try testing.expect(caps.needs_keyboard);
 }
 
 test "supervisor: Supervisor: SWITCH with no devices returns no-devices" {


### PR DESCRIPTION
## Summary

Addresses issue #142 — `padctl switch <mapping>` does not produce output for `KEY_*` remaps if the mapping's AuxDevice capabilities were not registered at daemon startup.

## Root cause

Three paths mutate a running instance's mapping in `src/supervisor.zig`:

- `reload()` — calls `rebuildAuxIfChanged` (line ~676). ✅
- `applySwitchMapping()` (dead code, line ~942) — calls `rebuildAuxIfChanged`. ✅
- `commitSwitchTarget()` (the **live** `padctl switch` path) — **missing** the call. ❌

When the daemon-startup default mapping has no `KEY_*` target, `buildAuxKeyCodes` returns an empty slice and `AuxDevice.create` registers zero KEY bits. `padctl switch` to a mapping containing `C = "KEY_G"` then:

1. Swaps `m.instance.mapper` and `mapping_cfg`.
2. Leaves the AuxDevice unchanged with its zero-key capability set.
3. Kernel uinput rejects emit of `KEY_G` because the capability was never declared.

The reporter observed that restarting the daemon with `default_mapping = relink` in `config.toml` "fixes" the issue — that path goes through `AuxDevice.create` with the new mapping's keys already in hand, bypassing the bug. Reload also "fixes" it temporarily, matching the branch with the missing call.

## Fix

Insert the existing `rebuildAuxIfChanged` call into `commitSwitchTarget` between the mapping swap and `restartManagedThread`. Mirrors the reload path: failure logs a warning rather than propagating, so the switch succeeds from the user's perspective even if `/dev/uinput` is transiently unavailable.

```zig
m.instance.mapping_cfg = &tx.parsed_ptr.?.value;
m.instance.rebuildAuxIfChanged(
    &tx.parsed_ptr.?.value,
    tx.old_mapping_cfg,
) catch |err| {
    std.log.warn("rebuildAuxIfChanged during switch: {}", .{err});
};
restartManagedThread(m) catch |err| { ... }
```

## Tests

New regression test `supervisor: switch to mapping with new aux KEY_* rebuilds aux caps (issue #142)` in `src/supervisor.zig`:

1. Spawns an instance via `spawnInstance` with `minimal_device_toml` (no `[output]`, so `rebuildAuxIfChanged` short-circuits — no `/dev/uinput` needed).
2. Asserts `rebuild_aux_calls == 0` baseline.
3. Writes a mapping file with `C = "KEY_G"` to disk.
4. Invokes `handleSwitch` (the full production IPC path).
5. Asserts the response is `OK <mapping_name>`, `rebuild_aux_calls == 1`, `mapping_cfg` is the new one, and `deriveAuxFromMapping(new).needs_keyboard == true`.

Test-only counter `rebuild_aux_calls` on `DeviceInstance` is a zero-sized `void` in release builds via `if (builtin.is_test) usize else void`, mirroring the existing `test_switch_fail_commit_index` pattern in the same file.

**Reverse verification**: temporarily replaced the 8-line fix block with a comment-only stub and re-ran tests. The regression test failed with `expected 1, found 0`, confirming it catches the bug. Restored the fix; all tests green.

Local verification:

```
zig build test       → exit 0 (863/865 pass, 2 pre-existing skips)
zig build test-tsan  → exit 0
```

## Commits

- `b0950da` fix(supervisor): rebuild aux device caps on padctl switch (issue #142)

## Notes for reviewers

- `applySwitchMapping` (dead code) and `reload` (correct) are untouched.
- Scope discipline: no changes to `buildAuxKeyCodes`, `deriveAuxFromMapping`, `device_instance.rebuildAuxIfChanged`, or `install.zig`.
- The reporter's "Steam no longer detects extra buttons" sub-case is separate — it is the expected behaviour of PR #124, which commented out C/Z/LM/RM in `devices/flydigi/vader5.toml` by default. Users who want those buttons must uncomment them.