### PR TITLE
fix(install): prevent systemd v254+ legacy state-dir symlink creation

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -424,23 +424,49 @@ fn removeBrokenSymlink(path: []const u8) void {
     };
 }
 
+// Removes `path` if it is a symlink, regardless of whether the target exists.
+// No-op if path is a real file/dir or does not exist. Best-effort.
+fn removeAnySymlink(path: []const u8) void {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = std.fs.readLinkAbsolute(path, &buf) catch return;
+    std.fs.deleteFileAbsolute(path) catch |err| {
+        var errbuf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(
+            &errbuf,
+            "warning: could not remove symlink {s}: {}\n",
+            .{ path, err },
+        ) catch "warning: symlink removal failed\n";
+        writeAll(std.posix.STDERR_FILENO, msg);
+    };
+}
+
 fn ensureUserXdgDirs(allocator: std.mem.Allocator, home: []const u8) !void {
+    // `.local/state/padctl` is included so systemd v254+ cannot auto-create it
+    // as a symlink to `$XDG_CONFIG_HOME/padctl` via its legacy migration path
+    // (exec-invoke.c:3044-3072). See removeAnySymlink call below.
     const dirs = [_][]const u8{
         ".config",
         ".config/systemd",
         ".config/systemd/user",
         ".local",
         ".local/state",
+        ".local/state/padctl",
         ".local/share",
     };
 
-    // Defensive cleanup: broken symlinks in StateDirectory/WorkingDirectory paths
-    // prevent systemd from creating the directory. User environments (XDG_STATE_HOME
-    // overrides, manual setup) occasionally leave these behind — padctl never creates them.
+    // Force `.local/state/padctl` to be a real directory: any pre-existing
+    // symlink there (valid or broken) is removed so the mkdir in the loop below
+    // succeeds. systemd v254+ creates a compatibility symlink from
+    // $XDG_STATE_HOME/padctl → $XDG_CONFIG_HOME/padctl when the state dir is
+    // missing and the config dir exists; that symlink makes the runtime write
+    // state to $XDG_CONFIG_HOME and breaks StateDirectory= semantics (#139).
     const state_padctl = try std.fmt.allocPrint(allocator, "{s}/.local/state/padctl", .{home});
     defer allocator.free(state_padctl);
-    removeBrokenSymlink(state_padctl);
+    removeAnySymlink(state_padctl);
 
+    // Keep defensive broken-symlink cleanup on .config/padctl: not the v254+
+    // trigger, but user environments occasionally leave dangling links that
+    // block systemd from using ConfigurationDirectory=.
     const config_padctl = try std.fmt.allocPrint(allocator, "{s}/.config/padctl", .{home});
     defer allocator.free(config_padctl);
     removeBrokenSymlink(config_padctl);
@@ -3893,7 +3919,7 @@ test "install: ensureUserXdgDirs idempotent (second call no error)" {
     try ensureUserXdgDirs(allocator, home);
 }
 
-test "install: ensureUserXdgDirs removes broken .local/state/padctl symlink" {
+test "install: ensureUserXdgDirs replaces broken .local/state/padctl symlink with real dir" {
     const testing = std.testing;
     const allocator = testing.allocator;
 
@@ -3914,11 +3940,20 @@ test "install: ensureUserXdgDirs removes broken .local/state/padctl symlink" {
 
     try ensureUserXdgDirs(allocator, home_path);
 
-    // Post-condition: broken symlink is gone.
-    try testing.expectError(error.FileNotFound, std.fs.cwd().statFile(state_path));
+    // Post-condition: path is a real directory, not a symlink.
+    const stat_result = try std.fs.cwd().statFile(state_path);
+    try testing.expect(stat_result.kind == .directory);
+
+    var rlbuf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectError(error.NotLink, std.fs.readLinkAbsolute(state_path, &rlbuf));
 }
 
-test "install: ensureUserXdgDirs preserves valid .local/state/padctl symlink" {
+// systemd v254+ creates $XDG_STATE_HOME/padctl → $XDG_CONFIG_HOME/padctl
+// compatibility symlink (exec-invoke.c:3044-3072 legacy migration) when the
+// state dir is missing. We force the state dir to be a real directory so that
+// symlink never has a reason to exist and StateDirectory= semantics are
+// preserved — see ensureUserXdgDirs for the full explanation. Issue #139.
+test "install: ensureUserXdgDirs replaces valid .local/state/padctl symlink with real dir (systemd v254+ migration workaround)" {
     const testing = std.testing;
     const allocator = testing.allocator;
 
@@ -3936,10 +3971,42 @@ test "install: ensureUserXdgDirs preserves valid .local/state/padctl symlink" {
 
     try ensureUserXdgDirs(allocator, home_path);
 
-    // Valid symlink must not be removed.
     const state_path = try std.fmt.allocPrint(allocator, "{s}/.local/state/padctl", .{home_path});
     defer allocator.free(state_path);
-    try std.fs.accessAbsolute(state_path, .{});
+
+    // Post-condition: path is a real directory, not a symlink.
+    const stat_result = try std.fs.cwd().statFile(state_path);
+    try testing.expect(stat_result.kind == .directory);
+
+    var rlbuf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectError(error.NotLink, std.fs.readLinkAbsolute(state_path, &rlbuf));
+}
+
+test "install: ensureUserXdgDirs preserves existing .local/state/padctl real directory (idempotent)" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const home_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(home_path);
+
+    // Seed: real directory with prior content that must survive.
+    try tmp.dir.makePath(".local/state/padctl/subdir");
+
+    const state_path = try std.fmt.allocPrint(allocator, "{s}/.local/state/padctl", .{home_path});
+    defer allocator.free(state_path);
+    const subdir_path = try std.fmt.allocPrint(allocator, "{s}/.local/state/padctl/subdir", .{home_path});
+    defer allocator.free(subdir_path);
+
+    try ensureUserXdgDirs(allocator, home_path);
+
+    const stat_result = try std.fs.cwd().statFile(state_path);
+    try testing.expect(stat_result.kind == .directory);
+
+    // Prior content preserved.
+    try std.fs.accessAbsolute(subdir_path, .{});
 }
 
 test "install: resolveTargetHomeFromFile reads home from passwd" {


### PR DESCRIPTION
## Summary

Addresses issue #139 root cause. Previous PRs #141 and #145 only cleaned up the symptom (`removeBrokenSymlink` was defensive only and preserved valid symlinks); the **actual source** of the `.local/state/padctl → .config/padctl` symlink is **systemd itself**, which creates it on every daemon start under the legacy-migration path and will continue to do so until the state dir exists as a real directory.

## Root cause

systemd v254+ `src/core/exec-invoke.c:3044-3072` runs this logic whenever a user-scope service starts:

1. user scope service ✓
2. `StateDirectory=padctl` is set ✓
3. `$XDG_STATE_HOME/padctl` does not exist ✓ (PR #141 only created `.local/state`, not the `padctl` leaf)
4. `$XDG_CONFIG_HOME/padctl` does exist ✓ (anyone who has ever configured padctl)

When all four conditions hold, systemd calls `symlink_idempotent(q, p, make_relative=true)` to create `$XDG_STATE_HOME/padctl` as a relative symlink back to `$XDG_CONFIG_HOME/padctl`. systemd logs an explicit notice during startup:

```
Unit state directory /home/<user>/.local/state/padctl missing but matching
configuration directory /home/<user>/.config/padctl exists, assuming update
from systemd 253 or older, creating compatibility symlink.
```

PR #141 was correct about adding XDG parent directories but missed the `padctl` leaf, so the trigger fired on every boot/restart. PR #141's `removeBrokenSymlink` only cleaned up dangling cases, preserving systemd's valid symlink.

## Fix

1. **`ensureUserXdgDirs` dirs[] adds `.local/state/padctl`** — the leaf directory is now always created at install time. systemd's trigger condition 3 (`$XDG_STATE_HOME/padctl` does not exist) can never be true after install.
2. **New `removeAnySymlink` helper** (alongside `removeBrokenSymlink`) — unconditionally removes any symlink at the given path, whether valid or dangling. Applied to `.local/state/padctl` before the mkdir loop so the path is guaranteed to become a real directory. `.config/padctl` keeps the conservative `removeBrokenSymlink` (it is the migration target, not the trigger).
3. **Test contract reversal**:
   - `replaces broken .local/state/padctl symlink with real dir` (post-condition is now "real directory exists", not "path is gone")
   - `replaces valid .local/state/padctl symlink with real dir (systemd v254+ migration workaround)` (reversed from the pre-existing `preserves valid symlink` test)
   - `preserves existing .local/state/padctl real directory (idempotent)` (new, confirms repeated install does not wipe existing content)

## Tests

```
zig build test       → exit 0, 919/922 passed, 3 skipped
zig build test-tsan  → exit 0, 915/918 passed, 3 skipped
```

Reverse-verification: with the fix removed (`.local/state/padctl` entry and `removeAnySymlink(state_padctl)` call both disabled), the two new symlink-replacement tests fail with the expected `FileNotFound` (broken) and `expected error.NotLink, found <target bytes>` (valid) messages. Restoring the fix → all green.

## Commits

- `75da0f6` fix(install): prevent systemd v254+ legacy state-dir symlink creation (issue #139 v2)

## Notes

- Install-time fix only; does not self-heal a user who runs `rm -rf ~/.local/state/padctl && systemctl --user restart padctl`. That path resurrects the symlink via the same systemd migration logic; running `padctl install` again fixes it. Runtime self-heal (e.g. systemd `ExecStartPre=` probe) is out of scope for this PR.
- No changes to the service unit file; the fix is purely at install-time directory creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved installation process to properly handle existing symlinks in configuration directories, preventing installation failures.
  * Enhanced compatibility with newer systemd versions through improved directory initialization.

* **Tests**
  * Expanded test coverage for directory and symlink handling to ensure installation stability across multiple runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->