### PR TITLE
fix(test): tighten docs concurrency, #79 assertions, regression corpus notes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/src/core/layer.zig
+++ b/src/core/layer.zig
@@ -344,7 +344,7 @@ test "layer: tap-hold: ACTIVE + release within timeout (race) → tap emitted (#
     const release_time: i128 = press_time + 150_000_000;
     const res2 = ls.onTriggerRelease(RemapTarget{ .key = 183 }, release_time);
     try testing.expect(res2.layer_deactivated);
-    try testing.expect(res2.tap_event != null);
+    try testing.expectEqual(@as(?RemapTarget, RemapTarget{ .key = 183 }), res2.tap_event);
     try testing.expect(ls.tap_hold == null);
 }
 
@@ -361,7 +361,7 @@ test "layer: tap-hold: ACTIVE + release at hold_timeout - 5ms → tap emitted (#
     const release_time: i128 = press_time + 195_000_000;
     const res = ls.onTriggerRelease(RemapTarget{ .key = 183 }, release_time);
     try testing.expect(res.layer_deactivated);
-    try testing.expect(res.tap_event != null);
+    try testing.expectEqual(@as(?RemapTarget, RemapTarget{ .key = 183 }), res.tap_event);
     try testing.expect(ls.tap_hold == null);
 }
 

--- a/src/test/properties/regression_corpus_props.zig
+++ b/src/test/properties/regression_corpus_props.zig
@@ -11,9 +11,11 @@ const helpers = @import("../helpers.zig");
 const mapper_oracle = @import("../gen/mapper_oracle.zig");
 const sequence_gen = @import("../gen/sequence_gen.zig");
 const mapping = @import("../../config/mapping.zig");
+const state_mod = @import("../../core/state.zig");
 
 const OracleState = mapper_oracle.OracleState;
 const Frame = sequence_gen.Frame;
+const ButtonId = state_mod.ButtonId;
 
 const RegressionCase = struct {
     name: []const u8,
@@ -23,11 +25,27 @@ const RegressionCase = struct {
     expected_buttons: []const u64,
 };
 
-// Corpus is empty until the generative harness discovers a reproducible bug
-// and its minimal case is committed here.
-const cases = [_]RegressionCase{
-    // Cases will be added here as bugs are found
-};
+// Note on corpus shape: the RegressionCase harness threads frames into
+// `Mapper.apply(delta, dt_ms, now_ns = 0)` without a real monotonic
+// clock or calls to `onTimerExpired`. That means:
+//
+//   * Issue #79 (tap-on-layer boundary near hold_timeout) needs a real
+//     now_ns progression plus an `onTimerExpired` call between frames,
+//     so it cannot be expressed as a plain frame list. It is pinned as
+//     a targeted test below instead.
+//   * Issue #142 (commitSwitchTarget must rebuildAuxIfChanged) and
+//     Issue #131-A (zombie uinput on rebind failure) are supervisor-
+//     level bugs; `Mapper.apply` cannot drive them. Targeted
+//     supervisor tests already live in
+//     `src/supervisor.zig` ("switch to mapping with new aux KEY_*")
+//     and `src/test/properties/supervisor_sm_props.zig:451-565,628-735`.
+//     Duplicating them here as oracle-comparison corpus entries would
+//     not be meaningful — flagging explicitly and not force-fitting.
+//
+// As the harness grows to cover timing and state-machine dimensions,
+// migrate the targeted-cases list below into proper RegressionCase
+// entries.
+const cases = [_]RegressionCase{};
 
 test "regression: all corpus cases pass" {
     const allocator = testing.allocator;
@@ -58,4 +76,36 @@ test "regression: all corpus cases pass" {
             };
         }
     }
+}
+
+// --- targeted regression cases (do not fit the plain-frames corpus shape) ---
+
+test "regression targeted: issue #79 — tap-on-layer at hold_timeout-5ms emits tap" {
+    // Pre-fix repro: apply() re-read CLOCK_MONOTONIC internally after the
+    // timer handler ran; physical release at press+195ms drifted past the
+    // 200ms hold_timeout, losing the tap. The fix threads a single
+    // ppoll-wakeup snapshot through both `onTimerExpired` and `apply`.
+    const allocator = testing.allocator;
+    var ctx = try helpers.makeMapper(
+        \\[[layer]]
+        \\name = "aim"
+        \\trigger = "LT"
+        \\activation = "hold"
+        \\tap = "A"
+        \\hold_timeout = 200
+    , allocator);
+    defer ctx.deinit();
+
+    const lt_mask: u64 = @as(u64, 1) << @as(u6, @intCast(@intFromEnum(ButtonId.LT)));
+    const a_mask: u64 = @as(u64, 1) << @as(u6, @intCast(@intFromEnum(ButtonId.A)));
+
+    const press_ns: i128 = 1_000_000_000;
+    _ = try ctx.mapper.apply(.{ .buttons = lt_mask }, 16, press_ns);
+
+    const timer_ns: i128 = press_ns + 200_000_000;
+    _ = ctx.mapper.onTimerExpired(timer_ns);
+
+    const release_ns: i128 = press_ns + 195_000_000;
+    const ev = try ctx.mapper.apply(.{ .buttons = 0 }, 16, release_ns);
+    try testing.expect((ev.gamepad.buttons & a_mask) != 0);
 }


