### PR TITLE
chore(release): bump version to 0.1.4

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.2",
+    .version = "0.1.4",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/refs/heads/main.tar.gz",


### PR DESCRIPTION
## Summary

Bumps `build.zig.zon` version `0.1.2` → `0.1.4`. Tags `v0.1.4` once merged.

Skips `0.1.3` (drafted release notes were never published).

## Scope

Since v0.1.2 (2026-04-22):

- 13 user-visible bug fixes (#79, #99, #72, #136, #162, #163, #131-A/B, #139, #142, #143, #147, #93)
- 10 hardening PRs (#168/#169/#170 audit V1/V4/V5; #140 UHID; #175-#181 X1-X6 + Y2)
- 5 features (#127/#132/#159/#160 Phase 13 UHID Wave 1-3 — closes #81 SDL IMU pairing; #130 padctl dump CLI)
- 5 docs PRs (#150/#158/#173/#174/#184)
- 6 internal/CI PRs (#156/#157, #153/#154/#155, #182/#185)

Not included: Wave 6 PIDFF (PR #166) — defers to v0.1.5/v0.2.0 after real-hardware matrix.

## Architecture review

`review/architecture-review-v0.1.4.md` (docs-repo): no BLOCKING for v0.1.4. Two HIGH structural concerns logged for Phase 14 planning:
- `supervisor.zig` poll-loop body duplication (run/serve/serveMulti)
- `cli/install.zig` 5005 LoC monolith

## Test plan

- [x] CI on main green at base (a539015)
- [ ] CI on this branch (matrix: default, wasm-false, libusb-false, tsan, distro-check, e2e, install-flow, lean, coverage)
- [ ] After merge: tag v0.1.4 on merge commit, push tag, release.yml auto-creates GitHub release
- [ ] Local pre-push tsan skipped via SKIP_TSAN=1 (kernel hidraw deadlock from prior session debris; CI is source of truth)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.1.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->