### PR TITLE
docs: README + docs/src cleanup (audit-2604)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ yay -S padctl-git   # build from source
 ### Debian / Ubuntu
 
 ```sh
-curl -fLO https://github.com/BANANASJIM/padctl/releases/latest/download/padctl_0.1.0_amd64.deb
-sudo dpkg -i padctl_0.1.0_amd64.deb
+curl -fLO https://github.com/BANANASJIM/padctl/releases/download/v0.1.2/padctl_0.1.2_amd64.deb
+sudo dpkg -i padctl_0.1.2_amd64.deb
 ```
 
 For arm64, replace `amd64` with `arm64`.

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -10,6 +10,7 @@ Device configs are TOML files in `devices/<vendor>/<model>.toml`.
 | `vid` | integer | yes | USB vendor ID (hex literal ok: `0x054c`) |
 | `pid` | integer | yes | USB product ID |
 | `mode` | string | no | Device mode identifier |
+| `block_kernel_drivers` | string[] | no | Kernel driver names to unbind via udev at install time, e.g. `block_kernel_drivers = ["xpad"]`. When `padctl install` runs as root, it also walks `/sys/bus/usb/drivers/<driver>/unbind` for matching VID:PID pairs immediately. |
 
 ### `[[device.interface]]`
 

--- a/docs/src/diagnostic-logging.md
+++ b/docs/src/diagnostic-logging.md
@@ -62,6 +62,8 @@ max_log_size_mb = 100 # rotation threshold (default 100 MB)
 
 `padctl dump enable` and `padctl dump disable` are just a convenience front-end for toggling `dump` and forwarding the change to the running daemon — you can also edit this section by hand and send `SIGHUP` (`padctl reload`) instead.
 
+<a id="schema-rewrite"></a>
+
 > ⚠️ **Rewrite behavior.** `padctl dump enable/disable` parses `config.toml`, rewrites it from the known schema, and atomically renames the result into place. Anything outside the documented schema — unknown sections, undocumented keys, hand-written comments — is **not preserved**. If you hand-edit `config.toml` with content that matters (e.g. a forward-looking `[experimental]` block, inline comments documenting a choice), keep it in a sibling file, or drive padctl via `SIGHUP` after the edit instead of using the `dump` subcommand. The current known schema is `version`, `[diagnostics]` (`dump`, `max_log_size_mb`), and `[[device]]` entries (`name`, `default_mapping`).
 
 ## Rotation

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -13,8 +13,8 @@ A prebuilt binary package (`padctl-bin`) is also available in the AUR.
 ### Debian / Ubuntu
 
 ```sh
-curl -fLO https://github.com/BANANASJIM/padctl/releases/latest/download/padctl_0.1.0_amd64.deb
-sudo dpkg -i padctl_0.1.0_amd64.deb
+curl -fLO https://github.com/BANANASJIM/padctl/releases/download/v0.1.2/padctl_0.1.2_amd64.deb
+sudo dpkg -i padctl_0.1.2_amd64.deb
 ```
 
 ## Prerequisites
@@ -65,7 +65,7 @@ sudo ./zig-out/bin/padctl install --prefix /usr --destdir "$DESTDIR"
 `padctl install` also sets up the following on all systems:
 
 - **`padctl-reconnect`** — A hotplug script triggered by udev when a controller is plugged in. It starts the daemon if not running, restarts it if failed, and re-applies the active mapping. After suspend/resume the kernel re-emits udev events for re-enumerated devices, so the same hook handles post-wake reconnect — no separate resume unit is needed.
