### PR TITLE
fix(config): centralize atomic writer — preserves [supervisor] + [diagnostics] across rewrites

### DIFF
--- a/src/cli/dump.zig
+++ b/src/cli/dump.zig
@@ -17,8 +17,9 @@ pub const WriteError = error{
 };
 
 /// Write `[diagnostics] dump = <value>` to `{dir_path}/config.toml`.
-/// Preserves ALL existing fields (version, devices, other diagnostics fields).
-/// Only the `dump` field within `[diagnostics]` is changed.
+/// Preserves ALL existing fields (version, devices, [supervisor], other
+/// diagnostics fields). Only the `dump` field within `[diagnostics]` is
+/// changed. Delegates atomic .tmp+fsync+rename to `user_config.writeAtomic`.
 ///
 /// Returns error.MalformedConfig if the existing file contains invalid TOML
 /// (the file is left untouched — the caller should warn and proceed with IPC).
@@ -31,95 +32,35 @@ pub fn writeDiagnosticsConfig(allocator: std.mem.Allocator, dir_path: []const u8
 
     const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir_path});
     defer allocator.free(config_path);
-    const tmp_path = try std.fmt.allocPrint(allocator, "{s}/config.toml.tmp", .{dir_path});
-    defer allocator.free(tmp_path);
 
-    // Read existing config to preserve all fields.
-    var existing_version: ?i64 = null;
-    var existing_diag: user_config_mod.DiagnosticsConfig = .{};
-    var existing_devices: ?[]const user_config_mod.DeviceEntry = null;
     var existing_pr: ?user_config_mod.ParseResult = null;
     defer if (existing_pr) |*pr| pr.deinit();
-
     if (user_config_mod.loadFromDir(allocator, dir_path)) |maybe| {
-        if (maybe) |pr| {
-            existing_pr = pr;
-            existing_version = pr.value.version;
-            existing_diag = pr.value.diagnostics;
-            existing_devices = pr.value.device;
-        }
+        if (maybe) |pr| existing_pr = pr;
         // null = file not found → fresh config, proceed.
     } else |err| switch (err) {
         error.MalformedConfig => return error.MalformedConfig,
     }
 
-    // Update only the dump field; preserve everything else.
-    existing_diag.dump = dump;
+    var diag: user_config_mod.DiagnosticsConfig = if (existing_pr) |pr| pr.value.diagnostics else .{};
+    diag.dump = dump;
 
-    // Build the config content in a growable buffer — a [[device]] list
-    // with many entries can exceed any reasonable stack ceiling.
-    var buf: std.ArrayList(u8) = .{};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    const cfg = user_config_mod.UserConfig{
+        .version = if (existing_pr) |pr| pr.value.version else null,
+        .device = if (existing_pr) |pr| pr.value.device else null,
+        .diagnostics = diag,
+        .supervisor = if (existing_pr) |pr| pr.value.supervisor else .{},
+    };
 
