### PR TITLE
chore(arch): cleanup N3+N4+N5+N7 from architecture-review-2026-04-29

### DIFF
--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -41,18 +41,20 @@ const freeArgv = services_mod.freeArgv;
 
 // udev.zig
 const UdevEntry = udev_mod.UdevEntry;
-const extractVidPid = udev_mod.extractVidPid;
-const isFieldKey = udev_mod.isFieldKey;
 const isValidIdentifier = udev_mod.isValidIdentifier;
-const parseStringArray = udev_mod.parseStringArray;
-const generateUdevRules = udev_mod.generateUdevRules;
-const generateDriverBlockRules = udev_mod.generateDriverBlockRules;
 const probeAndUnbindDrivers = udev_mod.probeAndUnbindDrivers;
 const readSysHex = udev_mod.readSysHex;
 const findDevicesSourceDir = udev_mod.findDevicesSourceDir;
 const imu_udev_rules_content = udev_mod.imu_udev_rules_content;
 const modules_load_content = udev_mod.modules_load_content;
-const parseHexOrDec = udev_mod.parseHexOrDec;
+// private helpers exposed via _internals_for_tests
+const _udev = udev_mod._internals_for_tests;
+const extractVidPid = _udev.extractVidPid;
+const isFieldKey = _udev.isFieldKey;
+const parseStringArray = _udev.parseStringArray;
+const parseHexOrDec = _udev.parseHexOrDec;
+const generateUdevRules = _udev.generateUdevRules;
+const generateDriverBlockRules = _udev.generateDriverBlockRules;
 
 // migration.zig
 const ensureUserXdgDirs = migration_mod.ensureUserXdgDirs;

