### PR TITLE
fix(test): supervisor startFromDirs test must use fake dev_root

### DIFF
--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -1586,6 +1586,15 @@ pub const Supervisor = struct {
         }
     }
 
+    /// Test-only seam: like startFromDirs but uses caller-provided dev_root
+    /// instead of /dev. Allows tests to bypass real /dev/hidraw* enumeration
+    /// (which can hang on leaked virtual UHID devices on dev machines).
+    pub fn startFromDirsWithRoot(self: *Supervisor, dirs: []const []const u8, dev_root: []const u8) !void {
+        for (dirs) |dir| {
+            try self.startFromDirWithRoot(dir, dev_root);
+        }
+    }
+
     fn doReloadFromDir(self: *Supervisor, dir_path: []const u8) void {
         if (self.user_cfg) |*uc| uc.deinit();
         self.user_cfg = user_config_mod.load(self.allocator);
@@ -3002,10 +3011,10 @@ test "supervisor: startFromDirs loads configs from two dirs" {
     // No real hidraw devices — both dirs scanned, zero instances spawned,
     // but configs from both dirs must have been attempted (no error, no panic).
     const dirs = &[_][]const u8{ path_a, path_b };
-    sup.startFromDirs(dirs);
+    try sup.startFromDirsWithRoot(dirs, "/nonexistent_dev_root_xyz");
 
     // With a non-existent dev root neither device will be found, so managed is empty.
-    // The key assertion: startFromDirs did not error out after scanning the first dir.
+    // The key assertion: startFromDirsWithRoot scanned both dirs without hanging.
     try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
 }
 


### PR DESCRIPTION
## Summary

- Add `startFromDirsWithRoot(dirs, dev_root)` public API mirroring the existing `startFromDirWithRoot` pattern at line 1416
- Update test `"supervisor: startFromDirs loads configs from two dirs"` to call `startFromDirsWithRoot(..., "/nonexistent_dev_root_xyz")` instead of `startFromDirs(...)`, matching sibling test convention at line 2527
- Production callers of `startFromDirs` are unchanged (still default to `/dev`)

## Problem

The test called `startFromDirs` which hard-codes `/dev` internally. On dev machines with a leaked virtual UHID device (from prior debugging), `hidraw_open → hid_hw_open` blocks indefinitely in D-state even with `O_NONBLOCK` (kernel-side behaviour for virtual UHID). `zig build test` never terminates locally. CI is unaffected (stateless runners have no leaked devices).

## Test plan

- `zig build` compile-clean on the branch
- `git show HEAD:src/supervisor.zig | grep -n 'startFromDirsWithRoot\|/nonexistent_dev_root_xyz'` shows both the new API and the test change
- No production caller of `startFromDirs` modified

refs: `src/supervisor.zig@0039d53`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for device discovery validation to improve test robustness across configuration directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->