### PR TITLE
fix(mapper): separate macro/layer timerfds — macro delays no longer clobbered (issue #72)

### DIFF
--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -359,7 +359,7 @@ pub const DeviceInstance = struct {
             }
         }
         const mapper: ?Mapper = if (init_mapping) |mcfg|
-            Mapper.init(mcfg, loop.timer_fd, allocator) catch |err| blk: {
+            Mapper.init(mcfg, loop.macro_timer_fd, allocator) catch |err| blk: {
                 std.log.warn("failed to init mapper from default_mapping: {}", .{err});
                 break :blk null;
             }
@@ -433,7 +433,7 @@ pub const DeviceInstance = struct {
             // Apply pending mapping before processing any fds
             if (@atomicLoad(?*MappingConfig, &self.pending_mapping, .acquire)) |new| {
                 const old_mcfg: ?*const MappingConfig = if (self.mapper) |*m| m.config else self.mapping_cfg;
-                if (Mapper.init(new, self.loop.timer_fd, self.allocator)) |nm| {
+                if (Mapper.init(new, self.loop.macro_timer_fd, self.allocator)) |nm| {
                     if (self.mapper) |*m| m.deinit();
                     self.mapper = nm;
                     self.mapping_cfg = new;
@@ -699,7 +699,7 @@ test "DeviceInstance: updateMapping sets pending_mapping and wakes run()" {
         .devices = devices,
         .loop = loop,
         .interp = Interpreter.init(&parsed.value),
-        .mapper = try Mapper.init(&mapping_parsed.value, loop.timer_fd, allocator),
+        .mapper = try Mapper.init(&mapping_parsed.value, loop.macro_timer_fd, allocator),
         .owner = .none,
         .primary_output = null,
         .imu_output = null,
@@ -768,7 +768,7 @@ test "DeviceInstance: updateMapping updates mapping_cfg after swap" {
         .devices = devices,
         .loop = loop,
         .interp = Interpreter.init(&parsed.value),
-        .mapper = try Mapper.init(&mapping_parsed.value, loop.timer_fd, allocator),
+        .mapper = try Mapper.init(&mapping_parsed.value, loop.macro_timer_fd, allocator),
         .owner = .none,
         .primary_output = null,
         .imu_output = null,

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -28,8 +28,8 @@ const RumbleScheduler = rumble_scheduler_mod.RumbleScheduler;
 const rumble_log = std.log.scoped(.rumble);
 const padctl_log = @import("log.zig");
 
-// signalfd(0) + stop_pipe(1) + macro timerfd(2) + rumble_stop_fd(3) + per-interface fds + uinput FF fd
-pub const MAX_FDS = 11;
+// signalfd(0) + stop_pipe(1) + layer timerfd(2) + rumble_stop_fd(3) + macro timerfd(4) + per-interface fds + uinput FF fd
+pub const MAX_FDS = 12;
 
 const signalfd_siginfo_size = 128;
 
@@ -309,13 +309,17 @@ pub const EventLoop = struct {
     stop_w: posix.fd_t,
     // device fds start at slot 2 (after signalfd + stop_pipe)
     device_base: usize,
+    /// Dedicated timerfd for layer hold-trigger arm/disarm (slot 2).
+    /// Written by `timer_request` returned from `Mapper.apply()`.
     timer_fd: posix.fd_t,
-    /// Dedicated timerfd for userspace rumble auto-stop. Separate from
-    /// `timer_fd` (which is reserved for macro timing) to keep the two
-    /// concerns from stomping on each other's arm/disarm schedule.
+    /// Dedicated timerfd for userspace rumble auto-stop (slot 3).
     rumble_stop_fd: posix.fd_t,
     /// pollfds slot where `rumble_stop_fd` is registered.
     rumble_stop_slot: usize,
+    /// Dedicated timerfd for macro delay / TimerQueue (slot 4).
+    /// Passed to `Mapper.init` so `TimerQueue` arms only this fd, keeping
+    /// it independent from the layer-hold `timer_fd`.
+    macro_timer_fd: posix.fd_t,
     /// State machine that tracks per-effect deadlines and decides when
     /// to fire a stop frame. See src/core/rumble_scheduler.zig.
     rumble_scheduler: RumbleScheduler,
@@ -363,6 +367,9 @@ pub const EventLoop = struct {
         const rumble_stop_fd = try posix.timerfd_create(.MONOTONIC, .{ .CLOEXEC = true, .NONBLOCK = true });
         errdefer posix.close(rumble_stop_fd);
 
+        const macro_timer_fd = try posix.timerfd_create(.MONOTONIC, .{ .CLOEXEC = true, .NONBLOCK = true });
+        errdefer posix.close(macro_timer_fd);
+
         var loop = EventLoop{
             .pollfds = undefined,
             .fd_count = 0,
@@ -374,6 +381,7 @@ pub const EventLoop = struct {
             .rumble_stop_fd = rumble_stop_fd,
             .rumble_stop_slot = 3,
             .rumble_scheduler = .{},
+            .macro_timer_fd = macro_timer_fd,
             .uinput_ff_slot = null,
             .disconnected = false,
             .running = false,
@@ -382,14 +390,15 @@ pub const EventLoop = struct {
             .last_rumble_ns = 0,
         };
 
-        // slot 0 = signalfd, slot 1 = stop pipe, slot 2 = macro timerfd,
-        // slot 3 = rumble-stop timerfd
+        // slot 0 = signalfd, slot 1 = stop pipe, slot 2 = layer timerfd,
+        // slot 3 = rumble-stop timerfd, slot 4 = macro timerfd
         loop.pollfds[0] = .{ .fd = sig_fd, .events = posix.POLL.IN, .revents = 0 };
         loop.pollfds[1] = .{ .fd = stop_r, .events = posix.POLL.IN, .revents = 0 };
         loop.pollfds[2] = .{ .fd = timer_fd, .events = posix.POLL.IN, .revents = 0 };
         loop.pollfds[3] = .{ .fd = rumble_stop_fd, .events = posix.POLL.IN, .revents = 0 };
-        loop.fd_count = 4;
-        loop.device_base = 4;
+        loop.pollfds[4] = .{ .fd = macro_timer_fd, .events = posix.POLL.IN, .revents = 0 };
+        loop.fd_count = 5;
+        loop.device_base = 5;
 
         return loop;
     }
@@ -476,8 +485,8 @@ pub const EventLoop = struct {
                 break;
             }
 
-            // Mapper timerfd (slot 2) is drained after the device fd loop
-            // below — see issue #79.
+            // Layer timerfd (slot 2) is handled inline; macro timerfd (slot 4) is
+            // drained after the device fd loop below — see issue #79.
 
             // Check rumble auto-stop timerfd (slot 3).
             if (self.pollfds[3].revents & posix.POLL.IN != 0) {
@@ -701,13 +710,26 @@ pub const EventLoop = struct {
                 }
             }
 
-            // Mapper timerfd (slot 2): drained after device fds so an
+            // Layer timerfd (slot 2): drained after device fds so an
             // on-wakeup tap release reaches apply() before PENDING is
             // promoted to ACTIVE (issue #79). Both handlers share the
             // `now` snapshot taken right after ppoll.
             if (self.pollfds[2].revents & posix.POLL.IN != 0) {
                 var expiry: [8]u8 = undefined;
                 _ = posix.read(self.timer_fd, &expiry) catch {};
+                if (ctx.mapper) |m| {
+                    const aux = m.onTimerExpired(now);
+                    if (aux.len > 0) {
+                        if (ctx.aux_output) |ao| ao.emitAux(aux.slice()) catch {};
+                    }
+                }
+            }
+
+            // Macro timerfd (slot 4): separate fd so macro delays cannot be
+            // clobbered by layer-hold arm/disarm (issue #72).
+            if (self.pollfds[4].revents & posix.POLL.IN != 0) {
+                var expiry: [8]u8 = undefined;
+                _ = posix.read(self.macro_timer_fd, &expiry) catch {};
                 if (ctx.mapper) |m| {
                     const macro_aux = m.onTimerExpired(now);
                     if (macro_aux.len > 0) {
@@ -730,6 +752,7 @@ pub const EventLoop = struct {
         posix.close(self.stop_w);
         posix.close(self.timer_fd);
         posix.close(self.rumble_stop_fd);
+        posix.close(self.macro_timer_fd);
     }
 };
 
@@ -877,14 +900,14 @@ test "event_loop: EventLoop.addDevice rejects overflow" {
     defer loop.deinit();
 
     // Fill remaining slots (already have 4: signalfd + stop_pipe + macro
-    // timerfd + rumble-stop timerfd).
-    var mocks: [MAX_FDS - 4]MockDeviceIO = undefined;
-    for (0..MAX_FDS - 4) |i| {
+    // timerfd + rumble-stop timerfd + macro timerfd).
+    var mocks: [MAX_FDS - 5]MockDeviceIO = undefined;
+    for (0..MAX_FDS - 5) |i| {
         mocks[i] = try MockDeviceIO.init(allocator, &.{});
     }
-    defer for (0..MAX_FDS - 4) |i| mocks[i].deinit();
+    defer for (0..MAX_FDS - 5) |i| mocks[i].deinit();
 
-    for (0..MAX_FDS - 4) |i| {
+    for (0..MAX_FDS - 5) |i| {
         const dev = mocks[i].deviceIO();
         try loop.addDevice(dev);
     }
@@ -945,7 +968,7 @@ test "event_loop: EventLoop timerfd: mapper.onTimerExpired invoked on timer expi
     );
     defer mapper_empty.deinit();
 
-    var m = try mapper_mod.Mapper.init(&mapper_empty.value, loop.timer_fd, allocator);
+    var m = try mapper_mod.Mapper.init(&mapper_empty.value, loop.macro_timer_fd, allocator);
     defer m.deinit();
 
     // Put layer in PENDING so timer expiry advances it to ACTIVE

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -307,7 +307,7 @@ pub const EventLoop = struct {
     signal_fd: posix.fd_t,
     stop_r: posix.fd_t,
     stop_w: posix.fd_t,
-    // device fds start at slot 2 (after signalfd + stop_pipe)
+    // device fds start at slot 5 (after signalfd + stop_pipe + timer_fd + rumble_stop_fd + macro_timer_fd)
     device_base: usize,
     /// Dedicated timerfd for layer hold-trigger arm/disarm (slot 2).
     /// Written by `timer_request` returned from `Mapper.apply()`.
@@ -795,11 +795,12 @@ test "event_loop: EventLoop.addUinputFf registers fd and increments fd_count" {
     defer posix.close(pfds[1]);
 
     try loop.addUinputFf(pfds[0]);
-    // Fixed slots 0..3 are signalfd, stop_pipe, macro timerfd, rumble_stop_fd;
-    // the FF fd becomes slot 4, fd_count goes 4 → 5.
-    try testing.expectEqual(@as(usize, 5), loop.fd_count);
-    try testing.expectEqual(@as(?usize, 4), loop.uinput_ff_slot);
-    try testing.expectEqual(pfds[0], loop.pollfds[4].fd);
+    // Fixed slots 0..4 are signalfd, stop_pipe, layer timer_fd,
+    // rumble_stop_fd, macro_timer_fd; the FF fd becomes slot 5,
+    // fd_count goes 5 → 6.
+    try testing.expectEqual(@as(usize, 6), loop.fd_count);
+    try testing.expectEqual(@as(?usize, 5), loop.uinput_ff_slot);
+    try testing.expectEqual(pfds[0], loop.pollfds[5].fd);
 }
 
 test "event_loop: EventLoop: Disconnected device causes loop to exit without panic" {
@@ -864,9 +865,10 @@ test "event_loop: EventLoop.initManaged creates eventfd and timerfds" {
     try testing.expect(loop.signal_fd >= 0);
     try testing.expect(loop.timer_fd >= 0);
     try testing.expect(loop.rumble_stop_fd >= 0);
-    // slot 0 = eventfd, slot 1 = stop_pipe, slot 2 = macro timerfd,
-    // slot 3 = rumble-stop timerfd
-    try testing.expectEqual(@as(usize, 4), loop.fd_count);
+    // slot 0 = eventfd, slot 1 = stop_pipe, slot 2 = layer timer_fd,
+    // slot 3 = rumble-stop timerfd, slot 4 = macro timerfd
+    try testing.expect(loop.macro_timer_fd >= 0);
+    try testing.expectEqual(@as(usize, 5), loop.fd_count);
 }
 
 test "event_loop: EventLoop.stop wakes ppoll" {
@@ -888,10 +890,11 @@ test "event_loop: EventLoop.addDevice registers fd" {
     const dev = mock.deviceIO();
 
     try loop.addDevice(dev);
-    // Fixed slots: 0=signalfd, 1=stop_pipe, 2=macro timerfd, 3=rumble_stop_fd.
-    // First device lands at slot 4, fd_count goes from 4 → 5.
-    try testing.expectEqual(@as(usize, 5), loop.fd_count);
-    try testing.expectEqual(mock.pipe_r, loop.pollfds[4].fd);
+    // Fixed slots: 0=signalfd, 1=stop_pipe, 2=layer timer_fd,
+    // 3=rumble_stop_fd, 4=macro timerfd. First device lands at slot 5,
+    // fd_count goes 5 → 6.
+    try testing.expectEqual(@as(usize, 6), loop.fd_count);
+    try testing.expectEqual(mock.pipe_r, loop.pollfds[5].fd);
 }
 
 test "event_loop: EventLoop.addDevice rejects overflow" {
@@ -899,8 +902,8 @@ test "event_loop: EventLoop.addDevice rejects overflow" {
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
 
-    // Fill remaining slots (already have 4: signalfd + stop_pipe + macro
-    // timerfd + rumble-stop timerfd + macro timerfd).
+    // Fill remaining slots (already have 5: signalfd + stop_pipe +
+    // layer timer_fd + rumble-stop timerfd + macro timerfd).
     var mocks: [MAX_FDS - 5]MockDeviceIO = undefined;
     for (0..MAX_FDS - 5) |i| {
         mocks[i] = try MockDeviceIO.init(allocator, &.{});

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -885,7 +885,7 @@ pub const Supervisor = struct {
 
                 // Rebuild the mapper so layer state/timers do not keep slices into
                 // the old mapping arena after the reset above.
-                var new_mapper = try Mapper.init(map_copy, m.instance.loop.timer_fd, self.allocator);
+                var new_mapper = try Mapper.init(map_copy, m.instance.loop.macro_timer_fd, self.allocator);
                 m.instance.mapper = new_mapper;
                 m.instance.mapping_cfg = map_copy;
                 m.instance.rebuildAuxIfChanged(map_copy, old_mapping_cfg) catch |err| {
@@ -1159,7 +1159,7 @@ pub const Supervisor = struct {
     }
 
     fn applySwitchMapping(self: *Supervisor, m: *ManagedInstance, parsed_ptr: *mapping_cfg.ParseResult) !void {
-        const new_mapper = try Mapper.init(&parsed_ptr.value, m.instance.loop.timer_fd, self.allocator);
+        const new_mapper = try Mapper.init(&parsed_ptr.value, m.instance.loop.macro_timer_fd, self.allocator);
         m.instance.stop();
         m.thread.join();
         self.clearSwitchMapping(m);
@@ -1261,7 +1261,7 @@ pub const Supervisor = struct {
                 return;
             };
             parsed_ptr.* = parsed;
-            const new_mapper = Mapper.init(&parsed_ptr.value, m.instance.loop.timer_fd, self.allocator) catch {
+            const new_mapper = Mapper.init(&parsed_ptr.value, m.instance.loop.macro_timer_fd, self.allocator) catch {
                 parsed_ptr.deinit();
                 self.allocator.destroy(parsed_ptr);
                 cs.sendResponse(fd, "ERR switch-failed\n");
@@ -2455,7 +2455,7 @@ test "supervisor: Supervisor: reload null mapping clears existing mapper" {
 
     const inst = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
     inst.mapping_cfg = &parsed_map.value;
-    inst.mapper = try mapper_mod.Mapper.init(&parsed_map.value, inst.loop.timer_fd, allocator);
+    inst.mapper = try mapper_mod.Mapper.init(&parsed_map.value, inst.loop.macro_timer_fd, allocator);
     try sup.spawnInstance("usb-1-1", inst, null);
     defer {
         sup.stopAll();
@@ -2491,7 +2491,7 @@ test "supervisor: reload with malformed TOML keeps old mapping active" {
 
     const inst = try makeTestInstance(allocator, &mock, &parsed_dev.value);
     inst.mapping_cfg = &parsed_map.value;
-    inst.mapper = try mapper_mod.Mapper.init(&parsed_map.value, inst.loop.timer_fd, allocator);
+    inst.mapper = try mapper_mod.Mapper.init(&parsed_map.value, inst.loop.macro_timer_fd, allocator);
     try sup.spawnInstance("usb-1-1", inst, null);
     defer {
         sup.stopAll();

--- a/src/test/bugfix_regression_test.zig
+++ b/src/test/bugfix_regression_test.zig
@@ -1,8 +1,11 @@
 const std = @import("std");
 const testing = std.testing;
+const posix = std.posix;
 const render = @import("../debug/render.zig");
 const hidraw = @import("../io/hidraw.zig");
 const Supervisor = @import("../supervisor.zig").Supervisor;
+const EventLoop = @import("../event_loop.zig").EventLoop;
+const armTimer = @import("../event_loop.zig").armTimer;
 
 // -- Test 1: renderFrame with empty raw slice --
 
@@ -100,4 +103,28 @@ test "walker: finds toml files in subdirectories" {
 
     // iterate() would find only top.toml (1); walk() finds all 3
     try testing.expectEqual(@as(usize, 3), toml_count);
+}
+
+// -- Test 6 (issue #72): macro timer and layer hold timer are independent fds --
+// Regression: both MacroPlayer delay and layer hold-trigger used the same timerfd.
+// A layer-hold arm/disarm after apply() would silently overwrite the macro delay,
+// causing { delay = N } steps to never fire and subsequent macro steps to be skipped.
+// Fix: EventLoop.macro_timer_fd is a dedicated timerfd for TimerQueue; timer_fd is
+// layer-hold only.  The two fds never share a timerfd_settime call path.
+
+test "issue #72: macro_timer_fd and timer_fd are independent — layer arm does not clobber macro delay" {
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    // Arm the macro timer for 30ms.
+    armTimer(loop.macro_timer_fd, 30);
+
+    // Immediately overwrite the layer timer (simulating timer_request.arm from apply()).
+    // Before the fix both pointed at the same fd, so this would kill the macro timer.
+    armTimer(loop.timer_fd, 5000);
+
+    // Macro timer must still fire within 200ms despite the layer arm above.
+    var pfd = [1]posix.pollfd{.{ .fd = loop.macro_timer_fd, .events = posix.POLL.IN, .revents = 0 }};
+    const ready = try posix.poll(&pfd, 200);
+    try testing.expectEqual(@as(usize, 1), ready);
 }


### PR DESCRIPTION
## Summary

- New `macro_timer_fd` (slot 4) dedicated to `TimerQueue` (macro delays, aux scheduling)
- `timer_fd` (slot 2) now exclusively serves layer hold-trigger
- Pre-fix root cause: both mechanisms wrote to the same `timer_fd`; the later `armTimer`/`disarmTimer` after `apply()` returned silently overwrote the macro-delay `timerfd_settime` call from `MacroPlayer.step` `.delay` arm
- `MAX_FDS` 11 → 12; `device_base` 4 → 5; ppoll dispatch gains a separate slot-4 branch for macro_timer_fd

## Test plan

- [x] Regression test in `bugfix_regression_test.zig`: arm macro_timer_fd 30ms, then arm timer_fd 5000ms (the failure pattern), assert macro_timer_fd still fires within 200ms
- [x] 3 pre-existing event_loop tests updated for new slot layout (fd_count 4/5→5/6, pollfds[4]→pollfds[5])
- [x] Full `zig build test` 16/16 build steps + 8/8 tests pass (5 skipped)
- [ ] CI matrix to verify

## References

- issue #72 (reporter @xl666 macro `{delay = N}` not delaying)
- `src/event_loop.zig`, `src/core/mapper.zig`, `src/test/bugfix_regression_test.zig`