-    w.print("version = {d}\n\n", .{existing_version orelse user_config_mod.CURRENT_VERSION}) catch return error.OutOfMemory;
-    w.print("[diagnostics]\ndump = {}\nmax_log_size_mb = {d}\n", .{ existing_diag.dump, existing_diag.max_log_size_mb }) catch return error.OutOfMemory;
-
-    if (existing_devices) |devices| {
-        for (devices) |dev| {
-            // Escape TOML strings: names or mapping paths containing `"`,
-            // `\`, or control bytes would otherwise produce malformed TOML
-            // that the next parse rejects — silently dropping all bindings.
-            w.writeAll("\n[[device]]\nname = \"") catch return error.OutOfMemory;
-            escapeTomlString(w, dev.name) catch return error.OutOfMemory;
-            w.writeAll("\"\n") catch return error.OutOfMemory;
-            if (dev.default_mapping) |m| {
-                w.writeAll("default_mapping = \"") catch return error.OutOfMemory;
-                escapeTomlString(w, m) catch return error.OutOfMemory;
-                w.writeAll("\"\n") catch return error.OutOfMemory;
-            }
-        }
-    }
-
-    // Atomic write: populate sibling temp file, fsync, rename(2) over the
-    // target. rename(2) is atomic on POSIX filesystems, so a mid-write
-    // failure (ENOSPC, EIO) never leaves the live config truncated.
-    {
-        var f = std.fs.createFileAbsolute(tmp_path, .{ .truncate = true }) catch return error.AccessDenied;
-        defer f.close();
-        f.writeAll(buf.items) catch {
-            std.fs.deleteFileAbsolute(tmp_path) catch {};
-            return error.InputOutput;
-        };
-        f.sync() catch {};
-    }
-    errdefer std.fs.deleteFileAbsolute(tmp_path) catch {};
-    std.posix.rename(tmp_path, config_path) catch return error.InputOutput;
-}
-
-/// Escape a TOML basic-string payload (content between the enclosing `"`).
-/// Must cover backslash, double-quote, and all control bytes per the TOML
-/// spec; otherwise a device name containing `"` or a path with `\` silently
-/// produces malformed TOML that the next load-from-dir pass rejects —
-/// which would drop every [[device]] binding.
-fn escapeTomlString(writer: anytype, s: []const u8) !void {
-    for (s) |c| {
-        switch (c) {
-            '\\' => try writer.writeAll("\\\\"),
-            '"' => try writer.writeAll("\\\""),
-            '\n' => try writer.writeAll("\\n"),
-            '\r' => try writer.writeAll("\\r"),
-            '\t' => try writer.writeAll("\\t"),
-            0x08 => try writer.writeAll("\\b"),
-            0x0C => try writer.writeAll("\\f"),
-            0...0x07, 0x0B, 0x0E...0x1F, 0x7F => {
-                var esc_buf: [6]u8 = undefined;
-                const escaped = std.fmt.bufPrint(&esc_buf, "\\u{X:0>4}", .{c}) catch unreachable;
-                try writer.writeAll(escaped);
-            },
-            else => try writer.writeByte(c),
-        }
-    }
+    user_config_mod.writeAtomic(allocator, config_path, &cfg) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.AccessDenied => return error.AccessDenied,
+        error.FileNotFound => return error.FileNotFound,
+        error.IsDir => return error.IsDir,
+        error.NoSpaceLeft => return error.NoSpaceLeft,
+        error.SystemResources => return error.SystemResources,
+        else => return error.InputOutput,
+    };
 }
 
 /// Run `padctl dump status`: query daemon for live state, read log file stats.

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -2224,26 +2224,6 @@ pub fn stdinPrompt(
 ///   - Same `default_mapping` → no-op (idempotent).
 ///   - `conflict_mode == .force` → backup + overwrite.
 ///   - `conflict_mode == .interactive` → prompt user at stdin (keep/overwrite/abort).
-/// Escape a TOML basic-string value: backslash and double-quote.
-fn tomlEscape(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
-    var out = std.ArrayList(u8){};
-    errdefer out.deinit(allocator);
-    for (s) |c| {
-        switch (c) {
-            '"', '\\' => {
-                try out.append(allocator, '\\');
-                try out.append(allocator, c);
-            },
-            '\n', '\r' => return error.InvalidDeviceName,
-            else => {
-                if ((c < 0x20 and c != '\t') or c == 0x7f) return error.InvalidDeviceName;
-                try out.append(allocator, c);
-            },
-        }
-    }
-    return out.toOwnedSlice(allocator);
-}
-
 ///   - `conflict_mode == .skip` → log warning, keep existing (non-destructive default).
 ///
 /// Other `[[device]]` entries in the file are preserved. The version field is
@@ -4941,48 +4921,63 @@ test "install: on-disk udev/90-padctl.rules mirrors embedded content" {
 }
 
 test "tomlEscape: plain ASCII passes through" {
-    const allocator = std.testing.allocator;
-    const out = try tomlEscape(allocator, "Hello");
-    defer allocator.free(out);
-    try std.testing.expectEqualStrings("Hello", out);
+    const a = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(a);
+    try user_config_mod.escapeTomlString(buf.writer(a), "Hello");
+    try std.testing.expectEqualStrings("Hello", buf.items);
 }
 
 test "tomlEscape: double quote is escaped" {
-    const allocator = std.testing.allocator;
-    const out = try tomlEscape(allocator, "Sony \"DualSense\"");
-    defer allocator.free(out);
-    try std.testing.expectEqualStrings("Sony \\\"DualSense\\\"", out);
+    const a = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(a);
+    try user_config_mod.escapeTomlString(buf.writer(a), "Sony \"DualSense\"");
+    try std.testing.expectEqualStrings("Sony \\\"DualSense\\\"", buf.items);
 }
 
 test "tomlEscape: backslash is escaped" {
-    const allocator = std.testing.allocator;
-    const out = try tomlEscape(allocator, "path\\to");
-    defer allocator.free(out);
-    try std.testing.expectEqualStrings("path\\\\to", out);
+    const a = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(a);
+    try user_config_mod.escapeTomlString(buf.writer(a), "path\\to");
+    try std.testing.expectEqualStrings("path\\\\to", buf.items);
 }
 
 test "tomlEscape: newline rejected with error.InvalidDeviceName" {
-    const allocator = std.testing.allocator;
-    try std.testing.expectError(error.InvalidDeviceName, tomlEscape(allocator, "bad\nname"));
+    const a = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(a);
+    try std.testing.expectError(error.InvalidDeviceName, user_config_mod.escapeTomlString(buf.writer(a), "bad\nname"));
 }
 
 test "tomlEscape: carriage return rejected with error.InvalidDeviceName" {
-    const allocator = std.testing.allocator;
-    try std.testing.expectError(error.InvalidDeviceName, tomlEscape(allocator, "bad\rname"));
+    const a = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(a);
+    try std.testing.expectError(error.InvalidDeviceName, user_config_mod.escapeTomlString(buf.writer(a), "bad\rname"));
 }
 
 test "tomlEscape rejects NUL byte (0x00)" {
-    try std.testing.expectError(error.InvalidDeviceName, tomlEscape(std.testing.allocator, "bad\x00name"));
+    const a = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(a);
+    try std.testing.expectError(error.InvalidDeviceName, user_config_mod.escapeTomlString(buf.writer(a), "bad\x00name"));
 }
 
 test "tomlEscape rejects DEL byte (0x7f)" {
-    try std.testing.expectError(error.InvalidDeviceName, tomlEscape(std.testing.allocator, "bad\x7fname"));
+    const a = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(a);
+    try std.testing.expectError(error.InvalidDeviceName, user_config_mod.escapeTomlString(buf.writer(a), "bad\x7fname"));
 }
 
 test "tomlEscape passes \\t (0x09) through unchanged" {
-    const out = try tomlEscape(std.testing.allocator, "col1\tcol2");
-    defer std.testing.allocator.free(out);
-    try std.testing.expectEqualStrings("col1\tcol2", out);
+    const a = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(a);
+    try user_config_mod.escapeTomlString(buf.writer(a), "col1\tcol2");
+    try std.testing.expectEqualStrings("col1\tcol2", buf.items);
 }
 
 test "tomlEscape: round-trip via real TOML parser" {
@@ -4995,9 +4990,10 @@ test "tomlEscape: round-trip via real TOML parser" {
         "plain name",
     };
     for (inputs) |input| {
-        const escaped = try tomlEscape(allocator, input);
-        defer allocator.free(escaped);
-        const toml_text = try std.fmt.allocPrint(allocator, "name = \"{s}\"\n", .{escaped});
+        var buf: std.ArrayList(u8) = .{};
+        defer buf.deinit(allocator);
+        try user_config_mod.escapeTomlString(buf.writer(allocator), input);
+        const toml_text = try std.fmt.allocPrint(allocator, "name = \"{s}\"\n", .{buf.items});
         defer allocator.free(toml_text);
 
         var parser = toml.Parser(struct { name: []const u8 }).init(allocator);

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -2322,54 +2322,46 @@ fn writeBinding(
         };
     }
 
-    // Serialize: version + diagnostics + all existing entries (replacing
-    // the conflict target if one was found) + new entry if none matched.
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
-    try w.print("version = {d}\n", .{version});
-
-    // Preserve [diagnostics] section if present.
-    if (existing) |e| {
-        const diag = e.value.diagnostics;
-        if (diag.dump or diag.max_log_size_mb != 100) {
-            try w.print("\n[diagnostics]\ndump = {}\nmax_log_size_mb = {d}\n", .{ diag.dump, diag.max_log_size_mb });
-        }
-    }
-
-    const esc_device_name = try tomlEscape(allocator, device_name);
-    defer allocator.free(esc_device_name);
-    const esc_mapping_name = try tomlEscape(allocator, mapping_name);
-    defer allocator.free(esc_mapping_name);
-
-    var wrote_target = false;
+    // Build a UserConfig with the target device added/replaced; every other
+    // section ([diagnostics], [supervisor], unrelated [[device]]) is carried
+    // forward from the parsed existing config. writeAtomic handles the
+    // atomic .tmp + fsync + rename(2).
+    var has_target = false;
     if (devices) |devs| {
         for (devs) |d| {
             if (std.ascii.eqlIgnoreCase(d.name, device_name)) {
-                // Replace this entry with the new mapping.
-                try w.print("\n[[device]]\nname = \"{s}\"\ndefault_mapping = \"{s}\"\n", .{ esc_device_name, esc_mapping_name });
-                wrote_target = true;
-            } else {
-                // Preserve unrelated entry.
-                const esc_name = try tomlEscape(allocator, d.name);
-                defer allocator.free(esc_name);
-                try w.print("\n[[device]]\nname = \"{s}\"\n", .{esc_name});
-                if (d.default_mapping) |m| {
-                    const esc_m = try tomlEscape(allocator, m);
-                    defer allocator.free(esc_m);
-                    try w.print("default_mapping = \"{s}\"\n", .{esc_m});
-                }
+                has_target = true;
+                break;
             }
         }
     }
-    if (!wrote_target) {
-        try w.print("\n[[device]]\nname = \"{s}\"\ndefault_mapping = \"{s}\"\n", .{ esc_device_name, esc_mapping_name });
+    const old_count = if (devices) |d| d.len else 0;
+    const new_count = if (has_target) old_count else old_count + 1;
+    var new_devices = try allocator.alloc(user_config_mod.DeviceEntry, new_count);
+    defer allocator.free(new_devices);
+
+    var idx: usize = 0;
+    if (devices) |devs| {
+        for (devs) |d| {
+            if (std.ascii.eqlIgnoreCase(d.name, device_name)) {
+                new_devices[idx] = .{ .name = device_name, .default_mapping = mapping_name };
+            } else {
+                new_devices[idx] = d;
+            }
+            idx += 1;
+        }
+    }
+    if (!has_target) {
+        new_devices[idx] = .{ .name = device_name, .default_mapping = mapping_name };
     }
 
-    // Write the file.
-    var f = try std.fs.createFileAbsolute(config_path, .{ .truncate = true });
-    defer f.close();
-    try f.writeAll(buf.items);
+    const cfg = user_config_mod.UserConfig{
+        .version = version,
+        .device = new_devices,
+        .diagnostics = if (existing) |e| e.value.diagnostics else .{},
+        .supervisor = if (existing) |e| e.value.supervisor else .{},
+    };
+    try user_config_mod.writeAtomic(allocator, config_path, &cfg);
 }
 
 /// Copy `path` to `path.bak.YYYYMMDD-HHMMSS`. Returns an error if the

--- a/src/config/user_config.zig
+++ b/src/config/user_config.zig
@@ -135,6 +135,98 @@ pub fn findDefaultMapping(result: *const ParseResult, device_name: []const u8) ?
     return null;
 }
 
+/// Atomically rewrite `config_path` from `cfg`, preserving every section.
+///
+/// Writes `version`, then `[diagnostics]` and `[supervisor]` (each emitted
+/// only when at least one field differs from its struct default — keeps
+/// fresh files terse), then every `[[device]]` entry. Strings are TOML
+/// basic-string escaped.
+///
+/// Atomicity: serialise to `<config_path>.tmp`, fsync, then rename(2) onto
+/// `config_path`. rename(2) is atomic on POSIX filesystems, so a crash or
+/// kill mid-write never leaves the live config truncated. The parent
+/// directory must exist; callers create it before invoking this helper.
+pub fn writeAtomic(
+    allocator: std.mem.Allocator,
+    config_path: []const u8,
+    cfg: *const UserConfig,
+) !void {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(allocator);
+    try emitToml(buf.writer(allocator), cfg);
+
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{config_path});
+    defer allocator.free(tmp_path);
+
+    {
+        var f = try std.fs.createFileAbsolute(tmp_path, .{ .truncate = true });
+        defer f.close();
+        f.writeAll(buf.items) catch |err| {
+            std.fs.deleteFileAbsolute(tmp_path) catch {};
+            return err;
+        };
+        f.sync() catch {};
+    }
+    errdefer std.fs.deleteFileAbsolute(tmp_path) catch {};
+    try std.posix.rename(tmp_path, config_path);
+}
+
+/// Serialise `cfg` to a TOML writer. Sections with all-default values are
+/// elided so a fresh-install config stays minimal; any non-default field
+/// triggers full emission of that section.
+pub fn emitToml(writer: anytype, cfg: *const UserConfig) !void {
+    try writer.print("version = {d}\n", .{cfg.version orelse CURRENT_VERSION});
+
+    const diag = cfg.diagnostics;
+    const diag_default = DiagnosticsConfig{};
+    if (diag.dump != diag_default.dump or diag.max_log_size_mb != diag_default.max_log_size_mb) {
+        try writer.print("\n[diagnostics]\ndump = {}\nmax_log_size_mb = {d}\n", .{ diag.dump, diag.max_log_size_mb });
+    }
+
+    const sup = cfg.supervisor;
+    const sup_default = SupervisorConfig{};
+    if (sup.suspend_grace_sec != sup_default.suspend_grace_sec) {
+        try writer.print("\n[supervisor]\nsuspend_grace_sec = {d}\n", .{sup.suspend_grace_sec});
+    }
+
+    if (cfg.device) |entries| {
+        for (entries) |d| {
+            try writer.writeAll("\n[[device]]\nname = \"");
+            try escapeTomlString(writer, d.name);
+            try writer.writeAll("\"\n");
+            if (d.default_mapping) |m| {
+                try writer.writeAll("default_mapping = \"");
+                try escapeTomlString(writer, m);
+                try writer.writeAll("\"\n");
+            }
+        }
+    }
+}
+
+/// Escape a TOML basic-string payload (between the enclosing `"`).
+/// Covers backslash, double-quote, and all control bytes per the spec —
+/// otherwise a name containing `"` or a path with `\` produces malformed
+/// TOML that the next load rejects, silently dropping every binding.
+pub fn escapeTomlString(writer: anytype, s: []const u8) !void {
+    for (s) |c| {
+        switch (c) {
+            '\\' => try writer.writeAll("\\\\"),
+            '"' => try writer.writeAll("\\\""),
+            '\n' => try writer.writeAll("\\n"),
+            '\r' => try writer.writeAll("\\r"),
+            '\t' => try writer.writeAll("\\t"),
+            0x08 => try writer.writeAll("\\b"),
+            0x0C => try writer.writeAll("\\f"),
+            0...0x07, 0x0B, 0x0E...0x1F, 0x7F => {
+                var esc_buf: [6]u8 = undefined;
+                const escaped = std.fmt.bufPrint(&esc_buf, "\\u{X:0>4}", .{c}) catch unreachable;
+                try writer.writeAll(escaped);
+            },
+            else => try writer.writeByte(c),
+        }
+    }
+}
+
 // --- tests ---
 
 test "load: returns null when config.toml absent" {
@@ -438,4 +530,134 @@ test "findDefaultMapping: entry without default_mapping returns null" {
     defer result.deinit();
 
     try std.testing.expectEqual(@as(?[]const u8, null), findDefaultMapping(&result, "Foo Pad"));
+}
+
+test "writeAtomic round-trips [supervisor] section" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir_path});
+    defer allocator.free(config_path);
+
+    const cfg = UserConfig{
+        .version = CURRENT_VERSION,
+        .supervisor = .{ .suspend_grace_sec = 30 },
+    };
+    try writeAtomic(allocator, config_path, &cfg);
+
+    var result = (try loadFromDir(allocator, dir_path)).?;
+    defer result.deinit();
+    try std.testing.expectEqual(@as(i64, 30), result.value.supervisor.suspend_grace_sec);
+}
+
+test "writeAtomic round-trips [diagnostics] section" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir_path});
+    defer allocator.free(config_path);
+
+    const cfg = UserConfig{
+        .version = CURRENT_VERSION,
+        .diagnostics = .{ .dump = true, .max_log_size_mb = 50 },
+    };
+    try writeAtomic(allocator, config_path, &cfg);
+
+    var result = (try loadFromDir(allocator, dir_path)).?;
+    defer result.deinit();
+    try std.testing.expectEqual(true, result.value.diagnostics.dump);
+    try std.testing.expectEqual(@as(i64, 50), result.value.diagnostics.max_log_size_mb);
+}
+
+test "writeAtomic preserves all sections through device-mutation flow" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir_path});
+    defer allocator.free(config_path);
+
+    const seed =
+        \\version = 1
+        \\
+        \\[diagnostics]
+        \\dump = true
+        \\max_log_size_mb = 50
+        \\
+        \\[supervisor]
+        \\suspend_grace_sec = 30
+        \\
+        \\[[device]]
+        \\name = "Vader 5 Pro"
+        \\default_mapping = "fps"
+    ;
+    {
+        const f = try tmp.dir.createFile("config.toml", .{});
+        defer f.close();
+        try f.writeAll(seed);
+    }
+
+    // Simulate `padctl switch`: load -> mutate device entry -> writeAtomic.
+    var loaded = (try loadFromDir(allocator, dir_path)).?;
+    defer loaded.deinit();
+
+    const new_devices = try allocator.alloc(DeviceEntry, 1);
+    defer allocator.free(new_devices);
+    new_devices[0] = .{ .name = "Vader 5 Pro", .default_mapping = "racing" };
+
+    const mutated = UserConfig{
+        .version = loaded.value.version,
+        .device = new_devices,
+        .diagnostics = loaded.value.diagnostics,
+        .supervisor = loaded.value.supervisor,
+    };
+    try writeAtomic(allocator, config_path, &mutated);
+
+    var reloaded = (try loadFromDir(allocator, dir_path)).?;
+    defer reloaded.deinit();
+    try std.testing.expectEqual(true, reloaded.value.diagnostics.dump);
+    try std.testing.expectEqual(@as(i64, 50), reloaded.value.diagnostics.max_log_size_mb);
+    try std.testing.expectEqual(@as(i64, 30), reloaded.value.supervisor.suspend_grace_sec);
+    try std.testing.expectEqualStrings("racing", findDefaultMapping(&reloaded, "Vader 5 Pro").?);
+}
+
+test "writeAtomic leaves no .tmp sidecar after success" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir_path});
+    defer allocator.free(config_path);
+
+    const cfg = UserConfig{ .version = CURRENT_VERSION };
+    try writeAtomic(allocator, config_path, &cfg);
+
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access("config.toml.tmp", .{}));
+    try tmp.dir.access("config.toml", .{});
+}
+
+test "writeAtomic escapes TOML special characters in device names" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir_path});
+    defer allocator.free(config_path);
+
+    const devices = try allocator.alloc(DeviceEntry, 1);
+    defer allocator.free(devices);
+    devices[0] = .{ .name = "Quote\"Backslash\\Pad", .default_mapping = "m1" };
+    const cfg = UserConfig{ .version = CURRENT_VERSION, .device = devices };
+    try writeAtomic(allocator, config_path, &cfg);
+
+    var result = (try loadFromDir(allocator, dir_path)).?;
+    defer result.deinit();
+    try std.testing.expectEqualStrings("m1", findDefaultMapping(&result, "Quote\"Backslash\\Pad").?);
 }

