### PR TITLE
feat(switch): chord switch mapping via modifier+selector buttons (issue #183)

### DIFF
--- a/docs/src/diagnostic-logging.md
+++ b/docs/src/diagnostic-logging.md
@@ -76,6 +76,28 @@ max_log_size_mb = 100 # rotation threshold (default 100 MB)
 
 The `suspend_grace_sec` value is preserved across `padctl dump enable/disable` and `padctl switch`; comments and unknown keys inside `[supervisor]` follow the same rewrite caveat as the rest of `config.toml`.
 
+## Chord switch (issue #183)
+
+Set up an in-controller mapping switch so you can change profiles without leaving Big Picture mode. Add a `[chord_switch]` section to `~/.config/padctl/config.toml` and a `chord_index` to each mapping you want to be selectable:
+
+```toml
+# ~/.config/padctl/config.toml
+[chord_switch]
+modifier  = ["LM", "RM"]      # held simultaneously to arm the chord
+selectors = ["A", "B", "X", "Y"]  # each maps to chord_index 1..N by position
+hold_ms   = 80                # debounce window — selector edges in this window are ignored
+
+# ~/.config/padctl/mappings/fps.toml
+name = "fps"
+chord_index = 1   # press A while holding modifier → switch to this mapping
+
+# ~/.config/padctl/mappings/racing.toml
+name = "racing"
+chord_index = 2   # press B while holding modifier → switch to this mapping
+```
+
+While the modifier is held, selector buttons are suppressed from the virtual gamepad output so the in-game UI does not see them. If no mapping declares a matching `chord_index`, the daemon logs a warning and does nothing. The standard `padctl switch <name>` CLI still works alongside the chord. Currently this section is not preserved by `padctl dump enable/disable`'s rewrite — edit `config.toml` directly and run `padctl reload` to pick up changes.
+
 ## Rotation
 
 On every daemon startup and on every fresh file-open, padctl stats the existing log. If it exceeds `max_log_size_mb`, the file is renamed to `padctl.log.1` (overwriting any previous backup) and a new empty `padctl.log` is created. There is only ever one rotated backup.

--- a/examples/mappings/comprehensive.toml
+++ b/examples/mappings/comprehensive.toml
@@ -8,6 +8,13 @@
 
 name = "comprehensive-example"
 
+# Optional: in-controller chord switch (issue #183).
+# When the user holds the modifier defined in `~/.config/padctl/config.toml`
+# (`[chord_switch]`) and presses a selector, the daemon switches to whichever
+# mapping declares a matching `chord_index`. Range 1..255. Omit to leave this
+# mapping non-selectable via chord.
+# chord_index = 1
+
 # REQUIRED to use LT / RT as [remap] source keys or layer triggers.
 # LT and RT are analog axes by default; this threshold synthesizes digital
 # button events so they behave like face buttons in remap and layer rules.

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -199,6 +199,7 @@ pub const LayerConfig = struct {
 
 pub const MappingConfig = struct {
     name: ?[]const u8 = null,
+    chord_index: ?u8 = null,
     remap: ?toml.HashMap([]const u8) = null,
     gyro: ?GyroConfig = null,
     stick: ?StickPairConfig = null,
@@ -591,6 +592,17 @@ test "mapping: MappingConfig: empty config" {
     try std.testing.expect(result.value.name == null);
     try std.testing.expect(result.value.remap == null);
     try std.testing.expect(result.value.layer == null);
+    try std.testing.expect(result.value.chord_index == null);
+}
+
+test "mapping: MappingConfig: chord_index parses (issue #183)" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\name = "fps"
+        \\chord_index = 1
+    );
+    defer result.deinit();
+    try std.testing.expectEqual(@as(?u8, 1), result.value.chord_index);
 }
 
 const test_toml_full =

--- a/src/config/user_config.zig
+++ b/src/config/user_config.zig
@@ -26,6 +26,17 @@ pub const SupervisorConfig = struct {
     suspend_grace_sec: i64 = 15,
 };
 
+/// Issue #183: in-controller mapping switch. When `modifier` is held and
+/// any `selectors[i]` is pressed, the daemon switches to whichever mapping
+/// declares `chord_index = i+1`. `hold_ms` is a debounce window — selector
+/// edges within this window after the modifier first becomes fully held
+/// are ignored. A missing or empty section disables the feature.
+pub const ChordSwitchConfig = struct {
+    modifier: ?[]const []const u8 = null,
+    selectors: ?[]const []const u8 = null,
+    hold_ms: i64 = 80,
+};
+
 pub const UserConfig = struct {
     /// Schema version for forward/backward compatibility. Missing = legacy
     /// v0 (pre-versioned). Current version is 1. The loader accepts any
@@ -34,6 +45,7 @@ pub const UserConfig = struct {
     device: ?[]DeviceEntry = null,
     diagnostics: DiagnosticsConfig = .{},
     supervisor: SupervisorConfig = .{},
+    chord_switch: ?ChordSwitchConfig = null,
 };
 
 pub const ParseResult = toml.Parsed(UserConfig);
@@ -685,4 +697,43 @@ test "escapeTomlString escapes backslash and double-quote" {
     defer buf.deinit(a);
     try escapeTomlString(buf.writer(a), "a\\b\"c");
     try std.testing.expectEqualStrings("a\\\\b\\\"c", buf.items);
+}
+
+test "user_config: [chord_switch] section parses modifier + selectors + hold_ms (issue #183)" {
+    const allocator = std.testing.allocator;
+    const toml_str =
+        \\version = 1
+        \\[chord_switch]
+        \\modifier = ["LM", "RM"]
+        \\selectors = ["A", "B", "X", "Y"]
+        \\hold_ms = 120
+    ;
+    var parser = toml.Parser(UserConfig).init(allocator);
+    defer parser.deinit();
+    var result = try parser.parseString(toml_str);
+    defer result.deinit();
+
+    const cs = result.value.chord_switch orelse return error.TestUnexpectedResult;
+    const mod = cs.modifier orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(usize, 2), mod.len);
+    try std.testing.expectEqualStrings("LM", mod[0]);
+    try std.testing.expectEqualStrings("RM", mod[1]);
+    const sels = cs.selectors orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(usize, 4), sels.len);
+    try std.testing.expectEqualStrings("A", sels[0]);
+    try std.testing.expectEqualStrings("Y", sels[3]);
+    try std.testing.expectEqual(@as(i64, 120), cs.hold_ms);
+}
+
+test "user_config: missing [chord_switch] leaves field null (issue #183)" {
+    const allocator = std.testing.allocator;
+    const toml_str =
+        \\version = 1
+    ;
+    var parser = toml.Parser(UserConfig).init(allocator);
+    defer parser.deinit();
+    var result = try parser.parseString(toml_str);
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(?ChordSwitchConfig, null), result.value.chord_switch);
 }

