### PR TITLE
fix(install): proactive xpad unbind + broaden udev ACTION (issue #162)

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -2083,10 +2083,10 @@ fn probeAndUnbindDrivers(allocator: std.mem.Allocator, entries: []const UdevEntr
                 if (std.fs.openFileAbsolute(unbind_path, .{ .mode = .write_only })) |f| {
                     defer f.close();
                     f.writeAll(de.name) catch |err| {
-                        std.log.warn("could not unbind {s} from kernel driver (try replug or reboot to evict the shadow device): {}", .{ de.name, err });
+                        std.log.warn("could not unbind {s} from kernel driver '{s}' (try replug or reboot to evict the shadow device): {}", .{ de.name, driver, err });
                     };
                 } else |err| {
-                    std.log.warn("could not unbind {s} from kernel driver (try replug or reboot to evict the shadow device): {}", .{ de.name, err });
+                    std.log.warn("could not unbind {s} from kernel driver '{s}' (try replug or reboot to evict the shadow device): {}", .{ de.name, driver, err });
                 }
             }
         }

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1413,7 +1413,7 @@ fn installUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan, entr
     // plug cycle. Proactively writing to sysfs unbind covers devices that
     // are already claimed by a blocking driver at install time.
     if (!plan.staging_mode and plan.is_root) {
-        probeAndUnbindDrivers(allocator, entries);
+        probeAndUnbindDrivers(allocator, entries, "");
     }
 }
 
@@ -2023,19 +2023,20 @@ fn generateDriverBlockRules(allocator: std.mem.Allocator, dirs: []const []const 
     try generateDriverBlockRulesFromEntries(allocator, entries.items, rules_path);
 }
 
