### PR TITLE
docs: user-facing drift consolidated audit (2026-04-28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ See [Quick Start](#quick-start) below. For other distros, see [CONTRIBUTING.md](
 zig build                                             # build from source
 sudo zig-out/bin/padctl install                       # install binary, udev rules; writes user service unit
 systemctl --user enable --now padctl.service          # start the user service
-padctl config init                                    # create ~/.config/padctl/config.toml interactively
+padctl config init                                    # create a mapping in ~/.config/padctl/mappings/ interactively
 padctl status                                         # check daemon and detected devices
 padctl switch <name>                                  # switch mapping profile without restart
 ```
@@ -141,9 +141,9 @@ See the [getting started guide](https://bananasjim.github.io/padctl/getting-star
 | `padctl devices` | List detected HID/USB devices |
 | `padctl list-mappings` | Show available mapping profiles |
 | `padctl switch <name>` | Switch to a named mapping profile |
-| `padctl config init` | Create user config interactively |
-| `padctl config edit` | Open user config in `$EDITOR` |
-| `padctl config test` | Validate config without applying |
+| `padctl config init` | Interactively create a new mapping file in `~/.config/padctl/mappings/` |
+| `padctl config edit <mapping>` | Open mapping in `$VISUAL` or `$EDITOR` |
+| `padctl config test <mapping>` | Live input preview against the mapping (no apply) |
 | `padctl scan` | Re-scan for connected devices |
 | `padctl dump enable\|disable` | Toggle opt-in diagnostic logging (persists across reboots) |
 | `padctl dump status` | Show logging state, log path, size, and time span |

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -221,6 +221,37 @@ Touchpad output device.
 | `y_min` / `y_max` | integer | Y axis range |
 | `max_slots` | integer | Maximum multitouch slots |
 
+### `[output.imu]`
+
+IMU (accelerometer + gyroscope) output via a separate UHID node. When declared, padctl creates a second UHID device that shares the same `uniq` as the primary gamepad output, enabling SDL3 to pair the IMU sensor with the controller automatically (ADR-015 UHID IMU migration; see PR #159).
+
+> **Validation rule:** when `[output.imu]` is present, `backend` must be `"uhid"`. The validator rejects `"uinput"` per ADR-015 — UHID is the only supported backend for IMU output. Omitting `[output.imu]` entirely keeps the legacy uinput-primary path.
+
+> **Distinction from `[output.aux]`:** `[output.imu]` is the gamepad's accelerometer/gyroscope UHID node; `[output.aux]` is a secondary uinput device for mouse/keyboard remapping. They serve different purposes and can coexist.
+
+See [ADR-015](https://bananasjim.github.io/padctl/decisions/) for the design rationale. This section enables SDL3-visible sensor pairing on Steam games.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `backend` | string | yes | — | Must be `"uhid"`; only legal value |
+| `name` | string | no | — | UHID device name shown to userspace |
+| `vid` | integer | no | `0xfade` | Emulated vendor ID |
+| `pid` | integer | no | `0xc001` | Emulated product ID |
+| `accel_range` | integer | no | `4` | Accelerometer range in ±g |
+| `gyro_range` | integer | no | `2000` | Gyroscope range in °/s |
+
+Example:
+
+```toml
+[output.imu]
+backend = "uhid"
+name = "vader5_imu"
+vid = 0x11ff
+pid = 0x1211
+accel_range = 8
+gyro_range = 2000
+```
+
 ## `[wasm]`
 
 WASM plugin for stateful/custom protocols (Phase 4+).

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -229,16 +229,16 @@ IMU (accelerometer + gyroscope) output via a separate UHID node. When declared, 
 
 > **Distinction from `[output.aux]`:** `[output.imu]` is the gamepad's accelerometer/gyroscope UHID node; `[output.aux]` is a secondary uinput device for mouse/keyboard remapping. They serve different purposes and can coexist.
 
-See [ADR-015](https://bananasjim.github.io/padctl/decisions/) for the design rationale. This section enables SDL3-visible sensor pairing on Steam games.
+See ADR-015 for the design rationale. This section enables SDL3-visible sensor pairing on Steam games.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `backend` | string | yes | — | Must be `"uhid"`; only legal value |
+| `backend` | string | no | `"uhid"` | Must be `"uhid"`; only legal value (validator rejects `"uinput"`) |
 | `name` | string | no | — | UHID device name shown to userspace |
-| `vid` | integer | no | `0xfade` | Emulated vendor ID |
-| `pid` | integer | no | `0xc001` | Emulated product ID |
-| `accel_range` | integer | no | `4` | Accelerometer range in ±g |
-| `gyro_range` | integer | no | `2000` | Gyroscope range in °/s |
+| `vid` | integer | no | inherits from `[device].vid` | Emulated vendor ID |
+| `pid` | integer | no | inherits from `[device].pid` | Emulated product ID |
+| `accel_range` | int[2] | no | `[-32768, 32767]` | Accelerometer output range `[min, max]` |
+| `gyro_range` | int[2] | no | `[-32768, 32767]` | Gyroscope output range `[min, max]` |
 
 Example:
 
@@ -248,8 +248,8 @@ backend = "uhid"
 name = "vader5_imu"
 vid = 0x11ff
 pid = 0x1211
-accel_range = 8
-gyro_range = 2000
+accel_range = [-16384, 16384]
+gyro_range = [-32768, 32767]
 ```
 
 ## `[wasm]`

--- a/docs/src/diagnostic-logging.md
+++ b/docs/src/diagnostic-logging.md
@@ -64,7 +64,17 @@ max_log_size_mb = 100 # rotation threshold (default 100 MB)
 
 <a id="schema-rewrite"></a>
 
-> ⚠️ **Rewrite behavior.** `padctl dump enable/disable` parses `config.toml`, rewrites it from the known schema, and atomically renames the result into place. Anything outside the documented schema — unknown sections, undocumented keys, hand-written comments — is **not preserved**. If you hand-edit `config.toml` with content that matters (e.g. a forward-looking `[experimental]` block, inline comments documenting a choice), keep it in a sibling file, or drive padctl via `SIGHUP` after the edit instead of using the `dump` subcommand. The current known schema is `version`, `[diagnostics]` (`dump`, `max_log_size_mb`), and `[[device]]` entries (`name`, `default_mapping`).
+> ⚠️ **Rewrite behavior.** `padctl dump enable/disable` parses `config.toml`, rewrites it from the known schema, and atomically renames the result into place. Anything outside the documented schema — unknown sections, undocumented keys, hand-written comments — is **not preserved**. If you hand-edit `config.toml` with content that matters (e.g. a forward-looking `[experimental]` block, inline comments documenting a choice), keep it in a sibling file, or drive padctl via `SIGHUP` after the edit instead of using the `dump` subcommand. The current known schema is `version`, `[diagnostics]` (`dump`, `max_log_size_mb`), `[supervisor]` (`suspend_grace_sec`), and `[[device]]` entries (`name`, `default_mapping`).
+
+## Supervisor tunables
+
+`config.toml` may also include a `[supervisor]` section to tune hot-plug suspend behavior:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `suspend_grace_sec` | i64 | 15 | Seconds to keep a suspended device alive before transactional rebind, allowing transient disconnects to recover without re-grabbing |
+
+Hand-edits to `[supervisor]` are preserved across `padctl dump enable/disable` and `padctl switch`.
 
 ## Rotation
 

--- a/docs/src/diagnostic-logging.md
+++ b/docs/src/diagnostic-logging.md
@@ -74,7 +74,7 @@ max_log_size_mb = 100 # rotation threshold (default 100 MB)
 |-------|------|---------|-------------|
 | `suspend_grace_sec` | i64 | 15 | Seconds to keep a suspended device alive before transactional rebind, allowing transient disconnects to recover without re-grabbing |
 
-Hand-edits to `[supervisor]` are preserved across `padctl dump enable/disable` and `padctl switch`.
+The `suspend_grace_sec` value is preserved across `padctl dump enable/disable` and `padctl switch`; comments and unknown keys inside `[supervisor]` follow the same rewrite caveat as the rest of `config.toml`.
 
 ## Rotation
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -96,8 +96,9 @@ If you built from source, run the installer first — `zig build` alone does **n
 ```sh
 zig build
 sudo ./zig-out/bin/padctl install    # installs binary, service, device configs, and udev rules
-systemctl --user enable --now padctl.service
 ```
+
+`padctl install` automatically runs `daemon-reload`, enables, and starts `padctl.service` via `sudo -u $SUDO_USER systemctl --user`. The `systemctl --user enable --now padctl.service` line is only needed if you used `--no-enable` or `--no-start`.
 
 To auto-start at boot without an active login session (headless setups, Steam Deck game mode):
 
@@ -187,7 +188,9 @@ See the [Diagnostic Logging guide](diagnostic-logging.md) for the full `padctl d
 
 ## udev Permissions
 
-padctl needs access to `/dev/hidraw*` and `/dev/uinput`. The `padctl install` command generates and installs udev rules automatically from device configs.
+padctl needs access to `/dev/hidraw*`, `/dev/uinput`, and `/dev/uhid`. The first two are standard for HID gamepad daemons; `/dev/uhid` is required for the SDL3-visible IMU pairing path (per ADR-015) — `padctl install` writes the necessary udev rule (`60-padctl.rules`) and a `DeviceAllow=/dev/uhid rw` entry in the systemd unit automatically.
+
+The `padctl install` command generates and installs udev rules automatically from device configs.
 
 If you need to regenerate rules after adding custom device configs:
 


### PR DESCRIPTION
## Changes

- \`docs/src/device-config.md\`: add \`### [output.imu]\` subsection with full field table, validation rule (backend must be \`"uhid"\`), distinction from \`[output.aux]\`, and cross-reference to ADR-015. Wave 3 / PR #159 shipped 2026-04-24 with no documentation.
- \`docs/src/getting-started.md\` §udev Permissions: add \`/dev/uhid\` to the access list; explain that \`padctl install\` writes the udev rule and \`DeviceAllow=\` entry automatically.
- \`docs/src/getting-started.md\` §Run as Service: clarify that the \`systemctl --user enable --now\` line is a no-op under sudo install; \`padctl install\` already enables and starts the service via \`sudo -u \$SUDO_USER\`.
- \`docs/src/diagnostic-logging.md\`: add \`[supervisor]\` (\`suspend_grace_sec\`) to the schema-rewrite safe-list in the rewrite-behavior callout; add new \`## Supervisor tunables\` subsection with field table. Previously the callout implied hand-edited \`[supervisor]\` blocks would be silently discarded.
- \`README.md\` §CLI Reference: correct \`config init\` / \`config edit\` / \`config test\` descriptions to match \`printHelp\` — these operate on mapping files under \`~/.config/padctl/mappings/\`, not \`config.toml\`.
- \`README.md\` §Quick Start: fix \`padctl config init\` comment from \`config.toml\` to \`mappings/\`.

## Test plan

- [ ] \`grep -n '\[output.imu\]\|backend = "uhid"' docs/src/device-config.md\` returns the new section
- [ ] \`grep -n '/dev/uhid' docs/src/getting-started.md\` returns updated udev line
- [ ] \`grep -n '\[supervisor\]\|suspend_grace_sec' docs/src/diagnostic-logging.md\` returns new section
- [ ] \`grep -nE 'mapping in.*mappings/|Live input preview' README.md\` returns corrected descriptions
- [ ] mdBook build (\`mdbook build docs/\`) passes with no broken references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration management to use discrete mapping files with enhanced `config edit` and `config test` commands
  * Added new `[output.imu]` configuration option for IMU device support
  * Documented supervisor tunables including `suspend_grace_sec` setting
  * Simplified installation process with automatic systemd setup; expanded device access to include `/dev/uhid`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->