### PR TITLE
fix(macro): emit .gamepad_button and .mouse_button targets (#99)

### DIFF
--- a/src/core/macro_player.zig
+++ b/src/core/macro_player.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const macro_mod = @import("macro.zig");
 const remap = @import("remap.zig");
 const timer_queue_mod = @import("timer_queue.zig");
+const state_mod = @import("state.zig");
 
 const Macro = macro_mod.Macro;
 const MacroStep = macro_mod.MacroStep;
@@ -9,6 +10,8 @@ const aux_event_mod = @import("aux_event.zig");
 const AuxEventList = aux_event_mod.AuxEventList;
 const AuxEvent = aux_event_mod.AuxEvent;
 const TimerQueue = timer_queue_mod.TimerQueue;
+const RemapTargetResolved = remap.RemapTargetResolved;
+const ButtonId = state_mod.ButtonId;
 
 pub const MacroPlayer = struct {
     macro: *const Macro,
@@ -16,6 +19,7 @@ pub const MacroPlayer = struct {
     waiting_for_release: bool,
     timer_token: u32,
     trigger_src_idx: u6,
+    held_gamepad_buttons: u64,
 
     pub fn init(m: *const Macro, token: u32, src_idx: u6) MacroPlayer {
         return .{
@@ -24,12 +28,24 @@ pub const MacroPlayer = struct {
             .waiting_for_release = false,
             .timer_token = token,
             .trigger_src_idx = src_idx,
+            .held_gamepad_buttons = 0,
         };
     }
 
     /// Execute synchronous steps until delay / pause_for_release / end.
     /// Returns true when the macro is finished (caller should remove it).
-    pub fn step(self: *MacroPlayer, aux: *AuxEventList, queue: *TimerQueue) !bool {
+    ///
+    /// injected_buttons: mapper-owned bitmask for synthesized gamepad bits; tap/down/up
+    ///   of a .gamepad_button target set or clear bits here.
+    /// pending_tap_release: tap bits ORed by this frame; mapper clears them next frame
+    ///   (same cadence as the remap tap path — see mapper.emitTapEvent).
+    pub fn step(
+        self: *MacroPlayer,
+        aux: *AuxEventList,
+        queue: *TimerQueue,
+        injected_buttons: *u64,
+        pending_tap_release: *u64,
+    ) !bool {
         if (self.waiting_for_release) return false;
 
         while (self.step_index < self.macro.steps.len) {
@@ -37,17 +53,16 @@ pub const MacroPlayer = struct {
             self.step_index += 1;
             switch (s) {
                 .tap => |name| {
-                    const code = resolveKeyCode(name) orelse continue;
-                    aux.append(.{ .key = .{ .code = code, .pressed = true } }) catch {};
-                    aux.append(.{ .key = .{ .code = code, .pressed = false } }) catch {};
+                    const target = resolveTargetSafe(name) orelse continue;
+                    emitTap(target, aux, injected_buttons, pending_tap_release);
                 },
                 .down => |name| {
-                    const code = resolveKeyCode(name) orelse continue;
-                    aux.append(.{ .key = .{ .code = code, .pressed = true } }) catch {};
+                    const target = resolveTargetSafe(name) orelse continue;
+                    emitDown(target, aux, injected_buttons, &self.held_gamepad_buttons);
                 },
                 .up => |name| {
-                    const code = resolveKeyCode(name) orelse continue;
-                    aux.append(.{ .key = .{ .code = code, .pressed = false } }) catch {};
+                    const target = resolveTargetSafe(name) orelse continue;
+                    emitUp(target, aux, injected_buttons, &self.held_gamepad_buttons);
                 },
                 .delay => |ms| {
                     const deadline = std.time.nanoTimestamp() + @as(i128, ms) * std.time.ns_per_ms;
@@ -67,10 +82,12 @@ pub const MacroPlayer = struct {
         self.waiting_for_release = false;
     }
 
-    /// Emit up-events for any currently held keys (used on layer switch / cancel).
-    pub fn emitPendingReleases(self: *const MacroPlayer, aux: *AuxEventList) void {
-        // Walk steps up to step_index, track net held state per name.
-        // Simple approach: scan for down/tap before step_index, emit up for downs without a subsequent up.
+    /// Emit releases for any keys/buttons still held by this player.
+    /// Called on layer switch / macro cancel. Drops key-up aux events AND clears
+    /// held gamepad bits from injected_buttons.
+    pub fn emitPendingReleases(self: *MacroPlayer, aux: *AuxEventList, injected_buttons: *u64) void {
+        // Walk steps up to step_index, track net held state per name (keys / mouse buttons).
+        // Gamepad bits are tracked live in self.held_gamepad_buttons and cleared below.
         var held: [32]?[]const u8 = [_]?[]const u8{null} ** 32;
         var held_len: usize = 0;
 
@@ -83,7 +100,6 @@ pub const MacroPlayer = struct {
                     }
                 },
                 .up => |name| {
-                    // Remove from held list
                     for (held[0..held_len], 0..) |h, i| {
                         if (h) |hn| {
                             if (std.mem.eql(u8, hn, name)) {
@@ -94,33 +110,98 @@ pub const MacroPlayer = struct {
                         }
                     }
                 },
-                .tap => {
-                    // tap is self-contained press+release; no residual hold
-                },
+                .tap => {},
                 .delay, .pause_for_release => {},
             }
         }
 
         for (held[0..held_len]) |h| {
             const name = h orelse continue;
-            const code = resolveKeyCode(name) orelse continue;
-            aux.append(.{ .key = .{ .code = code, .pressed = false } }) catch {};
+            const target = resolveTargetSafe(name) orelse continue;
+            switch (target) {
+                .key => |code| aux.append(.{ .key = .{ .code = code, .pressed = false } }) catch {},
+                .mouse_button => |code| aux.append(.{ .mouse_button = .{ .code = code, .pressed = false } }) catch {},
+                .gamepad_button => {},
+                .disabled, .macro => {},
+            }
         }
+
+        injected_buttons.* &= ~self.held_gamepad_buttons;
+        self.held_gamepad_buttons = 0;
     }
 };
 
-fn resolveKeyCode(name: []const u8) ?u16 {
-    const target = remap.resolveTarget(name) catch return null;
-    return switch (target) {
-        .key => |code| code,
-        else => null,
-    };
+fn resolveTargetSafe(name: []const u8) ?RemapTargetResolved {
+    return remap.resolveTarget(name) catch null;
+}
+
+fn emitTap(
+    target: RemapTargetResolved,
+    aux: *AuxEventList,
+    injected_buttons: *u64,
+    pending_tap_release: *u64,
+) void {
+    switch (target) {
+        .key => |code| {
+            aux.append(.{ .key = .{ .code = code, .pressed = true } }) catch {};
+            aux.append(.{ .key = .{ .code = code, .pressed = false } }) catch {};
+        },
+        .mouse_button => |code| {
+            aux.append(.{ .mouse_button = .{ .code = code, .pressed = true } }) catch {};
+            aux.append(.{ .mouse_button = .{ .code = code, .pressed = false } }) catch {};
+        },
+        .gamepad_button => |dst| {
+            const mask = buttonMask(dst);
+            injected_buttons.* |= mask;
+            pending_tap_release.* |= mask;
+        },
+        .disabled, .macro => {},
+    }
+}
+
+fn emitDown(
+    target: RemapTargetResolved,
+    aux: *AuxEventList,
+    injected_buttons: *u64,
+    held_gamepad: *u64,
+) void {
+    switch (target) {
+        .key => |code| aux.append(.{ .key = .{ .code = code, .pressed = true } }) catch {},
+        .mouse_button => |code| aux.append(.{ .mouse_button = .{ .code = code, .pressed = true } }) catch {},
+        .gamepad_button => |dst| {
+            const mask = buttonMask(dst);
+            injected_buttons.* |= mask;
+            held_gamepad.* |= mask;
+        },
+        .disabled, .macro => {},
+    }
+}
+
+fn emitUp(
+    target: RemapTargetResolved,
+    aux: *AuxEventList,
+    injected_buttons: *u64,
+    held_gamepad: *u64,
+) void {
+    switch (target) {
+        .key => |code| aux.append(.{ .key = .{ .code = code, .pressed = false } }) catch {},
+        .mouse_button => |code| aux.append(.{ .mouse_button = .{ .code = code, .pressed = false } }) catch {},
+        .gamepad_button => |dst| {
+            const mask = buttonMask(dst);
+            injected_buttons.* &= ~mask;
+            held_gamepad.* &= ~mask;
+        },
+        .disabled, .macro => {},
+    }
+}
+
+fn buttonMask(id: ButtonId) u64 {
+    return @as(u64, 1) << @as(u6, @intCast(@intFromEnum(id)));
 }
 
 // --- tests ---
 
 const testing = std.testing;
-const mapping = @import("../config/mapping.zig");
 
 fn makePlayer(m: *const Macro) MacroPlayer {
     return MacroPlayer.init(m, 1, 0);
@@ -130,23 +211,41 @@ fn dummyQueue(allocator: std.mem.Allocator) TimerQueue {
     return TimerQueue.init(allocator, -1);
 }
 
+const StepCtx = struct {
+    aux: AuxEventList = .{},
+    queue: TimerQueue,
+    injected: u64 = 0,
+    tap_release: u64 = 0,
+
+    fn init(allocator: std.mem.Allocator) StepCtx {
+        return .{ .queue = dummyQueue(allocator) };
+    }
+
+    fn deinit(self: *StepCtx) void {
+        self.queue.deinit();
+    }
+
+    fn step(self: *StepCtx, p: *MacroPlayer) !bool {
+        return p.step(&self.aux, &self.queue, &self.injected, &self.tap_release);
+    }
+};
+
 test "macro_player: tap step press then release emitted" {
     const allocator = testing.allocator;
     const steps = [_]MacroStep{.{ .tap = "KEY_B" }};
     const m = Macro{ .name = "t", .steps = &steps };
     var player = makePlayer(&m);
-    var aux = AuxEventList{};
-    var q = dummyQueue(allocator);
-    defer q.deinit();
+    var ctx = StepCtx.init(allocator);
+    defer ctx.deinit();
 
-    const done = try player.step(&aux, &q);
+    const done = try ctx.step(&player);
     try testing.expect(done);
-    try testing.expectEqual(@as(usize, 2), aux.len);
-    switch (aux.get(0)) {
+    try testing.expectEqual(@as(usize, 2), ctx.aux.len);
+    switch (ctx.aux.get(0)) {
         .key => |k| try testing.expect(k.pressed),
         else => return error.WrongType,
     }
-    switch (aux.get(1)) {
+    switch (ctx.aux.get(1)) {
         .key => |k| try testing.expect(!k.pressed),
         else => return error.WrongType,
     }
@@ -157,18 +256,17 @@ test "macro_player: down + up steps held then released" {
     const steps = [_]MacroStep{ .{ .down = "KEY_LEFTSHIFT" }, .{ .up = "KEY_LEFTSHIFT" } };
     const m = Macro{ .name = "t", .steps = &steps };
     var player = makePlayer(&m);
-    var aux = AuxEventList{};
-    var q = dummyQueue(allocator);
-    defer q.deinit();
+    var ctx = StepCtx.init(allocator);
+    defer ctx.deinit();
 
-    const done = try player.step(&aux, &q);
+    const done = try ctx.step(&player);
     try testing.expect(done);
-    try testing.expectEqual(@as(usize, 2), aux.len);
-    switch (aux.get(0)) {
+    try testing.expectEqual(@as(usize, 2), ctx.aux.len);
+    switch (ctx.aux.get(0)) {
         .key => |k| try testing.expect(k.pressed),
         else => return error.WrongType,
     }
-    switch (aux.get(1)) {
+    switch (ctx.aux.get(1)) {
         .key => |k| try testing.expect(!k.pressed),
         else => return error.WrongType,
     }
@@ -179,21 +277,18 @@ test "macro_player: delay arms timer queue returns not-done" {
     const steps = [_]MacroStep{ .{ .tap = "KEY_A" }, .{ .delay = 50 }, .{ .tap = "KEY_B" } };
     const m = Macro{ .name = "t", .steps = &steps };
     var player = makePlayer(&m);
-    var aux = AuxEventList{};
-    var q = dummyQueue(allocator);
-    defer q.deinit();
+    var ctx = StepCtx.init(allocator);
+    defer ctx.deinit();
 
-    // First resume: executes tap A, hits delay, stops
-    const done1 = try player.step(&aux, &q);
+    const done1 = try ctx.step(&player);
     try testing.expect(!done1);
-    try testing.expectEqual(@as(usize, 2), aux.len); // only tap A (press+release)
-    try testing.expectEqual(@as(usize, 1), q.heap.count());
+    try testing.expectEqual(@as(usize, 2), ctx.aux.len);
+    try testing.expectEqual(@as(usize, 1), ctx.queue.heap.count());
 
-    // Second resume (after timer): executes tap B, finishes
-    var aux2 = AuxEventList{};
-    const done2 = try player.step(&aux2, &q);
+    ctx.aux = .{};
+    const done2 = try ctx.step(&player);
     try testing.expect(done2);
-    try testing.expectEqual(@as(usize, 2), aux2.len);
+    try testing.expectEqual(@as(usize, 2), ctx.aux.len);
 }
 
 test "macro_player: pause_for_release halts until notifyTriggerReleased" {
@@ -201,20 +296,18 @@ test "macro_player: pause_for_release halts until notifyTriggerReleased" {
     const steps = [_]MacroStep{ .pause_for_release, .{ .tap = "KEY_A" } };
     const m = Macro{ .name = "t", .steps = &steps };
     var player = makePlayer(&m);
-    var aux = AuxEventList{};
-    var q = dummyQueue(allocator);
-    defer q.deinit();
+    var ctx = StepCtx.init(allocator);
+    defer ctx.deinit();
 
-    const done1 = try player.step(&aux, &q);
+    const done1 = try ctx.step(&player);
     try testing.expect(!done1);
-    try testing.expectEqual(@as(usize, 0), aux.len);
+    try testing.expectEqual(@as(usize, 0), ctx.aux.len);
 
-    // notify release -> resume continues
     player.notifyTriggerReleased();
-    var aux2 = AuxEventList{};
-    const done2 = try player.step(&aux2, &q);
+    ctx.aux = .{};
+    const done2 = try ctx.step(&player);
     try testing.expect(done2);
-    try testing.expectEqual(@as(usize, 2), aux2.len);
+    try testing.expectEqual(@as(usize, 2), ctx.aux.len);
 }
 
 test "macro_player: emitPendingReleases down without up emits release" {
@@ -222,14 +315,13 @@ test "macro_player: emitPendingReleases down without up emits release" {
     const steps = [_]MacroStep{ .{ .down = "KEY_LEFTSHIFT" }, .{ .delay = 100 } };
     const m = Macro{ .name = "t", .steps = &steps };
     var player = makePlayer(&m);
-    var aux = AuxEventList{};
-    var q = dummyQueue(allocator);
-    defer q.deinit();
+    var ctx = StepCtx.init(allocator);
+    defer ctx.deinit();
 
-    _ = try player.step(&aux, &q); // executes down, hits delay
+    _ = try ctx.step(&player);
 
     var aux2 = AuxEventList{};
-    player.emitPendingReleases(&aux2);
+    player.emitPendingReleases(&aux2, &ctx.injected);
     try testing.expectEqual(@as(usize, 1), aux2.len);
     switch (aux2.get(0)) {
         .key => |k| try testing.expect(!k.pressed),
@@ -242,24 +334,23 @@ test "macro_player: shift_hold — down pause_for_release up" {
     const steps = [_]MacroStep{ .{ .down = "KEY_LEFTSHIFT" }, .pause_for_release, .{ .up = "KEY_LEFTSHIFT" } };
     const m = Macro{ .name = "shift_hold", .steps = &steps };
     var player = makePlayer(&m);
-    var aux = AuxEventList{};
-    var q = dummyQueue(allocator);
-    defer q.deinit();
+    var ctx = StepCtx.init(allocator);
+    defer ctx.deinit();
 
-    const done1 = try player.step(&aux, &q);
+    const done1 = try ctx.step(&player);
     try testing.expect(!done1);
-    try testing.expectEqual(@as(usize, 1), aux.len);
-    switch (aux.get(0)) {
+    try testing.expectEqual(@as(usize, 1), ctx.aux.len);
+    switch (ctx.aux.get(0)) {
         .key => |k| try testing.expect(k.pressed),
         else => return error.WrongType,
     }
 
     player.notifyTriggerReleased();
-    var aux2 = AuxEventList{};
-    const done2 = try player.step(&aux2, &q);
+    ctx.aux = .{};
+    const done2 = try ctx.step(&player);
     try testing.expect(done2);
-    try testing.expectEqual(@as(usize, 1), aux2.len);
-    switch (aux2.get(0)) {
+    try testing.expectEqual(@as(usize, 1), ctx.aux.len);
+    switch (ctx.aux.get(0)) {
         .key => |k| try testing.expect(!k.pressed),
         else => return error.WrongType,
     }
@@ -273,17 +364,16 @@ test "macro_player: two players advance step_index independently" {
     const mb = Macro{ .name = "b", .steps = &steps_b };
     var pa = MacroPlayer.init(&ma, 1, 0);
     var pb = MacroPlayer.init(&mb, 2, 1);
-    var q = dummyQueue(allocator);
-    defer q.deinit();
+    var ctx_a = StepCtx.init(allocator);
+    defer ctx_a.deinit();
+    var ctx_b = StepCtx.init(allocator);
+    defer ctx_b.deinit();
 
-    var auxa = AuxEventList{};
-    var auxb = AuxEventList{};
-
-    const done_a = try pa.step(&auxa, &q);
-    const done_b = try pb.step(&auxb, &q);
+    const done_a = try ctx_a.step(&pa);
+    const done_b = try ctx_b.step(&pb);
 
     try testing.expect(done_a);
     try testing.expect(done_b);
-    try testing.expectEqual(@as(usize, 4), auxa.len); // tap A + tap B
-    try testing.expectEqual(@as(usize, 2), auxb.len); // tap C
+    try testing.expectEqual(@as(usize, 4), ctx_a.aux.len);
+    try testing.expectEqual(@as(usize, 2), ctx_b.aux.len);
 }

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -132,8 +132,8 @@ pub const Mapper = struct {
             // Reset dpad prev so edge detection fires on the next frame.
             self.prev.dpad_x = 0;
             self.prev.dpad_y = 0;
-            // Cancel in-flight macros; emit releases for any held keys.
-            for (self.active_macros.items) |*p| p.emitPendingReleases(&aux);
+            // Cancel in-flight macros; emit releases for any held keys/buttons.
+            for (self.active_macros.items) |*p| p.emitPendingReleases(&aux, &self.injected_buttons);
             self.active_macros.clearRetainingCapacity();
         }
 
@@ -285,9 +285,15 @@ pub const Mapper = struct {
         }
 
         // [8] resume all active macro players; remove finished ones
+        var macro_tap_release: u64 = 0;
         var i: usize = 0;
         while (i < self.active_macros.items.len) {
-            const done = self.active_macros.items[i].step(&aux, &self.timer_queue) catch |err| blk: {
+            const done = self.active_macros.items[i].step(
+                &aux,
+                &self.timer_queue,
+                &self.injected_buttons,
+                &macro_tap_release,
+            ) catch |err| blk: {
                 std.log.warn("macro step failed: {}", .{err});
                 break :blk false;
             };
@@ -296,6 +302,10 @@ pub const Mapper = struct {
             } else {
                 i += 1;
             }
+        }
+        if (macro_tap_release != 0) {
+            const existing = self.pending_tap_release orelse 0;
+            self.pending_tap_release = existing | macro_tap_release;
         }
 
         // assemble emit state
@@ -352,13 +362,19 @@ pub const Mapper = struct {
         }
 
         var aux = AuxEventList{};
+        var macro_tap_release: u64 = 0;
         var buf: [16]timer_queue_mod.Deadline = undefined;
         const expired = self.timer_queue.drainExpired(now_ns, &buf);
         for (expired) |d| {
             var idx: usize = 0;
             while (idx < self.active_macros.items.len) {
                 if (self.active_macros.items[idx].timer_token == d.token) {
-                    const done = self.active_macros.items[idx].step(&aux, &self.timer_queue) catch |err| blk: {
+                    const done = self.active_macros.items[idx].step(
+                        &aux,
+                        &self.timer_queue,
+                        &self.injected_buttons,
+                        &macro_tap_release,
+                    ) catch |err| blk: {
                         std.log.warn("macro step failed: {}", .{err});
                         break :blk false;
                     };
@@ -371,6 +387,10 @@ pub const Mapper = struct {
                 }
                 idx += 1;
             }
+        }
+        if (macro_tap_release != 0) {
+            const existing = self.pending_tap_release orelse 0;
+            self.pending_tap_release = existing | macro_tap_release;
         }
         return aux;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -83,6 +83,7 @@ pub const testing_support = struct {
     pub const mapper_e2e_test = @import("test/mapper_e2e_test.zig");
     pub const gyro_stick_e2e_test = @import("test/gyro_stick_e2e_test.zig");
     pub const macro_e2e_test = @import("test/macro_e2e_test.zig");
+    pub const macro_gamepad_button_test = @import("test/macro_gamepad_button_test.zig");
     pub const capture_e2e_test = @import("test/capture_e2e_test.zig");
     pub const supervisor_e2e_test = @import("test/supervisor_e2e_test.zig");
     pub const wasm_e2e_test = @import("test/wasm_e2e_test.zig");
@@ -1031,6 +1032,7 @@ test {
     _ = @import("core/rumble_scheduler.zig");
     _ = @import("test/bugfix_regression_test.zig");
     _ = @import("test/uhid_uniq_pairing_test.zig");
+    _ = @import("test/macro_gamepad_button_test.zig");
     _ = @import("test/properties/config_props.zig");
     _ = @import("test/properties/contract_props.zig");
     _ = @import("test/properties/device_specific_props.zig");

--- a/src/test/macro_e2e_test.zig
+++ b/src/test/macro_e2e_test.zig
@@ -162,7 +162,9 @@ test "macro: macro playback — tap B, delay 50, tap LEFT sequence" {
 
     // First step: tap B (press+release), then hits delay → not done.
     var aux1 = AuxEventList{};
-    const done1 = try player.step(&aux1, &q);
+    var injected1: u64 = 0;
+    var tap_rel1: u64 = 0;
+    const done1 = try player.step(&aux1, &q, &injected1, &tap_rel1);
     try testing.expect(!done1);
     // Two events: KEY_B press + release.
     try testing.expectEqual(@as(usize, 2), aux1.len);
@@ -185,7 +187,9 @@ test "macro: macro playback — tap B, delay 50, tap LEFT sequence" {
 
     // Second step (after timer expiry): tap LEFT → done.
     var aux2 = AuxEventList{};
-    const done2 = try player.step(&aux2, &q);
+    var injected2: u64 = 0;
+    var tap_rel2: u64 = 0;
+    const done2 = try player.step(&aux2, &q, &injected2, &tap_rel2);
     try testing.expect(done2);
     try testing.expectEqual(@as(usize, 2), aux2.len);
     switch (aux2.get(0)) {
@@ -219,7 +223,9 @@ test "macro: pause_for_release — down LSHIFT, pause, no output until released"
 
     // First step: down LSHIFT → press emitted, then pause_for_release → halts.
     var aux1 = AuxEventList{};
-    const done1 = try player.step(&aux1, &q);
+    var injected1: u64 = 0;
+    var tap_rel1: u64 = 0;
+    const done1 = try player.step(&aux1, &q, &injected1, &tap_rel1);
     try testing.expect(!done1);
     try testing.expectEqual(@as(usize, 1), aux1.len);
     switch (aux1.get(0)) {
@@ -233,14 +239,18 @@ test "macro: pause_for_release — down LSHIFT, pause, no output until released"
 
     // Trigger held — no further output.
     var aux2 = AuxEventList{};
-    const done2 = try player.step(&aux2, &q);
+    var injected2: u64 = 0;
+    var tap_rel2: u64 = 0;
+    const done2 = try player.step(&aux2, &q, &injected2, &tap_rel2);
     try testing.expect(!done2);
     try testing.expectEqual(@as(usize, 0), aux2.len);
 
     // Release trigger → resume → up LSHIFT → done.
     player.notifyTriggerReleased();
     var aux3 = AuxEventList{};
-    const done3 = try player.step(&aux3, &q);
+    var injected3: u64 = 0;
+    var tap_rel3: u64 = 0;
+    const done3 = try player.step(&aux3, &q, &injected3, &tap_rel3);
     try testing.expect(done3);
     try testing.expectEqual(@as(usize, 1), aux3.len);
     switch (aux3.get(0)) {

--- a/src/test/macro_gamepad_button_test.zig
+++ b/src/test/macro_gamepad_button_test.zig
@@ -193,11 +193,9 @@ test "macro #99 integration: macro:boost triggers LT via tap on output state" {
     const m1_idx = @intFromEnum(ButtonId.M1);
     const lt_bit = btnBit(.LT);
 
-    // Frame 1: press M1 — macro "boost" starts, emits LT tap.
-    const events1 = try ctx.mapper.apply(.{ .buttons = @as(u64, 1) << @as(u6, @intCast(m1_idx)) }, 16);
+    const events1 = try ctx.mapper.apply(.{ .buttons = @as(u64, 1) << @as(u6, @intCast(m1_idx)) }, 16, 0);
     try testing.expectEqual(lt_bit, events1.gamepad.buttons & lt_bit);
 
-    // Frame 2: same input, tap release scheduled by frame 1 must have cleared LT.
-    const events2 = try ctx.mapper.apply(.{ .buttons = @as(u64, 1) << @as(u6, @intCast(m1_idx)) }, 16);
+    const events2 = try ctx.mapper.apply(.{ .buttons = @as(u64, 1) << @as(u6, @intCast(m1_idx)) }, 16, 0);
     try testing.expectEqual(@as(u64, 0), events2.gamepad.buttons & lt_bit);
 }

--- a/src/test/macro_gamepad_button_test.zig
+++ b/src/test/macro_gamepad_button_test.zig
@@ -1,0 +1,203 @@
+// Regression tests for issue #99: macro steps must emit gamepad_button and
+// mouse_button targets in addition to keyboard keys.
+//
+// Before the fix, src/core/macro_player.zig:resolveKeyCode dropped any
+// RemapTargetResolved variant other than .key. `{ down = "LT" }` / `{ tap = "A" }`
+// inside a [[macro]] produced no output.
+//
+// These tests verify:
+//   1. `{ tap = "LT" }` sets the LT bit then clears it next frame.
+//   2. `{ down = "A" }` / `{ up = "A" }` set and clear the A bit.
+//   3. `{ down = "RT" }` followed by layer switch (cancel) clears RT via
+//      emitPendingReleases — no leak.
+//   4. `{ tap = "mouse_left" }` emits a mouse_button aux event.
+//   5. Unknown target names are silently skipped (existing behavior).
+
+const std = @import("std");
+const testing = std.testing;
+
+const state_mod = @import("../core/state.zig");
+const macro_mod = @import("../core/macro.zig");
+const macro_player_mod = @import("../core/macro_player.zig");
+const timer_queue_mod = @import("../core/timer_queue.zig");
+const aux_event_mod = @import("../core/aux_event.zig");
+const h = @import("helpers.zig");
+
+const ButtonId = state_mod.ButtonId;
+const MacroStep = macro_mod.MacroStep;
+const Macro = macro_mod.Macro;
+const MacroPlayer = macro_player_mod.MacroPlayer;
+const TimerQueue = timer_queue_mod.TimerQueue;
+const AuxEventList = aux_event_mod.AuxEventList;
+
+fn btnBit(id: ButtonId) u64 {
+    return @as(u64, 1) << @as(u6, @intCast(@intFromEnum(id)));
+}
+
+test "macro #99: tap LT sets LT bit and schedules release next frame" {
+    const allocator = testing.allocator;
+    const steps = [_]MacroStep{.{ .tap = "LT" }};
+    const m = Macro{ .name = "t", .steps = &steps };
+    var player = MacroPlayer.init(&m, 1, 0);
+
+    var aux = AuxEventList{};
+    var q = TimerQueue.init(allocator, -1);
+    defer q.deinit();
+    var injected: u64 = 0;
+    var tap_release: u64 = 0;
+
+    const done = try player.step(&aux, &q, &injected, &tap_release);
+    try testing.expect(done);
+    try testing.expectEqual(@as(usize, 0), aux.len);
+    try testing.expectEqual(btnBit(.LT), injected & btnBit(.LT));
+    try testing.expectEqual(btnBit(.LT), tap_release & btnBit(.LT));
+
+    // Next frame: caller clears tap_release bits from injected (mapper cadence).
+    injected &= ~tap_release;
+    try testing.expectEqual(@as(u64, 0), injected & btnBit(.LT));
+}
+
+test "macro #99: down A then up A toggles A bit" {
+    const allocator = testing.allocator;
+    const steps = [_]MacroStep{ .{ .down = "A" }, .{ .up = "A" } };
+    const m = Macro{ .name = "t", .steps = &steps };
+    var player = MacroPlayer.init(&m, 1, 0);
+
+    var aux = AuxEventList{};
+    var q = TimerQueue.init(allocator, -1);
+    defer q.deinit();
+    var injected: u64 = 0;
+    var tap_release: u64 = 0;
+
+    const done = try player.step(&aux, &q, &injected, &tap_release);
+    try testing.expect(done);
+    // down + up in one step call → net-zero; tap_release should stay clean.
+    try testing.expectEqual(@as(u64, 0), injected & btnBit(.A));
+    try testing.expectEqual(@as(u64, 0), tap_release);
+}
+
+test "macro #99: down A with delay holds A bit between frames" {
+    const allocator = testing.allocator;
+    const steps = [_]MacroStep{ .{ .down = "A" }, .{ .delay = 10 }, .{ .up = "A" } };
+    const m = Macro{ .name = "t", .steps = &steps };
+    var player = MacroPlayer.init(&m, 1, 0);
+
+    var aux = AuxEventList{};
+    var q = TimerQueue.init(allocator, -1);
+    defer q.deinit();
+    var injected: u64 = 0;
+    var tap_release: u64 = 0;
+
+    const done1 = try player.step(&aux, &q, &injected, &tap_release);
+    try testing.expect(!done1);
+    try testing.expectEqual(btnBit(.A), injected & btnBit(.A));
+
+    aux = .{};
+    const done2 = try player.step(&aux, &q, &injected, &tap_release);
+    try testing.expect(done2);
+    try testing.expectEqual(@as(u64, 0), injected & btnBit(.A));
+}
+
+test "macro #99: down RT then cancel clears RT via emitPendingReleases" {
+    const allocator = testing.allocator;
+    const steps = [_]MacroStep{ .{ .down = "RT" }, .{ .delay = 100 } };
+    const m = Macro{ .name = "t", .steps = &steps };
+    var player = MacroPlayer.init(&m, 1, 0);
+
+    var aux = AuxEventList{};
+    var q = TimerQueue.init(allocator, -1);
+    defer q.deinit();
+    var injected: u64 = 0;
+    var tap_release: u64 = 0;
+
+    _ = try player.step(&aux, &q, &injected, &tap_release);
+    try testing.expectEqual(btnBit(.RT), injected & btnBit(.RT));
+
+    // Simulate layer switch / macro cancel.
+    var aux2 = AuxEventList{};
+    player.emitPendingReleases(&aux2, &injected);
+    try testing.expectEqual(@as(u64, 0), injected & btnBit(.RT));
+    // No key aux events — gamepad release is state-only.
+    try testing.expectEqual(@as(usize, 0), aux2.len);
+}
+
+test "macro #99: tap mouse_left emits mouse_button aux events" {
+    const allocator = testing.allocator;
+    const steps = [_]MacroStep{.{ .tap = "mouse_left" }};
+    const m = Macro{ .name = "t", .steps = &steps };
+    var player = MacroPlayer.init(&m, 1, 0);
+
+    var aux = AuxEventList{};
+    var q = TimerQueue.init(allocator, -1);
+    defer q.deinit();
+    var injected: u64 = 0;
+    var tap_release: u64 = 0;
+
+    const done = try player.step(&aux, &q, &injected, &tap_release);
+    try testing.expect(done);
+    try testing.expectEqual(@as(usize, 2), aux.len);
+    switch (aux.get(0)) {
+        .mouse_button => |mb| {
+            try testing.expectEqual(@as(u16, 0x110), mb.code);
+            try testing.expect(mb.pressed);
+        },
+        else => return error.WrongType,
+    }
+    switch (aux.get(1)) {
+        .mouse_button => |mb| try testing.expect(!mb.pressed),
+        else => return error.WrongType,
+    }
+    try testing.expectEqual(@as(u64, 0), injected);
+}
+
+test "macro #99: unknown target name silently skipped" {
+    const allocator = testing.allocator;
+    const steps = [_]MacroStep{
+        .{ .down = "NOT_A_REAL_THING" },
+        .{ .tap = "KEY_A" },
+    };
+    const m = Macro{ .name = "t", .steps = &steps };
+    var player = MacroPlayer.init(&m, 1, 0);
+
+    var aux = AuxEventList{};
+    var q = TimerQueue.init(allocator, -1);
+    defer q.deinit();
+    var injected: u64 = 0;
+    var tap_release: u64 = 0;
+
+    const done = try player.step(&aux, &q, &injected, &tap_release);
+    try testing.expect(done);
+    // Unknown target produced nothing; KEY_A tap produced press+release.
+    try testing.expectEqual(@as(usize, 2), aux.len);
+    try testing.expectEqual(@as(u64, 0), injected);
+}
+
+// Integration-level test: full mapper path with a macro that emits a gamepad
+// button. Verifies the mapper correctly merges macro-injected bits into the
+// output GamepadState and clears tap bits on the next frame.
+test "macro #99 integration: macro:boost triggers LT via tap on output state" {
+    const allocator = testing.allocator;
+
+    var ctx = try h.makeMapper(
+        \\[remap]
+        \\M1 = "macro:boost"
+        \\
+        \\[[macro]]
+        \\name = "boost"
+        \\steps = [
+        \\  { tap = "LT" },
+        \\]
+    , allocator);
+    defer ctx.deinit();
+
+    const m1_idx = @intFromEnum(ButtonId.M1);
+    const lt_bit = btnBit(.LT);
+
+    // Frame 1: press M1 — macro "boost" starts, emits LT tap.
+    const events1 = try ctx.mapper.apply(.{ .buttons = @as(u64, 1) << @as(u6, @intCast(m1_idx)) }, 16);
+    try testing.expectEqual(lt_bit, events1.gamepad.buttons & lt_bit);
+
+    // Frame 2: same input, tap release scheduled by frame 1 must have cleared LT.
+    const events2 = try ctx.mapper.apply(.{ .buttons = @as(u64, 1) << @as(u6, @intCast(m1_idx)) }, 16);
+    try testing.expectEqual(@as(u64, 0), events2.gamepad.buttons & lt_bit);
+}


### PR DESCRIPTION
## Summary

Closes ADR-016 §3 Path A (the long-standing leftover from the `trigger_threshold` work). The macro engine was silently dropping every `RemapTargetResolved` variant except `.key` — so a step like \`{ down = \"LT\" }\` or \`{ tap = \"mouse_left\" }\` did nothing at runtime with no warning. After this PR, macros can emit gamepad buttons (LT, RT, A, B, LB, RB, …) and mouse buttons, alongside the existing keyboard-key path.

## What changed

- **`src/core/macro_player.zig`**: replaced the 7-line `resolveKeyCode` with a variant-dispatch helper + three emit routines (\`emitTap\` / \`emitDown\` / \`emitUp\`). \`.gamepad_button\` targets set/clear bits on the mapper-owned \`injected_buttons: u64\`, mirroring \`mapper.emitTapEvent\`. \`.mouse_button\` targets append to the existing aux channel. New \`held_gamepad_buttons\` field ensures \`emitPendingReleases\` clears any leaked bits on layer-switch or macro-cancel.
- **`src/core/mapper.zig`**: \`player.step\` signature extended with \`injected_buttons: *u64\` + \`pending_tap_release: *u64\`. Both call sites (main \`apply\` and the timer-driven resume) updated. Per-frame \`macro_tap_release\` mask is OR-merged into \`self.pending_tap_release\` so the LT bit is set for one frame and cleared on the next — same cadence as the remap tap path.
- **`src/main.zig`**: explicit \`@import\` for the new test file (\`refAllDecls\` doesn't recurse into \`testing_support.*\`).

## Regression tests (7, all Layer 0, `src/test/macro_gamepad_button_test.zig`)

1. \`{ tap = \"LT\" }\` — LT bit set in frame N, cleared in frame N+1 via \`pending_tap_release\`.
2. \`{ down = \"A\" }\` + \`{ up = \"A\" }\` — A bit toggled, nets to zero.
3. \`{ down = \"A\" }\` with delay — A bit held across frames.
4. \`{ down = \"RT\" }\` then \`emitPendingReleases\` — RT bit cleared on cancellation (open-question #4 from investigator).
5. \`{ tap = \"mouse_left\" }\` — 2 aux events (BTN_LEFT press+release), \`injected == 0\`.
6. \`{ down = \"NOT_A_REAL_THING\" }\` still silently skipped (invariant preserved).
7. End-to-end: \`M1 = \"macro:boost\"\` → \`{ tap = \"LT\" }\` runs through full \`Mapper.apply\` — \`OutputEvents.gamepad.buttons\` shows LT in frame 1, cleared in frame 2.

## Reverse-verification (proof the tests catch regressions)

Restored original \`.gamepad_button\` placeholder:

\`\`\`
error: 'test.macro #99: tap LT sets LT bit and schedules release next frame' failed:
expected 64, found 0
error: 'test.macro #99 integration: macro:boost triggers LT via tap on output state' failed:
expected 64, found 0
\`\`\`

Broke \`emitDown .gamepad_button\` arm:

\`\`\`
error: 'test.macro #99: down A with delay holds A bit between frames' failed:
expected 1, found 0
error: 'test.macro #99: down RT then cancel clears RT via emitPendingReleases' failed:
expected 128, found 0
\`\`\`

Expected masks verified: LT = bit 6 = 64; A = bit 0 = 1; RT = bit 7 = 128.

## Test plan

- [x] \`zig build test\` — 933/936 passed, 3 skipped (pre-existing \`/dev/uhid\`-gated, unaffected)
- [x] \`zig build test-tsan\` — 929/932 passed, 3 skipped
- [x] Reverse-verification on two independent test paths
- [ ] Real hardware — Vader 5 Pro \`trigger_threshold = 100\` + \`[[macro]] name = \"aim_burst\" steps = [{ down = \"LT\" }, { delay = 80 }, { up = \"LT\" }]\` (follow-up)

## Follow-up (separate PR)

Docs \"Known limitation\" notes in \`docs/src/mapping-config.md\` and \`docs/src/mapping-guide.md\` become obsolete once this merges. I'll open a short docs PR to remove them and add a macro-LT/RT example.