### PR TITLE
ci: add tee log to check-matrix timeout invocations for SIGTERM-survivable output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libusb-1.0-0-dev
       - name: Run all checks
         run: |
-          timeout 600 zig build ${{ matrix.zig_args }} check-all --summary all
+          set -eo pipefail
+          timeout 600 zig build ${{ matrix.zig_args }} check-all --summary all 2>&1 | tee check-all.log
 
   check:
     name: check
@@ -134,4 +135,4 @@ jobs:
               curl -fsSL https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz -o /tmp/zig.tar.xz
               tar -xJf /tmp/zig.tar.xz -C /tmp
               timeout 600 /tmp/zig-x86_64-linux-0.15.2/zig build -Dlibusb=false check-all --summary all
-            "
+            " 2>&1 | tee distro-check.log


### PR DESCRIPTION
## Summary

- Add `2>&1 | tee check-all.log` to `check-matrix` step so Zig test runner output accumulates incrementally and survives SIGTERM
- Add `2>&1 | tee distro-check.log` to `distro-check` container invocation for same reason
- Add `set -eo pipefail` to `check-matrix` run block so `timeout`'s exit code propagates through the pipe
- Pattern matches the existing `tsan` step which already uses `| tee tsan-build.log`

## Background

PR #166 commit `47a784e` hit `timeout 600` in `check-matrix` and produced zero test output between command-start and SIGTERM kill. Root cause: Zig's test runner buffers stdout and SIGTERM doesn't flush it. Piping through `tee` writes each chunk to the log file as it arrives, so partial output survives a kill signal.

## Test plan

- [ ] CI `check-matrix` job shows incremental build output in the step log (not empty on timeout)
- [ ] CI `distro-check` job shows incremental output in the step log
- [ ] `check-all.log` / `distro-check.log` artifacts visible on failure for post-mortem
- [ ] Exit code from `timeout`/`zig build` still propagates correctly (job fails when build fails)
- [ ] `tsan` step unchanged

refs: `.github/workflows/ci.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline with stricter error handling and improved logging capabilities to ensure more reliable builds and facilitate better troubleshooting of issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->