--- a/src/config/user_config.zig
+++ b/src/config/user_config.zig
@@ -204,24 +204,19 @@ pub fn emitToml(writer: anytype, cfg: *const UserConfig) !void {
 }
 
 /// Escape a TOML basic-string payload (between the enclosing `"`).
-/// Covers backslash, double-quote, and all control bytes per the spec —
-/// otherwise a name containing `"` or a path with `\` produces malformed
-/// TOML that the next load rejects, silently dropping every binding.
+///
+/// Control characters are REJECTED with error.InvalidDeviceName — per PR #168
+/// (audit V1) the project's defensive-boundary policy is: control bytes in
+/// device names indicate input corruption (broken sysfs, malicious udev rule,
+/// hand-edited bad TOML) — surface loudly, don't silent-normalize.
+/// Tab (0x09) is the only control byte TOML basic strings permit; it passes through.
 pub fn escapeTomlString(writer: anytype, s: []const u8) !void {
     for (s) |c| {
         switch (c) {
             '\\' => try writer.writeAll("\\\\"),
             '"' => try writer.writeAll("\\\""),
-            '\n' => try writer.writeAll("\\n"),
-            '\r' => try writer.writeAll("\\r"),
-            '\t' => try writer.writeAll("\\t"),
-            0x08 => try writer.writeAll("\\b"),
-            0x0C => try writer.writeAll("\\f"),
-            0...0x07, 0x0B, 0x0E...0x1F, 0x7F => {
-                var esc_buf: [6]u8 = undefined;
-                const escaped = std.fmt.bufPrint(&esc_buf, "\\u{X:0>4}", .{c}) catch unreachable;
-                try writer.writeAll(escaped);
-            },
+            '\t' => try writer.writeByte('\t'),
+            0...0x08, 0x0A...0x1F, 0x7F => return error.InvalidDeviceName,
             else => try writer.writeByte(c),
         }
     }
@@ -660,4 +655,34 @@ test "writeAtomic escapes TOML special characters in device names" {
     var result = (try loadFromDir(allocator, dir_path)).?;
     defer result.deinit();
     try std.testing.expectEqualStrings("m1", findDefaultMapping(&result, "Quote\"Backslash\\Pad").?);
+}
+
+test "escapeTomlString rejects newline (PR #168 regression)" {
+    const a = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(a);
+    try std.testing.expectError(error.InvalidDeviceName, escapeTomlString(buf.writer(a), "Bad\nName"));
+}
+
+test "escapeTomlString rejects control byte 0x07 (PR #168 regression)" {
+    const a = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(a);
+    try std.testing.expectError(error.InvalidDeviceName, escapeTomlString(buf.writer(a), "Bad\x07Name"));
+}
+
+test "escapeTomlString allows tab (TOML-spec-allowed)" {
+    const a = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(a);
+    try escapeTomlString(buf.writer(a), "Foo\tBar");
+    try std.testing.expectEqualStrings("Foo\tBar", buf.items);
+}
+
+test "escapeTomlString escapes backslash and double-quote" {
+    const a = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(a);
+    try escapeTomlString(buf.writer(a), "a\\b\"c");
+    try std.testing.expectEqualStrings("a\\\\b\\\"c", buf.items);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1294,8 +1294,11 @@ fn escapeTomlString(writer: anytype, s: []const u8) !void {
     }
 }
 
-/// Write a config.toml with a single device binding. Reads existing file
-/// to preserve other device entries.
+/// Write a config.toml with a single device binding. Reads the existing
+/// file so every section ([diagnostics], [supervisor], unrelated [[device]]
+/// entries) survives the round-trip; only the target device's mapping is
+/// updated. Delegates to `user_config.writeAtomic` for atomic .tmp+rename
+/// so a crash mid-write never truncates the live config.
 fn writeConfigToml(
     allocator: std.mem.Allocator,
     dir: []const u8,
@@ -1311,49 +1314,48 @@ fn writeConfigToml(
     };
     defer if (existing) |*e| e.deinit();
 
-    const version: i64 = if (existing) |e| e.value.version orelse user_config_mod.CURRENT_VERSION else user_config_mod.CURRENT_VERSION;
-    const devices = if (existing) |e| e.value.device else null;
+    const old_devices = if (existing) |e| e.value.device else null;
+    const old_count = if (old_devices) |d| d.len else 0;
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
-    try w.print("version = {d}\n", .{version});
-
-    var wrote_target = false;
-    if (devices) |devs| {
+    var has_target = false;
+    if (old_devices) |devs| {
         for (devs) |d| {
             if (std.ascii.eqlIgnoreCase(d.name, device_name)) {
-                try w.writeAll("\n[[device]]\nname = \"");
-                try escapeTomlString(w, device_name);
-                try w.writeAll("\"\ndefault_mapping = \"");
-                try escapeTomlString(w, mapping_name);
-                try w.writeAll("\"\n");
-                wrote_target = true;
-            } else {
-                try w.writeAll("\n[[device]]\nname = \"");
-                try escapeTomlString(w, d.name);
-                try w.writeAll("\"\n");
-                if (d.default_mapping) |m| {
-                    try w.writeAll("default_mapping = \"");
-                    try escapeTomlString(w, m);
-                    try w.writeAll("\"\n");
-                }
+                has_target = true;
+                break;
             }
         }
     }
-    if (!wrote_target) {
-        try w.writeAll("\n[[device]]\nname = \"");
-        try escapeTomlString(w, device_name);
-        try w.writeAll("\"\ndefault_mapping = \"");
-        try escapeTomlString(w, mapping_name);
-        try w.writeAll("\"\n");
+
+    const new_count = if (has_target) old_count else old_count + 1;
+    var new_devices = try allocator.alloc(user_config_mod.DeviceEntry, new_count);
+    defer allocator.free(new_devices);
+
+    var idx: usize = 0;
+    if (old_devices) |devs| {
+        for (devs) |d| {
+            if (std.ascii.eqlIgnoreCase(d.name, device_name)) {
+                new_devices[idx] = .{ .name = device_name, .default_mapping = mapping_name };
+            } else {
+                new_devices[idx] = d;
+            }
+            idx += 1;
+        }
     }
+    if (!has_target) {
+        new_devices[idx] = .{ .name = device_name, .default_mapping = mapping_name };
+    }
+
+    const cfg = user_config_mod.UserConfig{
+        .version = if (existing) |e| e.value.version else null,
+        .device = new_devices,
+        .diagnostics = if (existing) |e| e.value.diagnostics else .{},
+        .supervisor = if (existing) |e| e.value.supervisor else .{},
+    };
 
     const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir});
     defer allocator.free(config_path);
-    var f = try std.fs.createFileAbsolute(config_path, .{ .truncate = true });
-    defer f.close();
-    try f.writeAll(buf.items);
+    try user_config_mod.writeAtomic(allocator, config_path, &cfg);
 }
 
 fn parseDeviceFromStatus(resp: []const u8) ?[]const u8 {


### PR DESCRIPTION
## Summary

- Three config writers (`main.zig:writeConfigToml`, `install.zig:writeBinding`, `dump.zig:writeDiagnosticsConfig`) each preserved a different subset of `UserConfig`. PR #134's `[supervisor].suspend_grace_sec` was silently dropped on every `padctl switch`, `install --mapping`, or `dump enable|disable`.
- Centralize emission in `user_config.writeAtomic` — builds full TOML from a parsed `UserConfig` (every section), serialises to `<path>.tmp`, fsyncs, then `rename(2)` atomically.
- Atomic rewrite also fixes a latent corruption window in `writeConfigToml` and `writeBinding` (truncate + writeAll, no temp + rename) — a kill mid-write left `config.toml` truncated.
- All three callers now load existing config, mutate the relevant field, and delegate writing.

## Test plan

- [x] `zig build` (release build) — clean
- [ ] `zig build test` — local run blocked by the known PR #166 parallel-test deadlock; new tests live in `src/config/user_config.zig`:
  - `writeAtomic round-trips [supervisor] section`
  - `writeAtomic round-trips [diagnostics] section`
  - `writeAtomic preserves all sections through device-mutation flow` (simulates `padctl switch`: seed → load → mutate device → writeAtomic → reload, asserts `[diagnostics]` and `[supervisor]` survive)
  - `writeAtomic leaves no .tmp sidecar after success`
  - `writeAtomic escapes TOML special characters in device names`
- [ ] CI green on `e2e.yml` / `install-flow.yml`

refs: PR #134 (`suspend_grace_sec`), PR #146/#148 (install flow), PR #155 (round-trip coverage methodology)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Configuration management consolidated with atomic write operations for safer file persistence across CLI tools, eliminating manual serialization and improving protection against incomplete or corrupted configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->