### PR TITLE
test: adaptive trigger templates + UHID sendCreate uniq byte-pin (B3)

### DIFF
--- a/src/io/uhid.zig
+++ b/src/io/uhid.zig
@@ -293,7 +293,7 @@ pub const UhidDevice = struct {
         return self;
     }
 
-    fn sendCreate(fd: posix.fd_t, cfg: Config) InitError!void {
+    pub fn sendCreate(fd: posix.fd_t, cfg: Config) InitError!void {
         var ev = std.mem.zeroes(UhidCreate2Event);
         ev.type = UHID_CREATE2;
 
@@ -739,4 +739,96 @@ test "uhid: close() is idempotent (second call is a no-op)" {
     // buffer doesn't linger into a later test.
     var scratch: [UHID_EVENT_SIZE]u8 = undefined;
     _ = try posix.read(fds[0], &scratch);
+}
+
+test "uhid: sendCreate writes uniq bytes correctly into UHID_CREATE2 payload" {
+    if (@import("builtin").os.tag != .linux) return error.SkipZigTest;
+
+    var fds: [2]posix.fd_t = undefined;
+    fds = try posix.pipe();
+    defer posix.close(fds[0]);
+    defer posix.close(fds[1]);
+
+    const test_uniq = "padctl/steam-deck-0";
+    const cfg = Config{
+        .vid = 0x1234,
+        .pid = 0x5678,
+        .name = "test",
+        .uniq = test_uniq,
+        .descriptor = &[_]u8{ 0x05, 0x01, 0xC0 },
+    };
+
+    try UhidDevice.sendCreate(fds[1], cfg);
+
+    var buf: [UHID_EVENT_SIZE]u8 = undefined;
+    const n = try posix.read(fds[0], &buf);
+    try testing.expectEqual(UHID_EVENT_SIZE, n);
+
+    try testing.expectEqual(UHID_CREATE2, std.mem.readInt(u32, buf[0..4], .little));
+
+    const uniq_off = @offsetOf(UhidCreate2Event, "payload") + @offsetOf(UhidCreate2Req, "uniq");
+    try testing.expectEqualSlices(u8, test_uniq, buf[uniq_off..][0..test_uniq.len]);
+    try testing.expectEqual(@as(u8, 0), buf[uniq_off + test_uniq.len]);
+}
+
+test "uhid: sendCreate truncates uniq at 63 bytes (64-byte field, NUL reserved)" {
+    if (@import("builtin").os.tag != .linux) return error.SkipZigTest;
+
+    var fds: [2]posix.fd_t = undefined;
+    fds = try posix.pipe();
+    defer posix.close(fds[0]);
+    defer posix.close(fds[1]);
+
+    const uniq_off = @offsetOf(UhidCreate2Event, "payload") + @offsetOf(UhidCreate2Req, "uniq");
+
+    // 63 bytes — fits without truncation.
+    {
+        const uniq63 = "A" ** 63;
+        const cfg = Config{
+            .vid = 0x1,
+            .pid = 0x2,
+            .name = "t",
+            .uniq = uniq63,
+            .descriptor = &[_]u8{0xC0},
+        };
+        try UhidDevice.sendCreate(fds[1], cfg);
+        var buf: [UHID_EVENT_SIZE]u8 = undefined;
+        _ = try posix.read(fds[0], &buf);
+        try testing.expectEqualSlices(u8, uniq63, buf[uniq_off..][0..63]);
+        try testing.expectEqual(@as(u8, 0), buf[uniq_off + 63]);
+    }
+
+    // 64 bytes — truncated to 63 + NUL.
+    {
+        const uniq64 = "B" ** 64;
+        const cfg = Config{
+            .vid = 0x1,
+            .pid = 0x2,
+            .name = "t",
+            .uniq = uniq64,
+            .descriptor = &[_]u8{0xC0},
+        };
+        try UhidDevice.sendCreate(fds[1], cfg);
+        var buf: [UHID_EVENT_SIZE]u8 = undefined;
+        _ = try posix.read(fds[0], &buf);
+        try testing.expectEqualSlices(u8, "B" ** 63, buf[uniq_off..][0..63]);
+        try testing.expectEqual(@as(u8, 0), buf[uniq_off + 63]);
+    }
+
+    // 80 bytes — truncated to 63 + NUL.
+    {
+        const uniq80 = "C" ** 80;
+        const cfg = Config{
+            .vid = 0x1,
+            .pid = 0x2,
+            .name = "t",
+            .uniq = uniq80,
+            .descriptor = &[_]u8{0xC0},
+        };
+        try UhidDevice.sendCreate(fds[1], cfg);
+        var buf: [UHID_EVENT_SIZE]u8 = undefined;
+        _ = try posix.read(fds[0], &buf);
+        try testing.expectEqualSlices(u8, "C" ** 63, buf[uniq_off..][0..63]);
+        try testing.expectEqual(@as(u8, 0), buf[uniq_off + 63]);
+    }
 }

--- a/src/test/properties/device_specific_props.zig
+++ b/src/test/properties/device_specific_props.zig
@@ -11,6 +11,7 @@ const testing = std.testing;
 
 const device_mod = @import("../../config/device.zig");
 const interp_mod = @import("../../core/interpreter.zig");
+const command = @import("../../core/command.zig");
 
 const Interpreter = interp_mod.Interpreter;
 
@@ -234,4 +235,148 @@ test "device_specific: DualSense BT mode report parsing (report_id 0x31, CRC32)"
 
     try testing.expect(delta.gyro_x != null);
     try testing.expectEqual(gyro_x_val, delta.gyro_x.?);
+}
+
+// --- DualSense adaptive trigger template rendering tests ---
+//
+// fillTemplate u8 convention: Param.value is u16, the "u8" type extracts the
+// HIGH byte (value >> 8). To get byte b, pass value = @as(u16, b) << 8.
+
+fn p(name: []const u8, byte_val: u8) command.Param {
+    return .{ .name = name, .value = @as(u16, byte_val) << 8 };
+}
+
+test "dualsense: adaptive_trigger_off template renders to all-zero body except header" {
+    const allocator = testing.allocator;
+    const parsed = try device_mod.parseFile(allocator, "devices/sony/dualsense.toml");
+    defer parsed.deinit();
+
+    const cmds = parsed.value.commands orelse return error.NoCommands;
+    const cmd = cmds.map.get("adaptive_trigger_off") orelse return error.NoCmd;
+
+    const result = try command.fillTemplate(allocator, cmd.template, &.{});
+    defer allocator.free(result);
+
+    try testing.expectEqual(@as(usize, 63), result.len);
+    try testing.expectEqual(@as(u8, 0x02), result[0]);
+    try testing.expectEqual(@as(u8, 0x0c), result[1]);
+    for (result[2..]) |b| try testing.expectEqual(@as(u8, 0), b);
+}
+
+test "dualsense: adaptive_trigger_feedback template renders correct byte positions" {
+    const allocator = testing.allocator;
+    const parsed = try device_mod.parseFile(allocator, "devices/sony/dualsense.toml");
+    defer parsed.deinit();
+
+    const cmds = parsed.value.commands orelse return error.NoCommands;
+    const cmd = cmds.map.get("adaptive_trigger_feedback") orelse return error.NoCmd;
+
+    const result = try command.fillTemplate(allocator, cmd.template, &.{
+        p("r_position", 70),
+        p("r_strength", 200),
+        p("l_position", 50),
+        p("l_strength", 100),
+    });
+    defer allocator.free(result);
+
+    try testing.expectEqual(@as(usize, 63), result.len);
+    // Right trigger section
+    try testing.expectEqual(@as(u8, 0x01), result[11]); // mode = Feedback
+    try testing.expectEqual(@as(u8, 70), result[12]); // r_position
+    try testing.expectEqual(@as(u8, 200), result[13]); // r_strength
+    // Left trigger section
+    try testing.expectEqual(@as(u8, 0x01), result[22]); // mode = Feedback
+    try testing.expectEqual(@as(u8, 50), result[23]); // l_position
+    try testing.expectEqual(@as(u8, 100), result[24]); // l_strength
+}
+
+test "dualsense: adaptive_trigger_weapon template renders correct byte positions" {
+    const allocator = testing.allocator;
+    const parsed = try device_mod.parseFile(allocator, "devices/sony/dualsense.toml");
+    defer parsed.deinit();
+
+    const cmds = parsed.value.commands orelse return error.NoCommands;
+    const cmd = cmds.map.get("adaptive_trigger_weapon") orelse return error.NoCmd;
+
+    const result = try command.fillTemplate(allocator, cmd.template, &.{
+        p("r_start", 20),
+        p("r_end", 100),
+        p("r_strength", 128),
+        p("l_start", 30),
+        p("l_end", 90),
+        p("l_strength", 64),
+    });
+    defer allocator.free(result);
+
+    try testing.expectEqual(@as(usize, 63), result.len);
+    try testing.expectEqual(@as(u8, 0x02), result[11]); // mode = Weapon
+    try testing.expectEqual(@as(u8, 20), result[12]); // r_start
+    try testing.expectEqual(@as(u8, 100), result[13]); // r_end
+    try testing.expectEqual(@as(u8, 128), result[14]); // r_strength
+    try testing.expectEqual(@as(u8, 0x02), result[22]); // mode = Weapon
+    try testing.expectEqual(@as(u8, 30), result[23]); // l_start
+    try testing.expectEqual(@as(u8, 90), result[24]); // l_end
+    try testing.expectEqual(@as(u8, 64), result[25]); // l_strength
+}
+
+test "dualsense: adaptive_trigger_vibration template renders correct byte positions" {
+    const allocator = testing.allocator;
+    const parsed = try device_mod.parseFile(allocator, "devices/sony/dualsense.toml");
+    defer parsed.deinit();
+
+    const cmds = parsed.value.commands orelse return error.NoCommands;
+    const cmd = cmds.map.get("adaptive_trigger_vibration") orelse return error.NoCmd;
+
+    const result = try command.fillTemplate(allocator, cmd.template, &.{
+        p("r_position", 50),
+        p("r_amplitude", 180),
+        p("r_frequency", 20),
+        p("l_position", 40),
+        p("l_amplitude", 120),
+        p("l_frequency", 15),
+    });
+    defer allocator.free(result);
+
+    try testing.expectEqual(@as(usize, 63), result.len);
+    try testing.expectEqual(@as(u8, 0x06), result[11]); // mode = Vibration
+    try testing.expectEqual(@as(u8, 50), result[12]); // r_position
+    try testing.expectEqual(@as(u8, 180), result[13]); // r_amplitude
+    try testing.expectEqual(@as(u8, 20), result[14]); // r_frequency
+    try testing.expectEqual(@as(u8, 0x06), result[22]); // mode = Vibration
+    try testing.expectEqual(@as(u8, 40), result[23]); // l_position
+    try testing.expectEqual(@as(u8, 120), result[24]); // l_amplitude
+    try testing.expectEqual(@as(u8, 15), result[25]); // l_frequency
+}
+
+test "dualsense: adaptive_trigger_feedback substitution is position-sensitive" {
+    // Sanity check: swapping r_position and r_strength produces a different
+    // packet, proving the renderer is position-sensitive (not name-insensitive).
+    const allocator = testing.allocator;
+    const parsed = try device_mod.parseFile(allocator, "devices/sony/dualsense.toml");
+    defer parsed.deinit();
+
+    const cmds = parsed.value.commands orelse return error.NoCommands;
+    const cmd = cmds.map.get("adaptive_trigger_feedback") orelse return error.NoCmd;
+
+    const correct = try command.fillTemplate(allocator, cmd.template, &.{
+        p("r_position", 70),
+        p("r_strength", 200),
+        p("l_position", 50),
+        p("l_strength", 100),
+    });
+    defer allocator.free(correct);
+
+    // Deliberately swap position and strength values.
+    const swapped = try command.fillTemplate(allocator, cmd.template, &.{
+        p("r_position", 200),
+        p("r_strength", 70),
+        p("l_position", 100),
+        p("l_strength", 50),
+    });
+    defer allocator.free(swapped);
+
+    try testing.expect(!std.mem.eql(u8, correct, swapped));
+    // Position bytes differ at expected offsets.
+    try testing.expectEqual(@as(u8, 70), correct[12]);
+    try testing.expectEqual(@as(u8, 200), swapped[12]);
 }


### PR DESCRIPTION
## Summary

Two Layer 0 coverage gaps closed. One pre-existing test rescued from obscurity.

### Gap 1 — \`finalizeRebind\` rollback: **already covered**

Audit flagged this as missing. It wasn't — \`src/test/properties/supervisor_sm_props.zig:710\` (test T-B1b \"rebind restart failure preserves suspended + grace_deadline\") already sets \`sup.test_fail_rebind_restart = true\` and asserts all 5 rollback invariants including \`!sup.devname_map.contains(\"hidraw0\")\` at line 718.

Reverse-verify: removed the \`errdefer fetchRemove\` in \`supervisor.zig:626\` → T-B1b fails at line 718. Test correctly guards the path.

No code added. Dropping the false-positive audit finding.

### Gap 2 — DualSense adaptive trigger command templates (5 new tests)

The 4 adaptive trigger modes (off / feedback / weapon / vibration) had zero behavioral tests before. Template DSL (\`{r_position:u8}\` etc.) was only parse-validated. Added:
- byte-position test per mode (off / feedback / weapon / vibration)
- position-sensitivity test (swap r_position / r_strength → different bytes at expected offsets)

Discovered + documented: \`fillTemplate\` u8 params extract the HIGH byte from a u16 (consistent with rumble strength \`0xFF00\` convention). Plain u8 values are constructed as \`@as(u16, byte_value) << 8\`.

### Gap 3 — UHID \`sendCreate\` uniq byte-pin (2 new tests)

Production-side uniq byte layout was tested only kernel-side (\`EVIOCGUNIQ\`, L2 privileged). Added:
- \`sendCreate\` writes \`\"padctl/steam-deck-0\"\` into \`UHID_CREATE2\` payload (reads back via pipe)
- truncation: 63-byte fits, 64-byte → 63+NUL, 80-byte → 63+NUL

Reverse-verify: flipped \`@min\` → \`@max\` at \`uhid.zig:306\` → memcpy out-of-bounds panic in sendCreate test. \`@min\` is load-bearing.

## Production change

One char: \`sendCreate\` → \`pub fn sendCreate\` in \`src/io/uhid.zig\`. Not a test-only backdoor — the function is naturally testable by signature.

## Files

- \`src/io/uhid.zig\` (+93 tests, \`sendCreate\` → pub)
- \`src/test/properties/device_specific_props.zig\` (+145 LoC, 5 tests)

## Test plan

- [x] zig build test — 100% green
- [x] zig build test-tsan — 100% green
- [x] Reverse-verification on both gap-2 and gap-3 path