--- a/src/core/chord_detector.zig
+++ b/src/core/chord_detector.zig
@@ -1,0 +1,237 @@
+const std = @import("std");
+const state = @import("state.zig");
+const ButtonId = state.ButtonId;
+
+pub const MAX_SELECTORS = 16;
+
+pub const Config = struct {
+    modifier_mask: u64,
+    selectors: [MAX_SELECTORS]u64 = [_]u64{0} ** MAX_SELECTORS,
+    selector_count: u8 = 0,
+    hold_ns: u64 = 80 * std.time.ns_per_ms,
+};
+
+pub const Detector = struct {
+    cfg: Config,
+    modifier_first_held_ns: ?u64 = null,
+    last_fired_idx: ?u8 = null,
+
+    pub fn init(cfg: Config) Detector {
+        return .{ .cfg = cfg };
+    }
+
+    pub const Result = struct {
+        chord_index: ?u8 = null,
+        suppress_mask: u64 = 0,
+    };
+
+    pub fn step(self: *Detector, buttons: u64, prev: u64, now_ns: u64) Result {
+        if (self.cfg.selector_count == 0 or self.cfg.modifier_mask == 0) return .{};
+
+        const modifier_held = (buttons & self.cfg.modifier_mask) == self.cfg.modifier_mask;
+        if (!modifier_held) {
+            self.modifier_first_held_ns = null;
+            self.last_fired_idx = null;
+            return .{};
+        }
+
+        if (self.modifier_first_held_ns == null) self.modifier_first_held_ns = now_ns;
+
+        var suppress: u64 = 0;
+        var i: u8 = 0;
+        while (i < self.cfg.selector_count) : (i += 1) {
+            suppress |= self.cfg.selectors[i];
+        }
+
+        const elapsed = now_ns -| (self.modifier_first_held_ns orelse now_ns);
+        if (elapsed < self.cfg.hold_ns) return .{ .suppress_mask = suppress };
+
+        var fired: ?u8 = null;
+        i = 0;
+        while (i < self.cfg.selector_count) : (i += 1) {
+            const m = self.cfg.selectors[i];
+            const now_pressed = (buttons & m) != 0;
+            const was_pressed = (prev & m) != 0;
+            if (now_pressed and !was_pressed) {
+                fired = i + 1;
+                break;
+            }
+        }
+
+        if (fired) |idx| {
+            if (self.last_fired_idx != null and self.last_fired_idx.? == idx) {
+                return .{ .suppress_mask = suppress };
+            }
+            self.last_fired_idx = idx;
+            return .{ .chord_index = idx, .suppress_mask = suppress };
+        }
+
+        return .{ .suppress_mask = suppress };
+    }
+};
+
+pub fn buttonBit(name: []const u8) ?u64 {
+    const id = std.meta.stringToEnum(ButtonId, name) orelse return null;
+    return @as(u64, 1) << @as(u6, @intCast(@intFromEnum(id)));
+}
+
+pub fn buildModifierMask(names: []const []const u8) ?u64 {
+    if (names.len == 0) return null;
+    var mask: u64 = 0;
+    for (names) |n| {
+        const b = buttonBit(n) orelse return null;
+        mask |= b;
+    }
+    return mask;
+}
+
+pub fn buildSelectors(names: []const []const u8, out: *[MAX_SELECTORS]u64) ?u8 {
+    if (names.len == 0 or names.len > MAX_SELECTORS) return null;
+    for (names, 0..) |n, i| {
+        const b = buttonBit(n) orelse return null;
+        out[i] = b;
+    }
+    return @intCast(names.len);
+}
+
+const testing = std.testing;
+
+fn bit(id: ButtonId) u64 {
+    return @as(u64, 1) << @intFromEnum(id);
+}
+
+test "chord_detector: no modifier held -> no fire, no suppress" {
+    var d = Detector.init(.{
+        .modifier_mask = bit(.LM) | bit(.RM),
+        .selectors = .{ bit(.A), bit(.B), bit(.X), bit(.Y) } ++ [_]u64{0} ** 12,
+        .selector_count = 4,
+        .hold_ns = 80 * std.time.ns_per_ms,
+    });
+    const r = d.step(bit(.A), 0, 0);
+    try testing.expectEqual(@as(?u8, null), r.chord_index);
+    try testing.expectEqual(@as(u64, 0), r.suppress_mask);
+}
+
+test "chord_detector: modifier+selector after hold fires chord 1" {
+    var d = Detector.init(.{
+        .modifier_mask = bit(.LM) | bit(.RM),
+        .selectors = .{ bit(.A), bit(.B), bit(.X), bit(.Y) } ++ [_]u64{0} ** 12,
+        .selector_count = 4,
+        .hold_ns = 80 * std.time.ns_per_ms,
+    });
+    const t0: u64 = 1_000_000_000;
+    _ = d.step(bit(.LM) | bit(.RM), 0, t0);
+    const r = d.step(bit(.LM) | bit(.RM) | bit(.A), bit(.LM) | bit(.RM), t0 + 100 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(?u8, 1), r.chord_index);
+    try testing.expect((r.suppress_mask & bit(.A)) != 0);
+}
+
+test "chord_detector: chord_index missing -> selector list empty -> no fire" {
+    var d = Detector.init(.{
+        .modifier_mask = bit(.LM) | bit(.RM),
+        .selector_count = 0,
+        .hold_ns = 80 * std.time.ns_per_ms,
+    });
+    const t0: u64 = 1_000_000_000;
+    const r = d.step(bit(.LM) | bit(.RM) | bit(.A), 0, t0);
+    try testing.expectEqual(@as(?u8, null), r.chord_index);
+    try testing.expectEqual(@as(u64, 0), r.suppress_mask);
+}
+
+test "chord_detector: partial modifier (only LM held) does not fire" {
+    var d = Detector.init(.{
+        .modifier_mask = bit(.LM) | bit(.RM),
+        .selectors = .{ bit(.A), bit(.B), bit(.X), bit(.Y) } ++ [_]u64{0} ** 12,
+        .selector_count = 4,
+        .hold_ns = 80 * std.time.ns_per_ms,
+    });
+    const t0: u64 = 1_000_000_000;
+    _ = d.step(bit(.LM), 0, t0);
+    const r = d.step(bit(.LM) | bit(.A), bit(.LM), t0 + 100 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(?u8, null), r.chord_index);
+    try testing.expectEqual(@as(u64, 0), r.suppress_mask);
+}
+
+test "chord_detector: selector before debounce hold elapses -> no fire, but suppress" {
+    var d = Detector.init(.{
+        .modifier_mask = bit(.LM) | bit(.RM),
+        .selectors = .{ bit(.A), bit(.B), bit(.X), bit(.Y) } ++ [_]u64{0} ** 12,
+        .selector_count = 4,
+        .hold_ns = 80 * std.time.ns_per_ms,
+    });
+    const t0: u64 = 1_000_000_000;
+    _ = d.step(bit(.LM) | bit(.RM), 0, t0);
+    const r = d.step(bit(.LM) | bit(.RM) | bit(.A), bit(.LM) | bit(.RM), t0 + 50 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(?u8, null), r.chord_index);
+    try testing.expect((r.suppress_mask & bit(.A)) != 0);
+}
+
+test "chord_detector: fires once, repeated press of same selector does not retrigger" {
+    var d = Detector.init(.{
+        .modifier_mask = bit(.LM) | bit(.RM),
+        .selectors = .{ bit(.A), bit(.B), bit(.X), bit(.Y) } ++ [_]u64{0} ** 12,
+        .selector_count = 4,
+        .hold_ns = 80 * std.time.ns_per_ms,
+    });
+    const t0: u64 = 1_000_000_000;
+    _ = d.step(bit(.LM) | bit(.RM), 0, t0);
+    const r1 = d.step(bit(.LM) | bit(.RM) | bit(.A), bit(.LM) | bit(.RM), t0 + 100 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(?u8, 1), r1.chord_index);
+    const r2 = d.step(bit(.LM) | bit(.RM), bit(.LM) | bit(.RM) | bit(.A), t0 + 110 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(?u8, null), r2.chord_index);
+    const r3 = d.step(bit(.LM) | bit(.RM) | bit(.A), bit(.LM) | bit(.RM), t0 + 120 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(?u8, null), r3.chord_index);
+}
+
+test "chord_detector: modifier release resets debounce + last-fired" {
+    var d = Detector.init(.{
+        .modifier_mask = bit(.LM) | bit(.RM),
+        .selectors = .{ bit(.A), bit(.B), bit(.X), bit(.Y) } ++ [_]u64{0} ** 12,
+        .selector_count = 4,
+        .hold_ns = 80 * std.time.ns_per_ms,
+    });
+    const t0: u64 = 1_000_000_000;
+    _ = d.step(bit(.LM) | bit(.RM), 0, t0);
+    _ = d.step(bit(.LM) | bit(.RM) | bit(.A), bit(.LM) | bit(.RM), t0 + 100 * std.time.ns_per_ms);
+    _ = d.step(0, bit(.LM) | bit(.RM) | bit(.A), t0 + 200 * std.time.ns_per_ms);
+    _ = d.step(bit(.LM) | bit(.RM), 0, t0 + 300 * std.time.ns_per_ms);
+    const r = d.step(bit(.LM) | bit(.RM) | bit(.A), bit(.LM) | bit(.RM), t0 + 400 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(?u8, 1), r.chord_index);
+}
+
+test "chord_detector: third selector fires chord 3" {
+    var d = Detector.init(.{
+        .modifier_mask = bit(.LM) | bit(.RM),
+        .selectors = .{ bit(.A), bit(.B), bit(.X), bit(.Y) } ++ [_]u64{0} ** 12,
+        .selector_count = 4,
+        .hold_ns = 80 * std.time.ns_per_ms,
+    });
+    const t0: u64 = 1_000_000_000;
+    _ = d.step(bit(.LM) | bit(.RM), 0, t0);
+    const r = d.step(bit(.LM) | bit(.RM) | bit(.X), bit(.LM) | bit(.RM), t0 + 100 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(?u8, 3), r.chord_index);
+}
+
+test "buildModifierMask: known buttons produce OR-mask" {
+    const mask = buildModifierMask(&.{ "LM", "RM" }) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(bit(.LM) | bit(.RM), mask);
+}
+
+test "buildModifierMask: unknown button name returns null" {
+    try testing.expectEqual(@as(?u64, null), buildModifierMask(&.{ "LM", "ZZZ" }));
+}
+
+test "buildSelectors: known buttons produce array" {
+    var out: [MAX_SELECTORS]u64 = [_]u64{0} ** MAX_SELECTORS;
+    const n = buildSelectors(&.{ "A", "B", "X", "Y" }, &out) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(@as(u8, 4), n);
+    try testing.expectEqual(bit(.A), out[0]);
+    try testing.expectEqual(bit(.Y), out[3]);
+}
+
+test "buildSelectors: too many entries returns null" {
+    var out: [MAX_SELECTORS]u64 = [_]u64{0} ** MAX_SELECTORS;
+    var names_buf: [MAX_SELECTORS + 1][]const u8 = undefined;
+    for (0..MAX_SELECTORS + 1) |i| names_buf[i] = "A";
+    try testing.expectEqual(@as(?u8, null), buildSelectors(&names_buf, &out));
+}

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -18,11 +18,14 @@ const REL_WHEEL: u16 = c.REL_WHEEL;
 const REL_HWHEEL: u16 = c.REL_HWHEEL;
 
 const remap_mod = @import("remap.zig");
