### PR TITLE
test(device_instance): add imu_name ownership ordering regression test

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -120,6 +120,7 @@ pub const testing_support = struct {
     pub const steam_deck_fixture = @import("test/fixtures/steam_deck_reports.zig");
     pub const uhid_simulator = @import("test/harness/uhid_simulator.zig");
     pub const uhid_test_cleanup = @import("test/uhid_test_cleanup.zig");
+    pub const device_instance_imu_ownership_test = @import("test/device_instance_imu_ownership_test.zig");
 };
 
 pub const config = struct {

--- a/src/test/device_instance_imu_ownership_test.zig
+++ b/src/test/device_instance_imu_ownership_test.zig
@@ -1,0 +1,154 @@
+// Regression: DeviceInstance.deinit must destroy(imu_dev) BEFORE free(imu_name_owned).
+// imu_dev.close() runs inside destroy and writes UHID_DESTROY to the fd while
+// UhidDevice.name still points at the imu_name backing buffer. If the free order
+// is reversed the name pointer dangled during the UHID_DESTROY write.
+
+const std = @import("std");
+const posix = std.posix;
+const testing = std.testing;
+
+const src = @import("src");
+const device_instance = src.device_instance;
+const DeviceInstance = device_instance.DeviceInstance;
+const DeviceIO = src.io.device_io.DeviceIO;
+const MockDeviceIO = src.testing_support.mock_device_io.MockDeviceIO;
+const uhid = src.io.uhid;
+const EventLoop = src.event_loop.EventLoop;
+const Interpreter = src.core.interpreter.Interpreter;
+const device_mod = src.config.device;
+
+// Ordered event log shared between the recording allocator and the test.
+const EventKind = enum { destroy_imu_dev, free_imu_name };
+const MAX_EVENTS = 8;
+var g_log: [MAX_EVENTS]EventKind = undefined;
+var g_count: usize = 0;
+
+fn logEvent(k: EventKind) void {
+    if (g_count < MAX_EVENTS) {
+        g_log[g_count] = k;
+        g_count += 1;
+    }
+}
+
+// Allocator that records free() calls for two tracked pointers.
+const RecordingAllocator = struct {
+    inner: std.mem.Allocator,
+    imu_dev_ptr: [*]const u8, // raw byte ptr of the UhidDevice allocation
+    imu_name_ptr: [*]const u8,
+
+    fn alloc(ctx: *anyopaque, n: usize, al: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const s: *RecordingAllocator = @ptrCast(@alignCast(ctx));
+        return s.inner.rawAlloc(n, al, ra);
+    }
+
+    fn resize(ctx: *anyopaque, buf: []u8, al: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const s: *RecordingAllocator = @ptrCast(@alignCast(ctx));
+        return s.inner.rawResize(buf, al, new_len, ra);
+    }
+
+    fn free(ctx: *anyopaque, buf: []u8, al: std.mem.Alignment, ra: usize) void {
+        const s: *RecordingAllocator = @ptrCast(@alignCast(ctx));
+        if (buf.ptr == s.imu_dev_ptr) logEvent(.destroy_imu_dev);
+        if (buf.ptr == s.imu_name_ptr) logEvent(.free_imu_name);
+        s.inner.rawFree(buf, al, ra);
+    }
+
+    fn allocator(self: *RecordingAllocator) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = alloc,
+            .resize = resize,
+            .free = free,
+            .remap = std.mem.Allocator.noRemap,
+        } };
+    }
+};
+
+const MINIMAL_TOML =
+    \\[device]
+    \\name = "IMU Ordering Test"
+    \\vid = 0x1234
+    \\pid = 0x5678
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[[report]]
+    \\name = "input"
+    \\interface = 0
+    \\size = 3
+    \\[report.match]
+    \\offset = 0
+    \\expect = [0x01]
+    \\[report.fields]
+    \\left_x = { offset = 1, type = "i16le" }
+;
+
+test "DeviceInstance.deinit: imu_name freed after imu_dev destroyed" {
+    g_count = 0;
+
+    const base_alloc = testing.allocator;
+    const parsed = try device_mod.parseString(base_alloc, MINIMAL_TOML);
+    defer parsed.deinit();
+
+    // Pipe: write-end is the fake UHID fd; read-end lets us detect UHID_DESTROY.
+    const pipe_fds = try posix.pipe2(.{ .NONBLOCK = true });
+    const read_end = pipe_fds[0];
+    defer posix.close(read_end);
+
+    // Allocate imu_name and imu_dev struct via base_alloc to get stable pointers,
+    // then hand both to RecordingAllocator for tracking.
+    const imu_name_raw = try base_alloc.dupe(u8, "IMU Ordering Test IMU");
+    const imu_cfg = uhid.Config{
+        .name = imu_name_raw,
+        .uniq = "test-uniq",
+        .vid = 0x1234,
+        .pid = 0x5678,
+        .descriptor = &[_]u8{ 0x05, 0x01, 0x09, 0x05, 0xA1, 0x01, 0xC0 },
+    };
+    // initWithFd allocates the UhidDevice struct via base_alloc; we capture the ptr.
+    const imu_dev = try uhid.UhidDevice.initWithFd(base_alloc, pipe_fds[1], imu_cfg);
+
+    var rec = RecordingAllocator{
+        .inner = base_alloc,
+        .imu_dev_ptr = @ptrCast(imu_dev),
+        .imu_name_ptr = imu_name_raw.ptr,
+    };
+    const alloc = rec.allocator();
+
+    const devices = try alloc.alloc(DeviceIO, 0);
+    const loop = try EventLoop.initManaged();
+
+    var inst = DeviceInstance{
+        .allocator = alloc,
+        .devices = devices,
+        .loop = loop,
+        .interp = Interpreter.init(&parsed.value),
+        .mapper = null,
+        .owner = .none,
+        .primary_output = null,
+        .imu_output = null,
+        .imu_dev = imu_dev,
+        .imu_name_owned = imu_name_raw,
+        .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
+        .device_cfg = &parsed.value,
+        .pending_mapping = null,
+        .stopped = false,
+    };
+
+    inst.deinit();
+
+    // Confirm UHID_DESTROY reached the pipe (imu_dev.close() actually ran).
+    var buf: [uhid.UHID_EVENT_SIZE]u8 = undefined;
+    const n = posix.read(read_end, &buf) catch 0;
+    try testing.expect(n >= @sizeOf(u32));
+    try testing.expectEqual(uhid.UHID_DESTROY, std.mem.readInt(u32, buf[0..4], .little));
+
+    // Both allocator events must have fired.
+    try testing.expectEqual(@as(usize, 2), g_count);
+
+    // destroy(imu_dev) must precede free(imu_name_owned).
+    try testing.expectEqual(EventKind.destroy_imu_dev, g_log[0]);
+    try testing.expectEqual(EventKind.free_imu_name, g_log[1]);
+}


### PR DESCRIPTION
## Summary

- Adds `src/test/device_instance_imu_ownership_test.zig` with a recording-allocator harness
- The allocator intercepts `rawFree` calls and records the order of `destroy(imu_dev)` vs `free(imu_name_owned)` in a global event log
- Also reads `UHID_DESTROY` opcode from the pipe write-end to confirm `imu_dev.close()` actually ran
- Wired into `build.zig` as an independent `b.addTest` module (same pattern as `supervisor_uhid_routing_test.zig`), hooked to `test_step`
- Added to `testing_support` in `src/main.zig` for module graph completeness

## Test plan

- [ ] `zig build` compiles cleanly (no errors)
- [ ] `zig build check-fmt` passes
- [ ] If deinit body is reordered (`free(imu_name_owned)` before `destroy(imu_dev)`), `g_log[0]` becomes `free_imu_name` and `expectEqual(destroy_imu_dev, g_log[0])` fails
- [ ] If `imu_dev.close()` is skipped, `UHID_DESTROY` read returns 0 bytes and `expect(n >= @sizeOf(u32))` fails

refs: architecture-review-v0.1.4.md finding #9 (option B)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a regression test for device instance IMU ownership and resource cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->