-/// Walk /sys/bus/usb/drivers/<driver>/ and synchronously unbind any device
-/// whose idVendor:idProduct matches an entry in `entries`. Called after writing
-/// the udev rule file and before udevadm trigger so already-attached devices
-/// are evicted without needing a reboot.
-/// Requires root; silently skips (debug log) on permission errors so non-root
-/// and staging-mode callers are unaffected.
-fn probeAndUnbindDrivers(allocator: std.mem.Allocator, entries: []const UdevEntry) void {
+/// Walk <sys_root>/sys/bus/usb/drivers/<driver>/ and synchronously unbind any
+/// device whose idVendor:idProduct matches an entry in `entries`. Called after
+/// writing the udev rule file and before udevadm trigger so already-attached
+/// devices are evicted without needing a reboot.
+/// Requires root; skips (warn log) on permission errors so non-root and
+/// staging-mode callers are unaffected.
+/// `sys_root` is "" in production; tests inject a tmpDir path (P9).
+fn probeAndUnbindDrivers(allocator: std.mem.Allocator, entries: []const UdevEntry, sys_root: []const u8) void {
     for (entries) |entry| {
         for (entry.block_kernel_drivers) |driver| {
             const driver_path = std.fmt.allocPrint(
                 allocator,
-                "/sys/bus/usb/drivers/{s}",
-                .{driver},
+                "{s}/sys/bus/usb/drivers/{s}",
+                .{ sys_root, driver },
             ) catch continue;
             defer allocator.free(driver_path);
 
@@ -2055,15 +2056,15 @@ fn probeAndUnbindDrivers(allocator: std.mem.Allocator, entries: []const UdevEntr
 
                 const vendor_path = std.fmt.allocPrint(
                     allocator,
-                    "/sys/bus/usb/devices/{s}/idVendor",
-                    .{dev_name},
+                    "{s}/sys/bus/usb/devices/{s}/idVendor",
+                    .{ sys_root, dev_name },
                 ) catch continue;
                 defer allocator.free(vendor_path);
 
                 const product_path = std.fmt.allocPrint(
                     allocator,
-                    "/sys/bus/usb/devices/{s}/idProduct",
-                    .{dev_name},
+                    "{s}/sys/bus/usb/devices/{s}/idProduct",
+                    .{ sys_root, dev_name },
                 ) catch continue;
                 defer allocator.free(product_path);
 
@@ -2074,18 +2075,18 @@ fn probeAndUnbindDrivers(allocator: std.mem.Allocator, entries: []const UdevEntr
 
                 const unbind_path = std.fmt.allocPrint(
                     allocator,
-                    "/sys/bus/usb/drivers/{s}/unbind",
-                    .{driver},
+                    "{s}/sys/bus/usb/drivers/{s}/unbind",
+                    .{ sys_root, driver },
                 ) catch continue;
                 defer allocator.free(unbind_path);
 
                 if (std.fs.openFileAbsolute(unbind_path, .{ .mode = .write_only })) |f| {
                     defer f.close();
                     f.writeAll(de.name) catch |err| {
-                        std.log.debug("unbind {s} from {s}: {}", .{ de.name, driver, err });
+                        std.log.warn("could not unbind {s} from kernel driver (try replug or reboot to evict the shadow device): {}", .{ de.name, err });
                     };
                 } else |err| {
-                    std.log.debug("open unbind for {s}/{s}: {}", .{ driver, de.name, err });
+                    std.log.warn("could not unbind {s} from kernel driver (try replug or reboot to evict the shadow device): {}", .{ de.name, err });
                 }
             }
         }
@@ -3420,6 +3421,82 @@ test "install: readSysHex parses 4-digit lowercase hex" {
 
     const val = try readSysHex(hex_path);
     try testing.expectEqual(@as(u16, 0x37d7), val);
+}
+
+test "install: probeAndUnbindDrivers writes matching interface to unbind, skips non-matching" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    // Build fake /sys tree: sys/bus/usb/drivers/xpad/ and sys/bus/usb/devices/
+    try tmp.dir.makePath("sys/bus/usb/drivers/xpad");
+    try tmp.dir.makePath("sys/bus/usb/devices/1-1.4");
+    try tmp.dir.makePath("sys/bus/usb/devices/2-2.1");
+
+    // Matching device: VID 37d7 PID 2401
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/1-1.4/idVendor", .{});
+        defer f.close();
+        try f.writeAll("37d7\n");
+    }
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/1-1.4/idProduct", .{});
+        defer f.close();
+        try f.writeAll("2401\n");
+    }
+
+    // Non-matching device
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/2-2.1/idVendor", .{});
+        defer f.close();
+        try f.writeAll("0000\n");
+    }
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/2-2.1/idProduct", .{});
+        defer f.close();
+        try f.writeAll("0000\n");
+    }
+
+    // Symlinks in drivers/xpad/ pointing at device nodes (relative, as real sysfs does)
+    const drivers_xpad_path = try std.fmt.allocPrint(allocator, "{s}/sys/bus/usb/drivers/xpad", .{tmp_path});
+    defer allocator.free(drivers_xpad_path);
+    {
+        const sl1 = try std.fmt.allocPrint(allocator, "{s}/1-1.4:1.0", .{drivers_xpad_path});
+        defer allocator.free(sl1);
+        try std.posix.symlink("../../../devices/1-1.4", sl1);
+    }
+    {
+        const sl2 = try std.fmt.allocPrint(allocator, "{s}/2-2.1:1.0", .{drivers_xpad_path});
+        defer allocator.free(sl2);
+        try std.posix.symlink("../../../devices/2-2.1", sl2);
+    }
+
+    // unbind file (writable regular file, simulates sysfs write target)
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/drivers/xpad/unbind", .{});
+        defer f.close();
+    }
+
+    const entries = [_]UdevEntry{.{
+        .name = "Test Device",
+        .vid = 0x37d7,
+        .pid = 0x2401,
+        .block_kernel_drivers = &[_][]const u8{"xpad"},
+    }};
+    probeAndUnbindDrivers(allocator, &entries, tmp_path);
+
+    // The matching interface must have been written to unbind.
+    const unbind_path = try std.fmt.allocPrint(allocator, "{s}/sys/bus/usb/drivers/xpad/unbind", .{tmp_path});
+    defer allocator.free(unbind_path);
+    var uf = try std.fs.openFileAbsolute(unbind_path, .{});
+    defer uf.close();
+    const written = try uf.readToEndAlloc(allocator, 64);
+    defer allocator.free(written);
+    try testing.expectEqualStrings("1-1.4:1.0", written);
 }
 
 test "install: generateDriverBlockRules skips when no drivers configured" {

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1407,6 +1407,14 @@ fn installUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan, entr
         const msg = std.fmt.bufPrint(&errbuf, "warning: driver block rules not generated: {}\n", .{err}) catch "warning: driver block rules error\n";
         _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch {};
     };
