### PR TITLE
fix(mapper): split timer expiry handlers — macro fd must not promote PENDING layer

### DIFF
--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -378,14 +378,23 @@ pub const Mapper = struct {
         return .{ .gamepad = emit_state, .prev = masked_prev, .aux = aux, .timer_request = timer_request };
     }
 
-    // `now_ns` is the same ppoll-wakeup snapshot passed to apply().
-    pub fn onTimerExpired(self: *Mapper, now_ns: i128) AuxEventList {
+    // Layer-hold timerfd (slot 2) expiry: promote PENDING -> ACTIVE only.
+    // Must NOT drain the macro timer_queue — a macro fd expiry on slot 4
+    // arriving in the same wakeup is handled by onMacroTimerExpired().
+    pub fn onLayerTimerExpired(self: *Mapper) AuxEventList {
         const th_res = self.layer.onTimerExpired();
         if (th_res.layer_activated) {
             self.prev.dpad_x = 0;
             self.prev.dpad_y = 0;
         }
+        return AuxEventList{};
+    }
 
+    // Macro timerfd (slot 4) expiry: drain TimerQueue and step active macros.
+    // Must NOT call layer.onTimerExpired() — a macro `delay` shorter than the
+    // layer hold_timeout would otherwise prematurely promote a PENDING layer.
+    // `now_ns` is the same ppoll-wakeup CLOCK_MONOTONIC snapshot passed to apply().
+    pub fn onMacroTimerExpired(self: *Mapper, now_ns: i128) AuxEventList {
         var aux = AuxEventList{};
         var macro_tap_release: u64 = 0;
         var buf: [16]timer_queue_mod.Deadline = undefined;
@@ -419,6 +428,14 @@ pub const Mapper = struct {
             self.pending_tap_release = existing | macro_tap_release;
         }
         return aux;
+    }
+
+    // DEPRECATED: split per slot. Retained for tests / external callers that
+    // want both halves; production event_loop dispatches each half from its
+    // own pollfd slot. `now_ns` is the ppoll-wakeup snapshot.
+    pub fn onTimerExpired(self: *Mapper, now_ns: i128) AuxEventList {
+        _ = self.onLayerTimerExpired();
+        return self.onMacroTimerExpired(now_ns);
     }
 
     fn findMacro(self: *const Mapper, name: []const u8) ?*const mapping.Macro {

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -712,13 +712,14 @@ pub const EventLoop = struct {
 
             // Layer timerfd (slot 2): drained after device fds so an
             // on-wakeup tap release reaches apply() before PENDING is
-            // promoted to ACTIVE (issue #79). Both handlers share the
-            // `now` snapshot taken right after ppoll.
+            // promoted to ACTIVE (issue #79). Routes to the layer-only
+            // expiry handler so a concurrent macro fd expiry on slot 4
+            // does not cause the layer half to run twice.
             if (self.pollfds[2].revents & posix.POLL.IN != 0) {
                 var expiry: [8]u8 = undefined;
                 _ = posix.read(self.timer_fd, &expiry) catch {};
                 if (ctx.mapper) |m| {
-                    const aux = m.onTimerExpired(now);
+                    const aux = m.onLayerTimerExpired();
                     if (aux.len > 0) {
                         if (ctx.aux_output) |ao| ao.emitAux(aux.slice()) catch {};
                     }
@@ -726,12 +727,14 @@ pub const EventLoop = struct {
             }
 
             // Macro timerfd (slot 4): separate fd so macro delays cannot be
-            // clobbered by layer-hold arm/disarm (issue #72).
+            // clobbered by layer-hold arm/disarm (issue #72). Routes to the
+            // macro-only expiry handler — must not promote a PENDING layer
+            // when a macro `delay` shorter than hold_timeout fires.
             if (self.pollfds[4].revents & posix.POLL.IN != 0) {
                 var expiry: [8]u8 = undefined;
                 _ = posix.read(self.macro_timer_fd, &expiry) catch {};
                 if (ctx.mapper) |m| {
-                    const macro_aux = m.onTimerExpired(now);
+                    const macro_aux = m.onMacroTimerExpired(now);
                     if (macro_aux.len > 0) {
                         if (ctx.aux_output) |ao| ao.emitAux(macro_aux.slice()) catch {};
                     }

--- a/src/test/bugfix_regression_test.zig
+++ b/src/test/bugfix_regression_test.zig
@@ -6,6 +6,8 @@ const hidraw = @import("../io/hidraw.zig");
 const Supervisor = @import("../supervisor.zig").Supervisor;
 const EventLoop = @import("../event_loop.zig").EventLoop;
 const armTimer = @import("../event_loop.zig").armTimer;
+const helpers = @import("helpers.zig");
+const layer_mod = @import("../core/layer.zig");
 
 // -- Test 1: renderFrame with empty raw slice --
 
@@ -127,4 +129,108 @@ test "issue #72: macro_timer_fd and timer_fd are independent — layer arm does 
     var pfd = [1]posix.pollfd{.{ .fd = loop.macro_timer_fd, .events = posix.POLL.IN, .revents = 0 }};
     const ready = try posix.poll(&pfd, 200);
     try testing.expectEqual(@as(usize, 1), ready);
+}
+
+// -- Test 7 (PR #171 follow-up): timer expiry handlers must be split per slot --
+// Regression: Mapper.onTimerExpired ran self.layer.onTimerExpired() unconditionally,
+// promoting any PENDING layer to ACTIVE regardless of which timerfd fired. PR #171
+// only separated the arm path; the expiry handlers still routed through one entry,
+// so a macro `delay` shorter than hold_timeout collapsed the layer hold timing to
+// the macro deadline.
+
+test "macro timer expiry must NOT promote PENDING layer (PR #171 follow-up)" {
+    const allocator = testing.allocator;
+
+    var ctx = try helpers.makeMapper(
+        \\[[layer]]
+        \\name = "fps"
+        \\trigger = "LT"
+        \\activation = "hold"
+        \\hold_timeout = 200
+        \\
+        \\[[macro]]
+        \\name = "tap_b"
+        \\steps = [
+        \\  { delay = 50 },
+        \\  { tap = "KEY_B" },
+        \\]
+        \\
+        \\[remap]
+        \\A = "macro:tap_b"
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    // t=0: press A → macro arms TimerQueue for t+50ms via macro_timer_fd.
+    const press_a_ns: i128 = 0;
+    const a_mask = helpers.btnMask(.A);
+    _ = try m.apply(.{ .buttons = a_mask }, 16, press_a_ns);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
+
+    // t=20ms: press LT → layer goes PENDING; layer hold deadline at t=220ms.
+    const press_lt_ns: i128 = 20 * std.time.ns_per_ms;
+    const lt_mask = helpers.btnMask(.LT);
+    _ = try m.apply(.{ .buttons = a_mask | lt_mask }, 16, press_lt_ns);
+    try testing.expect(m.layer.tap_hold != null);
+    try testing.expectEqual(layer_mod.TapHoldPhase.pending, m.layer.tap_hold.?.phase);
+    try testing.expect(!m.layer.tap_hold.?.layer_activated);
+
+    // t=50ms: macro_timer_fd fires (slot 4). Calling the macro-only handler
+    // must NOT touch the layer state.
+    const macro_expiry_ns: i128 = 50 * std.time.ns_per_ms;
+    _ = m.onMacroTimerExpired(macro_expiry_ns);
+
+    // Layer must still be PENDING — premature promotion is the regression.
+    try testing.expect(m.layer.tap_hold != null);
+    try testing.expectEqual(layer_mod.TapHoldPhase.pending, m.layer.tap_hold.?.phase);
+    try testing.expect(!m.layer.tap_hold.?.layer_activated);
+
+    // Layer timer_fd fires (slot 2). Layer-only handler promotes PENDING → ACTIVE.
+    _ = m.onLayerTimerExpired();
+    try testing.expectEqual(layer_mod.TapHoldPhase.active, m.layer.tap_hold.?.phase);
+    try testing.expect(m.layer.tap_hold.?.layer_activated);
+}
+
+test "layer timer expiry must NOT drain macro queue (PR #171 follow-up)" {
+    const allocator = testing.allocator;
+
+    var ctx = try helpers.makeMapper(
+        \\[[layer]]
+        \\name = "fps"
+        \\trigger = "LT"
+        \\activation = "hold"
+        \\hold_timeout = 100
+        \\
+        \\[[macro]]
+        \\name = "delayed_b"
+        \\steps = [
+        \\  { delay = 500 },
+        \\  { tap = "KEY_B" },
+        \\]
+        \\
+        \\[remap]
+        \\A = "macro:delayed_b"
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    // t=0: press A → macro arms TimerQueue for t+500ms.
+    const a_mask = helpers.btnMask(.A);
+    _ = try m.apply(.{ .buttons = a_mask }, 16, 0);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
+    const initial_step_index = m.active_macros.items[0].step_index;
+
+    // t=10ms: press LT → layer PENDING; hold deadline at t=110ms.
+    const press_lt_ns: i128 = 10 * std.time.ns_per_ms;
+    const lt_mask = helpers.btnMask(.LT);
+    _ = try m.apply(.{ .buttons = a_mask | lt_mask }, 16, press_lt_ns);
+
+    // Layer-only handler must NOT advance the macro player (whose deadline is
+    // far in the future at t=510ms). The macro must still be at the same step.
+    _ = m.onLayerTimerExpired();
+
+    try testing.expect(m.layer.tap_hold != null);
+    try testing.expectEqual(layer_mod.TapHoldPhase.active, m.layer.tap_hold.?.phase);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
+    try testing.expectEqual(initial_step_index, m.active_macros.items[0].step_index);
 }

--- a/src/test/bugfix_regression_test.zig
+++ b/src/test/bugfix_regression_test.zig
@@ -220,10 +220,15 @@ test "layer timer expiry must NOT drain macro queue (PR #171 follow-up)" {
     try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
     const initial_step_index = m.active_macros.items[0].step_index;
 
-    // t=10ms: press LT → layer PENDING; hold deadline at t=110ms.
+    // Arm the layer PENDING directly: routing through m.apply() with the LT
+    // mask would set active_changed=true and intentionally clear active_macros
+    // (cancel-on-layer-arm; see macro_e2e_test.zig "shift_hold" test), which
+    // would mask the regression covered here.
     const press_lt_ns: i128 = 10 * std.time.ns_per_ms;
-    const lt_mask = helpers.btnMask(.LT);
-    _ = try m.apply(.{ .buttons = a_mask | lt_mask }, 16, press_lt_ns);
+    _ = m.layer.onTriggerPress("fps", 100, press_lt_ns);
+    try testing.expect(m.layer.tap_hold != null);
+    try testing.expectEqual(layer_mod.TapHoldPhase.pending, m.layer.tap_hold.?.phase);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
 
     // Layer-only handler must NOT advance the macro player (whose deadline is
     // far in the future at t=510ms). The macro must still be at the same step.


### PR DESCRIPTION
## Summary
- `Mapper.onTimerExpired` ran `self.layer.onTimerExpired()` unconditionally for both layer and macro timerfd expiries, promoting any PENDING layer to ACTIVE regardless of which fd actually fired.
- PR #171 separated the **arm** path (slot 2 vs slot 4) but the **expiry** path still routed both fds through the same entry point — a regression of the issue #79 family.
- Split into `onLayerTimerExpired()` and `onMacroTimerExpired(now)`; `event_loop.zig` slot 2 handler calls the layer half, slot 4 handler calls the macro half. The original `onTimerExpired(now)` is retained as a deprecated wrapper for existing tests.

## Repro (before fix)
- Hold-layer LT with `hold_timeout = 200`; button A bound to `[macro] delay = 50`.
- Press A at t=0 → press LT at t=20 → slot 4 fires at t=50.
- Layer was promoted PENDING → ACTIVE at t=50 instead of t=220.

## Test plan
- [ ] `zig build` — added regression tests in `src/test/bugfix_regression_test.zig`:
  - `macro timer expiry must NOT promote PENDING layer (PR #171 follow-up)` — direct repro.
  - `layer timer expiry must NOT drain macro queue (PR #171 follow-up)` — symmetric check.
- [ ] CI must run full test suite (local `zig build test-tsan` hangs on kernel 6.18 per Track A note; SKIP_TSAN bypass used for push).

## Refs
- PR #171 (`b795bcf`) — original arm-path fix.
- Issue #79 family — timer scheduling regressions.
- `src/core/mapper.zig`: `onLayerTimerExpired`, `onMacroTimerExpired`, deprecated wrapper `onTimerExpired`.
- `src/event_loop.zig`: slot-2 / slot-4 dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of layer hold and macro timer handling by separating their expiration paths, preventing potential interference between these timer events.

* **Tests**
  * Added regression tests to verify layer and macro timers function correctly when expiring independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->