### PR TITLE
test(interpreter): replace inline vader5 TOML with parseFile reference fixture

### DIFF
--- a/src/core/interpreter.zig
+++ b/src/core/interpreter.zig
@@ -587,49 +587,9 @@ const testing = std.testing;
 // [27..28] = accel_z i16le
 // [29..31] = padding
 
-const vader5_toml =
-    \\[device]
-    \\name = "Test Vader 5"
-    \\vid = 0x37d7
-    \\pid = 0x2401
-    \\
-    \\[[device.interface]]
-    \\id = 1
-    \\class = "hid"
-    \\
-    \\[device.init]
-    \\commands = ["5aa5 0102 03"]
-    \\response_prefix = [0x5a, 0xa5]
-    \\
-    \\[[report]]
-    \\name = "extended"
-    \\interface = 1
-    \\size = 32
-    \\
-    \\[report.match]
-    \\offset = 0
-    \\expect = [0x5a, 0xa5, 0xef]
-    \\
-    \\[report.fields]
-    \\left_x  = { offset = 3, type = "i16le" }
-    \\left_y  = { offset = 5, type = "i16le", transform = "negate" }
-    \\right_x = { offset = 7, type = "i16le" }
-    \\right_y = { offset = 9, type = "i16le", transform = "negate" }
-    \\lt      = { offset = 15, type = "u8" }
-    \\rt      = { offset = 16, type = "u8" }
-    \\gyro_x  = { offset = 17, type = "i16le" }
-    \\gyro_y  = { offset = 19, type = "i16le" }
-    \\gyro_z  = { offset = 21, type = "i16le" }
-    \\accel_x = { offset = 23, type = "i16le" }
-    \\accel_y = { offset = 25, type = "i16le" }
-    \\accel_z = { offset = 27, type = "i16le" }
-    \\
-    \\[report.button_group]
-    \\source = { offset = 11, size = 4 }
-    \\map = { DPadUp = 0, DPadRight = 1, DPadDown = 2, DPadLeft = 3, A = 4, B = 5, Select = 6, X = 7, Y = 8, Start = 9, LB = 10, RB = 11, LS = 14, RS = 15, C = 16, Z = 17, M1 = 18, M2 = 19, M3 = 20, M4 = 21, LM = 22, RM = 23, O = 24, Home = 27 }
-;
-
-const vader5_if0_toml =
+// intentionally minimal; not a vader5 fixture — exercises multi-interface routing
+// with a synthetic IF0 vendor report absent from the canonical device file.
+const synthetic_dual_if_toml =
     \\[device]
     \\name = "Test Vader 5"
     \\vid = 0x37d7
