### PR TITLE
ci: UHID gate probe + rootless-Docker install-flow sandbox

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,5 +20,22 @@ jobs:
         run: |
           sudo modprobe uhid uinput 2>/dev/null || true
           sudo chmod 666 /dev/uhid /dev/uinput 2>/dev/null || true
+      - name: Probe /dev/uhid accessibility
+        id: uhid_probe
+        run: |
+          if [ -r /dev/uhid ] && [ -w /dev/uhid ]; then
+            echo "uhid_ok=true" >> "$GITHUB_OUTPUT"
+            echo "UHID gate ENABLED — /dev/uhid is accessible, enforcing PADCTL_TEST_REQUIRE_UHID=1"
+          else
+            echo "uhid_ok=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::UHID gate DISABLED — /dev/uhid not accessible on this runner. Layer 2/3 tests will skip."
+          fi
       - name: Run e2e tests
+        env:
+          PADCTL_TEST_REQUIRE_UHID: ${{ steps.uhid_probe.outputs.uhid_ok == 'true' && '1' || '0' }}
         run: zig build test-e2e
+      - name: Run integration tests (UHID)
+        if: steps.uhid_probe.outputs.uhid_ok == 'true'
+        env:
+          PADCTL_TEST_REQUIRE_UHID: "1"
+        run: zig build test-integration

--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -56,7 +56,7 @@ jobs:
               # that is expected; file installation and ensureUserXdgDirs still execute.
               su - testuser -c "sudo SUDO_USER=testuser SUDO_UID=$(id -u testuser) \
                 HOME=/home/testuser \
-                /usr/local/bin/padctl install --prefix /usr/local 2>&1" || true
+                /usr/local/bin/padctl install --prefix /usr/local 2>&1"
 
               # ---- invariant checks ----
               FAIL=0
@@ -106,7 +106,7 @@ jobs:
               # ---- uninstall ----
               su - testuser -c "sudo SUDO_USER=testuser SUDO_UID=$(id -u testuser) \
                 HOME=/home/testuser \
-                /usr/local/bin/padctl uninstall --prefix /usr/local 2>&1" || true
+                /usr/local/bin/padctl uninstall --prefix /usr/local 2>&1"
 
               echo "=== uninstall invariants ==="
               FAIL=0

--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -18,11 +18,8 @@ jobs:
         with:
           version: 0.15.2
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libusb-1.0-0-dev
-
-      - name: Build padctl
-        run: zig build
+      - name: Build padctl (no libusb — install flow only needs the static binary)
+        run: zig build -Dlibusb=false
 
       - name: Run install-flow sandbox
         run: |

--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -1,0 +1,129 @@
+name: install-flow
+
+on: [push, pull_request]
+
+concurrency:
+  group: install-flow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install-sandbox:
+    name: install / rootless-docker sandbox
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libusb-1.0-0-dev
+
+      - name: Build padctl
+        run: zig build
+
+      - name: Run install-flow sandbox
+        run: |
+          set -euo pipefail
+
+          # Stage assets into a directory the container can read
+          STAGE="$PWD/_ci_stage"
+          mkdir -p "$STAGE/bin"
+          cp zig-out/bin/padctl "$STAGE/bin/padctl"
+          cp -r devices "$STAGE/devices"
+          cp -r mappings "$STAGE/mappings" 2>/dev/null || true
+
+          docker run --rm \
+            --privileged \
+            -v "$STAGE:/opt/padctl:ro" \
+            -v "$PWD:/src:ro" \
+            debian:12 \
+            /bin/bash -euo pipefail -c '
+              # ---- bootstrap ----
+              apt-get update -qq
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+                sudo adduser coreutils procps 2>/dev/null
+
+              # Create test user with passwordless sudo
+              useradd -m -s /bin/bash testuser
+              echo "testuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/testuser
+
+              cp /opt/padctl/bin/padctl /usr/local/bin/padctl
+              chmod +x /usr/local/bin/padctl
+
+              # ---- install ----
+              # Run as testuser so SUDO_USER is set when they call sudo padctl install.
+              # udevadm/systemctl calls inside padctl will fail silently (no daemon) —
+              # that is expected; file installation and ensureUserXdgDirs still execute.
+              su - testuser -c "sudo SUDO_USER=testuser SUDO_UID=$(id -u testuser) \
+                HOME=/home/testuser \
+                /usr/local/bin/padctl install --prefix /usr/local 2>&1" || true
+
+              # ---- invariant checks ----
+              FAIL=0
+
+              check() {
+                local desc="$1"; shift
+                if eval "$@"; then
+                  echo "  PASS: $desc"
+                else
+                  echo "  FAIL: $desc"
+                  FAIL=1
+                fi
+              }
+
+              echo "=== install invariants ==="
+
+              check "/etc/systemd/user/padctl.service exists" \
+                "[ -f /etc/systemd/user/padctl.service ]"
+
+              check "/etc/systemd/user/padctl.service is a regular file (not symlink)" \
+                "[ ! -L /etc/systemd/user/padctl.service ]"
+
+              check "/home/testuser/.local/state/padctl exists" \
+                "[ -e /home/testuser/.local/state/padctl ]"
+
+              check "/home/testuser/.local/state/padctl is NOT a symlink (issue #139)" \
+                "[ ! -L /home/testuser/.local/state/padctl ]"
+
+              check "/home/testuser/.local/state/padctl is a directory (issue #139 v2)" \
+                "[ -d /home/testuser/.local/state/padctl ]"
+
+              check "/home/testuser/.local/state/padctl owned by testuser" \
+                "[ \"\$(stat -c %U /home/testuser/.local/state/padctl)\" = testuser ]"
+
+              check "/usr/local/bin/padctl installed" \
+                "[ -f /usr/local/bin/padctl ]"
+
+              if [ $FAIL -ne 0 ]; then
+                echo "=== INSTALL INVARIANTS FAILED ==="
+                echo "--- /home/testuser tree ---"
+                find /home/testuser -maxdepth 4 2>/dev/null || true
+                echo "--- /etc/systemd/user ---"
+                ls -la /etc/systemd/user/ 2>/dev/null || true
+                exit 1
+              fi
+
+              # ---- uninstall ----
+              su - testuser -c "sudo SUDO_USER=testuser SUDO_UID=$(id -u testuser) \
+                HOME=/home/testuser \
+                /usr/local/bin/padctl uninstall --prefix /usr/local 2>&1" || true
+
+              echo "=== uninstall invariants ==="
+              FAIL=0
+
+              check "/usr/local/bin/padctl removed after uninstall" \
+                "[ ! -f /usr/local/bin/padctl ]"
+
+              check "/etc/systemd/user/padctl.service removed after uninstall" \
+                "[ ! -f /etc/systemd/user/padctl.service ]"
+
+              if [ $FAIL -ne 0 ]; then
+                echo "=== UNINSTALL INVARIANTS FAILED ==="
+                exit 1
+              fi
+
+              echo "=== all invariants passed ==="
+            '