-- **Driver conflict rules** — Auto-generated udev rules that unbind conflicting kernel drivers (e.g., `xpad`) from devices that padctl manages. Configured per-device via `block_kernel_drivers` in device TOML configs.
+- **Driver conflict rules** — Auto-generated udev rules that unbind conflicting kernel drivers (e.g., `xpad`) from devices that padctl manages. Configured per-device via `block_kernel_drivers` in device TOML configs. When run as root, `padctl install` also walks `/sys/bus/usb/drivers/<driver>/unbind` for matching VID:PID pairs immediately, so already-bound devices are evicted without waiting for replug (issue #162).
 
 ### Install a Mapping
 
@@ -96,11 +96,13 @@ If you built from source, run the installer first — `zig build` alone does **n
 ```sh
 zig build
 sudo ./zig-out/bin/padctl install    # installs binary, service, device configs, and udev rules
-sudo systemctl enable --now padctl
+systemctl --user enable --now padctl.service
 ```
 
+To auto-start at boot without an active login session (headless setups, Steam Deck game mode):
+
 ```sh
-systemctl --user enable --now padctl.service
+sudo loginctl enable-linger $USER
 ```
 
 The service runs padctl in daemon mode, scanning all config directories (user, system, and builtin) with automatic hotplug support. udev rules grant access via `uaccess` — no `sudo` needed for the logged-in user.
@@ -160,12 +162,12 @@ default_mapping = "fps"
 
 On daemon start, padctl matches the connected device name (case-insensitive) and loads the named mapping profile automatically. The system path is the fallback for environments where `HOME` is not set (e.g. systemd services).
 
-`padctl switch <name>` automatically updates the user config, so the choice is remembered for bare `padctl switch` (re-apply without a name). To make the choice survive reboots, use `padctl switch <name> --persist` which copies the mapping and config to `/etc/padctl/` via sudo.
+`padctl switch <name>` automatically updates the user config, so the choice is remembered for bare `padctl switch` (re-apply without a name). Bare `padctl switch` (no argument) reads `default_mapping` from the connected device's entry in `config.toml`; if no entry exists, it prints `error: no default_mapping in config.toml for device "<name>"` and exits. To make the choice survive reboots, use `padctl switch <name> --persist` which copies the mapping and config to `/etc/padctl/` via sudo.
 
 ## CLI Reference
 
 ```sh
-padctl switch [name] [--device <id>]       # switch mapping (omit name to re-apply from user config)
+padctl switch [name] [--device <id>]       # switch mapping; omit name to fall back to default_mapping from config.toml
 padctl switch <name> --persist             # switch + copy to /etc/padctl/ for reboot persistence (sudo)
 padctl status [--socket <path>]            # show daemon status
 padctl devices [--socket <path>]           # list connected devices

--- a/docs/src/immutable-install.md
+++ b/docs/src/immutable-install.md
@@ -24,7 +24,7 @@ What the script does:
 1. **Detects** immutable OS (checks for ostree or read-only `/usr`)
 2. **Installs dependencies** via Homebrew (Zig compiler, libusb) — no system reboot needed
 3. **Clones and builds** padctl from source with `ReleaseSafe` optimization
-4. **Installs** the daemon, systemd services, udev rules, and reconnect scripts
+4. **Installs** the daemon, systemd service, udev rules, and reconnect scripts
 5. **Persists** the selected mapping as a device binding in `/etc/padctl/config.toml` (auto-applies on every boot)
 6. **Applies** the mapping to the current session
 7. **Verifies** the installation
@@ -55,9 +55,10 @@ The `padctl install --immutable` flag changes where system files are placed:
 | Binaries | `/usr/bin/` | `/usr/local/bin/` |
 | Service file | `/usr/lib/systemd/system/` | `/etc/systemd/system/` |
 | Service drop-in | *(not created)* | `/etc/systemd/system/padctl.service.d/immutable.conf` |
-| Resume service | `/usr/lib/systemd/system/` | `/etc/systemd/system/` |
 | udev rules | `/usr/lib/udev/rules.d/` | `/etc/udev/rules.d/` |
 | Device configs | `/usr/share/padctl/devices/` | `/usr/local/share/padctl/devices/` |
+
+> `padctl-resume.service` was removed (issue #131-B); udev hotplug handles post-suspend reconnect.
 
 Files in `/etc/` persist across system updates on immutable distros.
 

--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -12,7 +12,18 @@ trigger_threshold = 100
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `name` | string | — | Mapping profile name. Used by `padctl switch <name>` and `default_mapping` in user config to identify this profile. |
-| `trigger_threshold` | integer (0–255) | null | Threshold for synthesizing digital `LT` / `RT` button events from the analog trigger axes. See below. |
+| `trigger_threshold` | integer (0–255) | null | Threshold for synthesizing digital `LT` / `RT` button events from the analog trigger axes. **Top-level only** — placing this inside `[[layer]]` is silently ignored. See below. |
+
+## Validation behaviour
+
+`padctl daemon` runs a post-parse linter on every mapping TOML file at startup. Unknown keys produce warnings to stderr with line numbers and section context:
+
+```
+config: unknown key 'trigger_threshold' inside [layer] (line 42) — typo or misplaced field?
+config: unknown key 'typo_field' at top-level (line 7) — typo or misplaced field?
+```
+
+The linter is fail-open: warnings only, the daemon still starts. This surfaces common mistakes such as placing `trigger_threshold` inside a `[[layer]]` block instead of at the top level (also surfaces preceding silent rewrites — see [Diagnostic logging](diagnostic-logging.md#schema-rewrite)).
 
 <a id="trigger_threshold"></a>
 ### trigger_threshold — analog triggers as digital buttons

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -46,8 +46,10 @@ padctl switch fps
 Every switch automatically saves your choice to `~/.config/padctl/config.toml`, so you can restore it later with a bare switch:
 
 ```sh
-padctl switch          # re-applies the last-switched mapping from user config
+padctl switch          # re-applies default_mapping from config.toml for the connected device
 ```
+
+Bare `padctl switch` queries the running daemon for the connected device name, then looks up `default_mapping` in `config.toml` (user path first, then `/etc/padctl/config.toml`). If no entry is found it exits with `error: no default_mapping in config.toml for device "<name>"`.
 
 ### Persist across reboots (`--persist`)
 
@@ -280,6 +282,11 @@ Bind in remap: `M1 = "macro:dodge_roll"`
 
 ### Trigger Threshold — analog LT / RT as digital buttons {#trigger-threshold}
 
+> **Warning:** `trigger_threshold` must be at the top level of the mapping file.
+> Placing it inside `[[layer]]` is silently ignored.
+> To use `LT` / `RT` as remap source keys or layer triggers, set this field once
+> at the top of your mapping file, outside any layer block.
+
 LT / RT are analog axes by default and cannot be used directly as `[remap]` source keys. Once `trigger_threshold` is declared, padctl synthesizes digital button events from the axis values each frame, making them available for `[remap]` and layer triggers:
 
 ```toml
@@ -313,7 +320,7 @@ Configures the resistance profile of the DualSense L2/R2 triggers. See [Mapping 
 
 ## Full Example
 
-See [`config/example-mapping.toml`](https://github.com/BANANASJIM/padctl/blob/main/config/example-mapping.toml) in the repository for a complete working config covering base remaps, two layers (hold + toggle), and macros.
+A copy-paste-ready example covering every major feature is included in the repository at [`examples/mappings/comprehensive.toml`](https://github.com/BANANASJIM/padctl/blob/main/examples/mappings/comprehensive.toml). It covers base remaps, two layers (hold + toggle), macros, stick modes, and gyro.
 
 ## Reference
 

--- a/examples/mappings/comprehensive.toml
+++ b/examples/mappings/comprehensive.toml
@@ -1,0 +1,107 @@
+# comprehensive.toml — padctl mapping reference example
+#
+# Copy this file to ~/.config/padctl/mappings/my-mapping.toml and adapt it.
+# Every major feature is shown here with a one-line explanation.
+# Remove or comment out any section your device does not need.
+#
+# Button names: A B X Y  LB RB LT RT  Start Select  LS RS  M1 M2 M3 M4  LM RM  C Z
+
+name = "comprehensive-example"
+
+# REQUIRED to use LT / RT as [remap] source keys or layer triggers.
+# LT and RT are analog axes by default; this threshold synthesizes digital
+# button events so they behave like face buttons in remap and layer rules.
+# Placing trigger_threshold inside [[layer]] is silently ignored —
+# it MUST appear at the top level of the mapping file (here).
+trigger_threshold = 128   # 0–255; axis value above this → button press
+
+# --- Top-level remapping (always active, no layer needed) ---
+
+[remap]
+Select  = "Start"           # swap Select and Start
+Y       = "KEY_F1"          # face button → keyboard key
+RB      = "mouse_left"      # shoulder button → mouse left click
+LT      = "KEY_LEFTSHIFT"   # trigger → Shift (needs trigger_threshold above)
+M1      = "macro:dodge_roll" # back paddle → named macro
+
+# --- Stick configuration ---
+
+[stick.left]
+mode      = "gamepad"   # "gamepad" | "mouse" | "scroll"
+deadzone  = 128
+sensitivity = 1.0
+
+[stick.right]
+mode             = "gamepad"
+deadzone         = 100
+sensitivity      = 1.5
+suppress_gamepad = true   # suppress raw axis when mode is mouse/scroll
+
+# --- Gyroscope (off by default) ---
+
+[gyro]
+mode = "off"   # set to "mouse" to enable gyro-to-mouse
+
+# --- Macros (referenced by "macro:<name>" in remap values) ---
+
+[[macro]]
+name  = "dodge_roll"
+steps = [
+    { tap   = "B"  },       # tap B (dodge)
+    { delay = 50   },       # wait 50 ms
+    { tap   = "A"  },       # tap A (roll)
+]
+
+[[macro]]
+name  = "shift_click"
+steps = [
+    { down = "KEY_LEFTSHIFT" },
+    "pause_for_release",      # hold until trigger button is released
+    { up   = "KEY_LEFTSHIFT" },
+]
+
+# --- Layer 1: hold LM to enable gyro + mouse aim (hold activation) ---
+#
+# While LM is held, the overrides below replace the base remap/stick/gyro.
+# A short press (< hold_timeout ms) fires `tap` instead of activating the layer.
+
+[[layer]]
+name         = "aim"
+trigger      = "LM"
+activation   = "hold"
+hold_timeout = 200        # ms; short press fires the tap action
+tap          = "mouse_side"
+
+[layer.remap]
+RB = "mouse_left"
+RT = "mouse_right"        # RT works here because trigger_threshold is set above
+
+[layer.gyro]
+mode        = "mouse"
+sensitivity = 2.0
+deadzone    = 300
+smoothing   = 0.3
+invert_y    = true
+
+[layer.stick_right]
+mode             = "mouse"
+sensitivity      = 1.0
+suppress_gamepad = true
+
+[layer.stick_left]
+mode = "scroll"
+
+# --- Layer 2: toggle fn-key row on Select (toggle activation) ---
+#
+# Press Select once to enter; press Select again to exit.
+
+[[layer]]
+name       = "fn"
+trigger    = "Select"
+activation = "toggle"
+
+[layer.remap]
+A = "KEY_F1"
+B = "KEY_F2"
+X = "KEY_F3"
+Y = "KEY_F4"


### PR DESCRIPTION
## Summary

Consolidates code-vs-docs drift identified by the 2026-04-26 audit:

- Replaces legacy `sudo systemctl enable --now padctl` flow with the canonical user-service flow (`getting-started.md`).
- Removes the obsolete `padctl-resume.service` row from `immutable-install.md` (PR #133 deleted the unit).
- Fixes the broken `padctl_0.1.0_amd64.deb` download link (HTTP 404; v0.1.2 `.deb` confirmed present in release assets).
- Documents the post-parse schema linter introduced in PR #170 (`mapping-config.md`).
- Documents the `padctl switch` no-arg `default_mapping` fallback introduced in PR #172.
- Documents the proactive xpad sysfs unbind introduced in PR #165.
- Adds `block_kernel_drivers` to the `device-config.md` field table.
- Publishes `examples/mappings/comprehensive.toml` from a local-only branch.

## Test plan

- [ ] mdbook builds without errors (no broken cross-references)
- [ ] `padctl_0.1.0_amd64.deb` URL no longer present
- [ ] `padctl-resume` no longer appears in `immutable-install.md` table
- [ ] `block_kernel_drivers` row visible in `device-config.md`