@@ -689,9 +649,9 @@ fn makeIf1Sample() [32]u8 {
     raw[11] = 0x30;
     raw[15] = 128; // lt
     raw[16] = 64; // rt
-    std.mem.writeInt(i16, raw[17..19], 100, .little); // gyro_x
-    std.mem.writeInt(i16, raw[19..21], 200, .little); // gyro_y
-    std.mem.writeInt(i16, raw[21..23], 300, .little); // gyro_z
+    std.mem.writeInt(i16, raw[17..19], 100, .little); // gyro_x (offset 17)
+    std.mem.writeInt(i16, raw[19..21], 300, .little); // gyro_z (offset 19, canonical)
+    std.mem.writeInt(i16, raw[21..23], -200, .little); // gyro_y (offset 21, canonical negate → 200)
     std.mem.writeInt(i16, raw[23..25], -100, .little); // accel_x
     std.mem.writeInt(i16, raw[25..27], -200, .little); // accel_y
     std.mem.writeInt(i16, raw[27..29], -300, .little); // accel_z
@@ -700,7 +660,7 @@ fn makeIf1Sample() [32]u8 {
 
 test "interpreter: IF1 sample: axes, buttons, IMU" {
     const allocator = testing.allocator;
-    const parsed = try device.parseString(allocator, vader5_toml);
+    const parsed = try device.parseFile(allocator, "devices/flydigi/vader5.toml");
     defer parsed.deinit();
     const interp = Interpreter.init(&parsed.value);
     const raw = makeIf1Sample();
@@ -727,7 +687,7 @@ test "interpreter: IF1 sample: axes, buttons, IMU" {
 
 test "interpreter: match miss: wrong magic returns null" {
     const allocator = testing.allocator;
-    const parsed = try device.parseString(allocator, vader5_toml);
+    const parsed = try device.parseFile(allocator, "devices/flydigi/vader5.toml");
     defer parsed.deinit();
     const interp = Interpreter.init(&parsed.value);
     var raw = makeIf1Sample();
@@ -738,7 +698,7 @@ test "interpreter: match miss: wrong magic returns null" {
 
 test "interpreter: short raw returns null" {
     const allocator = testing.allocator;
-    const parsed = try device.parseString(allocator, vader5_toml);
+    const parsed = try device.parseFile(allocator, "devices/flydigi/vader5.toml");
     defer parsed.deinit();
     const interp = Interpreter.init(&parsed.value);
     const raw = [_]u8{ 0x5a, 0xa5, 0xef, 0x01 }; // only 4 bytes, report.size=32
@@ -748,7 +708,7 @@ test "interpreter: short raw returns null" {
 
 test "interpreter: wrong interface_id returns null" {
     const allocator = testing.allocator;
-    const parsed = try device.parseString(allocator, vader5_toml);
+    const parsed = try device.parseFile(allocator, "devices/flydigi/vader5.toml");
     defer parsed.deinit();
     const interp = Interpreter.init(&parsed.value);
     const raw = makeIf1Sample();
@@ -758,7 +718,7 @@ test "interpreter: wrong interface_id returns null" {
 
 test "interpreter: different interface_id matches different report" {
     const allocator = testing.allocator;
-    const parsed = try device.parseString(allocator, vader5_if0_toml);
+    const parsed = try device.parseString(allocator, synthetic_dual_if_toml);
     defer parsed.deinit();
     const interp = Interpreter.init(&parsed.value);
 
@@ -1474,7 +1434,7 @@ test "interpreter: checksum crc32 with seed" {
 
 test "interpreter: empty report (0 bytes) returns null without panic" {
     const allocator = testing.allocator;
-    const parsed = try device.parseString(allocator, vader5_toml);
+    const parsed = try device.parseFile(allocator, "devices/flydigi/vader5.toml");
     defer parsed.deinit();
     const interp = Interpreter.init(&parsed.value);
     const result = try interp.processReport(1, &[_]u8{});
@@ -1483,7 +1443,7 @@ test "interpreter: empty report (0 bytes) returns null without panic" {
 
 test "interpreter: oversized report parsed without bounds error" {
     const allocator = testing.allocator;
-    const parsed = try device.parseString(allocator, vader5_toml);
+    const parsed = try device.parseFile(allocator, "devices/flydigi/vader5.toml");
     defer parsed.deinit();
     const interp = Interpreter.init(&parsed.value);
     // 128 bytes, magic correct — should match and parse normally
@@ -1499,7 +1459,7 @@ test "interpreter: oversized report parsed without bounds error" {
 
 test "interpreter: all-0xFF report does not panic" {
     const allocator = testing.allocator;
-    const parsed = try device.parseString(allocator, vader5_toml);
+    const parsed = try device.parseFile(allocator, "devices/flydigi/vader5.toml");
     defer parsed.deinit();
     const interp = Interpreter.init(&parsed.value);
     var raw = [_]u8{0xFF} ** 32;
@@ -1510,7 +1470,7 @@ test "interpreter: all-0xFF report does not panic" {
 
 test "interpreter: fuzz processReport: no panic on arbitrary input" {
     const allocator = testing.allocator;
-    const parsed = try device.parseString(allocator, vader5_toml);
+    const parsed = try device.parseFile(allocator, "devices/flydigi/vader5.toml");
     defer parsed.deinit();
     const interp = Interpreter.init(&parsed.value);
     try testing.fuzz(interp, struct {
@@ -1899,7 +1859,7 @@ test "mutation audit: crc32 initial value sensitivity" {
 // would be rejected. We verify both polarities.
 test "mutation audit: processReport match polarity" {
     const allocator = testing.allocator;
-    const parsed = try device.parseString(allocator, vader5_toml);
+    const parsed = try device.parseFile(allocator, "devices/flydigi/vader5.toml");
     defer parsed.deinit();
     const interp = Interpreter.init(&parsed.value);
     // Correct magic → must match and return non-null


### PR DESCRIPTION
## What

- Replaces 10 `parseString(allocator, vader5_toml)` calls in `src/core/interpreter.zig` with `parseFile(allocator, "devices/flydigi/vader5.toml")`, eliminating the 90-line inline literal that was a known drift candidate (6-agent audit 2026-04-23).
- Fixes `makeIf1Sample()` gyro layout to match canonical `devices/flydigi/vader5.toml`: `gyro_z` is at offset 19, `gyro_y` at offset 21 with `negate` transform — the inline had them swapped with no negate on `gyro_y`.
- Renames `vader5_if0_toml` → `synthetic_dual_if_toml` (kept as inline): the canonical device file has IF1 only; the dual-interface fixture exercises multi-interface routing with a synthetic IF0 vendor report absent from the canonical file. Added clarifying comment.

## Scope

Finding #10 (interpreter portion) from `architecture-review-v0.1.4.md`. Does not touch `event_loop.zig` (C1 scope).

## Test plan

- [ ] `zig build` — clean (no output)
- [ ] `zig build check-fmt` — clean (no output)
- [ ] `grep -c vader5_toml src/core/interpreter.zig` → 0
- [ ] `grep -c parseFile src/core/interpreter.zig` → 10 (vader5 fixture loads)

refs: `review/architecture-review-v0.1.4.md` Finding #10