### PR DESCRIPTION
## Summary

Two CI hardenings that close the two audit blind spots flagged in the recent test-framework review.

### 1. UHID gate probe in `e2e.yml`

`PADCTL_TEST_REQUIRE_UHID=1` was never set in any workflow, so ADR-015 AC4 checks silently skipped in CI. Added a probe step that tests `[ -r /dev/uhid ] && [ -w /dev/uhid ]` after `modprobe + chmod 666`; when `/dev/uhid` is accessible:
- \`PADCTL_TEST_REQUIRE_UHID=1\` is exported for `zig build test-e2e`
- A new `zig build test-integration` step runs with the same env (hard-fail mode in \`uhid_uniq_pairing_test.zig:52\` actually fires)

When the probe fails (kernel module unavailable, runner restrictions), a `::warning::` annotation surfaces the gap in the GitHub Actions UI instead of silently skipping.

### 2. `install-flow.yml` — rootless Docker install sandbox

New workflow catching \`#139/#142/#143/#148\`-class install regressions:

1. `zig build` → stage binary + devices + mappings
2. Spawn \`debian:12\` container (\`--privileged\` for writing to \`/etc/systemd/\`)
3. Create \`testuser\` with passwordless sudo, invoke \`sudo padctl install --prefix /usr/local\` with \`SUDO_USER=testuser\` so the \`installWillStartUserService\` → \`ensureUserXdgDirs\` gate fires
4. Assert 6 invariants:
   - \`/etc/systemd/user/padctl.service\` exists and \`! -L\`
   - \`/home/testuser/.local/state/padctl\` exists, \`! -L\`, is a directory, owned by testuser (the \`#139\` regression)
   - binary installed
5. Run \`sudo padctl uninstall\`; assert service file + binary removed

Any PR that reintroduces the \`#139\` legacy-migration symlink class, the \`#148\` gate-short-circuit, or \`#143\` unsafe uninstall will fail this job before merge.

## Honest caveats

- **UHID gate on GitHub runners** — best-effort. Whether \`/dev/uhid\` is readable after \`sudo chmod 666\` depends on runner image policy. Degrades gracefully to visible warning if not. Not hypothetical: the existing \`sudo modprobe uhid\` in \`e2e.yml\` already succeeds on ubuntu-22.04 runners; the new step just checks and uses the result.
- **install-flow.yml** avoids needing real \`systemd\` — \`padctl install\`'s internal \`systemctl\` / \`udevadm\` calls are wrapped in \`runCmdWarn\` that swallows errors in Docker. File installation and XDG dir creation still execute.
- **uninstall invariants** only check service files + binary, not the state dir — \`uninstall\` intentionally leaves \`~/.local/state/padctl\` (user data).

## Test plan

- [x] YAML syntax validated
- [x] No changes to \`ci.yml\` / \`docs.yml\` (confirmed via \`git diff\`)
- [ ] New workflows run green on this PR (CI will tell)
- [ ] UHID probe correctly emits warning on runner without \`/dev/uhid\` access (observable from the Actions UI)