### PR DESCRIPTION
## Summary

Three small, independent fixes that close gaps surfaced by a full test-framework audit. All three are pure test / CI hygiene — no production-code behavior changes.

## What changed

### 1. `.github/workflows/docs.yml` — per-PR concurrency group

Flat `group: pages` caused cross-branch self-cancellation. Observed real occurrence on 2026-04-23 17:28:55 UTC: run 24849266084 on \`docs/trigger-threshold-user-guide\` cancelled 13 s after start by an unrelated push. Fix:

\`\`\`yaml
group: pages-\${{ github.event.pull_request.number || github.ref }}
\`\`\`

PR builds never deploy (the \`deploy\` job already gates on \`refs/heads/main\`); main-push still serializes on the stable \`pages-refs/heads/main\` group. No regression.

### 2. `src/core/layer.zig` — upgrade #79 assertions from `!= null` to `expectEqual`

Two regression tests for issue #79 (tap-on-layer near \`hold_timeout\`) used weak presence checks at lines **347** and **364**. A future refactor that set \`tap_event\` to the wrong variant (e.g. \`.disabled\`) would pass silently.

**Reverse-verified**: temporarily set \`tap_event = .disabled\` inside \`onTriggerRelease\` ACTIVE branch.
- Old assertions: **2 / 2** #79 layer tests still passed (missed the regression)
- New assertions: **2 / 2** fail with \`expected .key, found .disabled\`

\`mapper.zig\` #79 dual-ready ppoll test at L1503 already used a tight bit-mask check — no change needed.

### 3. `src/test/properties/regression_corpus_props.zig` — explanatory comment + first targeted case

The corpus harness passes \`now_ns = 0\` to \`Mapper.apply\` with no \`onTimerExpired\` between frames — so it cannot express timing-dependent bugs like #79, and supervisor-level bugs (#142 \`commitSwitchTarget\`, #131-A zombie uinput) are out of shape entirely.

Added:
- A block comment above \`const cases = [_]RegressionCase{}\` explaining which issues fit the corpus shape and pointing to the existing targeted tests (\`supervisor.zig\` test "switch to mapping with new aux KEY_*"; \`supervisor_sm_props.zig:451-565, 628-735\`).
- One **targeted test** \`"regression targeted: issue #79 — tap-on-layer at hold_timeout-5ms emits tap"\` — exercises the pre-fix repro directly (press → \`onTimerExpired\` at +200ms → release snapshot at +195ms → asserts \`A\` button mask present).

This keeps the corpus honest: no shoehorned fits; the pinned reproducer for #79 lives beside the corpus even though it can't be a \`RegressionCase{}\`.

## Test plan

- [x] \`zig build\` green
- [x] \`zig build test\` green
- [x] \`zig build test-tsan\` green
- [x] Reverse-verification recorded (old assertions passed with \`.disabled\` injection, new ones fail)

## Follow-up (tracked, separate PRs)

- **B2** rootless-Docker install-flow CI job + \`PADCTL_TEST_REQUIRE_UHID=1\` enforcement (closes #139/#142/#143/#148-class install regressions + ADR-015 AC4 CI enforcement)
- **B3** \`finalizeRebind\` Layer 0 test via \`test_fail_rebind_restart\` + DualSense adaptive trigger command-template tests + UHID uniq byte-pin
- **B4** \`monotonicNs\` de-duplication + \`applyTarget\` common dispatch + \`timer_queue\` \`now_ns\` parameterization
- **B5** \`install.zig\` \`InstallPlan\` struct extraction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hold-tap timing behavior validation, addressing Issue #79 to ensure correct tap output when releasing before or after hold timeout boundaries.

* **Tests**
  * Enhanced tap-hold test assertions to validate expected behavior more thoroughly.
  * Added targeted regression test for hold-tap timing edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->