### PR TITLE
docs(install): document glibc 2.43+ R_X86_64_PC64 build failure (issue #147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ zig build check-all    # all checks (test + safe + fmt)
 
 **GCC 15 — `R_X86_64_PC64 in .sframe` linker error (issue #147)**
 
-Arch Linux, Artix, and other cutting-edge distros ship GCC 15.x, which emits `.sframe` sections in `crt1.o` and related startup objects. Zig 0.15.x's linker does not yet handle the `R_X86_64_PC64` relocation type used there, producing:
+**glibc 2.43+** (shipped on Arch, Artix, and similar bleeding-edge distros) adds `.sframe` sections to `crt1.o` and related startup objects. Zig 0.15.x's linker does not yet handle the `R_X86_64_PC64` relocation type used there, producing:
 
 ```
 error: relocation R_X86_64_PC64 in .sframe section is unsupported
@@ -178,8 +178,8 @@ error: relocation R_X86_64_PC64 in .sframe section is unsupported
 This is an upstream Zig limitation, not a padctl bug. Workarounds:
 
 1. **Use the Debian bookworm Docker container (recommended)** — `Dockerfile.wave5` in the repo root builds with Zig 0.15.2 from the official tarball against Debian's GCC 12, which is the supported CI build environment.
-2. **Install Zig 0.15.2 from the official tarball** (`https://ziglang.org/download/`) on a system with GCC ≤ 14 (Debian 12 / Ubuntu 22.04 or 24.04 work fine).
-3. Track upstream fix progress at [ziglang/zig#22453](https://github.com/ziglang/zig/issues/22453).
+2. **Install Zig 0.15.2 from the official tarball** (`https://ziglang.org/download/`) on a system with **glibc ≤ 2.41** (Debian 12 = glibc 2.36, Ubuntu 22.04 = glibc 2.35, Ubuntu 24.04 = glibc 2.39 all work; Arch with glibc 2.43+ does NOT).
+3. Track upstream fix progress at [ziglang/zig#31272](https://codeberg.org/ziglang/zig/issues/31272).
 
 ## Bazzite / Immutable Distros
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ zig build check-all    # all checks (test + safe + fmt)
 | `-Dlibusb=false` | `true` | Disable libusb linkage (hidraw-only) |
 | `-Dwasm=false` | `true` | Disable WASM plugin runtime |
 
+### Known build issues
+
+**GCC 15 — `R_X86_64_PC64 in .sframe` linker error (issue #147)**
+
+Arch Linux, Artix, and other cutting-edge distros ship GCC 15.x, which emits `.sframe` sections in `crt1.o` and related startup objects. Zig 0.15.x's linker does not yet handle the `R_X86_64_PC64` relocation type used there, producing:
+
+```
+error: relocation R_X86_64_PC64 in .sframe section is unsupported
+```
+
+This is an upstream Zig limitation, not a padctl bug. Workarounds:
+
+1. **Use the Debian bookworm Docker container (recommended)** — `Dockerfile.wave5` in the repo root builds with Zig 0.15.2 from the official tarball against Debian's GCC 12, which is the supported CI build environment.
+2. **Install Zig 0.15.2 from the official tarball** (`https://ziglang.org/download/`) on a system with GCC ≤ 14 (Debian 12 / Ubuntu 22.04 or 24.04 work fine).
+3. Track upstream fix progress at [ziglang/zig#22453](https://github.com/ziglang/zig/issues/22453).
+
 ## Bazzite / Immutable Distros
 
 On immutable distributions (Bazzite, Fedora Atomic, etc.) where `/usr` is read-only, use the bootstrap script for a complete one-command setup:

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -37,6 +37,12 @@ Optional build flags:
 - `-Dlibusb=false` — disable libusb linkage (uses hidraw-only path)
 - `-Dwasm=false` — disable WASM plugin runtime
 
+> **GCC 15 build failure (issue #147):** Arch Linux and other distros with GCC 15.x may hit
+> `error: relocation R_X86_64_PC64 in .sframe section is unsupported`. This is an upstream Zig
+> limitation, not a padctl bug. Use `Dockerfile.wave5` (Debian bookworm + Zig 0.15.2 tarball) or
+> install Zig 0.15.2 from the [official tarball](https://ziglang.org/download/) on a system with
+> GCC ≤ 14. Upstream fix: [ziglang/zig#22453](https://github.com/ziglang/zig/issues/22453).
+
 ## Install
 
 ```sh

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -37,11 +37,14 @@ Optional build flags:
 - `-Dlibusb=false` — disable libusb linkage (uses hidraw-only path)
 - `-Dwasm=false` — disable WASM plugin runtime
 
-> **GCC 15 build failure (issue #147):** Arch Linux and other distros with GCC 15.x may hit
-> `error: relocation R_X86_64_PC64 in .sframe section is unsupported`. This is an upstream Zig
-> limitation, not a padctl bug. Use `Dockerfile.wave5` (Debian bookworm + Zig 0.15.2 tarball) or
-> install Zig 0.15.2 from the [official tarball](https://ziglang.org/download/) on a system with
-> GCC ≤ 14. Upstream fix: [ziglang/zig#22453](https://github.com/ziglang/zig/issues/22453).
+> **GCC 15 build failure (issue #147):** Arch Linux and similar distros with **glibc 2.43+** may
+> hit `error: relocation R_X86_64_PC64 in .sframe section is unsupported` — glibc 2.43 adds
+> `.sframe` sections to `crt1.o` startup objects, which Zig 0.15.x's linker does not yet handle.
+> This is an upstream Zig limitation, not a padctl bug. Use `Dockerfile.wave5` (Debian bookworm +
+> Zig 0.15.2 tarball, glibc 2.36) or install Zig 0.15.2 from the
+> [official tarball](https://ziglang.org/download/) on a system with glibc ≤ 2.41 (Debian 12,
+> Ubuntu 22.04/24.04 all work; Arch with glibc 2.43+ does NOT).
+> Upstream fix: [ziglang/zig#31272](https://codeberg.org/ziglang/zig/issues/31272).
 
 ## Install
 


### PR DESCRIPTION
## Summary

- Adds "Known build issues" section to `README.md` documenting the upstream Zig + glibc 2.43+ `.sframe` linker issue (`R_X86_64_PC64 in .sframe section is unsupported`)
- Compact note in `docs/src/getting-started.md` mirrors the workarounds
- Correct attribution: `.sframe` sections come from **glibc 2.43+** in `crt1.o` (NOT GCC 15 — they co-vary on Arch but are independent; Dockerfile.wave5 already states this correctly)
- Workarounds: Dockerfile.wave5 (Debian bookworm + Zig tarball), or system with glibc ≤ 2.41 (Debian 12 / Ubuntu 22.04 / Ubuntu 24.04)
- Upstream tracker: ziglang/zig issue #31272 (Codeberg mirror — SFrame relocation coverage)

## Test plan

- [x] Doc-only — error string `R_X86_64_PC64` and `.sframe` appear verbatim for Ctrl-F discoverability
- [x] Issue #147 cross-referenced explicitly
- [ ] N/A — no code changes

## References

- issue #147 (reporter @Tenyun on Arch + GCC 15.2.1 + glibc 2.43+)
- `README.md`, `docs/src/getting-started.md`