### PR TITLE
docs: drop stale macro LT/RT "Known limitation" + add working example

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -43,8 +43,6 @@ Use `padctl dump enable` to observe raw LT / RT axis readings and dial in the th
 
 Without `trigger_threshold`, `LT` / `RT` emit analog axis events only and do not participate in `[remap]` or layer trigger matching.
 
-> **Known limitation:** `[[macro]]` steps do **not** currently support `LT` / `RT` as `down` / `up` targets. The macro player's `.gamepad_button` dispatch arm is not yet implemented (see ADR-016 §3 Path A and issue #99). A macro step such as `{ down = "LT" }` is silently skipped. The supported paths are `[remap]` and the `[[layer]] trigger` field.
-
 ## `[remap]`
 
 Top-level button remapping (active when no layer overrides). Keys are ButtonId names, values are target button names, `KEY_*` codes, `mouse_left`/`mouse_right`/`mouse_middle`/`mouse_side`/`mouse_forward`/`mouse_back`, `disabled`, or `macro:<name>`.

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -292,7 +292,20 @@ RT = "mouse_right"        # axis > 100 → synthesize RT press → emit right cl
 
 See [Mapping Config Reference — trigger_threshold](mapping-config.md#trigger_threshold) for the full field description.
 
-> **Known limitation:** `[[macro]]` steps do **not** currently support `LT` / `RT` as `down` / `up` targets. The `.gamepad_button` dispatch arm is not yet wired in the macro engine (issue #99 + ADR-016 §3 Path A). A macro step such as `{ down = "LT" }` is silently skipped. The supported paths today are `[remap]` and the `[[layer]] trigger` field.
+LT / RT also work as `down` / `up` targets inside `[[macro]]` — press and release the virtual trigger from any macro step:
+
+```toml
+[remap]
+M1 = "macro:aim_burst"
+
+[[macro]]
+name = "aim_burst"
+steps = [
+    { down = "LT" },
+    { delay = 80 },
+    { up = "LT" },
+]
+```
 
 ### Adaptive Trigger (`[adaptive_trigger]`) — DualSense only
 


### PR DESCRIPTION
## Summary

PR #152 (\`f018178\`, MERGED today) wired \`.gamepad_button\` dispatch in \`src/core/macro_player.zig\` — \`{ down = \"LT\" }\` / \`{ up = \"LT\" }\` / \`{ tap = \"LT\" }\` inside \`[[macro]]\` now work as advertised.

This PR removes the two \"Known limitation\" blockquotes that warned those steps were silently skipped (they aren't anymore) and adds a short working example to \`mapping-guide.md\` showing the macro + \`trigger_threshold\` combination for analog-trigger devices like the Vader 5 Pro.

## Files

- \`docs/src/mapping-config.md\` — remove blockquote (3 lines)
- \`docs/src/mapping-guide.md\` — remove blockquote + add 11-line \`aim_burst\` example

## Test plan

- [x] mdbook renders (no structural markdown errors)
- [x] Cross-reference \`mapping-config.md#trigger_threshold\` still resolves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated limitation documentation from macro step configuration guide
  * Updated macro step user guide with clarified feature support information  
  * Added detailed example demonstrating macro step capabilities in practical remapping scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->