### PR TITLE
fix(macro): delay step must yield frame; subsequent steps wait for timerfd expiry (issue #72)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,6 +8,7 @@ pub fn build(b: *std.Build) void {
     const use_libusb = b.option(bool, "libusb", "Link libusb-1.0 (default: true)") orelse true;
     const use_wasm = b.option(bool, "wasm", "Link wasm3 runtime (default: true)") orelse true;
     const coverage = b.option(bool, "test-coverage", "Run tests with kcov coverage") orelse false;
+    const test_filter = b.option([]const u8, "test-filter", "Substring filter passed to addTest.filters (local dev)");
 
     const wasm3_c_flags: []const []const u8 = &.{ "-std=c99", "-DDEBUG=0", "-Dd_m3HasWASI=0" };
 
@@ -100,7 +101,8 @@ pub fn build(b: *std.Build) void {
     unit_mod.addImport("toml_gen", capture_toml_gen_mod);
     unit_mod.addImport("build_options", build_opts.createModule());
     if (use_wasm) addWasm3(b, unit_mod, wasm3_c_flags);
-    const unit_tests = b.addTest(.{ .root_module = unit_mod });
+    const unit_filters: []const []const u8 = if (test_filter) |f| &.{f} else &.{};
+    const unit_tests = b.addTest(.{ .root_module = unit_mod, .filters = unit_filters });
     if (use_libusb) {
         unit_tests.linkSystemLibrary("usb-1.0");
     } else {

--- a/src/core/macro_player.zig
+++ b/src/core/macro_player.zig
@@ -17,6 +17,10 @@ pub const MacroPlayer = struct {
     timer_token: u32,
     trigger_src_idx: u6,
     held_gamepad_buttons: u64,
+    // issue #72: deadline at which the next step becomes eligible. While now_ns
+    // is below this, step() must yield the frame so per-poll Mapper.apply calls
+    // do not race past delay= boundaries.
+    next_step_eligible_at_ns: i128,
 
     pub fn init(m: *const Macro, token: u32, src_idx: u6) MacroPlayer {
         return .{
@@ -26,6 +30,7 @@ pub const MacroPlayer = struct {
             .timer_token = token,
             .trigger_src_idx = src_idx,
             .held_gamepad_buttons = 0,
+            .next_step_eligible_at_ns = 0,
         };
     }
 
@@ -45,6 +50,9 @@ pub const MacroPlayer = struct {
         now_ns: i128,
     ) !bool {
         if (self.waiting_for_release) return false;
+        // issue #72: prevent same-frame double-emit — only the macro timerfd
+        // expiry advances state past a delay boundary.
+        if (now_ns < self.next_step_eligible_at_ns) return false;
 
         while (self.step_index < self.macro.steps.len) {
             const s = self.macro.steps[self.step_index];
@@ -65,6 +73,7 @@ pub const MacroPlayer = struct {
                 .delay => |ms| {
                     const deadline = now_ns + @as(i128, ms) * std.time.ns_per_ms;
                     try queue.arm(deadline, self.timer_token, now_ns);
+                    self.next_step_eligible_at_ns = deadline;
                     return false;
                 },
                 .pause_for_release => {
@@ -220,7 +229,9 @@ test "macro_player: delay arms timer queue returns not-done" {
     try testing.expectEqual(@as(usize, 1), ctx.queue.heap.count());
 
     ctx.aux = .{};
-    const done2 = try ctx.step(&player);
+    // issue #72: must advance now_ns past the delay deadline before step resumes.
+    const after_delay: i128 = 50 * std.time.ns_per_ms + 1;
+    const done2 = try player.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, after_delay);
     try testing.expect(done2);
     try testing.expectEqual(@as(usize, 2), ctx.aux.len);
 }

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -59,6 +59,10 @@ pub const Mapper = struct {
     suppressed_buttons: u64,
     injected_buttons: u64,
     pending_tap_release: ?u64,
+    // issue #72: gamepad-button taps emitted by macro timer expiry need one
+    // apply() cycle to reach output before pending_tap_release fires; staged
+    // here, promoted to injected+pending_tap_release at the next apply.
+    macro_timer_tap_pending: u64,
     timer_fd: std.posix.fd_t,
     allocator: std.mem.Allocator,
     active_macros: std.ArrayList(MacroPlayer),
@@ -93,6 +97,7 @@ pub const Mapper = struct {
             .suppressed_buttons = 0,
             .injected_buttons = 0,
             .pending_tap_release = null,
+            .macro_timer_tap_pending = 0,
             .timer_fd = timer_fd,
             .allocator = allocator,
             .active_macros = .{},
@@ -160,11 +165,22 @@ pub const Mapper = struct {
             // Cancel in-flight macros; emit releases for any held keys/buttons.
             for (self.active_macros.items) |*p| p.emitPendingReleases(&aux, &self.injected_buttons);
             self.active_macros.clearRetainingCapacity();
+            // issue #72: discard tap bits staged from a cancelled macro's timer expiry.
+            self.macro_timer_tap_pending = 0;
         }
 
         // reset accumulators
         self.suppressed_buttons = 0;
         self.injected_buttons = 0;
+
+        // issue #72: promote macro-timer tap bits staged at last expiry — emit
+        // press this frame, schedule release for the next apply.
+        if (self.macro_timer_tap_pending != 0) {
+            self.injected_buttons |= self.macro_timer_tap_pending;
+            const existing = self.pending_tap_release orelse 0;
+            self.pending_tap_release = existing | self.macro_timer_tap_pending;
+            self.macro_timer_tap_pending = 0;
+        }
 
         // Suppress layer trigger buttons so they don't leak to uinput output.
         // Trigger buttons are consumed by the layer system regardless of
@@ -312,6 +328,10 @@ pub const Mapper = struct {
         var macro_tap_release: u64 = 0;
         var i: usize = 0;
         while (i < self.active_macros.items.len) {
+            // issue #72: re-assert macro-held gamepad bits each frame; injected_buttons
+            // is reset above, but held_gamepad_buttons (set by past `down=`) must persist
+            // across the delay window and outlive same-frame step advancement.
+            self.injected_buttons |= self.active_macros.items[i].held_gamepad_buttons;
             const done = self.active_macros.items[i].step(
                 &aux,
                 &self.timer_queue,
@@ -419,8 +439,11 @@ pub const Mapper = struct {
             }
         }
         if (macro_tap_release != 0) {
-            const existing = self.pending_tap_release orelse 0;
-            self.pending_tap_release = existing | macro_tap_release;
+            // issue #72: stage tap bits for the next apply rather than promoting
+            // to pending_tap_release here — apply() resets injected_buttons on
+            // entry, so a same-cycle pending_tap_release would clear the bit
+            // before the gamepad output is ever emitted.
+            self.macro_timer_tap_pending |= macro_tap_release;
         }
         return aux;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1042,6 +1042,7 @@ test {
     _ = @import("test/bugfix_regression_test.zig");
     _ = @import("test/uhid_uniq_pairing_test.zig");
     _ = @import("test/macro_gamepad_button_test.zig");
+    _ = @import("test/macro_e2e_test.zig");
     _ = @import("test/properties/config_props.zig");
     _ = @import("test/properties/contract_props.zig");
     _ = @import("test/properties/device_specific_props.zig");

--- a/src/test/macro_e2e_test.zig
+++ b/src/test/macro_e2e_test.zig
@@ -191,7 +191,9 @@ test "macro: macro playback — tap B, delay 50, tap LEFT sequence" {
     var aux2 = AuxEventList{};
     var injected2: u64 = 0;
     var tap_rel2: u64 = 0;
-    const done2 = try player.step(&aux2, &q, &injected2, &tap_rel2, 0);
+    // issue #72: advance now_ns past the 50ms delay deadline.
+    const after_delay: i128 = 50 * std.time.ns_per_ms + 1;
+    const done2 = try player.step(&aux2, &q, &injected2, &tap_rel2, after_delay);
     try testing.expect(done2);
     try testing.expectEqual(@as(usize, 2), aux2.len);
     switch (aux2.get(0)) {
@@ -294,12 +296,10 @@ test "macro: layer switch while macro active — held keys released, macros clea
     _ = try m.apply(.{ .buttons = m1_mask }, 16, 0);
     try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
 
-    // Now activate layer (LT hold) — active_changed fires → macros cleared, releases emitted.
-    const configs = ctx.parsed.value.layer.?;
-    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
-    _ = m.layer.onTimerExpired();
-
-    const ev = try m.apply(.{ .buttons = m1_mask }, 16, 0);
+    // Press LT — processLayerTriggers fires action.active_changed on the rising
+    // edge of a hold trigger, which clears active_macros and emits releases.
+    const lt_mask = btnMask(.LT);
+    const ev = try m.apply(.{ .buttons = m1_mask | lt_mask }, 16, 0);
 
     // active_macros must be empty after layer switch.
     try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
@@ -365,6 +365,9 @@ test "macro: hot-reload — updateMapping swaps config; next apply uses new mapp
         .primary_output = null,
         .imu_output = null,
         .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
         .device_cfg = &parsed_dev.value,
         .pending_mapping = null,
         .stopped = false,
@@ -472,5 +475,81 @@ test "macro: mapper macro trigger — no second player on held button (no re-tri
 
     // Frame 2: still held → no new player (no rising edge).
     _ = try m.apply(.{ .buttons = m1_mask }, 16, 0);
+    try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
+}
+
+// --- Issue #72 regression: delay must yield frame ---
+//
+// Reporter @xl666: with steps [down=Home, delay=100, tap=A, delay=100, up=Home]
+// every poll-frame `Mapper.apply` resumes the player, so subsequent steps fire
+// in the same frame as the delay-arming step. This produces a same-frame race
+// where Home-down and A-down emit together and only one is observed downstream.
+test "macro #72: delay must gate subsequent steps until timer expiry" {
+    const allocator = testing.allocator;
+
+    var ctx = try makeMapper(
+        \\[[macro]]
+        \\name = "menu"
+        \\steps = [
+        \\  { down = "Home" },
+        \\  { delay = 100 },
+        \\  { tap = "A" },
+        \\  { delay = 100 },
+        \\  { up = "Home" },
+        \\]
+        \\
+        \\[remap]
+        \\C = "macro:menu"
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const c_mask = btnMask(.C);
+    const home_bit = btnMask(.Home);
+    const a_bit = btnMask(.A);
+
+    const ns_per_ms: i128 = std.time.ns_per_ms;
+    const t0: i128 = 1_000_000_000;
+
+    // Frame 0 (rising edge): only Home should be held.
+    const ev0 = try m.apply(.{ .buttons = c_mask }, 16, t0);
+    try testing.expectEqual(home_bit, ev0.gamepad.buttons & home_bit);
+    try testing.expectEqual(@as(u64, 0), ev0.gamepad.buttons & a_bit);
+
+    // Mid-delay frames (USB poll cadence ~4ms): macro must not advance, so
+    // Home stays held and A stays clear. Reporter's bug: A fires here.
+    var t: i128 = t0 + 4 * ns_per_ms;
+    while (t < t0 + 100 * ns_per_ms) : (t += 4 * ns_per_ms) {
+        const evN = try m.apply(.{ .buttons = c_mask }, 4, t);
+        try testing.expectEqual(home_bit, evN.gamepad.buttons & home_bit);
+        try testing.expectEqual(@as(u64, 0), evN.gamepad.buttons & a_bit);
+    }
+
+    // Timer expiry: tap=A staged. Next apply emits press; the apply after that
+    // releases via pending_tap_release. Home stays held throughout.
+    const t_expire1: i128 = t0 + 100 * ns_per_ms;
+    _ = m.onMacroTimerExpired(t_expire1);
+
+    const ev_press = try m.apply(.{ .buttons = c_mask }, 4, t_expire1 + ns_per_ms);
+    try testing.expectEqual(home_bit, ev_press.gamepad.buttons & home_bit);
+    try testing.expectEqual(a_bit, ev_press.gamepad.buttons & a_bit);
+
+    const ev_release = try m.apply(.{ .buttons = c_mask }, 4, t_expire1 + 2 * ns_per_ms);
+    try testing.expectEqual(home_bit, ev_release.gamepad.buttons & home_bit);
+    try testing.expectEqual(@as(u64, 0), ev_release.gamepad.buttons & a_bit);
+
+    // Mid second-delay: still no premature up=Home.
+    var t2: i128 = t_expire1 + 4 * ns_per_ms;
+    while (t2 < t_expire1 + 100 * ns_per_ms) : (t2 += 4 * ns_per_ms) {
+        const evN = try m.apply(.{ .buttons = c_mask }, 4, t2);
+        try testing.expectEqual(home_bit, evN.gamepad.buttons & home_bit);
+        try testing.expectEqual(@as(u64, 0), evN.gamepad.buttons & a_bit);
+    }
+
+    // Second timer expiry: Home released.
+    const t_expire2: i128 = t_expire1 + 100 * ns_per_ms;
+    _ = m.onMacroTimerExpired(t_expire2);
+    const ev_after2 = try m.apply(.{ .buttons = c_mask }, 4, t_expire2 + ns_per_ms);
+    try testing.expectEqual(@as(u64, 0), ev_after2.gamepad.buttons & home_bit);
     try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
 }

--- a/src/test/macro_gamepad_button_test.zig
+++ b/src/test/macro_gamepad_button_test.zig
@@ -93,7 +93,9 @@ test "macro #99: down A with delay holds A bit between frames" {
     try testing.expectEqual(btnBit(.A), injected & btnBit(.A));
 
     aux = .{};
-    const done2 = try player.step(&aux, &q, &injected, &tap_release, 0);
+    // issue #72: now_ns must clear the 10ms delay deadline before step advances.
+    const after_delay: i128 = 10 * std.time.ns_per_ms + 1;
+    const done2 = try player.step(&aux, &q, &injected, &tap_release, after_delay);
     try testing.expect(done2);
     try testing.expectEqual(@as(u64, 0), injected & btnBit(.A));
 }


### PR DESCRIPTION
Closes nothing — issue #72 reporter @xl666 should re-test before maintainer closes.

Linked: https://github.com/BANANASJIM/padctl/issues/72

## Reporter repro

```toml
[[macro]]
name = "menu"
steps = [
    { down = "Home" },
    { delay = 100 },
    { tap = "A" },
    { delay = 100 },
    { up = "Home" }
]
[remap]
C = "macro:menu"
```

Reporter observed: pressing `C` made `Home` and `A` fire as a same-frame race; downstream apps registered only one of the two. The recommended `pause_for_release` workaround helped only intermittently.

## Root cause

`Mapper.apply` runs on every USB poll frame (~4 ms) and unconditionally resumed every active `MacroPlayer`. After `MacroPlayer.step()` armed the timerfd for `delay = N` and returned, the very next `apply()` re-entered `step()` and immediately walked into the next sequential step. The entire macro therefore collapsed into adjacent poll frames with no real wait. In addition, `Mapper.injected_buttons` is reset every frame, so a `down = "<gamepad-button>"` step was dropped after the first frame because nothing re-asserted the held bit while the macro waited.

## Fix

1. `MacroPlayer.next_step_eligible_at_ns` (i128) is set to the delay deadline; `step()` returns false immediately while `now_ns < next_step_eligible_at_ns`. Only the macro timerfd's expiry callback (`onMacroTimerExpired`) arrives with `now_ns >= deadline`, so only it advances the macro past a delay.
2. Section [8] of `Mapper.apply` re-ORs each player's `held_gamepad_buttons` into `injected_buttons` every frame so `down = "<gamepad>"` survives the delay window.
3. Gamepad-button taps that fire from `onMacroTimerExpired` are staged in a new `Mapper.macro_timer_tap_pending` field and promoted to `injected_buttons` + `pending_tap_release` at the next `apply()` entry. Without this staging the apply that follows the timer expiry would clear the tap bit before ever emitting it.
4. Layer-switch macro cancellation clears `macro_timer_tap_pending` along with `active_macros` and held bits.

The fix is deterministic — no sleeps, no thread coordination. Macro state strictly follows `now_ns` from the caller's CLOCK_MONOTONIC snapshot.

## Tests

- New: `src/test/macro_e2e_test.zig` test "macro #72: delay must gate subsequent steps until timer expiry" runs the reporter's exact macro through `Mapper.apply` + `onMacroTimerExpired` at realistic ppoll cadence (4 ms), asserting:
  - Frame 0: only `Home` is held.
  - All mid-delay frames before t+100 ms: `Home` still held, `A` not set.
  - Apply right after the first timer expiry: `Home` held AND `A` pressed.
  - Next apply: `A` released (via `pending_tap_release`), `Home` still held.
  - All mid-delay frames before t+200 ms: `Home` still held.
  - Apply right after the second timer expiry: `Home` released, no active macros.
- Updated:
  - `src/test/macro_e2e_test.zig` test "macro: layer switch while macro active" was passing only because the bug fired `up = KEY_LEFTSHIFT` prematurely. Updated to drive layer activation through `Mapper.apply` so `processLayerTriggers` correctly produces `active_changed`.
  - Pre-existing `macro: hot-reload` test gets `touchpad_dev` / `generic_state` / `generic_uinput` fields it was missing.
- Other touched tests advance `now_ns` past the delay before the second `step()` call (`macro_player.zig`, `macro_e2e_test.zig`, `macro_gamepad_button_test.zig`).
- `src/main.zig` adds `_ = @import("test/macro_e2e_test.zig");` — `refAllDecls` is non-recursive so the file's tests weren't compiled into the unit_tests binary previously.

## Local dev quality-of-life

`build.zig` accepts `-Dtest-filter=<substring>` and forwards it to `addTest.filters`, matching the existing `test-uhid-uniq` step pattern. Useful for triaging hidraw-deadlock-prone test runs without rebooting.

## Test plan

- [ ] Reporter @xl666 re-tests with the linked binary build and confirms the `down/delay/tap/delay/up` macro now produces the expected timing.
- [ ] CI green on `test`, `test-safe`, distro-check, coverage matrix.
- [ ] No regression in macro / mapper / layer / timer / bugfix-regression filter buckets (verified locally with `-Dtest-filter`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed timing race condition in macro execution during delays—macros now step correctly after delay deadlines expire.
  * Improved reliability of held button outputs during macro delays across polling frames.

* **Tests**
  * Enhanced macro testing with end-to-end and regression tests for delay timing scenarios.
  * Updated test suite to properly validate macro behavior with accurate timing inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->