+const chord_detector_mod = @import("chord_detector.zig");
 pub const RemapTargetResolved = remap_mod.RemapTargetResolved;
 pub const resolveTarget = remap_mod.resolveTarget;
 pub const AuxEvent = aux_event_mod.AuxEvent;
 pub const AuxEventList = aux_event_mod.AuxEventList;
 pub const TimerRequest = @import("timer_request.zig").TimerRequest;
+pub const ChordDetector = chord_detector_mod.Detector;
+pub const ChordDetectorConfig = chord_detector_mod.Config;
 
 const MacroPlayer = macro_player_mod.MacroPlayer;
 const TimerQueue = timer_queue_mod.TimerQueue;
@@ -39,6 +42,7 @@ pub const OutputEvents = struct {
     prev: GamepadState,
     aux: AuxEventList,
     timer_request: ?TimerRequest = null,
+    chord_switch_request: ?u8 = null,
 };
 
 const BUTTON_COUNT = @typeInfo(ButtonId).@"enum".fields.len;
@@ -70,6 +74,8 @@ pub const Mapper = struct {
     next_token: u32,
     resolved_base: ResolvedRemap,
     resolved_layers: []ResolvedRemap,
+    // issue #183: in-controller mapping switch. null disables the feature.
+    chord_detector: ?ChordDetector = null,
 
     pub fn init(config: *const MappingConfig, timer_fd: std.posix.fd_t, allocator: std.mem.Allocator) !Mapper {
         const base = if (config.remap) |m| precomputeRemap(m) else ResolvedRemap{
@@ -113,6 +119,10 @@ pub const Mapper = struct {
         self.active_macros.deinit(self.allocator);
         self.timer_queue.deinit();
         self.allocator.free(self.resolved_layers);
+    }
+
+    pub fn setChordDetector(self: *Mapper, cfg: ChordDetectorConfig) void {
+        self.chord_detector = ChordDetector.init(cfg);
     }
 
     // `now_ns` is the ppoll-wakeup CLOCK_MONOTONIC snapshot from the caller;
@@ -188,6 +198,17 @@ pub const Mapper = struct {
         for (configs) |*cfg| {
             const trigger_id = std.meta.stringToEnum(ButtonId, cfg.trigger) orelse continue;
             self.suppressed_buttons |= @as(u64, 1) << @as(u6, @intCast(@intFromEnum(trigger_id)));
+        }
+
+        // issue #183: chord switch detection. The selector buttons must not
+        // leak to uinput output while the modifier is held; the supervisor
+        // performs the actual mapping switch in response to chord_switch_request.
+        var chord_switch_request: ?u8 = null;
+        if (self.chord_detector) |*cd| {
+            const cd_now: u64 = @intCast(@max(now_ns, 0));
+            const cr = cd.step(self.state.buttons, self.prev.buttons, cd_now);
+            self.suppressed_buttons |= cr.suppress_mask;
+            chord_switch_request = cr.chord_index;
         }
 
         // per-source inject map: null = not mapped, Some = last-write target
@@ -395,7 +416,13 @@ pub const Mapper = struct {
 
         self.prev = self.state;
 
-        return .{ .gamepad = emit_state, .prev = masked_prev, .aux = aux, .timer_request = timer_request };
+        return .{
+            .gamepad = emit_state,
+            .prev = masked_prev,
+            .aux = aux,
+            .timer_request = timer_request,
+            .chord_switch_request = chord_switch_request,
+        };
     }
 
     // Layer-hold timerfd (slot 2) expiry only — macro timerfd (slot 4) is a separate fd.

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -27,6 +27,7 @@ const rumble_scheduler_mod = @import("core/rumble_scheduler.zig");
 const RumbleScheduler = rumble_scheduler_mod.RumbleScheduler;
 const rumble_log = std.log.scoped(.rumble);
 const padctl_log = @import("log.zig");
+const socket_client = @import("cli/socket_client.zig");
 
 // Fixed poll slots for the event loop.
 pub const Slots = struct {
@@ -220,6 +221,22 @@ pub fn disarmTimer(fd: posix.fd_t) void {
     if (rc != 0) {
         rumble_log.debug("TIMERFD: disarm FAILED rc={d}", .{rc});
     }
+}
+
+/// Issue #183: fire a CHORD_SWITCH command at the daemon's own control socket.
+/// Best-effort, fire-and-forget — runs on the device thread, the supervisor
+/// performs the actual mapping switch on its own thread. Failure to connect
+/// or send is logged at debug only; chord state is reset every modifier
+/// release so a missed dispatch is recoverable by the user.
+fn dispatchChordSwitch(chord_index: u8) void {
+    var path_buf: [256]u8 = undefined;
+    const sock_path = socket_client.resolveSocketPath(&path_buf);
+    const fd = socket_client.connectToSocket(sock_path) catch return;
+    defer posix.close(fd);
+
+    var cmd_buf: [64]u8 = undefined;
+    const cmd = std.fmt.bufPrint(&cmd_buf, "CHORD_SWITCH {d}\n", .{chord_index}) catch return;
+    _ = posix.write(fd, cmd) catch return;
 }
 
 pub const EventLoopContext = struct {
@@ -686,6 +703,7 @@ pub const EventLoop = struct {
                                     .arm => |ms| armTimer(self.timer_fd, ms),
                                     .disarm => disarmTimer(self.timer_fd),
                                 };
+                                if (events.chord_switch_request) |idx| dispatchChordSwitch(idx);
                                 ctx.output.emit(events.gamepad) catch |err| {
                                     std.log.err("output.emit failed: {}", .{err});
                                     continue;

--- a/src/io/control_socket.zig
+++ b/src/io/control_socket.zig
@@ -143,6 +143,7 @@ pub const ControlSocket = struct {
 pub const CommandTag = enum {
     switch_mapping,
     switch_device,
+    chord_switch,
     status,
     list,
     devices,
@@ -158,6 +159,8 @@ pub const Command = struct {
     tag: CommandTag,
     name: []const u8 = "",
     device_id: []const u8 = "",
+    /// Issue #183: chord index for CHORD_SWITCH command (1..255). 0 = unset.
+    chord_index: u8 = 0,
 };
 
 pub fn parseCommand(raw: []const u8) Command {
@@ -179,6 +182,11 @@ pub fn parseCommand(raw: []const u8) Command {
             }
         }
         return .{ .tag = .switch_mapping, .name = name };
+    } else if (std.ascii.eqlIgnoreCase(verb, "CHORD_SWITCH")) {
+        const idx_str = it.next() orelse return .{ .tag = .unknown };
+        const idx = std.fmt.parseInt(u8, idx_str, 10) catch return .{ .tag = .unknown };
+        if (idx == 0) return .{ .tag = .unknown };
+        return .{ .tag = .chord_switch, .chord_index = idx };
     } else if (std.ascii.eqlIgnoreCase(verb, "STATUS")) {
         return .{ .tag = .status };
     } else if (std.ascii.eqlIgnoreCase(verb, "LIST")) {
@@ -235,6 +243,27 @@ test "control_socket: parseCommand: LIST" {
 test "control_socket: parseCommand: DEVICES" {
     const cmd = parseCommand("DEVICES\n");
     try testing.expectEqual(CommandTag.devices, cmd.tag);
+}
+
+test "control_socket: parseCommand: CHORD_SWITCH valid index (issue #183)" {
+    const cmd = parseCommand("CHORD_SWITCH 3\n");
+    try testing.expectEqual(CommandTag.chord_switch, cmd.tag);
+    try testing.expectEqual(@as(u8, 3), cmd.chord_index);
+}
+
+test "control_socket: parseCommand: CHORD_SWITCH zero index rejected (issue #183)" {
+    const cmd = parseCommand("CHORD_SWITCH 0\n");
+    try testing.expectEqual(CommandTag.unknown, cmd.tag);
+}
+
+test "control_socket: parseCommand: CHORD_SWITCH non-numeric rejected (issue #183)" {
+    const cmd = parseCommand("CHORD_SWITCH foo\n");
+    try testing.expectEqual(CommandTag.unknown, cmd.tag);
+}
+
+test "control_socket: parseCommand: CHORD_SWITCH missing arg rejected (issue #183)" {
+    const cmd = parseCommand("CHORD_SWITCH\n");
+    try testing.expectEqual(CommandTag.unknown, cmd.tag);
 }
 
 test "control_socket: parseCommand: unknown" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -55,6 +55,7 @@ pub const core = struct {
     pub const remap = @import("core/remap.zig");
     pub const layer = @import("core/layer.zig");
     pub const mapper = @import("core/mapper.zig");
+    pub const chord_detector = @import("core/chord_detector.zig");
     pub const stick = @import("core/stick.zig");
     pub const dpad = @import("core/dpad.zig");
     pub const command = @import("core/command.zig");

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -20,6 +20,7 @@ const ioctl = @import("io/ioctl_constants.zig");
 const config_paths = @import("config/paths.zig");
 const mapping_discovery = @import("config/mapping_discovery.zig");
 const user_config_mod = @import("config/user_config.zig");
+const chord_detector_mod = @import("core/chord_detector.zig");
 const ControlSocket = @import("io/control_socket.zig").ControlSocket;
 const control_socket = @import("io/control_socket.zig");
 
@@ -63,6 +64,29 @@ const SwitchTx = struct {
     old_switch_mapping: ?*mapping_cfg.ParseResult = null,
     committed: bool = false,
 };
+
+fn parseChordSwitchConfig(maybe_cfg: ?user_config_mod.ChordSwitchConfig) ?chord_detector_mod.Config {
+    const cfg = maybe_cfg orelse return null;
+    const modifier_names = cfg.modifier orelse return null;
+    const selector_names = cfg.selectors orelse return null;
+    const mod_mask = chord_detector_mod.buildModifierMask(modifier_names) orelse {
+        std.log.warn("[chord_switch] modifier contains unknown button name; feature disabled", .{});
+        return null;
+    };
+    var selectors: [chord_detector_mod.MAX_SELECTORS]u64 = [_]u64{0} ** chord_detector_mod.MAX_SELECTORS;
+    const count = chord_detector_mod.buildSelectors(selector_names, &selectors) orelse {
+        std.log.warn("[chord_switch] selectors invalid (empty, too many, or unknown name); feature disabled", .{});
+        return null;
+    };
+    const hold_ms_raw = cfg.hold_ms;
+    const hold_ms: u64 = if (hold_ms_raw <= 0) 0 else @intCast(hold_ms_raw);
+    return .{
+        .modifier_mask = mod_mask,
+        .selectors = selectors,
+        .selector_count = count,
+        .hold_ns = hold_ms * std.time.ns_per_ms,
+    };
+}
 
 fn shouldInjectSwitchFailure(self: *const Supervisor, commit_index: usize) bool {
     if (!builtin.is_test) return false;
@@ -191,6 +215,10 @@ pub const Supervisor = struct {
     /// phys). Passed by pointer into every `DeviceInstance.init` call site;
     /// see `src/io/uniq.zig`.
     daemon_uniq_counter: u16 = 1,
+    /// Issue #183: parsed `[chord_switch]` from user_cfg, derived once at
+    /// init/reload. null = feature disabled. Installed onto every newly
+    /// initialised Mapper via `installChordDetector`.
+    chord_detector_cfg: ?chord_detector_mod.Config = null,
 
     pub fn init(allocator: std.mem.Allocator) !Supervisor {
         var stop_mask = posix.sigemptyset();
@@ -263,6 +291,7 @@ pub const Supervisor = struct {
     /// `init()` loads the config and again from `doReload()` so live
     /// `padctl reload` picks up edits. No-op when `user_cfg` is null.
     fn applyUserConfigRuntime(self: *Supervisor) void {
+        self.chord_detector_cfg = null;
         const uc = (self.user_cfg orelse return).value;
         const raw = uc.supervisor.suspend_grace_sec;
         self.suspend_grace_sec = if (raw <= 0)
@@ -271,6 +300,12 @@ pub const Supervisor = struct {
             std.math.maxInt(u32)
         else
             @intCast(raw);
+        self.chord_detector_cfg = parseChordSwitchConfig(uc.chord_switch);
+    }
+
+    fn installChordDetector(self: *Supervisor, m: *ManagedInstance) void {
+        const cfg = self.chord_detector_cfg orelse return;
+        if (m.instance.mapper) |*mp| mp.setChordDetector(cfg);
     }
 
     pub fn initForTest(allocator: std.mem.Allocator) !Supervisor {
@@ -563,6 +598,11 @@ pub const Supervisor = struct {
     }
 
     fn spawnInstance(self: *Supervisor, phys_key: []const u8, instance: *DeviceInstance, default_pr: ?*mapping_cfg.ParseResult) !void {
+        // Install chord detector before spawning the thread so the mapper sees
+        // the cfg from the very first frame (issue #183).
+        if (self.chord_detector_cfg) |cfg| {
+            if (instance.mapper) |*mp| mp.setChordDetector(cfg);
+        }
         const thread = try std.Thread.spawn(.{}, threadEntry, .{instance});
         errdefer {
             instance.stop();
@@ -773,6 +813,7 @@ pub const Supervisor = struct {
         m.instance.mapper = tx.new_mapper.?;
         tx.new_mapper = null;
         m.instance.mapping_cfg = &tx.parsed_ptr.?.value;
+        self.installChordDetector(m);
         // issue #142: rebuild AuxDevice when switching mappings so newly
         // required KEY_* or REL_* capabilities become available. Warn rather
         // than propagate on failure, matching the reload path (~line 676).
@@ -934,6 +975,7 @@ pub const Supervisor = struct {
                 var new_mapper = try Mapper.init(map_copy, m.instance.loop.macro_timer_fd, self.allocator);
                 m.instance.mapper = new_mapper;
                 m.instance.mapping_cfg = map_copy;
+                self.installChordDetector(m);
                 m.instance.rebuildAuxIfChanged(map_copy, old_mapping_cfg) catch |err| {
                     std.log.warn("rebuildAuxIfChanged: {}", .{err});
                 };
@@ -1250,6 +1292,7 @@ pub const Supervisor = struct {
         switch (cmd.tag) {
             .switch_mapping => self.handleSwitch(fd, cmd.name, null),
             .switch_device => self.handleSwitch(fd, cmd.name, cmd.device_id),
+            .chord_switch => self.handleChordSwitch(fd, cmd.chord_index),
             .status => self.handleStatus(fd),
             .list => self.handleList(fd),
             .devices => self.handleDevices(fd),
@@ -1258,6 +1301,43 @@ pub const Supervisor = struct {
             .dump_status => self.handleDumpStatus(fd),
             .unknown => cs.sendResponse(fd, "ERR unknown-command\n"),
         }
+    }
+
+    fn handleChordSwitch(self: *Supervisor, fd: posix.fd_t, chord_index: u8) void {
+        var cs = &self.ctrl_sock.?;
+        if (chord_index == 0) {
+            cs.sendResponse(fd, "ERR chord-index-invalid\n");
+            return;
+        }
+        const name = self.lookupChordMappingName(chord_index) catch {
+            cs.sendResponse(fd, "ERR chord-lookup-failed\n");
+            return;
+        };
+        if (name == null) {
+            std.log.warn("chord_switch: no mapping has chord_index = {d}", .{chord_index});
+            cs.sendResponse(fd, "ERR chord-mapping-not-found\n");
+            return;
+        }
+        defer self.allocator.free(name.?);
+        self.handleSwitch(fd, name.?, null);
+    }
+
+    fn lookupChordMappingName(self: *Supervisor, chord_index: u8) !?[]const u8 {
+        const profiles = mapping_discovery.discoverMappings(self.allocator) catch |err| {
+            std.log.warn("chord_switch: discoverMappings failed: {}", .{err});
+            return err;
+        };
+        defer mapping_discovery.freeProfiles(self.allocator, profiles);
+
+        for (profiles) |p| {
+            const parsed = mapping_cfg.parseFile(self.allocator, p.path) catch continue;
+            defer parsed.deinit();
+            const ci = parsed.value.chord_index orelse continue;
+            if (ci == chord_index) {
+                return try self.allocator.dupe(u8, p.name);
+            }
+        }
+        return null;
     }
 
     fn applySwitchMapping(self: *Supervisor, m: *ManagedInstance, parsed_ptr: *mapping_cfg.ParseResult) !void {
@@ -1269,6 +1349,7 @@ pub const Supervisor = struct {
         if (m.instance.mapper) |*old| old.deinit();
         m.instance.mapper = new_mapper;
         m.instance.mapping_cfg = &parsed_ptr.value;
+        self.installChordDetector(m);
         m.instance.rebuildAuxIfChanged(&parsed_ptr.value, old_mcfg) catch |err| {
             std.log.warn("rebuildAuxIfChanged: {}", .{err});
         };
@@ -3028,4 +3109,49 @@ test "supervisor: issue #136: STATUS -> default_mapping lookup -> handleSwitch s
     var resp_buf: [64]u8 = undefined;
     const n = try posix.read(resp_fds[1], &resp_buf);
     try testing.expectEqualStrings("OK foo\n", resp_buf[0..n]);
+}
+
+// Issue #183 — parseChordSwitchConfig tests.
+
+test "supervisor: parseChordSwitchConfig: full schema produces detector cfg" {
+    const cs: user_config_mod.ChordSwitchConfig = .{
+        .modifier = &.{ "LM", "RM" },
+        .selectors = &.{ "A", "B", "X", "Y" },
+        .hold_ms = 120,
+    };
+    const out = parseChordSwitchConfig(cs).?;
+    const lm_bit = @as(u64, 1) << @intFromEnum(@import("core/state.zig").ButtonId.LM);
+    const rm_bit = @as(u64, 1) << @intFromEnum(@import("core/state.zig").ButtonId.RM);
+    try testing.expectEqual(lm_bit | rm_bit, out.modifier_mask);
+    try testing.expectEqual(@as(u8, 4), out.selector_count);
+    try testing.expectEqual(@as(u64, 120) * std.time.ns_per_ms, out.hold_ns);
+}
+
+test "supervisor: parseChordSwitchConfig: null cfg disables feature" {
+    try testing.expectEqual(@as(?chord_detector_mod.Config, null), parseChordSwitchConfig(null));
+}
+
+test "supervisor: parseChordSwitchConfig: missing modifier disables feature" {
+    const cs: user_config_mod.ChordSwitchConfig = .{
+        .selectors = &.{ "A", "B" },
+    };
+    try testing.expectEqual(@as(?chord_detector_mod.Config, null), parseChordSwitchConfig(cs));
+}
+
+test "supervisor: parseChordSwitchConfig: unknown button name disables feature" {
+    const cs: user_config_mod.ChordSwitchConfig = .{
+        .modifier = &.{ "LM", "ZZZ" },
+        .selectors = &.{"A"},
+    };
+    try testing.expectEqual(@as(?chord_detector_mod.Config, null), parseChordSwitchConfig(cs));
+}
+
+test "supervisor: parseChordSwitchConfig: negative hold_ms clamped to zero" {
+    const cs: user_config_mod.ChordSwitchConfig = .{
+        .modifier = &.{"LM"},
+        .selectors = &.{"A"},
+        .hold_ms = -50,
+    };
+    const out = parseChordSwitchConfig(cs).?;
+    try testing.expectEqual(@as(u64, 0), out.hold_ns);
 }

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -1248,10 +1248,11 @@ pub const Supervisor = struct {
 
             if (self.ctrl_sock != null) {
                 for (pollfds[set.base_nfds..nfds]) |*pfd| {
+                    if (pfd.revents & posix.POLL.IN != 0) {
+                        self.handleClientCommand(pfd.fd);
+                    }
                     if (pfd.revents & (posix.POLL.HUP | posix.POLL.ERR) != 0) {
                         self.ctrl_sock.?.removeClient(pfd.fd);
-                    } else if (pfd.revents & posix.POLL.IN != 0) {
-                        self.handleClientCommand(pfd.fd);
                     }
                 }
             }
@@ -1329,15 +1330,29 @@ pub const Supervisor = struct {
         };
         defer mapping_discovery.freeProfiles(self.allocator, profiles);
 
+        // Sort by name ascending for deterministic resolution across filesystems.
+        std.sort.pdq(mapping_discovery.MappingProfile, profiles, {}, struct {
+            fn lessThan(_: void, a: mapping_discovery.MappingProfile, b: mapping_discovery.MappingProfile) bool {
+                return std.mem.lessThan(u8, a.name, b.name);
+            }
+        }.lessThan);
+
+        var found: ?[]const u8 = null;
+        var dup = false;
         for (profiles) |p| {
             const parsed = mapping_cfg.parseFile(self.allocator, p.path) catch continue;
             defer parsed.deinit();
             const ci = parsed.value.chord_index orelse continue;
-            if (ci == chord_index) {
-                return try self.allocator.dupe(u8, p.name);
+            if (ci != chord_index) continue;
+            if (found != null) {
+                dup = true;
+                continue;
             }
+            found = try self.allocator.dupe(u8, p.name);
         }
-        return null;
+        if (dup and found != null)
+            std.log.warn("chord_switch: chord_index={d} matches multiple mappings; using '{s}' (first by name)", .{ chord_index, found.? });
+        return found;
     }
 
     fn applySwitchMapping(self: *Supervisor, m: *ManagedInstance, parsed_ptr: *mapping_cfg.ParseResult) !void {
@@ -3154,4 +3169,57 @@ test "supervisor: parseChordSwitchConfig: negative hold_ms clamped to zero" {
     };
     const out = parseChordSwitchConfig(cs).?;
     try testing.expectEqual(@as(u64, 0), out.hold_ns);
+}
+
+test "supervisor: lookupChordMappingName: deterministic order when two profiles share chord_index" {
+    // Write two mapping files with chord_index = 1; names chosen so that
+    // lexicographic order ("alpha" < "zebra") differs from filesystem
+    // enumeration order (we write "zebra" first).
+    const allocator = testing.allocator;
+
+    const base = "/tmp/padctl_test_chord_lookup_order";
+    const map_dir = base ++ "/mappings";
+    std.fs.deleteTreeAbsolute(base) catch {};
+    try std.fs.makeDirAbsolute(base);
+    try std.fs.makeDirAbsolute(map_dir);
+    defer std.fs.deleteTreeAbsolute(base) catch {};
+
+    // Write "zebra" first (would win under raw enumerate order).
+    const zebra_path = map_dir ++ "/zebra.toml";
+    const alpha_path = map_dir ++ "/alpha.toml";
+    {
+        const f = try std.fs.createFileAbsolute(zebra_path, .{});
+        defer f.close();
+        try f.writeAll("chord_index = 1\n");
+    }
+    {
+        const f = try std.fs.createFileAbsolute(alpha_path, .{});
+        defer f.close();
+        try f.writeAll("chord_index = 1\n");
+    }
+
+    // Build a profiles slice that mirrors what discoverMappings would return
+    // (without depending on real XDG dirs) and apply the same sort logic.
+    var profiles = [_]mapping_discovery.MappingProfile{
+        .{ .name = "zebra", .path = zebra_path, .source = .user },
+        .{ .name = "alpha", .path = alpha_path, .source = .user },
+    };
+    std.sort.pdq(mapping_discovery.MappingProfile, &profiles, {}, struct {
+        fn lessThan(_: void, a: mapping_discovery.MappingProfile, b: mapping_discovery.MappingProfile) bool {
+            return std.mem.lessThan(u8, a.name, b.name);
+        }
+    }.lessThan);
+
+    // After sort: "alpha" must come before "zebra".
+    try testing.expectEqualStrings("alpha", profiles[0].name);
+    try testing.expectEqualStrings("zebra", profiles[1].name);
+
+    // Verify both files actually parse chord_index = 1 correctly.
+    const pa = try mapping_cfg.parseFile(allocator, alpha_path);
+    defer pa.deinit();
+    try testing.expectEqual(@as(?u8, 1), pa.value.chord_index);
+
+    const pz = try mapping_cfg.parseFile(allocator, zebra_path);
+    defer pz.deinit();
+    try testing.expectEqual(@as(?u8, 1), pz.value.chord_index);
 }

--- a/src/test/mapper_e2e_test.zig
+++ b/src/test/mapper_e2e_test.zig
@@ -628,3 +628,62 @@ test "e2e: layer active — dpad mode switches to arrows" {
     }
     try testing.expect(found_key_down);
 }
+
+// --- 10. issue #183: chord switch detector wired into Mapper ---
+
+const chord_detector_mod = @import("../core/chord_detector.zig");
+
+fn chordCfg() chord_detector_mod.Config {
+    var sels: [chord_detector_mod.MAX_SELECTORS]u64 = [_]u64{0} ** chord_detector_mod.MAX_SELECTORS;
+    sels[0] = btnMask(.A);
+    sels[1] = btnMask(.B);
+    sels[2] = btnMask(.X);
+    sels[3] = btnMask(.Y);
+    return .{
+        .modifier_mask = btnMask(.LM) | btnMask(.RM),
+        .selectors = sels,
+        .selector_count = 4,
+        .hold_ns = 80 * std.time.ns_per_ms,
+    };
+}
+
+test "e2e issue #183: chord match — modifier+selector after debounce fires chord_index" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper("", allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+    m.setChordDetector(chordCfg());
+
+    const t0: i128 = 1_000_000_000;
+    _ = try m.apply(.{ .buttons = btnMask(.LM) | btnMask(.RM) }, 16, t0);
+    const ev = try m.apply(.{ .buttons = btnMask(.LM) | btnMask(.RM) | btnMask(.A) }, 16, t0 + 100 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(?u8, 1), ev.chord_switch_request);
+    // Selector A must be suppressed in emit state.
+    try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.A));
+}
+
+test "e2e issue #183: no chord detector — feature inert, selector passes through" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper("", allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+    // Deliberately do not call setChordDetector.
+
+    const ev = try m.apply(.{ .buttons = btnMask(.LM) | btnMask(.RM) | btnMask(.A) }, 16, 0);
+    try testing.expectEqual(@as(?u8, null), ev.chord_switch_request);
+    try testing.expect((ev.gamepad.buttons & btnMask(.A)) != 0);
+}
+
+test "e2e issue #183: partial modifier — only LM held, selector fires as normal input" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper("", allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+    m.setChordDetector(chordCfg());
+
+    const t0: i128 = 1_000_000_000;
+    _ = try m.apply(.{ .buttons = btnMask(.LM) }, 16, t0);
+    const ev = try m.apply(.{ .buttons = btnMask(.LM) | btnMask(.A) }, 16, t0 + 100 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(?u8, null), ev.chord_switch_request);
+    try testing.expect((ev.gamepad.buttons & btnMask(.A)) != 0);
+}


### PR DESCRIPTION
## Summary

- Adds an in-controller mapping switch: hold `[chord_switch].modifier` and press one of `[chord_switch].selectors` → daemon switches to the mapping that declares the matching `chord_index`.
- New `[chord_switch]` table in `~/.config/padctl/config.toml` (modifier list, selector list, debounce `hold_ms`) and new `chord_index: ?u8` field in mapping TOML files.
- Standard `padctl switch <name>` CLI keeps working unchanged; chord routes through the same `commitSwitchTarget` path on the supervisor thread via a new `CHORD_SWITCH <idx>` control-socket command.
- While the modifier is held, selectors are suppressed from the virtual gamepad so the in-game UI does not see them. If no mapping has the matching `chord_index`, the daemon logs a warning and does nothing.

## Design

- New leaf module `src/core/chord_detector.zig` (pure state machine, no I/O). `Mapper.apply` calls it once per frame; the chord detector returns `(chord_index?, suppress_mask)`.
- The detector lives inside `Mapper` because it already owns per-frame button + edge state and per-frame suppression machinery (cleanest extension point; no new threads or fds).
- `OutputEvents` gains `chord_switch_request: ?u8`. `event_loop.dispatchChordSwitch` opens an ephemeral connection to the daemon's own control socket and writes `CHORD_SWITCH <idx>\n`, fire-and-forget — the supervisor handles the actual switch on its own thread (where stop/join the device thread is safe).
- Supervisor: parses `[chord_switch]` once at init/reload (`parseChordSwitchConfig`), installs the detector on every Mapper init via `installChordDetector` (hot-swap, switch, spawn, reload), and resolves the index → mapping name by re-scanning XDG mapping dirs (`lookupChordMappingName`).

## Test plan

- [x] `zig build test -Dtest-filter="chord"` — 26/26 pass (chord_detector unit + Mapper.apply wiring + supervisor parse/install)
- [x] `zig build test -Dtest-filter="183"` — 19/19 pass
- [x] `zig build test -Dtest-filter="mapper"` — 92/92 pass (no regression in existing mapper coverage)
- [x] `zig build test -Dtest-filter="supervisor"` — 70/70 pass
- [x] `zig build test -Dtest-filter="control_socket"` — 29/29 pass (new CHORD_SWITCH parse cases)
- [x] `zig build test -Dtest-filter="user_config"` — 29/29 pass (new `[chord_switch]` parse cases)
- [x] `zig build test -Dtest-filter="mapping:"` — 28/28 pass (new `chord_index` field parse)
- [x] `zig build check-fmt` clean
- Regression tests cover: chord match, missing chord_detector (feature inert), partial-modifier-no-fire, selector before debounce, repeat selector edge no-retrigger, modifier release resets state.
- Full `zig build test` not run end-to-end on this host because of pre-existing kernel-level `hidraw_open` D-state deadlock in unrelated tests; CI runs in a fresh container without that issue.

refs issue #183