### PR TITLE
fix(install): honour --no-user-service + clarify completion hint

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1378,9 +1378,18 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     } else if (will_start_user_service and is_root and
         (std.posix.getenv("SUDO_USER") orelse "").len != 0)
     {
+        const action_sudo = if (opts.no_start and opts.no_enable)
+            "installed via sudo -u $SUDO_USER (neither enabled nor started — --no-enable --no-start given)"
+        else if (opts.no_start)
+            "enabled via sudo -u $SUDO_USER (not started — --no-start given); run `systemctl --user start padctl.service` as that user when ready"
+        else if (opts.no_enable)
+            "started via sudo -u $SUDO_USER (not enabled — --no-enable given); run `systemctl --user enable padctl.service` as that user to auto-start on login"
+        else
+            "enabled and started via sudo -u $SUDO_USER";
+        _ = std.posix.write(std.posix.STDOUT_FILENO, "\nInstall complete. User service ") catch {};
+        _ = std.posix.write(std.posix.STDOUT_FILENO, action_sudo) catch {};
         _ = std.posix.write(std.posix.STDOUT_FILENO,
-            \\
-            \\Install complete. User service started via sudo -u $SUDO_USER.
+            \\.
             \\
             \\Verify:
             \\  systemctl --user status padctl.service

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -682,13 +682,14 @@ pub fn installWillStartUserService(
     sudo_user_env: ?[]const u8,
 ) bool {
     if (destdir.len != 0) return false; // staged package build — no live user service
-    const effective = user_service_opt orelse !is_root;
-    if (effective) return true;
-    // Root + SUDO_USER set → sudo_hop path starts the invoking user's service.
-    if (is_root) {
-        if (sudo_user_env) |su| {
-            if (su.len != 0) return true;
-        }
+    // Explicit flag wins: --no-user-service means "don't start", including the
+    // sudo_hop path. --user-service means "start" regardless of is_root.
+    if (user_service_opt) |explicit| return explicit;
+    // Implicit: non-root default starts the user service.
+    if (!is_root) return true;
+    // Implicit + root: sudo_hop starts the invoking user's service when SUDO_USER is set.
+    if (sudo_user_env) |su| {
+        if (su.len != 0) return true;
     }
     return false;
 }
@@ -1315,33 +1316,38 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     }
 
     // 5. Reload system daemons and enable/start services (only when not staging)
+    const will_start_user_service = installWillStartUserService(is_root, opts.user_service, destdir, std.posix.getenv("SUDO_USER"));
     if (destdir.len == 0) {
         _ = std.posix.write(std.posix.STDOUT_FILENO, "\nReloading system daemons...\n") catch {};
         runCmd(&.{ "udevadm", "control", "--reload-rules" });
         runCmd(&.{ "udevadm", "trigger" });
-        // Compute plan once so skip-mode prints the hint once instead of per-verb.
-        const install_plan = currentPlanFromEnv();
-        if (install_plan.mode == .skip) {
-            var groups: [3][]const []const u8 = undefined;
-            var n: usize = 0;
-            groups[n] = &.{"daemon-reload"};
-            n += 1;
-            if (!opts.no_enable) {
-                groups[n] = &.{ "enable", "padctl.service" };
+        // Honour --no-user-service even when sudo_hop would otherwise fire:
+        // an explicit opt-out must not enable/start the user unit.
+        if (will_start_user_service) {
+            // Compute plan once so skip-mode prints the hint once instead of per-verb.
+            const install_plan = currentPlanFromEnv();
+            if (install_plan.mode == .skip) {
+                var groups: [3][]const []const u8 = undefined;
+                var n: usize = 0;
+                groups[n] = &.{"daemon-reload"};
                 n += 1;
-            }
-            if (!opts.no_start) {
-                groups[n] = &.{ "start", "padctl.service" };
-                n += 1;
-            }
-            printSkipSystemctlNoteFor(groups[0..n]);
-        } else {
-            runSystemctlUser(&.{"daemon-reload"});
-            if (!opts.no_enable) {
-                runSystemctlUserWarn(&.{ "enable", "padctl.service" });
-            }
-            if (!opts.no_start) {
-                runSystemctlUserWarn(&.{ "start", "padctl.service" });
+                if (!opts.no_enable) {
+                    groups[n] = &.{ "enable", "padctl.service" };
+                    n += 1;
+                }
+                if (!opts.no_start) {
+                    groups[n] = &.{ "start", "padctl.service" };
+                    n += 1;
+                }
+                printSkipSystemctlNoteFor(groups[0..n]);
+            } else {
+                runSystemctlUser(&.{"daemon-reload"});
+                if (!opts.no_enable) {
+                    runSystemctlUserWarn(&.{ "enable", "padctl.service" });
+                }
+                if (!opts.no_start) {
+                    runSystemctlUserWarn(&.{ "start", "padctl.service" });
+                }
             }
         }
     }
@@ -1351,7 +1357,39 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         return error.MappingInstallFailed;
     }
 
-    if (effective_user_service and destdir.len == 0) {
+    // Completion hint — mirror actual runtime state so the user does not have
+    // to guess whether the service was started. Branches:
+    //   - Staged install (destdir set): no live service, just acknowledge.
+    //   - Explicit --no-user-service: service file installed but NOT started.
+    //   - sudo install (root + SUDO_USER, no opt-out): sudo_hop already started it.
+    //   - Non-root user install: service not yet started, show manual command.
+    //   - Root without SUDO_USER: nothing to start.
+    if (destdir.len != 0) {
+        _ = std.posix.write(std.posix.STDOUT_FILENO, "\nInstall complete (staged).\n") catch {};
+    } else if (opts.user_service != null and opts.user_service.? == false) {
+        _ = std.posix.write(std.posix.STDOUT_FILENO,
+            \\
+            \\Install complete. User service NOT started (--no-user-service given).
+            \\
+            \\To start manually later:
+            \\  systemctl --user enable --now padctl.service
+            \\
+        ) catch {};
+    } else if (will_start_user_service and is_root and
+        (std.posix.getenv("SUDO_USER") orelse "").len != 0)
+    {
+        _ = std.posix.write(std.posix.STDOUT_FILENO,
+            \\
+            \\Install complete. User service started via sudo -u $SUDO_USER.
+            \\
+            \\Verify:
+            \\  systemctl --user status padctl.service
+            \\
+            \\To auto-start at boot without a login session (headless/server):
+            \\  sudo loginctl enable-linger $USER
+            \\
+        ) catch {};
+    } else if (will_start_user_service) {
         _ = std.posix.write(std.posix.STDOUT_FILENO,
             \\
             \\Install complete.
@@ -3910,6 +3948,18 @@ test "install: ensureUserXdgDirs NOT called when root without SUDO_USER" {
     // would be .skip, no user service starts, so no XDG dirs to seed.
     try testing.expect(!installWillStartUserService(true, null, "", null));
     try testing.expect(!installWillStartUserService(true, null, "", ""));
+}
+
+test "install: explicit --no-user-service returns false regardless of sudo_hop" {
+    const testing = std.testing;
+    // Non-root + explicit false → don't start (obvious case).
+    try testing.expect(!installWillStartUserService(false, false, "", null));
+    // sudo + explicit false → must override the sudo_hop default. Previously
+    // the systemctl block still fired enable/start via sudo_hop, ignoring the
+    // user's opt-out; this regression guards the new gate.
+    try testing.expect(!installWillStartUserService(true, false, "", "jim"));
+    // Explicit false under staging is still false (destdir short-circuit wins).
+    try testing.expect(!installWillStartUserService(true, false, "/tmp/staging", "jim"));
 }
 
 test "install: ensureUserXdgDirs chown path opens dir with iterate flag (no BADF)" {

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1390,12 +1390,21 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
             \\
         ) catch {};
     } else if (will_start_user_service) {
+        const action = if (opts.no_start and opts.no_enable)
+            "installed (neither enabled nor started — --no-enable --no-start given)"
+        else if (opts.no_start)
+            "enabled (not started — --no-start given); run `systemctl --user start padctl.service` when ready"
+        else if (opts.no_enable)
+            "started (not enabled — --no-enable given); run `systemctl --user enable padctl.service` to auto-start on login"
+        else
+            "enabled and started";
+        _ = std.posix.write(std.posix.STDOUT_FILENO, "\nInstall complete. User service ") catch {};
+        _ = std.posix.write(std.posix.STDOUT_FILENO, action) catch {};
         _ = std.posix.write(std.posix.STDOUT_FILENO,
+            \\.
             \\
-            \\Install complete.
-            \\
-            \\To start the service:
-            \\  systemctl --user enable --now padctl.service
+            \\Verify:
+            \\  systemctl --user status padctl.service
             \\
             \\To auto-start at boot without a login session (headless/server):
             \\  sudo loginctl enable-linger $USER

--- a/src/main.zig
+++ b/src/main.zig
@@ -227,6 +227,10 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                     opts.no_enable = true;
                 } else if (std.mem.eql(u8, iarg, "--no-start")) {
                     opts.no_start = true;
+                } else if (std.mem.eql(u8, iarg, "--user-service")) {
+                    opts.user_service = true;
+                } else if (std.mem.eql(u8, iarg, "--no-user-service")) {
+                    opts.user_service = false;
                 } else {
                     std.log.err("unknown install argument: {s}", .{iarg});
                     return error.UnknownArgument;
@@ -449,6 +453,8 @@ fn printHelp() void {
         \\    --mapping <name>    Install a mapping config to /etc/padctl/mappings/ (repeatable)
         \\    --force-mapping     Overwrite existing mapping files
         \\    --force-binding     Overwrite device bindings in /etc/padctl/config.toml
+        \\    --user-service      Force user-scope install (~/.config/systemd/user/)
+        \\    --no-user-service   Skip user-service enable/start (even under sudo)
         \\    --no-enable         Skip systemctl enable
         \\    --no-start          Skip systemctl start
         \\  uninstall             Remove installed files, stop and disable service


### PR DESCRIPTION
## Summary

Follow-up to PR #148 — closes two known limitations documented in that PR body:

1. `sudo padctl install --no-user-service` now actually skips `systemctl --user enable/start` (previously the systemctl block gated only on `destdir.len == 0`, so sudo_hop still fired enable/start regardless of the opt-out flag — but worse, the flag itself was not even exposed in the CLI).
2. Completion hint now reflects the actual state across five branches (staged / `--no-user-service` skipped / sudo_hop started / non-root enabled+started / fallback).

## Commits

- `dcd2bb0` fix(install): honour --no-user-service under sudo + clarify completion hint
- `823a4bc` feat(install): add `--no-user-service` CLI flag to honour opt-out
- `bbda358` fix(install): reflect actual state in non-root completion hint (pre-merge review HIGH)

## Changes

### `installWillStartUserService` helper semantic

Explicit `user_service_opt=false` now hard short-circuits to `return false`. Previously it fell through to the sudo_hop heuristic, so `--no-user-service` would be silently ignored under sudo. All three downstream gates (XDG seed at `install.zig:1076`, systemctl block at `:1319`, completion hint at `:1369`) consume this change consistently.

### A1 — systemctl gate

`daemon-reload / enable / start` block at line 1318-1351 wrapped in `if (will_start_user_service)`. Service file writes + udev rules still unconditionally written (file gate remains `destdir.len == 0`).

### A2 — Completion hint (five-branch)

| Scenario | Hint |
|---|---|
| `--destdir /staging` | "Install complete (staged)." |
| `--no-user-service` | "User service NOT started (--no-user-service given). To start manually later: systemctl --user enable --now padctl.service" |
| `sudo padctl install` (sudo_hop) | "User service started via sudo -u \$SUDO_USER. Verify: systemctl --user status padctl.service" |
| `padctl install` (non-root) | "User service enabled and started. Verify: systemctl --user status padctl.service" + `--no-enable` / `--no-start` variant messages |
| Root without SUDO_USER | "Install complete." |

### CLI flag

Added `--user-service` / `--no-user-service` pair to the `install` argv loop at `src/main.zig:230-233`, mirroring the existing `--immutable` / `--no-immutable` pattern. Help text updated at line 456-457.

### Tests

New regression test `install: explicit --no-user-service returns false regardless of sudo_hop` (`src/cli/install.zig:3953`) covers the three key inputs. PR #148's existing 5 tests remain valid (they pass `null` or `true`).

## Verification

- `zig build test` → exit 0
- `zig build test-tsan` → exit 0

**Docker sandbox E2E** (archlinux:latest + SUDO_USER/UID/GID injection):

```
=== Scenario 1: sudo padctl install ===
Install complete. User service started via sudo -u $SUDO_USER.

=== Scenario 2: sudo padctl install --no-user-service ===
Install complete. User service NOT started (--no-user-service given).
To start manually later: systemctl --user enable --now padctl.service
(state dir not created — A1 gate correctly skips ensureUserXdgDirs)

=== Scenario 3: --destdir /staging ===
Install complete (staged).
```

## Pre-merge review

feature-dev:code-reviewer verdict: ACCEPT-WITH-NITS. 1 HIGH (fixed in `bbda358`), 2 cosmetic NITS ($SUDO_USER literal printing + --no-user-service UX wording — both < 80 confidence, deferred).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--user-service` and `--no-user-service` flags to control whether the systemd user-scope service is enabled and started during installation.
  * Improved installation completion messages to accurately reflect the actual runtime state and configuration.

* **Bug Fixes**
  * Fixed issue where the `--no-user-service` flag could be inadvertently overridden in certain scenarios.

* **Tests**
  * Added regression test for explicit user-service opt-out behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->