### PR TITLE
fix(event_loop): snapshot now_ns + reorder timerfd after devices (#79)

### DIFF
--- a/src/core/layer.zig
+++ b/src/core/layer.zig
@@ -348,6 +348,36 @@ test "layer: tap-hold: ACTIVE + release within timeout (race) → tap emitted (#
     try testing.expect(ls.tap_hold == null);
 }
 
+test "layer: tap-hold: ACTIVE + release at hold_timeout - 5ms → tap emitted (#79 boundary)" {
+    // Release physically happens at press+195ms (just below 200ms
+    // hold_timeout). The fix ensures the caller's ppoll-wakeup snapshot
+    // reaches onTriggerRelease unmodified — see issue #79.
+    var ls = LayerState.init(testing.allocator);
+    defer ls.deinit();
+    const press_time: i128 = 1_000_000_000;
+    _ = ls.onTriggerPress("aim", 200, press_time);
+    _ = ls.onTimerExpired();
+
+    const release_time: i128 = press_time + 195_000_000;
+    const res = ls.onTriggerRelease(RemapTarget{ .key = 183 }, release_time);
+    try testing.expect(res.layer_deactivated);
+    try testing.expect(res.tap_event != null);
+    try testing.expect(ls.tap_hold == null);
+}
+
+test "layer: tap-hold: ACTIVE + release at hold_timeout → no tap (upper boundary)" {
+    var ls = LayerState.init(testing.allocator);
+    defer ls.deinit();
+    const press_time: i128 = 1_000_000_000;
+    _ = ls.onTriggerPress("aim", 200, press_time);
+    _ = ls.onTimerExpired();
+
+    const release_time: i128 = press_time + 200_000_000;
+    const res = ls.onTriggerRelease(RemapTarget{ .key = 183 }, release_time);
+    try testing.expect(res.layer_deactivated);
+    try testing.expect(res.tap_event == null);
+}
+
 test "layer: tap-hold: IDLE + release → no-op" {
     var ls = LayerState.init(testing.allocator);
     defer ls.deinit();

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -12,11 +12,6 @@ const c = @cImport(@cInclude("linux/input-event-codes.h"));
 
 const posix = std.posix;
 
-fn monotonicNs() i128 {
-    const ts = posix.clock_gettime(.MONOTONIC) catch return 0;
-    return @as(i128, ts.sec) * std.time.ns_per_s + @as(i128, ts.nsec);
-}
-
 const REL_X: u16 = c.REL_X;
 const REL_Y: u16 = c.REL_Y;
 const REL_WHEEL: u16 = c.REL_WHEEL;
@@ -90,7 +85,10 @@ pub const Mapper = struct {
         self.timer_queue.deinit();
     }
 
-    pub fn apply(self: *Mapper, delta: GamepadStateDelta, dt_ms: u32) !OutputEvents {
+    // `now_ns` is the ppoll-wakeup CLOCK_MONOTONIC snapshot from the caller;
+    // must match the value passed to onTimerExpired() in the same wakeup so
+    // tap/hold boundary decisions see a single timeline (issue #79).
+    pub fn apply(self: *Mapper, delta: GamepadStateDelta, dt_ms: u32, now_ns: i128) !OutputEvents {
         // flush pending tap release from previous frame
         var aux = AuxEventList{};
         if (self.pending_tap_release) |mask| {
@@ -120,7 +118,6 @@ pub const Mapper = struct {
 
         // [2] layer trigger processing
         const configs = self.config.layer orelse &.{};
-        const now_ns = monotonicNs();
         const action = self.layer.processLayerTriggers(configs, self.state.buttons, self.prev.buttons, now_ns);
         var timer_request: ?TimerRequest = null;
         if (action.arm_timer_ms) |ms| {
@@ -346,7 +343,8 @@ pub const Mapper = struct {
         return .{ .gamepad = emit_state, .prev = masked_prev, .aux = aux, .timer_request = timer_request };
     }
 
-    pub fn onTimerExpired(self: *Mapper) AuxEventList {
+    // `now_ns` is the same ppoll-wakeup snapshot passed to apply().
+    pub fn onTimerExpired(self: *Mapper, now_ns: i128) AuxEventList {
         const th_res = self.layer.onTimerExpired();
         if (th_res.layer_activated) {
             self.prev.dpad_x = 0;
@@ -355,7 +353,7 @@ pub const Mapper = struct {
 
         var aux = AuxEventList{};
         var buf: [16]timer_queue_mod.Deadline = undefined;
-        const expired = self.timer_queue.drainExpired(std.time.nanoTimestamp(), &buf);
+        const expired = self.timer_queue.drainExpired(now_ns, &buf);
         for (expired) |d| {
             var idx: usize = 0;
             while (idx < self.active_macros.items.len) {
@@ -539,7 +537,7 @@ test "mapper: no layer no remap: apply passes through unchanged" {
     defer m.deinit();
 
     const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
-    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16);
+    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16, 0);
     try testing.expect((events.gamepad.buttons & (@as(u64, 1) << a_idx)) != 0);
     try testing.expectEqual(@as(usize, 0), events.aux.len);
 }
@@ -556,7 +554,7 @@ test "mapper: base remap disabled: source button suppressed" {
     defer m.deinit();
 
     const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
-    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16);
+    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16, 0);
     try testing.expectEqual(@as(u64, 0), events.gamepad.buttons & (@as(u64, 1) << a_idx));
     try testing.expectEqual(@as(usize, 0), events.aux.len);
 }
@@ -573,7 +571,7 @@ test "mapper: base remap key: source -> KEY_F13 aux event" {
     defer m.deinit();
 
     const m1_idx: u6 = @intCast(@intFromEnum(ButtonId.M1));
-    const events = try m.apply(.{ .buttons = @as(u64, 1) << m1_idx }, 16);
+    const events = try m.apply(.{ .buttons = @as(u64, 1) << m1_idx }, 16, 0);
 
     try testing.expectEqual(@as(u64, 0), events.gamepad.buttons & (@as(u64, 1) << m1_idx));
     try testing.expectEqual(@as(usize, 1), events.aux.len);
@@ -599,7 +597,7 @@ test "mapper: base remap gamepad_button: A -> B" {
 
     const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
     const b_idx: u6 = @intCast(@intFromEnum(ButtonId.B));
-    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16);
+    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16, 0);
 
     try testing.expectEqual(@as(u64, 0), events.gamepad.buttons & (@as(u64, 1) << a_idx));
     try testing.expect((events.gamepad.buttons & (@as(u64, 1) << b_idx)) != 0);
@@ -634,7 +632,7 @@ test "mapper: layer remap overrides base: base A->B, layer A->C" {
     const b_idx: u6 = @intCast(@intFromEnum(ButtonId.B));
     const x_idx: u6 = @intCast(@intFromEnum(ButtonId.X));
 
-    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16);
+    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16, 0);
 
     // A suppressed
     try testing.expectEqual(@as(u64, 0), events.gamepad.buttons & (@as(u64, 1) << a_idx));
@@ -670,7 +668,7 @@ test "mapper: suppress accumulates: base suppress A + layer suppress B" {
     const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
     const b_idx: u6 = @intCast(@intFromEnum(ButtonId.B));
     const both = (@as(u64, 1) << a_idx) | (@as(u64, 1) << b_idx);
-    const events = try m.apply(.{ .buttons = both }, 16);
+    const events = try m.apply(.{ .buttons = both }, 16, 0);
 
     try testing.expectEqual(@as(u64, 0), events.gamepad.buttons & (@as(u64, 1) << a_idx));
     try testing.expectEqual(@as(u64, 0), events.gamepad.buttons & (@as(u64, 1) << b_idx));
@@ -704,7 +702,7 @@ test "mapper: inject last-write wins: layer inject overrides base inject for sam
     const x_idx: u6 = @intCast(@intFromEnum(ButtonId.X));
     const y_idx: u6 = @intCast(@intFromEnum(ButtonId.Y));
 
-    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16);
+    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16, 0);
 
     try testing.expectEqual(@as(u64, 0), events.gamepad.buttons & (@as(u64, 1) << x_idx));
     try testing.expect((events.gamepad.buttons & (@as(u64, 1) << y_idx)) != 0);
@@ -725,12 +723,12 @@ test "mapper: prev frame masking: suppress produces correct diff" {
     const a_mask: u64 = @as(u64, 1) << a_idx;
 
     // Frame N-1: A pressed, remap disabled
-    const ev1 = try m.apply(.{ .buttons = a_mask }, 16);
+    const ev1 = try m.apply(.{ .buttons = a_mask }, 16, 0);
     // A is suppressed in output, prev is now raw a_mask
     try testing.expectEqual(@as(u64, 0), ev1.gamepad.buttons & a_mask);
 
     // Frame N: A still pressed — should produce no change (both masked_prev and gamepad have A=0)
-    const ev2 = try m.apply(.{ .buttons = a_mask }, 16);
+    const ev2 = try m.apply(.{ .buttons = a_mask }, 16, 0);
     try testing.expectEqual(@as(u64, 0), ev2.gamepad.buttons & a_mask);
     // masked_prev should also have A=0 (same suppress applied)
     try testing.expectEqual(@as(u64, 0), ev2.prev.buttons & a_mask);
@@ -759,13 +757,13 @@ test "mapper: onTimerExpired: PENDING -> ACTIVE activates layer" {
     try testing.expect(!m.layer.tap_hold.?.layer_activated);
 
     // Timer fires — goes ACTIVE
-    _ = m.onTimerExpired();
+    _ = m.onTimerExpired(0);
     try testing.expect(m.layer.tap_hold.?.layer_activated);
 
     // Now layer remap should be active
     const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
     const b_idx: u6 = @intCast(@intFromEnum(ButtonId.B));
-    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16);
+    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16, 0);
     try testing.expect((events.gamepad.buttons & (@as(u64, 1) << b_idx)) != 0);
 }
 
@@ -853,16 +851,16 @@ test "mapper: dpad arrows layer: key events fire after hold-timer activation" {
     const lt_mask: u64 = @as(u64, 1) << lt_idx;
 
     // Frame 1: LT + dpad-up pressed simultaneously → layer PENDING, dpad recorded in prev
-    _ = try m.apply(.{ .buttons = lt_mask, .dpad_y = -1 }, 16);
+    _ = try m.apply(.{ .buttons = lt_mask, .dpad_y = -1 }, 16, 0);
 
     // Timer fires: PENDING → ACTIVE
-    _ = m.onTimerExpired();
+    _ = m.onTimerExpired(0);
 
     // Frame 2: still holding LT + dpad-up, but now layer is ACTIVE (active_changed=true)
     // prev.dpad_y should be reset to 0 so edge triggers KEY_UP press
     const configs = parsed.value.layer.?;
     _ = configs; // suppress unused warning
-    const ev = try m.apply(.{ .buttons = lt_mask, .dpad_y = -1 }, 16);
+    const ev = try m.apply(.{ .buttons = lt_mask, .dpad_y = -1 }, 16, 0);
 
     var got_key_up = false;
     for (ev.aux.slice()) |e| switch (e) {
@@ -894,15 +892,15 @@ test "mapper: gamepad_button tap: injected this frame, released next frame" {
     const a_mask: u64 = @as(u64, 1) << a_idx;
 
     // Press LT -> PENDING
-    _ = try m.apply(.{ .buttons = lt_mask }, 16);
+    _ = try m.apply(.{ .buttons = lt_mask }, 16, 0);
     // Release LT -> tap fires (PENDING->IDLE with tap)
-    const ev_tap = try m.apply(.{ .buttons = 0 }, 16);
+    const ev_tap = try m.apply(.{ .buttons = 0 }, 16, 0);
     // A should be injected this frame
     try testing.expect((ev_tap.gamepad.buttons & a_mask) != 0);
     try testing.expect(m.pending_tap_release != null);
 
     // Next frame: pending_tap_release should clear A
-    const ev_release = try m.apply(.{}, 16);
+    const ev_release = try m.apply(.{}, 16, 0);
     try testing.expectEqual(@as(u64, 0), ev_release.gamepad.buttons & a_mask);
     try testing.expect(m.pending_tap_release == null);
 }
@@ -927,7 +925,7 @@ test "mapper: dt_ms propagation: stick mouse output scales with dt" {
 
     var total4: i32 = 0;
     for (0..4) |_| {
-        const ev = try m4.apply(.{ .rx = 10000 }, 4);
+        const ev = try m4.apply(.{ .rx = 10000 }, 4, 0);
         for (ev.aux.slice()) |e| switch (e) {
             .rel => |r| if (r.code == 0) {
                 total4 += r.value;
@@ -937,7 +935,7 @@ test "mapper: dt_ms propagation: stick mouse output scales with dt" {
     }
 
     var total16: i32 = 0;
-    const ev16 = try m16.apply(.{ .rx = 10000 }, 16);
+    const ev16 = try m16.apply(.{ .rx = 10000 }, 16, 0);
     for (ev16.aux.slice()) |e| switch (e) {
         .rel => |r| if (r.code == 0) {
             total16 += r.value;
@@ -963,11 +961,11 @@ test "mapper: dpad prev mask: suppress_dpad_hat applied to masked_prev" {
     defer m.deinit();
 
     // Frame 1: dpad up
-    const ev1 = try m.apply(.{ .dpad_x = 0, .dpad_y = -1 }, 16);
+    const ev1 = try m.apply(.{ .dpad_x = 0, .dpad_y = -1 }, 16, 0);
     try testing.expectEqual(@as(i8, 0), ev1.gamepad.dpad_y);
 
     // Frame 2: same dpad — masked_prev should also have dpad_y = 0
-    const ev2 = try m.apply(.{ .dpad_x = 0, .dpad_y = -1 }, 16);
+    const ev2 = try m.apply(.{ .dpad_x = 0, .dpad_y = -1 }, 16, 0);
     try testing.expectEqual(@as(i8, 0), ev2.prev.dpad_y);
 }
 
@@ -1012,10 +1010,10 @@ test "mapper: Mapper.apply toggle OOM is silently swallowed" {
     const sel_idx: u6 = @intCast(@intFromEnum(ButtonId.Select));
     const sel_mask: u64 = @as(u64, 1) << sel_idx;
     // Rising edge then release — toggle fires, toggled.put OOMs silently.
-    _ = try m.apply(.{ .buttons = sel_mask }, 16);
-    _ = try m.apply(.{}, 16);
+    _ = try m.apply(.{ .buttons = sel_mask }, 16, 0);
+    _ = try m.apply(.{}, 16, 0);
     // Mapper must stay usable: third frame must produce no-crash and empty aux events.
-    const ev = try m.apply(.{}, 16);
+    const ev = try m.apply(.{}, 16, 0);
     try testing.expectEqual(@as(usize, 0), ev.aux.len);
 }
 
@@ -1043,7 +1041,7 @@ test "mapper: active_macros append OOM is silently ignored" {
     defer m.deinit();
     const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
     // Rising edge triggers macro dispatch; append failure must not crash.
-    const ev = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16);
+    const ev = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16, 0);
     // OOM swallowed: no aux events emitted (macro not started), A suppressed by remap.
     const a_mask: u64 = @as(u64, 1) << a_idx;
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & a_mask);
@@ -1082,10 +1080,10 @@ test "mapper: gyro activate: inactive frame no REL events and processor reset" {
     // Seed EMA with large gyro input while RB is held
     const rb_idx: u6 = @intCast(@intFromEnum(ButtonId.RB));
     const rb_mask: u64 = @as(u64, 1) << rb_idx;
-    _ = try m.apply(.{ .buttons = rb_mask, .gyro_x = 10000, .gyro_y = 10000 }, 16);
+    _ = try m.apply(.{ .buttons = rb_mask, .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
 
     // Release RB — gyro should be deactivated, processor reset, no REL events
-    const ev = try m.apply(.{ .buttons = 0, .gyro_x = 10000, .gyro_y = 10000 }, 16);
+    const ev = try m.apply(.{ .buttons = 0, .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
     try testing.expectEqual(@as(usize, 0), ev.aux.len);
     // After reset, EMA should be zero
     try testing.expectApproxEqAbs(@as(f32, 0.0), m.gyro_proc.ema_x, 1e-5);
@@ -1110,7 +1108,7 @@ test "mapper: gyro activate: active when RB held, inactive when released" {
     const rb_mask: u64 = @as(u64, 1) << rb_idx;
 
     // RB held, large gyro — should produce REL events
-    const ev_active = try m.apply(.{ .buttons = rb_mask, .gyro_x = 10000, .gyro_y = 10000 }, 16);
+    const ev_active = try m.apply(.{ .buttons = rb_mask, .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
     try testing.expect(ev_active.aux.len > 0);
     // At least one REL event must be present (not just any aux event)
     var found_rel = false;
@@ -1120,7 +1118,7 @@ test "mapper: gyro activate: active when RB held, inactive when released" {
     try testing.expect(found_rel);
 
     // RB released — no REL events
-    const ev_inactive = try m.apply(.{ .buttons = 0, .gyro_x = 10000, .gyro_y = 10000 }, 16);
+    const ev_inactive = try m.apply(.{ .buttons = 0, .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
     try testing.expectEqual(@as(usize, 0), ev_inactive.aux.len);
 }
 
@@ -1139,7 +1137,7 @@ test "mapper: gyro joystick mode: overrides emit_state.rx/ry, suppresses origina
     defer m.deinit();
 
     // Feed large gyro input so joy_x/joy_y are non-zero
-    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000, .rx = 5000, .ry = 5000 }, 16);
+    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000, .rx = 5000, .ry = 5000 }, 16, 0);
 
     // rx/ry must be gyro-derived (not the raw 5000)
     try testing.expect(ev.gamepad.rx != 5000);
@@ -1167,7 +1165,7 @@ test "mapper: gyro joystick mode: null joy_x does not touch rx" {
     var m = try makeMapper(&parsed.value, allocator);
     defer m.deinit();
 
-    const ev = try m.apply(.{ .rx = 1234, .ry = -1234 }, 16);
+    const ev = try m.apply(.{ .rx = 1234, .ry = -1234 }, 16, 0);
     // mode=off: no override, axes pass through unchanged
     try testing.expectEqual(@as(i16, 1234), ev.gamepad.rx);
     try testing.expectEqual(@as(i16, -1234), ev.gamepad.ry);
@@ -1187,7 +1185,7 @@ test "mapper: gyro mouse mode: joy_x/y do not affect emit_state axes" {
     var m = try makeMapper(&parsed.value, allocator);
     defer m.deinit();
 
-    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000, .rx = 999, .ry = 888 }, 16);
+    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000, .rx = 999, .ry = 888 }, 16, 0);
     // mouse mode: rx/ry must be untouched (suppress_right_stick_gyro stays false)
     try testing.expectEqual(@as(i16, 999), ev.gamepad.rx);
     try testing.expectEqual(@as(i16, 888), ev.gamepad.ry);
@@ -1221,11 +1219,11 @@ test "mapper: layer switch resets gyro EMA and accumulators" {
     // Trigger layer activation: LT press → PENDING
     const lt_idx: u6 = @intCast(@intFromEnum(ButtonId.LT));
     const lt_mask: u64 = @as(u64, 1) << lt_idx;
-    _ = try m.apply(.{ .buttons = lt_mask }, 16);
+    _ = try m.apply(.{ .buttons = lt_mask }, 16, 0);
 
     // Timer fires → ACTIVE (active_changed = true inside onTimerExpired, but processLayerTriggers
     // sets active_changed on press too — here we drive it through the full path)
-    _ = m.onTimerExpired();
+    _ = m.onTimerExpired(0);
     // Manually trigger a frame that will see active_changed via release
     // Instead: drive through processLayerTriggers which sets active_changed on ACTIVE→IDLE release
     // For simplicity: re-dirty the processor and then release LT to deactivate
@@ -1235,7 +1233,7 @@ test "mapper: layer switch resets gyro EMA and accumulators" {
     m.stick_right.scroll_accum = 0.9;
 
     // LT release → layer deactivates → active_changed = true → reset fires
-    _ = try m.apply(.{ .buttons = 0 }, 16);
+    _ = try m.apply(.{ .buttons = 0 }, 16, 0);
 
     try testing.expectEqual(@as(f32, 0), m.gyro_proc.ema_x);
     try testing.expectEqual(@as(f32, 0), m.gyro_proc.accum_x);
@@ -1254,7 +1252,7 @@ test "mapper: no layer switch — processor state preserved" {
     m.gyro_proc.ema_x = 42.0;
     m.stick_left.mouse_accum_x = 0.6;
 
-    _ = try m.apply(.{}, 16);
+    _ = try m.apply(.{}, 16, 0);
 
     // No layer change: state must not be reset
     try testing.expectEqual(@as(f32, 42.0), m.gyro_proc.ema_x);
@@ -1278,14 +1276,14 @@ test "mapper: toggle layer switch resets processors" {
     const sel_mask: u64 = @as(u64, 1) << sel_idx;
 
     // Frame 1: Select pressed (rising edge only, toggle fires on release)
-    _ = try m.apply(.{ .buttons = sel_mask }, 16);
+    _ = try m.apply(.{ .buttons = sel_mask }, 16, 0);
 
     // Dirty processor state to simulate residual accumulation
     m.gyro_proc.ema_y = -200.0;
     m.stick_right.mouse_accum_y = 0.8;
 
     // Frame 2: Select released → toggle fires → active_changed = true → reset
-    _ = try m.apply(.{ .buttons = 0 }, 16);
+    _ = try m.apply(.{ .buttons = 0 }, 16, 0);
 
     try testing.expectEqual(@as(f32, 0), m.gyro_proc.ema_y);
     try testing.expectEqual(@as(f32, 0), m.stick_right.mouse_accum_y);
@@ -1307,7 +1305,7 @@ test "mapper: gyro mouse REL events carry REL_X/REL_Y codes" {
     defer m.deinit();
 
     // Positive gyro input → REL_X and REL_Y events with matching codes and positive values.
-    const ev = try m.apply(.{ .gyro_x = 20000, .gyro_y = 20000 }, 16);
+    const ev = try m.apply(.{ .gyro_x = 20000, .gyro_y = 20000 }, 16, 0);
 
     var rel_x_value: ?i32 = null;
     var rel_y_value: ?i32 = null;
@@ -1338,7 +1336,7 @@ test "mapper: gyro mouse REL sign follows gyro input sign" {
     var m = try makeMapper(&parsed.value, allocator);
     defer m.deinit();
 
-    const ev = try m.apply(.{ .gyro_x = -20000, .gyro_y = -20000 }, 16);
+    const ev = try m.apply(.{ .gyro_x = -20000, .gyro_y = -20000 }, 16, 0);
 
     var rel_x_value: ?i32 = null;
     var rel_y_value: ?i32 = null;
@@ -1372,7 +1370,7 @@ test "mapper: stick scroll REL_WHEEL and REL_HWHEEL codes verified" {
     var wheel_value: i32 = 0;
     var hwheel_value: i32 = 0;
     for (0..30) |_| {
-        const ev = try m.apply(.{ .rx = 32000, .ry = -32000 }, 16);
+        const ev = try m.apply(.{ .rx = 32000, .ry = -32000 }, 16, 0);
         for (ev.aux.slice()) |e| switch (e) {
             .rel => |r| {
                 if (r.code == REL_WHEEL) wheel_value += r.value;
@@ -1401,7 +1399,7 @@ test "mapper: stick scroll positive ry gives negative REL_WHEEL values" {
     // ry > 0 = stick down → REL_WHEEL < 0 (scroll down)
     var wheel_value: i32 = 0;
     for (0..30) |_| {
-        const ev = try m.apply(.{ .rx = 0, .ry = 32000 }, 16);
+        const ev = try m.apply(.{ .rx = 0, .ry = 32000 }, 16, 0);
         for (ev.aux.slice()) |e| switch (e) {
             .rel => |r| if (r.code == REL_WHEEL) {
                 wheel_value += r.value;
@@ -1425,7 +1423,7 @@ test "mapper: invalid remap target does not suppress source button" {
     defer m.deinit();
 
     const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
-    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16);
+    const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16, 0);
     // A must still pass through — bad target must not suppress the source
     try testing.expect((events.gamepad.buttons & (@as(u64, 1) << a_idx)) != 0);
 }
@@ -1443,7 +1441,7 @@ test "mapper: trigger_threshold: lt above threshold sets LT button" {
     const lt_bit = @as(u64, 1) << @intCast(@intFromEnum(ButtonId.LT));
     const rt_bit = @as(u64, 1) << @intCast(@intFromEnum(ButtonId.RT));
 
-    const events = try m.apply(.{ .lt = 200, .rt = 50 }, 16);
+    const events = try m.apply(.{ .lt = 200, .rt = 50 }, 16, 0);
     try testing.expect((events.gamepad.buttons & lt_bit) != 0);
     try testing.expect((events.gamepad.buttons & rt_bit) == 0);
 }
@@ -1458,7 +1456,7 @@ test "mapper: trigger_threshold: null threshold does not synthesize buttons" {
 
     const lt_bit = @as(u64, 1) << @intCast(@intFromEnum(ButtonId.LT));
 
-    const events = try m.apply(.{ .lt = 200 }, 16);
+    const events = try m.apply(.{ .lt = 200 }, 16, 0);
     try testing.expect((events.gamepad.buttons & lt_bit) == 0);
 }
 
@@ -1475,11 +1473,11 @@ test "mapper: trigger_threshold: boundary — equal to threshold does not trigge
     const lt_bit = @as(u64, 1) << @intCast(@intFromEnum(ButtonId.LT));
 
     // lt == threshold: should NOT trigger (strictly greater required)
-    const e1 = try m.apply(.{ .lt = 128 }, 16);
+    const e1 = try m.apply(.{ .lt = 128 }, 16, 0);
     try testing.expect((e1.gamepad.buttons & lt_bit) == 0);
 
     // lt == threshold + 1: should trigger
-    const e2 = try m.apply(.{ .lt = 129 }, 16);
+    const e2 = try m.apply(.{ .lt = 129 }, 16, 0);
     try testing.expect((e2.gamepad.buttons & lt_bit) != 0);
 }
 
@@ -1495,9 +1493,58 @@ test "mapper: trigger_threshold: release clears button bit" {
 
     const lt_bit = @as(u64, 1) << @intCast(@intFromEnum(ButtonId.LT));
 
-    const e1 = try m.apply(.{ .lt = 200 }, 16);
+    const e1 = try m.apply(.{ .lt = 200 }, 16, 0);
     try testing.expect((e1.gamepad.buttons & lt_bit) != 0);
 
-    const e2 = try m.apply(.{ .lt = 50 }, 16);
+    const e2 = try m.apply(.{ .lt = 50 }, 16, 0);
     try testing.expect((e2.gamepad.buttons & lt_bit) == 0);
+}
+
+test "mapper: #79 dual-ready ppoll — apply uses caller now_ns, tap fires at press+195ms" {
+    // Issue #79: on a single ppoll wakeup the timerfd (promote PENDING
+    // → ACTIVE) and the device fd (release) can both be ready. Before
+    // the fix, apply() re-read CLOCK_MONOTONIC internally after the
+    // timer handler ran, and the drift pushed a 195ms physical tap
+    // past the 200ms hold_timeout. Now the caller snapshots `now` once
+    // and threads it through both onTimerExpired and apply.
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[[layer]]
+        \\name = "fps"
+        \\trigger = "LT"
+        \\activation = "hold"
+        \\tap = "A"
+        \\hold_timeout = 200
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const lt_idx: u6 = @intCast(@intFromEnum(ButtonId.LT));
+    const lt_mask: u64 = @as(u64, 1) << lt_idx;
+    const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
+    const a_mask: u64 = @as(u64, 1) << a_idx;
+
+    // Frame 1: press at t=0 → PENDING
+    const press_ns: i128 = 1_000_000_000;
+    _ = try m.apply(.{ .buttons = lt_mask }, 16, press_ns);
+
+    // Timer fires at t=200ms → ACTIVE
+    const timer_ns: i128 = press_ns + 200_000_000;
+    _ = m.onTimerExpired(timer_ns);
+    try testing.expect(m.layer.tap_hold.?.layer_activated);
+
+    // Frame 2: release observed on the same ppoll wakeup as the timer,
+    // but the caller-supplied snapshot is the physical release instant
+    // (t=195ms — below hold_timeout). The race-case branch must still
+    // emit the tap.
+    const release_ns: i128 = press_ns + 195_000_000;
+    const ev_tap = try m.apply(.{ .buttons = 0 }, 16, release_ns);
+    try testing.expect((ev_tap.gamepad.buttons & a_mask) != 0);
+    try testing.expect(m.pending_tap_release != null);
+
+    // Next frame clears the injected tap release.
+    const ev_clear = try m.apply(.{}, 16, release_ns + 1_000_000);
+    try testing.expectEqual(@as(u64, 0), ev_clear.gamepad.buttons & a_mask);
 }

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -471,17 +471,8 @@ pub const EventLoop = struct {
                 break;
             }
 
-            // Check timerfd (slot 2)
-            if (self.pollfds[2].revents & posix.POLL.IN != 0) {
-                var expiry: [8]u8 = undefined;
-                _ = posix.read(self.timer_fd, &expiry) catch {};
-                if (ctx.mapper) |m| {
-                    const macro_aux = m.onTimerExpired();
-                    if (macro_aux.len > 0) {
-                        if (ctx.aux_output) |ao| ao.emitAux(macro_aux.slice()) catch {};
-                    }
-                }
-            }
+            // Mapper timerfd (slot 2) is drained after the device fd loop
+            // below — see issue #79.
 
             // Check rumble auto-stop timerfd (slot 3).
             if (self.pollfds[3].revents & posix.POLL.IN != 0) {
@@ -666,7 +657,7 @@ pub const EventLoop = struct {
                             self.gamepad_state.applyDelta(delta);
 
                             if (ctx.mapper) |m| {
-                                const events = m.apply(delta, dt_ms) catch |err| {
+                                const events = m.apply(delta, dt_ms, now) catch |err| {
                                     std.log.err("mapper.apply failed: {}", .{err});
                                     continue;
                                 };
@@ -691,6 +682,21 @@ pub const EventLoop = struct {
                                 if (ctx.touchpad_output) |tp| tp.emitTouch(self.gamepad_state) catch {};
                             }
                         }
+                    }
+                }
+            }
+
+            // Mapper timerfd (slot 2): drained after device fds so an
+            // on-wakeup tap release reaches apply() before PENDING is
+            // promoted to ACTIVE (issue #79). Both handlers share the
+            // `now` snapshot taken right after ppoll.
+            if (self.pollfds[2].revents & posix.POLL.IN != 0) {
+                var expiry: [8]u8 = undefined;
+                _ = posix.read(self.timer_fd, &expiry) catch {};
+                if (ctx.mapper) |m| {
+                    const macro_aux = m.onTimerExpired(now);
+                    if (macro_aux.len > 0) {
+                        if (ctx.aux_output) |ao| ao.emitAux(macro_aux.slice()) catch {};
                     }
                 }
             }

--- a/src/test/gyro_stick_e2e_test.zig
+++ b/src/test/gyro_stick_e2e_test.zig
@@ -137,7 +137,7 @@ test "e2e: gyro activate hold_RB — RB held produces REL, released produces non
     const rb = btnMask(.RB);
 
     // RB held + gyro input → REL events expected
-    const ev_active = try m.apply(.{ .buttons = rb, .gyro_x = 10000, .gyro_y = 10000 }, 16);
+    const ev_active = try m.apply(.{ .buttons = rb, .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
     var has_rel = false;
     for (ev_active.aux.slice()) |e| switch (e) {
         .rel => {
@@ -148,7 +148,7 @@ test "e2e: gyro activate hold_RB — RB held produces REL, released produces non
     try testing.expect(has_rel);
 
     // RB released → no REL events
-    const ev_inactive = try m.apply(.{ .buttons = 0, .gyro_x = 10000, .gyro_y = 10000 }, 16);
+    const ev_inactive = try m.apply(.{ .buttons = 0, .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
     try testing.expectEqual(@as(usize, 0), ev_inactive.aux.len);
     // EMA zeroed by reset
     try testing.expectApproxEqAbs(@as(f32, 0.0), m.gyro_proc.ema_x, 1e-5);
@@ -169,7 +169,7 @@ test "e2e: gyro joystick — gyro overrides emit_state.rx/ry, no REL events" {
     var m = &ctx.mapper;
 
     // Large gyro with original rx/ry set to known value
-    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000, .rx = 5000, .ry = 5000 }, 16);
+    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000, .rx = 5000, .ry = 5000 }, 16, 0);
 
     // rx/ry overridden by gyro output (not the raw 5000)
     try testing.expect(ev.gamepad.rx != 5000);
@@ -196,7 +196,7 @@ test "e2e: gyro joystick — zero gyro leaves rx/ry at zero (deadzone)" {
     var m = &ctx.mapper;
 
     // gyro within deadzone → joy_x/y = 0
-    const ev = try m.apply(.{ .gyro_x = 100, .gyro_y = 100, .rx = 0, .ry = 0 }, 16);
+    const ev = try m.apply(.{ .gyro_x = 100, .gyro_y = 100, .rx = 0, .ry = 0 }, 16, 0);
     try testing.expectEqual(@as(i16, 0), ev.gamepad.rx);
     try testing.expectEqual(@as(i16, 0), ev.gamepad.ry);
 }
@@ -214,7 +214,7 @@ test "e2e: gyro joystick target=left_stick — gyro overrides ax/ay, not rx/ry" 
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000, .ax = 5000, .ay = 5000, .rx = 1234, .ry = 4321 }, 16);
+    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000, .ax = 5000, .ay = 5000, .rx = 1234, .ry = 4321 }, 16, 0);
 
     // ax/ay overridden by gyro (not original 5000)
     try testing.expect(ev.gamepad.ax != 5000);
@@ -244,7 +244,7 @@ test "e2e: gyro joystick target=right_stick (explicit) — same as default" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000, .rx = 5000, .ry = 5000, .ax = 1234, .ay = 4321 }, 16);
+    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000, .rx = 5000, .ry = 5000, .ax = 1234, .ay = 4321 }, 16, 0);
 
     // rx/ry overridden by gyro
     try testing.expect(ev.gamepad.rx != 5000);
@@ -281,12 +281,12 @@ test "e2e: layer switch resets gyro EMA — no jump after activation" {
 
     // LT press → PENDING
     const lt = btnMask(.LT);
-    _ = try m.apply(.{ .buttons = lt }, 16);
+    _ = try m.apply(.{ .buttons = lt }, 16, 0);
     // Timer → ACTIVE (active_changed fires inside onTimerExpired → reset)
-    _ = m.onTimerExpired();
+    _ = m.onTimerExpired(0);
 
     // LT release → IDLE (active_changed again → reset)
-    _ = try m.apply(.{ .buttons = 0 }, 16);
+    _ = try m.apply(.{ .buttons = 0 }, 16, 0);
 
     try testing.expectEqual(@as(f32, 0), m.gyro_proc.ema_x);
     try testing.expectEqual(@as(f32, 0), m.gyro_proc.ema_y);
@@ -303,7 +303,7 @@ test "e2e: no layer switch — EMA preserved across frames" {
     m.gyro_proc.ema_x = 55.0;
     m.stick_right.mouse_accum_x = 0.3;
 
-    _ = try m.apply(.{}, 16);
+    _ = try m.apply(.{}, 16, 0);
 
     try testing.expectEqual(@as(f32, 55.0), m.gyro_proc.ema_x);
     try testing.expectEqual(@as(f32, 0.3), m.stick_right.mouse_accum_x);
@@ -332,7 +332,7 @@ test "e2e: dt_ms scaling — 4 frames@4ms == 1 frame@16ms (right stick mouse)" {
 
     var total4: i32 = 0;
     for (0..4) |_| {
-        const ev = try m4.apply(.{ .rx = 10000 }, 4);
+        const ev = try m4.apply(.{ .rx = 10000 }, 4, 0);
         for (ev.aux.slice()) |e| switch (e) {
             .rel => |r| if (r.code == REL_X) {
                 total4 += r.value;
@@ -342,7 +342,7 @@ test "e2e: dt_ms scaling — 4 frames@4ms == 1 frame@16ms (right stick mouse)" {
     }
 
     var total16: i32 = 0;
-    const ev16 = try m16.apply(.{ .rx = 10000 }, 16);
+    const ev16 = try m16.apply(.{ .rx = 10000 }, 16, 0);
     for (ev16.aux.slice()) |e| switch (e) {
         .rel => |r| if (r.code == REL_X) {
             total16 += r.value;
@@ -366,7 +366,7 @@ test "e2e: dt_ms=1 clamp — stick still produces output (no divide-by-zero)" {
     var m = &ctx.mapper;
 
     // dt=1 is minimum; should not crash or return zero unexpectedly for large input
-    _ = try m.apply(.{ .rx = 32767 }, 1);
+    _ = try m.apply(.{ .rx = 32767 }, 1, 0);
     // Just verify no panic; accumulator may or may not cross integer threshold at dt=1
 }
 

--- a/src/test/macro_e2e_test.zig
+++ b/src/test/macro_e2e_test.zig
@@ -279,7 +279,7 @@ test "macro: layer switch while macro active — held keys released, macros clea
 
     // Press M1 to start macro — down LSHIFT emitted, delay armed.
     const m1_mask = btnMask(.M1);
-    _ = try m.apply(.{ .buttons = m1_mask }, 16);
+    _ = try m.apply(.{ .buttons = m1_mask }, 16, 0);
     try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
 
     // Now activate layer (LT hold) — active_changed fires → macros cleared, releases emitted.
@@ -287,7 +287,7 @@ test "macro: layer switch while macro active — held keys released, macros clea
     _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
-    const ev = try m.apply(.{ .buttons = m1_mask }, 16);
+    const ev = try m.apply(.{ .buttons = m1_mask }, 16, 0);
 
     // active_macros must be empty after layer switch.
     try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
@@ -391,7 +391,7 @@ test "macro: hot-reload — updateMapping swaps config; next apply uses new mapp
     // Verify new mapping: M1 press produces KEY_A, not macro.
     var m = &inst.mapper.?;
     const m1_mask = btnMask(.M1);
-    const ev = try m.apply(.{ .buttons = m1_mask }, 16);
+    const ev = try m.apply(.{ .buttons = m1_mask }, 16, 0);
 
     // With new mapping M1 = "KEY_A", active_macros must be empty.
     try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
@@ -429,7 +429,7 @@ test "macro: mapper macro trigger — M1=macro:dodge_roll press starts player" {
 
     // Rising edge: M1 press → macro player added.
     const m1_mask = btnMask(.M1);
-    const ev = try m.apply(.{ .buttons = m1_mask }, 16);
+    const ev = try m.apply(.{ .buttons = m1_mask }, 16, 0);
     _ = ev;
 
     // Macro player started and immediately ran synchronous steps (tap B + tap LEFT = 4 events).
@@ -453,10 +453,10 @@ test "macro: mapper macro trigger — no second player on held button (no re-tri
 
     const m1_mask = btnMask(.M1);
     // Frame 1: rising edge → macro starts and finishes.
-    _ = try m.apply(.{ .buttons = m1_mask }, 16);
+    _ = try m.apply(.{ .buttons = m1_mask }, 16, 0);
     try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
 
     // Frame 2: still held → no new player (no rising edge).
-    _ = try m.apply(.{ .buttons = m1_mask }, 16);
+    _ = try m.apply(.{ .buttons = m1_mask }, 16, 0);
     try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
 }

--- a/src/test/mapper_e2e_test.zig
+++ b/src/test/mapper_e2e_test.zig
@@ -58,7 +58,7 @@ test "e2e: layer hold — PENDING → ACTIVE, layer remap activates" {
     try testing.expect(m.layer.tap_hold.?.layer_activated);
 
     // Frame 2: A press while layer active → mouse_left aux event
-    const ev = try m.apply(.{ .buttons = btnMask(.A) }, 16);
+    const ev = try m.apply(.{ .buttons = btnMask(.A) }, 16, 0);
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.A));
 
     var found_mouse_left = false;
@@ -75,7 +75,7 @@ test "e2e: layer hold — PENDING → ACTIVE, layer remap activates" {
     // Frame 3: LT release → layer IDLE, A restores
     _ = m.layer.onTriggerRelease(null, 500_000_000);
     try testing.expect(m.layer.tap_hold == null);
-    const ev2 = try m.apply(.{ .buttons = btnMask(.A) }, 16);
+    const ev2 = try m.apply(.{ .buttons = btnMask(.A) }, 16, 0);
     try testing.expect((ev2.gamepad.buttons & btnMask(.A)) != 0);
     try testing.expectEqual(@as(usize, 0), ev2.aux.len);
 }
@@ -146,7 +146,7 @@ test "e2e: suppress/inject — no layer: A→KEY_F13, mouse_side unaffected" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .buttons = btnMask(.A) }, 16);
+    const ev = try m.apply(.{ .buttons = btnMask(.A) }, 16, 0);
     // A suppressed in gamepad
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.A));
     // KEY_F13 in aux
@@ -182,7 +182,7 @@ test "e2e: suppress/inject — layer ACTIVE: A→mouse_left overrides base A→K
     _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
-    const ev = try m.apply(.{ .buttons = btnMask(.A) }, 16);
+    const ev = try m.apply(.{ .buttons = btnMask(.A) }, 16, 0);
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.A));
 
     var found_mouse_left = false;
@@ -216,7 +216,7 @@ test "e2e: gyro mouse mode — non-zero gyro produces REL_X/REL_Y aux events" {
     var m = &ctx.mapper;
 
     // Large gyro value to ensure accumulation crosses integer threshold
-    const ev = try m.apply(.{ .gyro_x = 10, .gyro_y = 10 }, 16);
+    const ev = try m.apply(.{ .gyro_x = 10, .gyro_y = 10 }, 16, 0);
 
     var found_rel_x = false;
     var found_rel_y = false;
@@ -240,7 +240,7 @@ test "e2e: gyro off mode — no REL events" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000 }, 16);
+    const ev = try m.apply(.{ .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
     for (ev.aux.slice()) |e| {
         switch (e) {
             .rel => return error.UnexpectedRelEvent,
@@ -260,7 +260,7 @@ test "e2e: dual uinput routing — gamepad_button remap stays on main device, no
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .buttons = btnMask(.A) }, 16);
+    const ev = try m.apply(.{ .buttons = btnMask(.A) }, 16, 0);
     // A suppressed, B injected in gamepad (main device)
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.A));
     try testing.expect((ev.gamepad.buttons & btnMask(.B)) != 0);
@@ -277,7 +277,7 @@ test "e2e: dual uinput routing — key remap goes to aux, not main device" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .buttons = btnMask(.A) }, 16);
+    const ev = try m.apply(.{ .buttons = btnMask(.A) }, 16, 0);
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.A));
     try testing.expectEqual(@as(usize, 1), ev.aux.len);
     switch (ev.aux.get(0)) {
@@ -298,7 +298,7 @@ test "e2e: dual uinput routing — mouse_button remap goes to aux" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .buttons = btnMask(.RB) }, 16);
+    const ev = try m.apply(.{ .buttons = btnMask(.RB) }, 16, 0);
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.RB));
     try testing.expectEqual(@as(usize, 1), ev.aux.len);
     switch (ev.aux.get(0)) {
@@ -321,7 +321,7 @@ test "e2e: dual uinput routing — same frame: gamepad remap + key remap both ro
     var m = &ctx.mapper;
 
     const buttons = btnMask(.A) | btnMask(.RB);
-    const ev = try m.apply(.{ .buttons = buttons }, 16);
+    const ev = try m.apply(.{ .buttons = buttons }, 16, 0);
 
     // A→B on main device
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.A));
@@ -352,7 +352,7 @@ test "e2e: dpad arrows — dpad_y=-1 (first press) → KEY_UP press" {
     var m = &ctx.mapper;
 
     // prev dpad_y = 0 (default), current = -1
-    const ev = try m.apply(.{ .dpad_y = -1 }, 16);
+    const ev = try m.apply(.{ .dpad_y = -1 }, 16, 0);
     var found_key_up_press = false;
     for (ev.aux.slice()) |e| {
         switch (e) {
@@ -375,10 +375,10 @@ test "e2e: dpad arrows — dpad_y returns to 0 → KEY_UP release" {
     var m = &ctx.mapper;
 
     // Set prev to dpad_y = -1 by applying that state first
-    _ = try m.apply(.{ .dpad_y = -1 }, 16);
+    _ = try m.apply(.{ .dpad_y = -1 }, 16, 0);
 
     // Now dpad_y returns to 0 → KEY_UP release
-    const ev = try m.apply(.{ .dpad_y = 0 }, 16);
+    const ev = try m.apply(.{ .dpad_y = 0 }, 16, 0);
     var found_key_up_release = false;
     for (ev.aux.slice()) |e| {
         switch (e) {
@@ -398,7 +398,7 @@ test "e2e: dpad gamepad mode — dpad passes through unchanged, no aux KEY event
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .dpad_y = -1 }, 16);
+    const ev = try m.apply(.{ .dpad_y = -1 }, 16, 0);
     for (ev.aux.slice()) |e| {
         switch (e) {
             .key => return error.UnexpectedKeyEvent,
@@ -418,7 +418,7 @@ test "e2e: dpad arrows suppress_gamepad — dpad_x/y zeroed in emit_state" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .dpad_y = -1 }, 16);
+    const ev = try m.apply(.{ .dpad_y = -1 }, 16, 0);
     try testing.expectEqual(@as(i8, 0), ev.gamepad.dpad_y);
     try testing.expectEqual(@as(i8, 0), ev.gamepad.dpad_x);
 }
@@ -441,7 +441,7 @@ test "e2e: prev-frame mask — layer activates mid-stream, no spurious release f
     const configs = ctx.parsed.value.layer.?;
 
     // Frame N-1: B pressed, no layer → B passes through
-    const ev1 = try m.apply(.{ .buttons = btnMask(.B) }, 16);
+    const ev1 = try m.apply(.{ .buttons = btnMask(.B) }, 16, 0);
     try testing.expect((ev1.gamepad.buttons & btnMask(.B)) != 0);
 
     // Layer activates (simulate timer)
@@ -449,7 +449,7 @@ test "e2e: prev-frame mask — layer activates mid-stream, no spurious release f
     _ = m.layer.onTimerExpired();
 
     // Frame N: B still held + layer ACTIVE → B suppressed in both current and masked_prev
-    const ev2 = try m.apply(.{ .buttons = btnMask(.B) }, 16);
+    const ev2 = try m.apply(.{ .buttons = btnMask(.B) }, 16, 0);
     // B suppressed in emit output
     try testing.expectEqual(@as(u64, 0), ev2.gamepad.buttons & btnMask(.B));
     // B also suppressed in masked_prev (no spurious release diff)
@@ -481,7 +481,7 @@ test "e2e: toggle layer — Select release toggles fn layer on/off, A remap appl
     try testing.expect(m.layer.toggled.contains("fn"));
 
     // A press → KEY_F1 in aux
-    const ev1 = try m.apply(.{ .buttons = btnMask(.A) }, 16);
+    const ev1 = try m.apply(.{ .buttons = btnMask(.A) }, 16, 0);
     var found_f1 = false;
     for (ev1.aux.slice()) |e| {
         switch (e) {
@@ -500,7 +500,7 @@ test "e2e: toggle layer — Select release toggles fn layer on/off, A remap appl
     try testing.expect(!m.layer.toggled.contains("fn"));
 
     // A press now → A passes through on main device
-    const ev2 = try m.apply(.{ .buttons = btnMask(.A) }, 16);
+    const ev2 = try m.apply(.{ .buttons = btnMask(.A) }, 16, 0);
     try testing.expect((ev2.gamepad.buttons & btnMask(.A)) != 0);
     var no_f1 = true;
     for (ev2.aux.slice()) |e| {
@@ -538,7 +538,7 @@ test "e2e: layer remap fall-through — button not in layer remap uses base rema
     _ = m.layer.onTimerExpired();
 
     // X pressed — not in layer remap, should fall through to base (KEY_F13)
-    const ev = try m.apply(.{ .buttons = btnMask(.X) }, 16);
+    const ev = try m.apply(.{ .buttons = btnMask(.X) }, 16, 0);
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.X));
     var found_f13 = false;
     for (ev.aux.slice()) |e| {
@@ -563,7 +563,7 @@ test "e2e: remap to mouse_forward produces BTN_FORWARD aux event" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .buttons = btnMask(.M1) }, 16);
+    const ev = try m.apply(.{ .buttons = btnMask(.M1) }, 16, 0);
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.M1));
 
     var found_forward = false;
@@ -603,7 +603,7 @@ test "e2e: layer active — dpad mode switches to arrows" {
     _ = m.layer.onTimerExpired();
 
     // dpad_y = -1 → KEY_UP (arrows mode active via layer)
-    const ev_up = try m.apply(.{ .dpad_y = -1 }, 16);
+    const ev_up = try m.apply(.{ .dpad_y = -1 }, 16, 0);
     var found_key_up = false;
     for (ev_up.aux.slice()) |e| {
         switch (e) {
@@ -616,7 +616,7 @@ test "e2e: layer active — dpad mode switches to arrows" {
     try testing.expect(found_key_up);
 
     // dpad_y = 1 → KEY_DOWN
-    const ev_down = try m.apply(.{ .dpad_y = 1 }, 16);
+    const ev_down = try m.apply(.{ .dpad_y = 1 }, 16, 0);
     var found_key_down = false;
     for (ev_down.aux.slice()) |e| {
         switch (e) {

--- a/src/test/properties/e2e_pipeline_props.zig
+++ b/src/test/properties/e2e_pipeline_props.zig
@@ -349,7 +349,7 @@ test "e2e pipeline: vader5 — axes + button A → remap A→KEY_F13" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(delta, 16);
+    const ev = try m.apply(delta, 16, 0);
     // A suppressed in gamepad output
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.A));
     // KEY_F13 emitted as aux
@@ -389,7 +389,7 @@ test "e2e pipeline: dualsense USB — scaled axes + buttons → remap B→mouse_
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(delta, 16);
+    const ev = try m.apply(delta, 16, 0);
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.B));
     var found_mouse_left = false;
     for (ev.aux.slice()) |e| {
@@ -428,7 +428,7 @@ test "e2e pipeline: switch-pro — button press → remap A→B, Y→KEY_F1" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(delta, 16);
+    const ev = try m.apply(delta, 16, 0);
     // A suppressed, B injected
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.A));
     try testing.expect((ev.gamepad.buttons & btnMask(.B)) != 0);
@@ -475,7 +475,7 @@ test "e2e pipeline: random packets through full pipeline — no crash" {
         raw[2] = 0xef;
 
         const delta = (interp.processReport(1, &raw) catch continue) orelse continue;
-        const ev = try m.apply(delta, 16);
+        const ev = try m.apply(delta, 16, 0);
         // Invariant: aux key/mouse codes must be non-zero.
         for (ev.aux.slice()) |aux| {
             switch (aux) {

--- a/src/test/properties/generative_mapper_props.zig
+++ b/src/test/properties/generative_mapper_props.zig
@@ -41,7 +41,7 @@ fn runHarness(
         sequence_gen.randomSequence(rng, frames, ctx.parsed.value);
 
         for (frames) |frame| {
-            _ = try ctx.mapper.apply(frame.delta, @as(u32, frame.dt_ms));
+            _ = try ctx.mapper.apply(frame.delta, @as(u32, frame.dt_ms), 0);
         }
         pass += 1;
     }
@@ -163,7 +163,7 @@ test "generative: layer hold -> pending -> active -> deactivate" {
 
     // idle -> pending
     var prev = oracle;
-    _ = ctx.mapper.apply(.{ .buttons = lt }, 0) catch unreachable;
+    _ = ctx.mapper.apply(.{ .buttons = lt }, 0, 0) catch unreachable;
     _ = mapper_oracle.apply(&oracle, .{ .buttons = lt }, &parsed.value, 0);
     transition_id.classify(&tracker, &prev, &oracle, .{ .buttons = lt }, &parsed.value);
     try testing.expect(tracker.seen[@intFromEnum(transition_id.TransitionId.layer_idle_to_pending)]);
@@ -172,20 +172,20 @@ test "generative: layer hold -> pending -> active -> deactivate" {
     prev = oracle;
     // Fire production timer BEFORE apply so layer is active for remap processing
     _ = ctx.mapper.layer.onTimerExpired();
-    _ = ctx.mapper.apply(.{ .buttons = lt }, 101) catch unreachable;
+    _ = ctx.mapper.apply(.{ .buttons = lt }, 101, 0) catch unreachable;
     _ = mapper_oracle.apply(&oracle, .{ .buttons = lt }, &parsed.value, 101);
     transition_id.classify(&tracker, &prev, &oracle, .{ .buttons = lt }, &parsed.value);
     try testing.expect(tracker.seen[@intFromEnum(transition_id.TransitionId.layer_pending_to_active)]);
 
     // verify layer remap active: A -> X
     // Production suppresses layer trigger buttons; oracle doesn't — mask out LT for comparison
-    const prod = ctx.mapper.apply(.{ .buttons = lt | a }, 0) catch unreachable;
+    const prod = ctx.mapper.apply(.{ .buttons = lt | a }, 0, 0) catch unreachable;
     const oout = mapper_oracle.apply(&oracle, .{ .buttons = lt | a }, &parsed.value, 0);
     try testing.expectEqual(oout.gamepad.buttons & ~lt, prod.gamepad.buttons);
 
     // active -> idle (release LT)
     prev = oracle;
-    _ = ctx.mapper.apply(.{ .buttons = 0 }, 0) catch unreachable;
+    _ = ctx.mapper.apply(.{ .buttons = 0 }, 0, 0) catch unreachable;
     _ = mapper_oracle.apply(&oracle, .{ .buttons = 0 }, &parsed.value, 0);
     transition_id.classify(&tracker, &prev, &oracle, .{ .buttons = 0 }, &parsed.value);
     try testing.expect(tracker.seen[@intFromEnum(transition_id.TransitionId.layer_active_to_idle)]);
@@ -214,24 +214,24 @@ test "generative: layer toggle on/off" {
     const a = helpers.btnMask(.A);
 
     // press + release Select -> toggle on
-    _ = ctx.mapper.apply(.{ .buttons = sel }, 0) catch unreachable;
+    _ = ctx.mapper.apply(.{ .buttons = sel }, 0, 0) catch unreachable;
     _ = mapper_oracle.apply(&oracle, .{ .buttons = sel }, &parsed.value, 0);
     var prev = oracle;
-    _ = ctx.mapper.apply(.{ .buttons = 0 }, 0) catch unreachable;
+    _ = ctx.mapper.apply(.{ .buttons = 0 }, 0, 0) catch unreachable;
     _ = mapper_oracle.apply(&oracle, .{ .buttons = 0 }, &parsed.value, 0);
     transition_id.classify(&tracker, &prev, &oracle, .{ .buttons = 0 }, &parsed.value);
     try testing.expect(tracker.seen[@intFromEnum(transition_id.TransitionId.layer_toggle_on)]);
 
     // A should be remapped to KEY_F1
-    const prod = ctx.mapper.apply(.{ .buttons = a }, 0) catch unreachable;
+    const prod = ctx.mapper.apply(.{ .buttons = a }, 0, 0) catch unreachable;
     const oout = mapper_oracle.apply(&oracle, .{ .buttons = a }, &parsed.value, 0);
     try testing.expectEqual(oout.gamepad.buttons, prod.gamepad.buttons);
 
     // press + release Select -> toggle off
-    _ = ctx.mapper.apply(.{ .buttons = sel }, 0) catch unreachable;
+    _ = ctx.mapper.apply(.{ .buttons = sel }, 0, 0) catch unreachable;
     _ = mapper_oracle.apply(&oracle, .{ .buttons = sel }, &parsed.value, 0);
     prev = oracle;
-    _ = ctx.mapper.apply(.{ .buttons = 0 }, 0) catch unreachable;
+    _ = ctx.mapper.apply(.{ .buttons = 0 }, 0, 0) catch unreachable;
     _ = mapper_oracle.apply(&oracle, .{ .buttons = 0 }, &parsed.value, 0);
     transition_id.classify(&tracker, &prev, &oracle, .{ .buttons = 0 }, &parsed.value);
     try testing.expect(tracker.seen[@intFromEnum(transition_id.TransitionId.layer_toggle_off)]);
@@ -251,7 +251,7 @@ test "generative: dpad arrows mode emits KEY events" {
     const parsed = try mapping.parseString(allocator, toml_str);
     defer parsed.deinit();
 
-    const prod = ctx.mapper.apply(.{ .dpad_x = -1 }, 0) catch unreachable;
+    const prod = ctx.mapper.apply(.{ .dpad_x = -1 }, 0, 0) catch unreachable;
     const oout = mapper_oracle.apply(&oracle, .{ .dpad_x = -1 }, &parsed.value, 0);
 
     try testing.expectEqual(oout.gamepad.dpad_x, prod.gamepad.dpad_x);
@@ -287,15 +287,15 @@ test "generative: simultaneous buttons + layer remap" {
     const b = helpers.btnMask(.B);
 
     // Activate layer
-    _ = ctx.mapper.apply(.{ .buttons = lt }, 0) catch unreachable;
+    _ = ctx.mapper.apply(.{ .buttons = lt }, 0, 0) catch unreachable;
     _ = mapper_oracle.apply(&oracle, .{ .buttons = lt }, &parsed.value, 0);
     _ = ctx.mapper.layer.onTimerExpired();
-    _ = ctx.mapper.apply(.{ .buttons = lt }, 51) catch unreachable;
+    _ = ctx.mapper.apply(.{ .buttons = lt }, 51, 0) catch unreachable;
     _ = mapper_oracle.apply(&oracle, .{ .buttons = lt }, &parsed.value, 51);
 
     // Press A + B simultaneously while layer active
     // Production suppresses layer trigger buttons; oracle doesn't — mask out LT for comparison
-    const prod = ctx.mapper.apply(.{ .buttons = lt | a | b }, 0) catch unreachable;
+    const prod = ctx.mapper.apply(.{ .buttons = lt | a | b }, 0, 0) catch unreachable;
     const oout = mapper_oracle.apply(&oracle, .{ .buttons = lt | a | b }, &parsed.value, 0);
     try testing.expectEqual(oout.gamepad.buttons & ~lt, prod.gamepad.buttons);
     try compareAux(&oout.aux, &prod.aux);
@@ -335,7 +335,7 @@ test "generative: real device configs x compatible mapping x random sequences" {
         sequence_gen.randomSequence(rng, &frames_buf, map_parsed.value);
 
         for (frames_buf) |frame| {
-            _ = try mc.mapper.apply(frame.delta, @as(u32, frame.dt_ms));
+            _ = try mc.mapper.apply(frame.delta, @as(u32, frame.dt_ms), 0);
         }
         tested += 1;
     }

--- a/src/test/properties/mapper_props.zig
+++ b/src/test/properties/mapper_props.zig
@@ -40,7 +40,7 @@ test "property: random input deltas never crash mapper" {
 
     for (0..1000) |_| {
         const delta = state_mod.generateRandomDelta(rng);
-        const ev = try m.apply(delta, 16);
+        const ev = try m.apply(delta, 16, 0);
         // Invariant: aux key/mouse codes must be non-zero (no code 0 in Linux input).
         for (ev.aux.slice()) |aux| {
             switch (aux) {
@@ -65,12 +65,12 @@ test "property: all 64 button bits set — no panic or overflow" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .buttons = 0xFFFFFFFFFFFFFFFF }, 16);
+    const ev = try m.apply(.{ .buttons = 0xFFFFFFFFFFFFFFFF }, 16, 0);
     // mapper must return without panic; buttons field is valid
     _ = ev.gamepad.buttons;
 
     // release all
-    _ = try m.apply(.{ .buttons = 0 }, 16);
+    _ = try m.apply(.{ .buttons = 0 }, 16, 0);
 }
 
 // P3: rapid layer toggle — 1000 cycles
@@ -158,7 +158,7 @@ test "property: random button remap pairs — no crash" {
         var m = &ctx.mapper;
 
         const delta = state_mod.generateRandomDelta(rng);
-        const ev = try m.apply(delta, 16);
+        const ev = try m.apply(delta, 16, 0);
         for (ev.aux.slice()) |aux| {
             switch (aux) {
                 .key => |k| try testing.expect(k.code > 0),
@@ -193,7 +193,7 @@ test "property: extreme axis values — no overflow after processing" {
     };
 
     for (extreme_deltas) |delta| {
-        _ = try m.apply(delta, 16);
+        _ = try m.apply(delta, 16, 0);
     }
 
     // also fuzz with random extreme-biased values
@@ -220,7 +220,7 @@ test "property: extreme axis values — no overflow after processing" {
         if (rng.boolean()) {
             delta.buttons = rng.int(u64);
         }
-        _ = try m.apply(delta, 16);
+        _ = try m.apply(delta, 16, 0);
     }
 }
 
@@ -236,7 +236,7 @@ test "property: empty config — passthrough no crash" {
 
     for (0..1000) |_| {
         const delta = state_mod.generateRandomDelta(rng);
-        const ev = try m.apply(delta, 16);
+        const ev = try m.apply(delta, 16, 0);
         // No remaps → gamepad output equals input (passthrough).
         if (delta.buttons) |b| try testing.expectEqual(b, ev.gamepad.buttons);
         if (delta.ax) |v| try testing.expectEqual(v, ev.gamepad.ax);
@@ -262,7 +262,7 @@ test "property: empty layer array — no crash" {
 
     for (0..1000) |_| {
         const delta = state_mod.generateRandomDelta(rng);
-        const ev = try m.apply(delta, 16);
+        const ev = try m.apply(delta, 16, 0);
         for (ev.aux.slice()) |aux| {
             switch (aux) {
                 .key => |k| try testing.expect(k.code > 0),
@@ -288,7 +288,7 @@ test "property: duplicate remap targets — last write wins, no crash" {
     var m = &ctx.mapper;
 
     // press both A and B → both map to Y
-    const ev1 = try m.apply(.{ .buttons = btnMask(.A) | btnMask(.B) }, 16);
+    const ev1 = try m.apply(.{ .buttons = btnMask(.A) | btnMask(.B) }, 16, 0);
     // Y should be injected (at least one source is pressed)
     try testing.expect((ev1.gamepad.buttons & btnMask(.Y)) != 0);
     // A and B should be suppressed
@@ -299,7 +299,7 @@ test "property: duplicate remap targets — last write wins, no crash" {
     var prng = std.Random.DefaultPrng.init(0xAAAA);
     const rng = prng.random();
     for (0..1000) |_| {
-        _ = try m.apply(.{ .buttons = rng.int(u64) }, 16);
+        _ = try m.apply(.{ .buttons = rng.int(u64) }, 16, 0);
     }
 }
 
@@ -319,8 +319,8 @@ test "property: apply same delta twice — no duplicate button press events" {
 
     for (0..1000) |_| {
         const delta = GamepadStateDelta{ .buttons = rng.int(u64) };
-        const ev1 = try m.apply(delta, 16);
-        const ev2 = try m.apply(delta, 16);
+        const ev1 = try m.apply(delta, 16, 0);
+        const ev2 = try m.apply(delta, 16, 0);
 
         // second apply with identical state should produce no key/mouse press events
         for (ev2.aux.slice()) |aux| {
@@ -358,13 +358,13 @@ test "property: layer and base remap to same target — no crash" {
     _ = m.layer.onTimerExpired();
 
     // both A and B pressed — both map to KEY_F1
-    _ = try m.apply(.{ .buttons = btnMask(.A) | btnMask(.B) }, 16);
+    _ = try m.apply(.{ .buttons = btnMask(.A) | btnMask(.B) }, 16, 0);
 
     // fuzz
     var prng = std.Random.DefaultPrng.init(0xBBBB);
     const rng = prng.random();
     for (0..1000) |_| {
         const delta = state_mod.generateRandomDelta(rng);
-        _ = try m.apply(delta, 16);
+        _ = try m.apply(delta, 16, 0);
     }
 }

--- a/src/test/properties/regression_corpus_props.zig
+++ b/src/test/properties/regression_corpus_props.zig
@@ -41,7 +41,7 @@ test "regression: all corpus cases pass" {
         std.debug.assert(case.frames.len == case.expected_buttons.len);
 
         for (case.frames, case.expected_buttons, 0..) |frame, expected, idx| {
-            const prod = try ctx.mapper.apply(frame.delta, @as(u32, frame.dt_ms));
+            const prod = try ctx.mapper.apply(frame.delta, @as(u32, frame.dt_ms), 0);
             const oout = mapper_oracle.apply(&oracle, frame.delta, &ctx.parsed.value, @as(u64, frame.dt_ms));
 
             testing.expectEqual(expected, prod.gamepad.buttons) catch |err| {

--- a/tools/padctl-debug.zig
+++ b/tools/padctl-debug.zig
@@ -447,7 +447,11 @@ pub fn main() !void {
                                 prev_buttons = new_btns;
                             }
                             if (mapper) |*m| {
-                                if (m.apply(delta, 16)) |out| {
+                                const now_ns: i128 = blk: {
+                                    const ts = std.posix.clock_gettime(.MONOTONIC) catch break :blk 0;
+                                    break :blk @as(i128, ts.sec) * std.time.ns_per_s + @as(i128, ts.nsec);
+                                };
+                                if (m.apply(delta, 16, now_ns)) |out| {
                                     mapped_gs = out.gamepad;
                                     mapped_gs.synthesizeDpadAxes();
                                     // Process aux events


### PR DESCRIPTION
## Summary

Completes the fix for #79 (Vader 5 Pro tap-on-layer misses near `hold_timeout`). PR #104 moved tap/hold to a timestamp comparison but the timerfd (slot 2) still drained **before** the device fd loop on a dual-ready ppoll wakeup. When a release landed near `hold_timeout` (195–205 ms), the timer handler promoted PENDING → ACTIVE, and `mapper.apply` then re-read `CLOCK_MONOTONIC` internally — the drift pushed `(now_ns - press_ns)` past the threshold and the tap was suppressed.

Fix combines both mitigations identified in the investigation:
- **A**: reorder slot-2 timerfd dispatch to run **after** the device fd loop, so a release on the same wakeup reaches `apply()` before PENDING can promote.
- **B**: snapshot `now_ns` once per wakeup in `event_loop.zig` and thread it through `mapper.apply(delta, dt_ms, now_ns)` and `mapper.onTimerExpired(now_ns)`. Delete the internal `monotonicNs()` helper — the caller owns the timeline.

## Regression tests

- `src/core/layer.zig`: release at `press + 195 ms` → tap fires; release at `press + 200 ms` → no tap (pins exact-boundary semantics).
- `src/core/mapper.zig`: full dual-ready ppoll replay — `apply(press, press_ns)` → `onTimerExpired(press_ns + 200 ms)` → `apply(release, press_ns + 195 ms)` must inject the tap bit on `gamepad.buttons`.
- Reverse-verified: injecting +10 ms drift to the final `apply` makes the test fail; reverting → `zig build test` green.

## Test plan

- [x] `zig build test` (Layer 0+1) green on host
- [x] `zig build test-tsan` green
- [x] New boundary tests fail without the fix (reverse-verification captured in commit body)
- [ ] Real Vader 5 Pro — manual layer-tap near `hold_timeout = 200` (issue reporter follow-up)