--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -228,7 +228,7 @@ pub fn cleanupLegacyUdevFiles(allocator: std.mem.Allocator, plan: *const Install
 /// Scan all device TOML files in dirs, extract VID/PID/name/block_kernel_drivers,
 /// and deduplicate by VID:PID (preferring entries with richer data).
 /// Caller owns the returned entries and must call freeDeviceEntries when done.
-pub fn collectDeviceEntries(allocator: std.mem.Allocator, dirs: []const []const u8) !std.ArrayList(UdevEntry) {
+fn collectDeviceEntries(allocator: std.mem.Allocator, dirs: []const []const u8) !std.ArrayList(UdevEntry) {
     var entries = std.ArrayList(UdevEntry){};
     errdefer {
         for (entries.items) |e| {
@@ -331,8 +331,8 @@ pub fn generateUdevRulesFromEntries(allocator: std.mem.Allocator, entries: []con
     try f.writeAll(buf.items);
 }
 
-/// Kept for test compatibility — collects entries then generates rules.
-pub fn generateUdevRulesFromDirs(allocator: std.mem.Allocator, dirs: []const []const u8, rules_path: []const u8, prefix: []const u8) !void {
+/// Collects entries then generates rules.
+fn generateUdevRulesFromDirs(allocator: std.mem.Allocator, dirs: []const []const u8, rules_path: []const u8, prefix: []const u8) !void {
     var entries = try collectDeviceEntries(allocator, dirs);
     defer freeDeviceEntries(allocator, &entries);
     try generateUdevRulesFromEntries(allocator, entries.items, rules_path, prefix);
@@ -373,8 +373,8 @@ pub fn generateDriverBlockRulesFromEntries(allocator: std.mem.Allocator, entries
     try f.writeAll(buf.items);
 }
 
-/// Convenience wrapper for tests — collects entries then generates driver block rules.
-pub fn generateDriverBlockRules(allocator: std.mem.Allocator, dirs: []const []const u8, rules_path: []const u8) !void {
+/// Collects entries then generates driver block rules.
+fn generateDriverBlockRules(allocator: std.mem.Allocator, dirs: []const []const u8, rules_path: []const u8) !void {
     var entries = try collectDeviceEntries(allocator, dirs);
     defer freeDeviceEntries(allocator, &entries);
     try generateDriverBlockRulesFromEntries(allocator, entries.items, rules_path);
@@ -459,12 +459,12 @@ pub fn readSysHex(path: []const u8) !u16 {
     return std.fmt.parseInt(u16, trimmed, 16);
 }
 
-pub fn generateUdevRules(allocator: std.mem.Allocator, devices_dir: []const u8, rules_path: []const u8, prefix: []const u8) !void {
+fn generateUdevRules(allocator: std.mem.Allocator, devices_dir: []const u8, rules_path: []const u8, prefix: []const u8) !void {
     const dirs = [_][]const u8{devices_dir};
     return generateUdevRulesFromDirs(allocator, &dirs, rules_path, prefix);
 }
 
-pub fn isFieldKey(line: []const u8, key: []const u8) bool {
+fn isFieldKey(line: []const u8, key: []const u8) bool {
     if (!std.mem.startsWith(u8, line, key)) return false;
     if (line.len == key.len) return true;
     const next = line[key.len];
@@ -482,7 +482,7 @@ pub fn isValidIdentifier(s: []const u8) bool {
 }
 
 /// Parse a TOML inline array of strings, e.g. `["xpad", "hid_generic"]`.
-pub fn parseStringArray(allocator: std.mem.Allocator, value: []const u8) ![]const []const u8 {
+fn parseStringArray(allocator: std.mem.Allocator, value: []const u8) ![]const []const u8 {
     const trimmed = std.mem.trim(u8, value, " \t");
     if (trimmed.len < 2 or trimmed[0] != '[' or trimmed[trimmed.len - 1] != ']') return &.{};
     const inner = trimmed[1 .. trimmed.len - 1];
@@ -509,7 +509,7 @@ pub fn parseStringArray(allocator: std.mem.Allocator, value: []const u8) ![]cons
     return result;
 }
 
-pub fn extractVidPid(allocator: std.mem.Allocator, path: []const u8, entries: *std.ArrayList(UdevEntry)) !void {
+fn extractVidPid(allocator: std.mem.Allocator, path: []const u8, entries: *std.ArrayList(UdevEntry)) !void {
     var f = try std.fs.openFileAbsolute(path, .{});
     defer f.close();
     const content = try f.readToEndAlloc(allocator, 1 << 20);
@@ -548,13 +548,25 @@ pub fn extractVidPid(allocator: std.mem.Allocator, path: []const u8, entries: *s
     });
 }
 
-pub fn parseHexOrDec(comptime T: type, s: []const u8) !T {
+fn parseHexOrDec(comptime T: type, s: []const u8) !T {
     const trimmed = std.mem.trim(u8, s, " \t\r");
     if (std.mem.startsWith(u8, trimmed, "0x") or std.mem.startsWith(u8, trimmed, "0X")) {
         return std.fmt.parseInt(T, trimmed[2..], 16);
     }
     return std.fmt.parseInt(T, trimmed, 10);
 }
+
+/// Private helpers exposed to tests. Production code must use collectAllDeviceEntries
+/// + generateUdevRulesFromEntries instead of reaching through this namespace.
+pub const _internals_for_tests = struct {
+    pub const isFieldKey = @import("udev.zig").isFieldKey;
+    pub const parseStringArray = @import("udev.zig").parseStringArray;
+    pub const extractVidPid = @import("udev.zig").extractVidPid;
+    pub const parseHexOrDec = @import("udev.zig").parseHexOrDec;
+    pub const collectDeviceEntries = @import("udev.zig").collectDeviceEntries;
+    pub const generateUdevRules = @import("udev.zig").generateUdevRules;
+    pub const generateDriverBlockRules = @import("udev.zig").generateDriverBlockRules;
+};
 
 // setupTestUdev writes a udev rule that grants world-read access to UHID virtual
 // hidraw nodes and reloads udevd. Run once before test-e2e via:

--- a/src/main.zig
+++ b/src/main.zig
@@ -76,6 +76,10 @@ pub const io = struct {
     pub const netlink = @import("io/netlink.zig");
 };
 
+// Every new src/test/*.zig file MUST be added to this namespace.
+// The test block near the bottom of this file calls refAllDecls(@This()), which
+// pulls in every declaration here as a test artifact. A file omitted from this
+// namespace will compile but its tests will silently never run under `zig build test`.
 pub const testing_support = struct {
     pub const mock_device_io = @import("test/mock_device_io.zig");
     pub const mock_output = @import("test/mock_output.zig");

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -1649,7 +1649,8 @@ pub const Supervisor = struct {
                 };
                 // Register devname → phys so detach() can find this instance.
                 const devname = std.fs.path.basename(hidraw_path);
-                self.bindManagedDevname(&self.managed.items[self.managed.items.len - 1], devname, phys) catch {};
+                self.bindManagedDevname(&self.managed.items[self.managed.items.len - 1], devname, phys) catch |err|
+                    std.log.warn("bindManagedDevname failed for {s}: {s}", .{ phys, @errorName(err) });
                 // phys stays in seen (owned there) and also duped by spawnInstance for ManagedInstance.
                 spawned += 1;
             }


### PR DESCRIPTION
## Changes

- **N3** (`src/supervisor.zig:1652`): replace silent `catch {}` on `bindManagedDevname` with `catch |err| std.log.warn(...)` including phys path and error name
- **N4** (`src/cli/install/udev.zig`): demote `generateUdevRulesFromDirs`, `generateUdevRules`, `collectDeviceEntries`, and `generateDriverBlockRules` from `pub fn` to `fn`; keep `collectAllDeviceEntries` + `generateUdevRulesFromEntries` as the only public entry points
- **N5** (`src/cli/install/udev.zig`): demote `isFieldKey`, `parseStringArray`, `extractVidPid`, `parseHexOrDec` from `pub fn` to `fn`; expose via `pub const _internals_for_tests` namespace (keeps `isValidIdentifier` public — used by `mappings.zig` and `phase.zig`)
- **N7** (`src/main.zig`): add 4-line comment above `pub const testing_support` explaining that every new `src/test/*.zig` must be added to this namespace or `refAllDecls` will silently skip its tests

No functional change. `zig build check-fmt` and `zig build test` pass.

## Test plan

- `zig build check-fmt` — passes
- `zig build test -Dtest-filter="install:"` — all install tests pass
- `zig build test` — full suite passes
- `zig build test-tsan` — passes locally

refs: `review/architecture-review-2026-04-29-post-cleanup.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics by emitting warnings for device binding failures instead of silently suppressing them, providing better visibility into potential issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->