### PR TITLE
feat(wave-3): ship udev rule + canary container test for SDL IMU detection (closes #81)

### DIFF
--- a/Dockerfile.wave5
+++ b/Dockerfile.wave5
@@ -1,0 +1,34 @@
+# Phase 13 Wave 5 canary container — run UHID integration tests on a real
+# kernel against the host's `/dev/uhid` without touching the user's physical
+# gamepad. The image ships only what `zig build test -Dlibusb=false` needs.
+#
+# We use Debian stable for its older glibc (2.38) which does NOT emit the
+# `.sframe` debuginfo sections that trip Zig 0.15.2's LLD invocation on
+# bleeding-edge Arch (glibc 2.43). Kernel UAPI headers come from
+# linux-libc-dev. Zig 0.15.2 is downloaded as a tarball — matches the
+# project's pinned `.zigversion`.
+FROM debian:bookworm-slim
+
+ARG ZIG_VERSION=0.15.2
+ARG ZIG_SHA256=02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        xz-utils \
+        build-essential \
+        linux-libc-dev \
+        evtest \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL \
+        "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" \
+        -o /tmp/zig.tar.xz \
+    && echo "${ZIG_SHA256}  /tmp/zig.tar.xz" | sha256sum -c - \
+    && tar -xJf /tmp/zig.tar.xz -C /opt/ \
+    && mv "/opt/zig-x86_64-linux-${ZIG_VERSION}" /opt/zig \
+    && rm /tmp/zig.tar.xz \
+    && ln -s /opt/zig/zig /usr/local/bin/zig
+
+WORKDIR /src

--- a/build.zig
+++ b/build.zig
@@ -309,6 +309,38 @@ pub fn build(b: *std.Build) void {
     gen_e2e_tests.linkLibC();
     e2e_step.dependOn(&b.addRunArtifact(gen_e2e_tests).step);
 
+    // test-uhid-uniq: Phase 13 Wave 5 canary — run ONLY the
+    // `src/test/uhid_uniq_pairing_test.zig` file as a standalone test binary.
+    // Split from `test` so the privileged Docker canary doesn't accidentally
+    // trigger other tests that probe real hidraw devices on the host and
+    // deadlock in `hid_hw_open`.
+    const uniq_step = b.step("test-uhid-uniq", "Run UHID uniq pairing test only (Wave 5 canary)");
+    // Root at src/ so the test's relative imports (../io/uhid.zig etc.)
+    // stay inside the module path. The `addTest` will still run the tests
+    // defined in `test/uhid_uniq_pairing_test.zig` via `test-filter`.
+    const uniq_mod = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+        .sanitize_c = .trap,
+    });
+    uniq_mod.addImport("toml", toml_mod);
+    uniq_mod.addImport("analyse", capture_analyse_mod);
+    uniq_mod.addImport("toml_gen", capture_toml_gen_mod);
+    uniq_mod.addImport("build_options", build_opts.createModule());
+    if (use_wasm) addWasm3(b, uniq_mod, wasm3_c_flags);
+    const uniq_tests = b.addTest(.{
+        .root_module = uniq_mod,
+        .filters = &.{"uhid_uniq_pairing_test"},
+    });
+    if (use_libusb) {
+        uniq_tests.linkSystemLibrary("usb-1.0");
+    } else {
+        uniq_tests.addIncludePath(b.path("compat"));
+    }
+    uniq_tests.linkLibC();
+    uniq_step.dependOn(&b.addRunArtifact(uniq_tests).step);
+
     // spike (only available when spike/toml_spike.zig exists)
     if (std.fs.cwd().access("spike/toml_spike.zig", .{})) |_| {
         const spike_mod = b.createModule(.{

--- a/scripts/wave5-canary-docker.sh
+++ b/scripts/wave5-canary-docker.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Phase 13 Wave 5 canary — validate Wave 3's UHID IMU descriptor on a real
+# kernel via Docker. Runs the `uhid_uniq_pairing_test` assertions (including
+# the EVIOCGPROP / EVIOCGBIT kernel-classification checks added for Wave 5)
+# inside a container that has access to the host's `/dev/uhid`.
+#
+# Goal: prove `buildForImu` emits a descriptor that the kernel 6.18 HID→evdev
+# mapper classifies as an accelerometer sensor (INPUT_PROP_ACCELEROMETER set,
+# zero EV_KEY bits), without touching the user's physical gamepad.
+#
+# Prerequisites on the host:
+#   - /dev/uhid present (kernel CONFIG_UHID=y)
+#   - docker running with permission to bind /dev/uhid
+#   - project root used as build context
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE_TAG="padctl-wave5-canary:latest"
+
+echo "[wave5] building image from $REPO_ROOT (tag=$IMAGE_TAG)"
+docker build \
+    -t "$IMAGE_TAG" \
+    -f "$REPO_ROOT/Dockerfile.wave5" \
+    "$REPO_ROOT"
+
+echo "[wave5] host /dev/uhid:"
+ls -l /dev/uhid || {
+    echo "[wave5] FAIL: /dev/uhid missing on host. Load the uhid module first (modprobe uhid)." >&2
+    exit 2
+}
+
+echo "[wave5] running tests with PADCTL_TEST_REQUIRE_UHID=1"
+# --privileged is required because the container must mount devtmpfs over
+# /dev so that evdev nodes created by UHID_CREATE2 in the kernel (which land
+# in the host's devtmpfs) are visible inside the container. Docker's default
+# /dev is a sanitised tmpfs and won't reflect late-binding input nodes.
+docker_run_args=(
+    --rm
+    --privileged
+    -v "$REPO_ROOT:/src"
+    -w /src
+    -e PADCTL_TEST_REQUIRE_UHID=1
+)
+
+docker run "${docker_run_args[@]}" \
+    "$IMAGE_TAG" \
+    bash -c '
+        set -euo pipefail
+        # Shadow Docker-provided tmpfs /dev with the host kernel devtmpfs so
+        # UHID-born evdev nodes are visible. Requires --privileged + CAP_SYS_ADMIN.
+        mount -t devtmpfs devtmpfs /dev
+        echo "[container] kernel: $(uname -r)"
+        echo "[container] zig: $(zig version)"
+        echo "[container] /dev/uhid: $(ls -l /dev/uhid 2>&1 || true)"
+        echo "[container] /dev/input count before: $(ls /dev/input | wc -l)"
+
+        echo "[container] zig build test-uhid-uniq -Dlibusb=false (isolated uhid_uniq_pairing test)"
+        # Narrow to the single canary test file so we do not accidentally
+        # trigger other tests that probe /dev/hidraw* on the host — they can
+        # deadlock in hid_hw_open on kernel 6.18 when real USB HID devices
+        # are attached to the host and the container runs as root.
+        zig build test-uhid-uniq -Dlibusb=false
+
+        echo "[container] post-run /dev/input count: $(ls /dev/input | wc -l)"
+    '

--- a/scripts/wave5-probe.sh
+++ b/scripts/wave5-probe.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Probe: does UHID_CREATE2 inside the container actually spawn an evdev node
+# we can see via `/dev/input/eventN`? Run a minimal C program that opens
+# /dev/uhid, sends UHID_CREATE2, waits, and lists /dev/input.
+set -euo pipefail
+cat > /tmp/uhid_probe.c <<'EOF'
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/uhid.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+static const unsigned char RDESC[] = {
+    0x05,0x01, 0x09,0x05, 0xA1,0x01,
+    0x05,0x09, 0x19,0x01, 0x29,0x01,
+    0x15,0x00, 0x25,0x01, 0x75,0x01, 0x95,0x01, 0x81,0x02,
+    0x75,0x07, 0x95,0x01, 0x81,0x03,
+    0x05,0x01, 0x09,0x30, 0x15,0x00, 0x26,0xFF,0x00,
+    0x75,0x08, 0x95,0x01, 0x81,0x02,
+    0xC0
+};
+
+int main(void) {
+    int fd = open("/dev/uhid", O_RDWR | O_CLOEXEC);
+    if (fd < 0) { perror("open /dev/uhid"); return 2; }
+    struct uhid_event ev = {0};
+    ev.type = UHID_CREATE2;
+    strcpy((char*)ev.u.create2.name, "wave5-probe");
+    strcpy((char*)ev.u.create2.uniq, "wave5-probe-uniq");
+    strcpy((char*)ev.u.create2.phys, "wave5-probe-phys");
+    ev.u.create2.rd_size = sizeof(RDESC);
+    ev.u.create2.bus = 0x03;
+    ev.u.create2.vendor = 0xFADE;
+    ev.u.create2.product = 0xBEEF;
+    memcpy(ev.u.create2.rd_data, RDESC, sizeof(RDESC));
+    ssize_t n = write(fd, &ev, sizeof(ev));
+    if (n < 0) { perror("write UHID_CREATE2"); return 3; }
+    printf("UHID_CREATE2 wrote %zd bytes\n", n);
+    fflush(stdout);
+    /* Block reading events — non-blocking, a few polls */
+    fcntl(fd, F_SETFL, O_NONBLOCK);
+    for (int i = 0; i < 5; i++) {
+        usleep(100000);
+        while (read(fd, &ev, sizeof(ev)) > 0) {
+            printf("uhid event type=%u\n", ev.type);
+            fflush(stdout);
+        }
+    }
+    /* Poll /dev/input for matching evdev node, up to 2s */
+    for (int sec = 0; sec < 20; sec++) {
+        for (int i = 0; i < 128; i++) {
+            char path[64];
+            snprintf(path, sizeof(path), "/dev/input/event%d", i);
+            int efd = open(path, O_RDONLY | O_NONBLOCK);
+            if (efd < 0) continue;
+            unsigned short id[4] = {0};
+            if (ioctl(efd, 0x80084502, id) == 0 && id[1] == 0xFADE) {
+                printf("  FOUND %s: bus=%04x vid=%04x pid=%04x\n",
+                       path, id[0], id[1], id[2]);
+                close(efd);
+                return 0;
+            }
+            close(efd);
+        }
+        usleep(100000);
+    }
+    printf("NOT FOUND after 2s poll\n");
+    return 1;
+}
+EOF
+gcc -o /tmp/uhid_probe /tmp/uhid_probe.c
+/tmp/uhid_probe

--- a/scripts/wave5-probe.sh
+++ b/scripts/wave5-probe.sh
@@ -56,7 +56,7 @@ int main(void) {
             int efd = open(path, O_RDONLY | O_NONBLOCK);
             if (efd < 0) continue;
             unsigned short id[4] = {0};
-            if (ioctl(efd, 0x80084502, id) == 0 && id[1] == 0xFADE) {
+            if (ioctl(efd, 0x80084502, id) == 0 && id[1] == 0xFADE && id[2] == 0xBEEF) {
                 printf("  FOUND %s: bus=%04x vid=%04x pid=%04x\n",
                        path, id[0], id[1], id[2]);
                 close(efd);

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -266,6 +266,46 @@ const modules_load_content =
     \\
 ;
 
+// Static udev rule tagging padctl's UHID IMU nodes as accelerometers so
+// systemd-udev's `input_id` builtin and SDL's `SDL_EVDEV_GuessDeviceClass`
+// treat them as sensors rather than joysticks. Kernel `hid-input.c` does not
+// set `INPUT_PROP_ACCELEROMETER` for generic HID — both the udev builtin and
+// SDL fall back to a heuristic ("no EV_KEY + ABS_X/Y/Z"); this explicit tag
+// hardens that signal and additionally clears `ID_INPUT_JOYSTICK` so SDL
+// never opens the sensor node as a gamepad.
+//
+// Match criteria:
+//   - SUBSYSTEM == input: only evdev nodes, never hidraw.
+//   - ATTRS{uniq} == "padctl/*": set by padctl via UHID_CREATE2 (`buildUniq`).
+//   - ATTRS{name} == "*IMU*": padctl IMU companion card uses "<device> IMU"
+//     (see device_instance.zig T5c) or an explicit imu.name override.
+const imu_udev_rules_content =
+    \\# padctl UHID IMU nodes: tag as accelerometer so SDL/Steam recognize them
+    \\# as sensors instead of joysticks. Matches padctl's uniq pattern `padctl/*`
+    \\# and a name containing "IMU" (padctl's convention for the IMU UHID card).
+    \\# Also untags ID_INPUT_JOYSTICK to avoid SDL opening the sensor as a gamepad.
+    \\SUBSYSTEM=="input", ATTRS{uniq}=="padctl/*", ATTRS{name}=="*IMU*", \
+    \\  ENV{ID_INPUT_ACCELEROMETER}="1", ENV{ID_INPUT_JOYSTICK}=""
+    \\
+;
+
+fn writeImuUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan) void {
+    const rules_path = std.fmt.allocPrint(allocator, "{s}/90-padctl.rules", .{plan.udev_dir}) catch return;
+    defer allocator.free(rules_path);
+
+    if (std.fs.createFileAbsolute(rules_path, .{ .truncate = true })) |f| {
+        defer f.close();
+        f.writeAll(imu_udev_rules_content) catch {};
+        _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
+        _ = std.posix.write(std.posix.STDOUT_FILENO, rules_path) catch {};
+        _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
+    } else |err| {
+        var errbuf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(&errbuf, "warning: 90-padctl.rules not written: {}\n", .{err}) catch "warning: 90-padctl.rules write error\n";
+        _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch {};
+    }
+}
+
 fn writeModulesLoad(allocator: std.mem.Allocator, destdir: []const u8, prefix: []const u8, immutable: bool) void {
     // Immutable systems use /etc; otherwise prefer prefix/lib/modules-load.d
     const dir_path = if (immutable)
@@ -1130,6 +1170,7 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
 
     try installUdevRules(allocator, &plan, device_entries.items);
     try cleanupLegacyUdevFiles(allocator, &plan);
+    writeImuUdevRules(allocator, &plan);
     writeModulesLoad(allocator, plan.opts.destdir, plan.prefix, plan.effective_immutable);
 
     var installed_mappings = std.ArrayList([]const u8){};
@@ -1632,6 +1673,7 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         "/lib/systemd/user/padctl.service",
         "/lib/udev/rules.d/60-padctl.rules",
         "/lib/udev/rules.d/61-padctl-driver-block.rules",
+        "/lib/udev/rules.d/90-padctl.rules",
         "/lib/udev/rules.d/99-padctl.rules",
         "/lib/modules-load.d/padctl.conf",
     };
@@ -1717,6 +1759,7 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
             "/etc/systemd/user/padctl.service",
             "/etc/udev/rules.d/60-padctl.rules",
             "/etc/udev/rules.d/61-padctl-driver-block.rules",
+            "/etc/udev/rules.d/90-padctl.rules",
             "/etc/udev/rules.d/99-padctl.rules",
             "/etc/modules-load.d/padctl.conf",
         };
@@ -4612,4 +4655,62 @@ test "uninstall: removes /etc/systemd/user/padctl.service on non-immutable /usr/
         return;
     };
     return error.FileStillExists;
+}
+
+// -----------------------------------------------------------------------------
+// Phase 13 Wave 5 — static udev rule tests. These validate the embedded
+// `imu_udev_rules_content` and the on-disk `udev/90-padctl.rules` are well-
+// formed and carry the critical ENV tags. Layer 0 only — no systemd needed.
+// -----------------------------------------------------------------------------
+
+test "install: imu_udev_rules_content matches input subsystem and padctl uniq" {
+    const testing = std.testing;
+    try testing.expect(std.mem.indexOf(u8, imu_udev_rules_content, "SUBSYSTEM==\"input\"") != null);
+    try testing.expect(std.mem.indexOf(u8, imu_udev_rules_content, "ATTRS{uniq}==\"padctl/") != null);
+    try testing.expect(std.mem.indexOf(u8, imu_udev_rules_content, "ATTRS{name}==\"*IMU*\"") != null);
+}
+
+test "install: imu_udev_rules_content sets accelerometer and clears joystick" {
+    const testing = std.testing;
+    try testing.expect(std.mem.indexOf(u8, imu_udev_rules_content, "ENV{ID_INPUT_ACCELEROMETER}=\"1\"") != null);
+    try testing.expect(std.mem.indexOf(u8, imu_udev_rules_content, "ENV{ID_INPUT_JOYSTICK}=\"\"") != null);
+}
+
+test "install: imu_udev_rules_content is syntactically well-formed" {
+    const testing = std.testing;
+    // Every non-empty, non-comment logical line must contain at least one
+    // key=value or key==value token. A logical line is the physical line
+    // plus any backslash-continuations. We only check the tokens exist.
+    var logical = std.ArrayList(u8){};
+    defer logical.deinit(testing.allocator);
+
+    var it = std.mem.splitScalar(u8, imu_udev_rules_content, '\n');
+    while (it.next()) |raw| {
+        var line = std.mem.trimRight(u8, raw, " \t\r");
+        const is_continuation = std.mem.endsWith(u8, line, "\\");
+        if (is_continuation) line = line[0 .. line.len - 1];
+        try logical.appendSlice(testing.allocator, line);
+        if (!is_continuation) {
+            const l = std.mem.trim(u8, logical.items, " \t");
+            defer logical.clearRetainingCapacity();
+            if (l.len == 0) continue;
+            if (l[0] == '#') continue;
+            try testing.expect(std.mem.indexOf(u8, l, "==") != null or
+                std.mem.indexOf(u8, l, "=") != null);
+        }
+    }
+}
+
+test "install: on-disk udev/90-padctl.rules mirrors embedded content" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    // The repo ships the same rule body as a standalone file for packagers
+    // that do not execute `padctl install`. Skip gracefully when the test
+    // runs outside the repo tree (e.g. from an installed binary).
+    const cwd = std.fs.cwd();
+    const file = cwd.openFile("udev/90-padctl.rules", .{}) catch return;
+    defer file.close();
+    const body = try file.readToEndAlloc(allocator, 64 * 1024);
+    defer allocator.free(body);
+    try testing.expectEqualStrings(imu_udev_rules_content, body);
 }

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -289,21 +289,16 @@ const imu_udev_rules_content =
     \\
 ;
 
-fn writeImuUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan) void {
-    const rules_path = std.fmt.allocPrint(allocator, "{s}/90-padctl.rules", .{plan.udev_dir}) catch return;
+fn writeImuUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan) !void {
+    const rules_path = try std.fmt.allocPrint(allocator, "{s}/90-padctl.rules", .{plan.udev_dir});
     defer allocator.free(rules_path);
 
-    if (std.fs.createFileAbsolute(rules_path, .{ .truncate = true })) |f| {
-        defer f.close();
-        f.writeAll(imu_udev_rules_content) catch {};
-        _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
-        _ = std.posix.write(std.posix.STDOUT_FILENO, rules_path) catch {};
-        _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
-    } else |err| {
-        var errbuf: [256]u8 = undefined;
-        const msg = std.fmt.bufPrint(&errbuf, "warning: 90-padctl.rules not written: {}\n", .{err}) catch "warning: 90-padctl.rules write error\n";
-        _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch {};
-    }
+    var f = try std.fs.createFileAbsolute(rules_path, .{ .truncate = true });
+    defer f.close();
+    try f.writeAll(imu_udev_rules_content);
+    _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
+    _ = std.posix.write(std.posix.STDOUT_FILENO, rules_path) catch {};
+    _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
 }
 
 fn writeModulesLoad(allocator: std.mem.Allocator, destdir: []const u8, prefix: []const u8, immutable: bool) void {
@@ -1170,7 +1165,7 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
 
     try installUdevRules(allocator, &plan, device_entries.items);
     try cleanupLegacyUdevFiles(allocator, &plan);
-    writeImuUdevRules(allocator, &plan);
+    try writeImuUdevRules(allocator, &plan);
     writeModulesLoad(allocator, plan.opts.destdir, plan.prefix, plan.effective_immutable);
 
     var installed_mappings = std.ArrayList([]const u8){};

--- a/src/test/uhid_uniq_pairing_test.zig
+++ b/src/test/uhid_uniq_pairing_test.zig
@@ -66,21 +66,37 @@ fn waitForEvdevNode(vid: u16, pid: u16, uniq: []const u8, timeout_ms: u32) !?[64
 }
 
 fn findEvdevByUniq(vid: u16, pid: u16, expect_uniq: []const u8) !?[64]u8 {
-    var i: u8 = 0;
-    while (i < 64) : (i += 1) {
+    // Walk /sys/class/input/event*/device/uevent and pick only entries whose
+    // uevent reports a matching PRODUCT= line, then open just that event node.
+    // This avoids opening host hardware (keyboards, the user's real gamepad,
+    // active evdev grabs by padctl/Steam) which on kernel 6.18 can block in
+    // evdev_release / input_flush_device during close() and deadlock the test.
+    var dir = std.fs.openDirAbsolute("/sys/class/input", .{ .iterate = true }) catch return null;
+    defer dir.close();
+    var it = dir.iterate();
+    while (try it.next()) |entry| {
+        if (!std.mem.startsWith(u8, entry.name, "event")) continue;
+
+        // Read /sys/class/input/eventN/device/uevent — contains "PRODUCT=bus/vid/pid/ver".
+        var uevent_path_buf: [128]u8 = undefined;
+        const uevent_path = std.fmt.bufPrint(&uevent_path_buf, "/sys/class/input/{s}/device/uevent", .{entry.name}) catch continue;
+        const uevent_file = std.fs.openFileAbsolute(uevent_path, .{}) catch continue;
+        defer uevent_file.close();
+        var uevent_buf: [4096]u8 = undefined;
+        const uevent_len = uevent_file.readAll(&uevent_buf) catch continue;
+        const uevent = uevent_buf[0..uevent_len];
+
+        if (!sysfsProductMatches(uevent, vid, pid)) continue;
+
+        // Matches by VID/PID — now open only this single device to verify uniq.
         var path_buf: [64]u8 = undefined;
-        const path = std.fmt.bufPrint(&path_buf, "/dev/input/event{d}", .{i}) catch continue;
+        const path = std.fmt.bufPrint(&path_buf, "/dev/input/{s}", .{entry.name}) catch continue;
         const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch continue;
         defer posix.close(fd);
 
-        var id: [4]u16 = std.mem.zeroes([4]u16); // bustype, vendor, product, version
-        const rc_id = linux.ioctl(fd, 0x80084502, @intFromPtr(&id)); // EVIOCGID
-        if (rc_id != 0) continue;
-        if (id[1] != vid or id[2] != pid) continue;
-
         var uniq_buf: [64]u8 = std.mem.zeroes([64]u8);
         const rc = linux.ioctl(fd, ioctl_constants.EVIOCGUNIQ(uniq_buf.len), @intFromPtr(&uniq_buf));
-        if (rc < 0) continue;
+        if (posix.errno(rc) != .SUCCESS) continue;
         const nul = std.mem.indexOfScalar(u8, &uniq_buf, 0) orelse uniq_buf.len;
         if (!std.mem.eql(u8, uniq_buf[0..nul], expect_uniq)) continue;
 
@@ -89,6 +105,26 @@ fn findEvdevByUniq(vid: u16, pid: u16, expect_uniq: []const u8) !?[64]u8 {
         return result;
     }
     return null;
+}
+
+/// Parse a sysfs uevent blob and return true iff a `PRODUCT=bus/vid/pid/ver`
+/// line matches the given VID/PID. `bus` is the host bus type (not our UHID
+/// pretend-USB bus), so we only check vid + pid positions.
+fn sysfsProductMatches(uevent: []const u8, vid: u16, pid: u16) bool {
+    var line_iter = std.mem.splitScalar(u8, uevent, '\n');
+    while (line_iter.next()) |line| {
+        const prefix = "PRODUCT=";
+        if (!std.mem.startsWith(u8, line, prefix)) continue;
+        const value = line[prefix.len..];
+        var field_iter = std.mem.splitScalar(u8, value, '/');
+        _ = field_iter.next() orelse return false; // bus
+        const vid_str = field_iter.next() orelse return false;
+        const pid_str = field_iter.next() orelse return false;
+        const parsed_vid = std.fmt.parseInt(u16, vid_str, 16) catch return false;
+        const parsed_pid = std.fmt.parseInt(u16, pid_str, 16) catch return false;
+        return parsed_vid == vid and parsed_pid == pid;
+    }
+    return false;
 }
 
 fn readUniqFromEvdevPath(path: []const u8) ![]u8 {
@@ -104,17 +140,111 @@ fn readUniqFromEvdevPath(path: []const u8) ![]u8 {
     return out;
 }
 
+// ---------------------------------------------------------------------------
+// Phase 13 Wave 5 canary — kernel-level evdev classification ioctls.
+//
+// SDL/Steam `GuessDeviceClass` keys off two ioctl signals *after* the kernel's
+// HID→evdev mapper (`drivers/hid/hid-input.c`) parses the descriptor:
+//   1. `EVIOCGPROP` → must expose `INPUT_PROP_ACCELEROMETER` (0x06) so the
+//      sensor is classified as an accelerometer, not a gamepad.
+//   2. `EVIOCGBIT(EV_KEY, ...)` → must be *empty* for the IMU node; any KEY
+//      bit set trips the gamepad heuristic and SDL won't pair the sensor.
+// The primary pad is the inverse: EV_KEY must have at least one bit so SDL
+// classifies it as a gamepad.
+//
+// Kernel constants (linux/input-event-codes.h):
+//   INPUT_PROP_ACCELEROMETER = 0x06 → byte 0 bit 6 (mask 0x40)
+//   INPUT_PROP_CNT           = 0x20 → props buffer = 4 bytes
+//   EV_KEY                   = 0x01
+//   KEY_MAX                  = 0x2ff → key bitmap = 96 bytes
+//
+// EVIOCGPROP(len)     = _IOR('E', 0x09, len)
+// EVIOCGBIT(ev, len)  = _IOR('E', 0x20 + ev, len)
+const INPUT_PROP_ACCELEROMETER: u8 = 0x06;
+const INPUT_PROP_CNT: usize = 0x20;
+const EV_KEY_CODE: u8 = 0x01;
+const KEY_MAX: usize = 0x2ff;
+const KEY_BYTES: usize = (KEY_MAX + 7) / 8 + 1; // 96 bytes
+
+fn EVIOCGPROP(len: u14) u32 {
+    const req = std.os.linux.IOCTL.Request{ .dir = 2, .io_type = 'E', .nr = 0x09, .size = len };
+    return @bitCast(req);
+}
+
+fn EVIOCGBIT(ev: u8, len: u14) u32 {
+    const req = std.os.linux.IOCTL.Request{ .dir = 2, .io_type = 'E', .nr = 0x20 + ev, .size = len };
+    return @bitCast(req);
+}
+
+fn readPropBitmap(path: []const u8) ![INPUT_PROP_CNT / 8]u8 {
+    const fd = try posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0);
+    defer posix.close(fd);
+
+    var props: [INPUT_PROP_CNT / 8]u8 = std.mem.zeroes([INPUT_PROP_CNT / 8]u8);
+    const rc = linux.ioctl(fd, EVIOCGPROP(@intCast(props.len)), @intFromPtr(&props));
+    if (posix.errno(rc) != .SUCCESS) return error.EvdevPropIoctlFailed;
+    return props;
+}
+
+fn readKeyBitmap(path: []const u8) ![KEY_BYTES]u8 {
+    const fd = try posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0);
+    defer posix.close(fd);
+
+    var key_bits: [KEY_BYTES]u8 = std.mem.zeroes([KEY_BYTES]u8);
+    const rc = linux.ioctl(fd, EVIOCGBIT(EV_KEY_CODE, @intCast(key_bits.len)), @intFromPtr(&key_bits));
+    if (posix.errno(rc) != .SUCCESS) return error.EvdevKeyBitIoctlFailed;
+    return key_bits;
+}
+
+fn hasPropBit(props: []const u8, bit: u8) bool {
+    const byte_idx: usize = bit / 8;
+    const bit_idx: u3 = @intCast(bit % 8);
+    if (byte_idx >= props.len) return false;
+    return ((props[byte_idx] >> bit_idx) & 1) == 1;
+}
+
+fn keyBitmapPopcount(bits: []const u8) usize {
+    var total: usize = 0;
+    for (bits) |b| total += @popCount(b);
+    return total;
+}
+
+fn printHex(label: []const u8, bytes: []const u8) void {
+    std.debug.print("{s} (len={d}):", .{ label, bytes.len });
+    for (bytes) |b| std.debug.print(" {x:0>2}", .{b});
+    std.debug.print("\n", .{});
+}
+
 // A minimal Generic-Desktop Gamepad descriptor for the main-pad fd — the IMU
 // fd now uses the production `UhidDescriptorBuilder.buildForImu` so this AC
 // test evaluates the exact descriptor padctl ships (previously it hard-coded
 // a copy, which let R-C B1's Sensor-page bug escape CI).
+//
+// The Wave 5 canary assertions rely on the primary pad exposing at least one
+// EV_KEY bit (so SDL classifies it as a gamepad). We include one Button Page
+// usage (BTN_SOUTH = button 1) so the kernel's hid-input mapper emits exactly
+// one BTN_* bit on the evdev node. Without this, the EV_KEY control sample
+// would be vacuous.
 const MAIN_DESCRIPTOR = [_]u8{
     0x05, 0x01, // Usage Page (Generic Desktop)
     0x09, 0x05, // Usage (Game Pad)
     0xA1, 0x01, // Collection (Application)
+    // --- Button Page: 1 button ---
+    0x05, 0x09, // Usage Page (Button)
+    0x19, 0x01, // Usage Minimum (1)
+    0x29, 0x01, // Usage Maximum (1)
+    0x15, 0x00, 0x25, 0x01, // Logical Min/Max 0..1
+    0x75, 0x01, 0x95, 0x01, // Report Size 1, Count 1
+    0x81, 0x02, // Input (Data, Var, Abs)
+    // padding to byte boundary (7 bits)
+    0x75, 0x07,
+    0x95, 0x01,
+    0x81, 0x03, // Input (Const, Var, Abs) padding
+    // --- Axis X ---
+    0x05, 0x01, // Usage Page (Generic Desktop)
     0x09, 0x30, // Usage (X)
     0x15, 0x00, 0x26, 0xFF, 0x00, // Logical Min/Max 0..255
-    0x75, 0x08, 0x95, 0x01, // Report Size/Count 8/1
+    0x75, 0x08, 0x95, 0x01, // Report Size 8, Count 1
     0x81, 0x02, // Input (Data, Var, Abs)
     0xC0, // End Collection
 };
@@ -175,6 +305,47 @@ test "uhid: EVIOCGUNIQ returns identical strings on a paired main-pad + IMU (ADR
     try testing.expectEqualStrings(SHARED_UNIQ, main_uniq);
     try testing.expectEqualStrings(SHARED_UNIQ, imu_uniq);
     try testing.expectEqualSlices(u8, main_uniq, imu_uniq);
+
+    // -----------------------------------------------------------------------
+    // Wave 5 canary — kernel evdev classification. If `buildForImu`'s
+    // descriptor is kernel-accepted, the IMU node must expose
+    // INPUT_PROP_ACCELEROMETER and carry zero EV_KEY bits. The primary pad
+    // node must carry at least one EV_KEY bit (control sample).
+    // -----------------------------------------------------------------------
+    const imu_props = try readPropBitmap(imu_path[0..imu_path_len]);
+    const imu_keys = try readKeyBitmap(imu_path[0..imu_path_len]);
+    const main_keys = try readKeyBitmap(main_path[0..main_path_len]);
+
+    if (!hasPropBit(&imu_props, INPUT_PROP_ACCELEROMETER)) {
+        printHex("IMU EVIOCGPROP", &imu_props);
+        printHex("IMU EVIOCGBIT(EV_KEY)", &imu_keys);
+        std.debug.print(
+            "IMU node '{s}' lacks INPUT_PROP_ACCELEROMETER (bit 0x{x}) — SDL will NOT classify as sensor.\n",
+            .{ imu_path[0..imu_path_len], INPUT_PROP_ACCELEROMETER },
+        );
+    }
+    try testing.expect(hasPropBit(&imu_props, INPUT_PROP_ACCELEROMETER));
+
+    const imu_key_count = keyBitmapPopcount(&imu_keys);
+    if (imu_key_count != 0) {
+        printHex("IMU EVIOCGBIT(EV_KEY)", &imu_keys);
+        std.debug.print(
+            "IMU node '{s}' has {d} EV_KEY bits — SDL will reclassify as gamepad.\n",
+            .{ imu_path[0..imu_path_len], imu_key_count },
+        );
+    }
+    try testing.expectEqual(@as(usize, 0), imu_key_count);
+
+    // Control: primary pad must still look like a gamepad.
+    const main_key_count = keyBitmapPopcount(&main_keys);
+    if (main_key_count == 0) {
+        printHex("primary pad EVIOCGBIT(EV_KEY)", &main_keys);
+        std.debug.print(
+            "primary pad node '{s}' carries zero EV_KEY bits — regression: SDL will not classify as gamepad.\n",
+            .{main_path[0..main_path_len]},
+        );
+    }
+    try testing.expect(main_key_count >= 1);
 }
 
 fn sendCreateWithUniq(

--- a/src/test/uhid_uniq_pairing_test.zig
+++ b/src/test/uhid_uniq_pairing_test.zig
@@ -143,47 +143,47 @@ fn readUniqFromEvdevPath(path: []const u8) ![]u8 {
 // ---------------------------------------------------------------------------
 // Phase 13 Wave 5 canary — kernel-level evdev classification ioctls.
 //
-// SDL/Steam `GuessDeviceClass` keys off two ioctl signals *after* the kernel's
-// HID→evdev mapper (`drivers/hid/hid-input.c`) parses the descriptor:
-//   1. `EVIOCGPROP` → must expose `INPUT_PROP_ACCELEROMETER` (0x06) so the
-//      sensor is classified as an accelerometer, not a gamepad.
-//   2. `EVIOCGBIT(EV_KEY, ...)` → must be *empty* for the IMU node; any KEY
-//      bit set trips the gamepad heuristic and SDL won't pair the sensor.
-// The primary pad is the inverse: EV_KEY must have at least one bit so SDL
-// classifies it as a gamepad.
+// The kernel's generic HID→evdev mapper (`drivers/hid/hid-input.c`) does NOT
+// set `INPUT_PROP_ACCELEROMETER` for our descriptor — that bit is only
+// hard-coded by device-specific drivers (hid-sony / hid-nintendo / hid-
+// playstation). Both systemd-udev's `input_id` builtin and SDL's
+// `SDL_EVDEV_GuessDeviceClass` fall back to a heuristic instead:
+//
+//   "EV_KEY empty AND ABS_X + ABS_Y + ABS_Z present" → classify as
+//   accelerometer/sensor.
+//
+// The padctl Wave 3 IMU descriptor (`UhidDescriptorBuilder.buildForImu`)
+// emits a Generic-Desktop Multi-axis Controller with Usage X/Y/Z + Rx/Ry/Rz
+// and no Button Page usages, which the kernel maps to ABS_X/Y/Z + ABS_RX/RY/RZ
+// with no EV_KEY bits. This test verifies those kernel-observable signals
+// so any regression (e.g. reintroducing a Button Page) flips red.
+//
+// The ENV{ID_INPUT_ACCELEROMETER} tag is enforced by the shipped udev rule
+// `/lib/udev/rules.d/90-padctl.rules` (or `/etc/udev/rules.d/` on immutable
+// systems) and is verified separately via udev's `input_id` output in
+// system-integration tests — this file stays focused on the kernel-level
+// heuristic signals that must hold regardless of udev availability.
 //
 // Kernel constants (linux/input-event-codes.h):
-//   INPUT_PROP_ACCELEROMETER = 0x06 → byte 0 bit 6 (mask 0x40)
-//   INPUT_PROP_CNT           = 0x20 → props buffer = 4 bytes
-//   EV_KEY                   = 0x01
-//   KEY_MAX                  = 0x2ff → key bitmap = 96 bytes
+//   EV_KEY = 0x01, EV_ABS = 0x03
+//   KEY_MAX = 0x2ff → key bitmap = 96 bytes
+//   ABS_MAX = 0x3f  → abs bitmap = 8 bytes
+//   ABS_X = 0x00, ABS_Y = 0x01, ABS_Z = 0x02
 //
-// EVIOCGPROP(len)     = _IOR('E', 0x09, len)
-// EVIOCGBIT(ev, len)  = _IOR('E', 0x20 + ev, len)
-const INPUT_PROP_ACCELEROMETER: u8 = 0x06;
-const INPUT_PROP_CNT: usize = 0x20;
+// EVIOCGBIT(ev, len) = _IOR('E', 0x20 + ev, len)
 const EV_KEY_CODE: u8 = 0x01;
+const EV_ABS_CODE: u8 = 0x03;
 const KEY_MAX: usize = 0x2ff;
 const KEY_BYTES: usize = (KEY_MAX + 7) / 8 + 1; // 96 bytes
-
-fn EVIOCGPROP(len: u14) u32 {
-    const req = std.os.linux.IOCTL.Request{ .dir = 2, .io_type = 'E', .nr = 0x09, .size = len };
-    return @bitCast(req);
-}
+const ABS_MAX: usize = 0x3f;
+const ABS_BYTES: usize = (ABS_MAX + 7) / 8 + 1; // 8 bytes
+const ABS_X: u8 = 0x00;
+const ABS_Y: u8 = 0x01;
+const ABS_Z: u8 = 0x02;
 
 fn EVIOCGBIT(ev: u8, len: u14) u32 {
     const req = std.os.linux.IOCTL.Request{ .dir = 2, .io_type = 'E', .nr = 0x20 + ev, .size = len };
     return @bitCast(req);
-}
-
-fn readPropBitmap(path: []const u8) ![INPUT_PROP_CNT / 8]u8 {
-    const fd = try posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0);
-    defer posix.close(fd);
-
-    var props: [INPUT_PROP_CNT / 8]u8 = std.mem.zeroes([INPUT_PROP_CNT / 8]u8);
-    const rc = linux.ioctl(fd, EVIOCGPROP(@intCast(props.len)), @intFromPtr(&props));
-    if (posix.errno(rc) != .SUCCESS) return error.EvdevPropIoctlFailed;
-    return props;
 }
 
 fn readKeyBitmap(path: []const u8) ![KEY_BYTES]u8 {
@@ -196,11 +196,21 @@ fn readKeyBitmap(path: []const u8) ![KEY_BYTES]u8 {
     return key_bits;
 }
 
-fn hasPropBit(props: []const u8, bit: u8) bool {
-    const byte_idx: usize = bit / 8;
-    const bit_idx: u3 = @intCast(bit % 8);
-    if (byte_idx >= props.len) return false;
-    return ((props[byte_idx] >> bit_idx) & 1) == 1;
+fn readAbsBitmap(path: []const u8) ![ABS_BYTES]u8 {
+    const fd = try posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0);
+    defer posix.close(fd);
+
+    var abs_bits: [ABS_BYTES]u8 = std.mem.zeroes([ABS_BYTES]u8);
+    const rc = linux.ioctl(fd, EVIOCGBIT(EV_ABS_CODE, @intCast(abs_bits.len)), @intFromPtr(&abs_bits));
+    if (posix.errno(rc) != .SUCCESS) return error.EvdevAbsBitIoctlFailed;
+    return abs_bits;
+}
+
+fn hasAbsBit(bits: []const u8, code: u8) bool {
+    const byte_idx: usize = code / 8;
+    const bit_idx: u3 = @intCast(code % 8);
+    if (byte_idx >= bits.len) return false;
+    return ((bits[byte_idx] >> bit_idx) & 1) == 1;
 }
 
 fn keyBitmapPopcount(bits: []const u8) usize {
@@ -307,24 +317,25 @@ test "uhid: EVIOCGUNIQ returns identical strings on a paired main-pad + IMU (ADR
     try testing.expectEqualSlices(u8, main_uniq, imu_uniq);
 
     // -----------------------------------------------------------------------
-    // Wave 5 canary — kernel evdev classification. If `buildForImu`'s
-    // descriptor is kernel-accepted, the IMU node must expose
-    // INPUT_PROP_ACCELEROMETER and carry zero EV_KEY bits. The primary pad
-    // node must carry at least one EV_KEY bit (control sample).
+    // Wave 5 canary — kernel evdev classification. The heuristic implemented
+    // by systemd-udev's `input_id` builtin AND by SDL's
+    // `SDL_EVDEV_GuessDeviceClass` is: *no EV_KEY bits set* AND
+    // *ABS_X + ABS_Y + ABS_Z present* → accelerometer/sensor. Our Wave 3
+    // `buildForImu` descriptor maps to this exact shape. The primary pad is
+    // the inverse control sample: at least one EV_KEY bit must be set so
+    // SDL classifies it as a gamepad.
+    //
+    // We deliberately do NOT assert `INPUT_PROP_ACCELEROMETER` on the evdev
+    // node — kernel `hid-input.c` never sets that bit for generic HID (only
+    // hid-sony/hid-nintendo/hid-playstation do, via hard-coded quirks). The
+    // bit is set instead by user-space via our shipped udev rule
+    // `/lib/udev/rules.d/90-padctl.rules`, which tags
+    // `ENV{ID_INPUT_ACCELEROMETER}=1` — that tag is orthogonal to this
+    // kernel-level heuristic test and is validated separately.
     // -----------------------------------------------------------------------
-    const imu_props = try readPropBitmap(imu_path[0..imu_path_len]);
     const imu_keys = try readKeyBitmap(imu_path[0..imu_path_len]);
+    const imu_abs = try readAbsBitmap(imu_path[0..imu_path_len]);
     const main_keys = try readKeyBitmap(main_path[0..main_path_len]);
-
-    if (!hasPropBit(&imu_props, INPUT_PROP_ACCELEROMETER)) {
-        printHex("IMU EVIOCGPROP", &imu_props);
-        printHex("IMU EVIOCGBIT(EV_KEY)", &imu_keys);
-        std.debug.print(
-            "IMU node '{s}' lacks INPUT_PROP_ACCELEROMETER (bit 0x{x}) — SDL will NOT classify as sensor.\n",
-            .{ imu_path[0..imu_path_len], INPUT_PROP_ACCELEROMETER },
-        );
-    }
-    try testing.expect(hasPropBit(&imu_props, INPUT_PROP_ACCELEROMETER));
 
     const imu_key_count = keyBitmapPopcount(&imu_keys);
     if (imu_key_count != 0) {
@@ -335,6 +346,20 @@ test "uhid: EVIOCGUNIQ returns identical strings on a paired main-pad + IMU (ADR
         );
     }
     try testing.expectEqual(@as(usize, 0), imu_key_count);
+
+    // ABS_X/Y/Z present is the other half of the heuristic — without these,
+    // the kernel has no axes to classify and both udev + SDL fall through
+    // to "unknown".
+    if (!hasAbsBit(&imu_abs, ABS_X) or !hasAbsBit(&imu_abs, ABS_Y) or !hasAbsBit(&imu_abs, ABS_Z)) {
+        printHex("IMU EVIOCGBIT(EV_ABS)", &imu_abs);
+        std.debug.print(
+            "IMU node '{s}' missing one of ABS_X/Y/Z — heuristic classification will fail.\n",
+            .{imu_path[0..imu_path_len]},
+        );
+    }
+    try testing.expect(hasAbsBit(&imu_abs, ABS_X));
+    try testing.expect(hasAbsBit(&imu_abs, ABS_Y));
+    try testing.expect(hasAbsBit(&imu_abs, ABS_Z));
 
     // Control: primary pad must still look like a gamepad.
     const main_key_count = keyBitmapPopcount(&main_keys);

--- a/udev/90-padctl.rules
+++ b/udev/90-padctl.rules
@@ -1,0 +1,6 @@
+# padctl UHID IMU nodes: tag as accelerometer so SDL/Steam recognize them
+# as sensors instead of joysticks. Matches padctl's uniq pattern `padctl/*`
+# and a name containing "IMU" (padctl's convention for the IMU UHID card).
+# Also untags ID_INPUT_JOYSTICK to avoid SDL opening the sensor as a gamepad.
+SUBSYSTEM=="input", ATTRS{uniq}=="padctl/*", ATTRS{name}=="*IMU*", \
+  ENV{ID_INPUT_ACCELEROMETER}="1", ENV{ID_INPUT_JOYSTICK}=""


### PR DESCRIPTION
## Summary

Wave 3 (PR #159) shipped the UHID IMU routing but empirical kernel-6.18 testing in a Docker canary revealed the descriptor-only path did **not** trigger `INPUT_PROP_ACCELEROMETER` on the evdev node — which our initial canary test (wrongly) asserted as required. Deep kernel research (`drivers/hid/hid-input.c` mainline + v5.15, 0 occurrences) confirmed the kernel NEVER auto-sets this bit for generic HID; only hardware-specific drivers (`hid-sony.c`, `hid-nintendo.c`, `hid-playstation.c`) hardcode it.

**But** systemd-udev's \`input_id\` builtin + SDL's \`GuessDeviceClass\` both have heuristic fallback: `no EV_KEY + ABS_X+Y+Z → accelerometer`. Our Wave 3 descriptor already matches this heuristic. The missing piece was explicit udev tagging for robustness across SDL versions + edge cases where udev doesn't fire.

This PR closes the gap with two artefacts:

### 1. `udev/90-padctl.rules` — explicit accelerometer tagging

\`\`\`
SUBSYSTEM=="input", ATTRS{uniq}=="padctl/*", ATTRS{name}=="*IMU*", \
  ENV{ID_INPUT_ACCELEROMETER}="1", ENV{ID_INPUT_JOYSTICK}=""
\`\`\`

- Matches padctl's UHID IMU nodes via uniq prefix (set by \`buildUniq\`) + name containing "IMU" (set in T5c)
- Tags as accelerometer AND untags joystick (avoids SDL opening sensor as gamepad)
- Installed by \`padctl install\` to \`<prefix>/lib/udev/rules.d/\` (immutable: \`/etc/udev/rules.d/\`)
- Removed by \`padctl uninstall\` (both prefix-relative + immutable etc_files lists)
- \`udevadm control --reload-rules\` + \`udevadm trigger\` already run by existing install flow — no extra wiring needed

### 2. Container canary test with corrected heuristic-aligned assertions

\`Dockerfile.wave5\` + \`scripts/wave5-canary-docker.sh\` + extension to \`src/test/uhid_uniq_pairing_test.zig\`:

- Docker: Debian bookworm + Zig 0.15.2 tarball (Arch+Zig 0.15.2 hits #147 \`.sframe\` LLD bug — confirmed; Debian sidesteps)
- Container mount: \`--device=/dev/uhid --privileged\` + \`mount -t devtmpfs devtmpfs /dev\` (Docker tmpfs otherwise hides UHID-born evdev nodes)
- New \`test-uhid-uniq\` build step with test-name filter (full \`zig build test\` as root deadlocks on host \`/dev/hidraw*\` — kernel-6.18 HID bug, worth upstream report)
- Assertions (corrected after research):
  - \`EVIOCGUNIQ\` byte-equal on primary + IMU (ADR-015 AC4, unchanged)
  - IMU \`EV_KEY\` all-zero (heuristic input)
  - IMU \`ABS_X/Y/Z\` present (heuristic input)
- Removed: the false-negative \`INPUT_PROP_ACCELEROMETER\` kernel-propbit assertion (kernel never sets it for generic HID)

### Container canary result on kernel 6.18

**3/3 tests pass** — Wave 3 descriptor now empirically verified to match SDL's accelerometer heuristic signal on a real kernel.

## Commits

- \`37d35f8\` test: Docker canary + EVIOCGPROP/EVIOCGBIT scaffolding
- \`029c210\` feat(udev): ship 90-padctl.rules
- \`1f13143\` test: replace false-negative \`INPUT_PROP_ACCELEROMETER\` assertion with ABS_X/Y/Z check

## Test plan

- [x] zig build — green
- [x] zig build test-uhid-uniq (focused) — 3/3 green on host kernel 6.18
- [x] \`scripts/wave5-canary-docker.sh\` — exit 0, 3/3 tests pass inside container
- [x] zig build check-fmt — clean
- [ ] zig build test (full) — **pre-existing** kernel 6.18 + HID hardware D-state hang (NOT regression, verified by stashing); CI on ubuntu-22.04 kernel 5.15 will run clean
- [ ] zig build test-tsan — same kernel 6.18 host issue; CI validates
- [ ] Real hardware (Vader 5 Pro / Steam Deck with \`[output.imu].backend = "uhid"\`) — you to validate post-merge

## Honest caveats

1. **Host kernel 6.18 D-state hang on \`/dev/hidraw*\`**: \`zig build test\` and \`test-tsan\` hang on probing host HID devices. Pre-existing, reproduced on unmodified baseline. Used the hook's own documented \`SKIP_TSAN=1\` escape for push. CI on ubuntu-22.04 (kernel 5.15) doesn't have this bug.
2. **Container test is Linux-only** (systemd-udev + UHID are Linux-native). \`builtin.os.tag != .linux\` paths skip cleanly.
3. **This does NOT replace real-device validation** — it proves the kernel-level signal SDL expects is present. Actual SDL3 + Steam pairing on real Vader 5 Pro / Steam Deck is Wave 5 T4 scope and can't be containerized without a full display stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic classification of IMU input devices as accelerometers to prevent SDL from treating them as joysticks.

* **Tests**
  * Enhanced UHID integration testing with new test infrastructure and validation for device discovery and classification.

* **Chores**
  * Added Docker image and testing scripts for canary UHID testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->