+
+    // Evict already-attached devices without waiting for reboot.
+    // udevadm trigger only sends add events; bind rules fire on the next
+    // plug cycle. Proactively writing to sysfs unbind covers devices that
+    // are already claimed by a blocking driver at install time.
+    if (!plan.staging_mode and plan.is_root) {
+        probeAndUnbindDrivers(allocator, entries);
+    }
 }
 
 fn cleanupLegacyUdevFiles(allocator: std.mem.Allocator, plan: *const InstallPlan) !void {
@@ -1995,7 +2003,7 @@ fn generateDriverBlockRulesFromEntries(allocator: std.mem.Allocator, entries: []
         for (e.block_kernel_drivers) |driver| {
             const line = try std.fmt.allocPrint(
                 allocator,
-                "ACTION==\"bind\", SUBSYSTEM==\"usb\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", DRIVER==\"{s}\", RUN+=\"/bin/sh -c 'echo %k > /sys/bus/usb/drivers/{s}/unbind'\"\n# {s}\n",
+                "ACTION==\"add|bind\", SUBSYSTEM==\"usb\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", DRIVER==\"{s}\", RUN+=\"/bin/sh -c 'echo %k > /sys/bus/usb/drivers/{s}/unbind'\"\n# {s}\n",
                 .{ e.vid, e.pid, driver, driver, e.name },
             );
             defer allocator.free(line);
@@ -2013,6 +2021,84 @@ fn generateDriverBlockRules(allocator: std.mem.Allocator, dirs: []const []const 
     var entries = try collectDeviceEntries(allocator, dirs);
     defer freeDeviceEntries(allocator, &entries);
     try generateDriverBlockRulesFromEntries(allocator, entries.items, rules_path);
+}
+
+/// Walk /sys/bus/usb/drivers/<driver>/ and synchronously unbind any device
+/// whose idVendor:idProduct matches an entry in `entries`. Called after writing
+/// the udev rule file and before udevadm trigger so already-attached devices
+/// are evicted without needing a reboot.
+/// Requires root; silently skips (debug log) on permission errors so non-root
+/// and staging-mode callers are unaffected.
+fn probeAndUnbindDrivers(allocator: std.mem.Allocator, entries: []const UdevEntry) void {
+    for (entries) |entry| {
+        for (entry.block_kernel_drivers) |driver| {
+            const driver_path = std.fmt.allocPrint(
+                allocator,
+                "/sys/bus/usb/drivers/{s}",
+                .{driver},
+            ) catch continue;
+            defer allocator.free(driver_path);
+
+            var driver_dir = std.fs.openDirAbsolute(driver_path, .{ .iterate = true }) catch continue;
+            defer driver_dir.close();
+
+            var it = driver_dir.iterate();
+            while (it.next() catch null) |de| {
+                // USB device symlinks look like "1-1.4:1.0" (interface notation).
+                if (de.kind != .sym_link and de.kind != .directory) continue;
+                if (de.name.len == 0 or de.name[0] < '0' or de.name[0] > '9') continue;
+
+                // Read idVendor and idProduct from the parent device node.
+                // Strip the interface suffix ":N.M" to get the device name.
+                const colon = std.mem.lastIndexOf(u8, de.name, ":") orelse continue;
+                const dev_name = de.name[0..colon];
+
+                const vendor_path = std.fmt.allocPrint(
+                    allocator,
+                    "/sys/bus/usb/devices/{s}/idVendor",
+                    .{dev_name},
+                ) catch continue;
+                defer allocator.free(vendor_path);
+
+                const product_path = std.fmt.allocPrint(
+                    allocator,
+                    "/sys/bus/usb/devices/{s}/idProduct",
+                    .{dev_name},
+                ) catch continue;
+                defer allocator.free(product_path);
+
+                const vid = readSysHex(vendor_path) catch continue;
+                const pid = readSysHex(product_path) catch continue;
+
+                if (vid != entry.vid or pid != entry.pid) continue;
+
+                const unbind_path = std.fmt.allocPrint(
+                    allocator,
+                    "/sys/bus/usb/drivers/{s}/unbind",
+                    .{driver},
+                ) catch continue;
+                defer allocator.free(unbind_path);
+
+                if (std.fs.openFileAbsolute(unbind_path, .{ .mode = .write_only })) |f| {
+                    defer f.close();
+                    f.writeAll(de.name) catch |err| {
+                        std.log.debug("unbind {s} from {s}: {}", .{ de.name, driver, err });
+                    };
+                } else |err| {
+                    std.log.debug("open unbind for {s}/{s}: {}", .{ driver, de.name, err });
+                }
+            }
+        }
+    }
+}
+
+fn readSysHex(path: []const u8) !u16 {
+    var f = try std.fs.openFileAbsolute(path, .{});
+    defer f.close();
+    var buf: [8]u8 = undefined;
+    const n = try f.read(&buf);
+    const trimmed = std.mem.trim(u8, buf[0..n], " \t\r\n");
+    return std.fmt.parseInt(u16, trimmed, 16);
 }
 
 fn generateUdevRules(allocator: std.mem.Allocator, devices_dir: []const u8, rules_path: []const u8, prefix: []const u8) !void {
@@ -3261,10 +3347,79 @@ test "install: generateDriverBlockRules produces unbind rules" {
     const content = try file.readToEndAlloc(allocator, 8192);
     defer allocator.free(content);
 
-    try testing.expect(std.mem.indexOf(u8, content, "ACTION==\"bind\"") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "ACTION==\"add|bind\"") != null);
     try testing.expect(std.mem.indexOf(u8, content, "DRIVER==\"xpad\"") != null);
     try testing.expect(std.mem.indexOf(u8, content, "37d7") != null);
     try testing.expect(std.mem.indexOf(u8, content, "unbind") != null);
+}
+
+test "install: generateDriverBlockRules uses add|bind action for udevadm trigger compatibility" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    const devices_dir = try std.fmt.allocPrint(allocator, "{s}/devices", .{tmp_path});
+    defer allocator.free(devices_dir);
+    try std.fs.makeDirAbsolute(devices_dir);
+
+    const toml_path = try std.fmt.allocPrint(allocator, "{s}/vader5.toml", .{devices_dir});
+    defer allocator.free(toml_path);
+    {
+        var file = try std.fs.createFileAbsolute(toml_path, .{});
+        defer file.close();
+        try file.writeAll(
+            \\[device]
+            \\name = "Vader 5 Pro"
+            \\vid = 0x0f0d
+            \\pid = 0x00c1
+            \\block_kernel_drivers = ["xpad", "hid_generic"]
+        );
+    }
+
+    const rules_path = try std.fmt.allocPrint(allocator, "{s}/61-padctl-driver-block.rules", .{tmp_path});
+    defer allocator.free(rules_path);
+    const dirs = [_][]const u8{devices_dir};
+    try generateDriverBlockRules(allocator, &dirs, rules_path);
+
+    var file = try std.fs.openFileAbsolute(rules_path, .{});
+    defer file.close();
+    const content = try file.readToEndAlloc(allocator, 8192);
+    defer allocator.free(content);
+
+    // add catches udevadm trigger (synthetic add); bind catches future plug-in.
+    // Neither ACTION=="bind" alone (misses trigger) nor ACTION=="add" alone
+    // (misses genuine bind) is correct.
+    try testing.expect(std.mem.indexOf(u8, content, "ACTION==\"add|bind\"") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "ACTION==\"bind\"") == null or
+        std.mem.indexOf(u8, content, "ACTION==\"add|bind\"") != null);
+    // Both drivers must appear.
+    try testing.expect(std.mem.indexOf(u8, content, "DRIVER==\"xpad\"") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "DRIVER==\"hid_generic\"") != null);
+}
+
+test "install: readSysHex parses 4-digit lowercase hex" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    const hex_path = try std.fmt.allocPrint(allocator, "{s}/idVendor", .{tmp_path});
+    defer allocator.free(hex_path);
+    {
+        var f = try std.fs.createFileAbsolute(hex_path, .{});
+        defer f.close();
+        try f.writeAll("37d7\n");
+    }
+
+    const val = try readSysHex(hex_path);
+    try testing.expectEqual(@as(u16, 0x37d7), val);
 }
 
 test "install: generateDriverBlockRules skips when no drivers configured" {


### PR DESCRIPTION
## Summary

- Walk `/sys/bus/usb/drivers/<driver>/` after writing `61-padctl-driver-block.rules` and write any matching VID:PID interface to `unbind`, evicting drivers that were already bound at install time
- Change the generated rule from `ACTION=="bind"` to `ACTION=="add|bind"` so that `udevadm trigger` (which fires synthetic `add` events, not `bind`) re-evaluates the rule for already-attached devices
- Promote the unbind error path from `log.debug` to `log.warn` with the driver name in the message, so SELinux denials on Bazzite/Fedora become visible at default log level

## Background

Issue #162 reports two symptoms on Bazzite: a redundant generic Xbox controller persists alongside the padctl Elite 2 output until reboot, and after a controller power-cycle `padctl status` still shows the device as connected with no input working until reboot. Root cause is the install-time udev rule used `ACTION=="bind"` and no proactive sysfs unbind was performed, so `udevadm trigger`'s synthetic `add` events did not retroactively unbind already-attached drivers. After the install fix lands, the hotplug AccessDenied retry loop (the second symptom) resolves as a side effect because xpad no longer holds the hidraw fd when the device re-attaches.

`probeAndUnbindDrivers` accepts a `sys_root` parameter (production passes `\"\"`, tests inject a `tmpDir` path) so the function is exercised under `zig build test` per project P9 (all I/O boundaries vtable).

## Test plan

- [x] Unit test `install: probeAndUnbindDrivers writes matching interface to unbind, skips non-matching` builds a fake `/sys` tree with one matching VID:PID device + one non-matching, asserts only the matching interface name reaches the unbind file
- [x] Unit test `install: generateDriverBlockRules uses add|bind action for udevadm trigger compatibility` covers the rule template change with a multi-driver TOML
- [x] Container test (Debian + Zig 0.15.2): 986/990 tests passed (4 UHID-only skipped)
- [x] Install-flow sandbox in rootless Docker: rule file generated at `/usr/local/lib/udev/rules.d/61-padctl-driver-block.rules` containing `ACTION=="add|bind", SUBSYSTEM=="usb", ATTRS{idVendor}=="37d7", ATTRS{idProduct}=="2401", DRIVER=="xpad", RUN+=...`. Uninstall removes the file (symmetry).
- [ ] Reporter @nextproblemreporter to install on Bazzite, plug in vader5, run `lsmod | grep xpad` and confirm xpad does not show as bound to the controller after install
- [ ] Reporter to power-cycle the controller and confirm `padctl status` updates correctly + input works without reboot