### PR TITLE
feat(macro): repeatable macros via repeat_delay_ms (issue #119)

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -269,4 +269,32 @@ Step types:
 | `{ delay = N }` | Wait N milliseconds |
 | `"pause_for_release"` | Wait until the trigger button is released |
 
+Macro fields:
+
+| Field | Description |
+|-------|-------------|
+| `name` | Identifier referenced from remap as `macro:<name>` |
+| `steps` | Ordered step list |
+| `repeat_delay_ms` | Optional. While the trigger button is held, restart the macro `N` ms after the previous run finishes. Releasing the trigger lets the current iteration finish naturally and stops further restarts. Omit for single-shot (legacy) behaviour. |
+
+```toml
+# Turbo: spam A while RM is held, 50 ms between presses.
+[[macro]]
+name = "spam_a"
+repeat_delay_ms = 50
+steps = [{ tap = "A" }]
+
+# Combo: XYX every 100 ms while held.
+[[macro]]
+name = "xyx_combo"
+repeat_delay_ms = 100
+steps = [
+    { tap = "X" },
+    { delay = 30 },
+    { tap = "Y" },
+    { delay = 30 },
+    { tap = "X" },
+]
+```
+
 Bind a macro in remap: `M1 = "macro:dodge_roll"`

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -280,6 +280,24 @@ steps = [
 
 Bind in remap: `M1 = "macro:dodge_roll"`
 
+#### Repeat-while-held — turbo / combo (`repeat_delay_ms`)
+
+Add `repeat_delay_ms = N` to a `[[macro]]` block to make the macro restart while
+the trigger button is held. Releasing the trigger lets the current iteration
+finish naturally and stops further restarts. Omit the field for legacy
+single-shot behaviour.
+
+```toml
+# Spam A while RM held: tap, wait 50 ms, tap again, ...
+[[macro]]
+name = "spam_a"
+repeat_delay_ms = 50
+steps = [{ tap = "A" }]
+
+[remap]
+RM = "macro:spam_a"
+```
+
 ### Trigger Threshold — analog LT / RT as digital buttons {#trigger-threshold}
 
 > **Warning:** `trigger_threshold` must be at the top level of the mapping file.

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -857,6 +857,32 @@ test "mapping: [[macro]] multi-entry parse: all step primitives correct" {
     try validate(&cfg);
 }
 
+test "mapping: [[macro]] repeat_delay_ms parses; absent stays null (issue #119)" {
+    const allocator = std.testing.allocator;
+    const toml_str =
+        \\[[macro]]
+        \\name = "spam_a"
+        \\repeat_delay_ms = 50
+        \\steps = [{ tap = "A" }]
+        \\
+        \\[[macro]]
+        \\name = "once"
+        \\steps = [{ tap = "B" }]
+        \\
+        \\[remap]
+        \\C = "macro:spam_a"
+        \\D = "macro:once"
+    ;
+    const result = try parseString(allocator, toml_str);
+    defer result.deinit();
+
+    const macros = result.value.macro.?;
+    try std.testing.expectEqual(@as(usize, 2), macros.len);
+    try std.testing.expectEqual(@as(?u32, 50), macros[0].repeat_delay_ms);
+    try std.testing.expectEqual(@as(?u32, null), macros[1].repeat_delay_ms);
+    try validate(&result.value);
+}
+
 test "mapping: validate: macro:name remap target references unknown macro returns error" {
     const allocator = std.testing.allocator;
     const toml_str =

--- a/src/core/macro.zig
+++ b/src/core/macro.zig
@@ -11,6 +11,11 @@ pub const MacroStep = union(enum) {
 pub const Macro = struct {
     name: []const u8,
     steps: []const MacroStep,
+    // issue #119: when set, after the steps array finishes the player schedules a
+    // restart this many ms later — provided the trigger source button is still
+    // held. Releasing the trigger lets the current iteration finish naturally
+    // and stops further restarts. Absent / null = legacy single-shot behaviour.
+    repeat_delay_ms: ?u32 = null,
 };
 
 // --- tests ---

--- a/src/core/macro_player.zig
+++ b/src/core/macro_player.zig
@@ -21,6 +21,14 @@ pub const MacroPlayer = struct {
     // is below this, step() must yield the frame so per-poll Mapper.apply calls
     // do not race past delay= boundaries.
     next_step_eligible_at_ns: i128,
+    // issue #119: repeat-macro trigger-held flag, refreshed by Mapper each frame
+    // before invoking step(). step() consults this when reaching end-of-steps to
+    // decide whether to schedule a restart. A falling edge stops further repeats.
+    trigger_held: bool,
+    // issue #119: when non-null, the macro has finished its current iteration and
+    // is waiting for now_ns to reach this deadline before restarting from
+    // step_index = 0. Same gating mechanism as next_step_eligible_at_ns.
+    awaiting_restart_at_ns: ?i128,
 
     pub fn init(m: *const Macro, token: u32, src_idx: u6) MacroPlayer {
         return .{
@@ -31,6 +39,8 @@ pub const MacroPlayer = struct {
             .trigger_src_idx = src_idx,
             .held_gamepad_buttons = 0,
             .next_step_eligible_at_ns = 0,
+            .trigger_held = true,
+            .awaiting_restart_at_ns = null,
         };
     }
 
@@ -53,6 +63,15 @@ pub const MacroPlayer = struct {
         // issue #72: prevent same-frame double-emit — only the macro timerfd
         // expiry advances state past a delay boundary.
         if (now_ns < self.next_step_eligible_at_ns) return false;
+
+        // issue #119: gate restart on trigger_held — released triggers stop
+        // further iterations even after the restart timer fires.
+        if (self.awaiting_restart_at_ns) |deadline| {
+            if (now_ns < deadline) return false;
+            self.awaiting_restart_at_ns = null;
+            if (!self.trigger_held) return true;
+            self.step_index = 0;
+        }
 
         while (self.step_index < self.macro.steps.len) {
             const s = self.macro.steps[self.step_index];
@@ -82,7 +101,24 @@ pub const MacroPlayer = struct {
                 },
             }
         }
+
+        // issue #119: end of steps. Schedule restart if repeat_delay_ms set and
+        // trigger still held; otherwise legacy single-shot completion.
+        if (self.macro.repeat_delay_ms) |delay_ms| {
+            if (self.trigger_held) {
+                const deadline = now_ns + @as(i128, delay_ms) * std.time.ns_per_ms;
+                try queue.arm(deadline, self.timer_token, now_ns);
+                self.awaiting_restart_at_ns = deadline;
+                return false;
+            }
+        }
         return true;
+    }
+
+    // issue #119: refreshed each Mapper.apply frame for repeat-mode macros so
+    // step() can decide at end-of-steps whether to schedule another iteration.
+    pub fn setTriggerHeld(self: *MacroPlayer, held: bool) void {
+        self.trigger_held = held;
     }
 
     pub fn notifyTriggerReleased(self: *MacroPlayer) void {
@@ -321,4 +357,92 @@ test "macro_player: two players advance step_index independently" {
     try testing.expect(done_b);
     try testing.expectEqual(@as(usize, 4), ctx_a.aux.len);
     try testing.expectEqual(@as(usize, 2), ctx_b.aux.len);
+}
+
+// --- issue #119: repeat_delay_ms ---
+
+test "macro_player: repeat_delay_ms — held trigger reschedules; release stops" {
+    const allocator = testing.allocator;
+    const steps = [_]MacroStep{.{ .tap = "KEY_A" }};
+    const m = Macro{ .name = "spam", .steps = &steps, .repeat_delay_ms = 50 };
+    var p = makePlayer(&m);
+    var ctx = StepCtx.init(allocator);
+    defer ctx.deinit();
+
+    const ns_per_ms: i128 = std.time.ns_per_ms;
+    const t0: i128 = 0;
+
+    // First iteration: tap fires (press+release events), player not done, restart armed.
+    const done0 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, t0);
+    try testing.expect(!done0);
+    try testing.expectEqual(@as(usize, 2), ctx.aux.len);
+    try testing.expectEqual(@as(usize, 1), ctx.queue.heap.count());
+    try testing.expect(p.awaiting_restart_at_ns != null);
+
+    // Mid-restart-window: must not advance.
+    ctx.aux = .{};
+    const done_mid = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, t0 + 20 * ns_per_ms);
+    try testing.expect(!done_mid);
+    try testing.expectEqual(@as(usize, 0), ctx.aux.len);
+
+    // Restart deadline reached, trigger still held: second iteration fires.
+    ctx.aux = .{};
+    p.setTriggerHeld(true);
+    const done1 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, t0 + 50 * ns_per_ms);
+    try testing.expect(!done1);
+    try testing.expectEqual(@as(usize, 2), ctx.aux.len); // press + release of KEY_A again
+
+    // Release trigger; reach next restart deadline → player completes (returns true).
+    ctx.aux = .{};
+    p.setTriggerHeld(false);
+    const done2 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, t0 + 100 * ns_per_ms + 1);
+    try testing.expect(done2);
+    try testing.expectEqual(@as(usize, 0), ctx.aux.len); // no further taps after release
+}
+
+test "macro_player: repeat_delay_ms — release mid-iteration completes current pass then stops" {
+    const allocator = testing.allocator;
+    // XYX combo: two taps separated by a delay.
+    const steps = [_]MacroStep{
+        .{ .tap = "KEY_A" },
+        .{ .delay = 10 },
+        .{ .tap = "KEY_B" },
+    };
+    const m = Macro{ .name = "combo", .steps = &steps, .repeat_delay_ms = 100 };
+    var p = makePlayer(&m);
+    var ctx = StepCtx.init(allocator);
+    defer ctx.deinit();
+
+    const ns_per_ms: i128 = std.time.ns_per_ms;
+
+    // Frame 0: trigger held, first tap fires, then delay arms.
+    const done0 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, 0);
+    try testing.expect(!done0);
+    try testing.expectEqual(@as(usize, 2), ctx.aux.len); // KEY_A press+release
+
+    // User releases trigger BEFORE delay expiry. The current iteration must
+    // still finish naturally (KEY_B tap), but no restart should be scheduled.
+    p.setTriggerHeld(false);
+
+    // Delay expires: second tap fires AND end-of-steps reached. trigger_held=false
+    // means the macro completes (returns true) — no restart armed.
+    ctx.aux = .{};
+    const done1 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, 10 * ns_per_ms + 1);
+    try testing.expect(done1);
+    try testing.expectEqual(@as(usize, 2), ctx.aux.len); // KEY_B press+release
+    try testing.expect(p.awaiting_restart_at_ns == null);
+}
+
+test "macro_player: repeat_delay_ms absent — legacy single-shot completion" {
+    const allocator = testing.allocator;
+    const steps = [_]MacroStep{.{ .tap = "KEY_A" }};
+    const m = Macro{ .name = "once", .steps = &steps };
+    var p = makePlayer(&m);
+    var ctx = StepCtx.init(allocator);
+    defer ctx.deinit();
+
+    const done = try ctx.step(&p);
+    try testing.expect(done);
+    try testing.expectEqual(@as(usize, 2), ctx.aux.len);
+    try testing.expect(p.awaiting_restart_at_ns == null);
 }

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -332,6 +332,10 @@ pub const Mapper = struct {
             // is reset above, but held_gamepad_buttons (set by past `down=`) must persist
             // across the delay window and outlive same-frame step advancement.
             self.injected_buttons |= self.active_macros.items[i].held_gamepad_buttons;
+            // issue #119: refresh trigger-held flag so repeat-mode macros stop
+            // scheduling restarts once the source button is released.
+            const src_bit: u64 = @as(u64, 1) << self.active_macros.items[i].trigger_src_idx;
+            self.active_macros.items[i].setTriggerHeld((self.state.buttons & src_bit) != 0);
             const done = self.active_macros.items[i].step(
                 &aux,
                 &self.timer_queue,

--- a/src/test/macro_e2e_test.zig
+++ b/src/test/macro_e2e_test.zig
@@ -553,3 +553,94 @@ test "macro #72: delay must gate subsequent steps until timer expiry" {
     try testing.expectEqual(@as(u64, 0), ev_after2.gamepad.buttons & home_bit);
     try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
 }
+
+// --- Issue #119: repeat_delay_ms — turbo / combo while-held ---
+//
+// Reporter @VaisVaisov: bind a macro to RM, enable repeat. While the trigger is
+// held the macro restarts after repeat_delay_ms; releasing the trigger lets the
+// in-flight iteration finish naturally and stops further restarts.
+test "macro #119: repeat_delay_ms emits gamepad-button taps repeatedly while held" {
+    const allocator = testing.allocator;
+
+    var ctx = try makeMapper(
+        \\[[macro]]
+        \\name = "spam_a"
+        \\repeat_delay_ms = 50
+        \\steps = [
+        \\  { tap = "A" },
+        \\]
+        \\
+        \\[remap]
+        \\C = "macro:spam_a"
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const c_mask = btnMask(.C);
+    const a_bit = btnMask(.A);
+    const ns_per_ms: i128 = std.time.ns_per_ms;
+    const t0: i128 = 1_000_000_000;
+
+    // Frame 0 (rising edge of C): macro spawns; first tap stages A press.
+    const ev0 = try m.apply(.{ .buttons = c_mask }, 16, t0);
+    try testing.expectEqual(a_bit, ev0.gamepad.buttons & a_bit);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
+
+    // Frame 1: A release fires (pending_tap_release), restart still pending.
+    const ev1 = try m.apply(.{ .buttons = c_mask }, 4, t0 + 4 * ns_per_ms);
+    try testing.expectEqual(@as(u64, 0), ev1.gamepad.buttons & a_bit);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
+
+    // Mid restart-window: A stays clear.
+    var t: i128 = t0 + 8 * ns_per_ms;
+    while (t < t0 + 50 * ns_per_ms) : (t += 4 * ns_per_ms) {
+        const evN = try m.apply(.{ .buttons = c_mask }, 4, t);
+        try testing.expectEqual(@as(u64, 0), evN.gamepad.buttons & a_bit);
+    }
+
+    // Restart timer fires: second tap staged via macro_timer_tap_pending,
+    // then promoted on the next apply().
+    const t_restart1: i128 = t0 + 50 * ns_per_ms;
+    _ = m.onMacroTimerExpired(t_restart1);
+    const ev_press = try m.apply(.{ .buttons = c_mask }, 4, t_restart1 + ns_per_ms);
+    try testing.expectEqual(a_bit, ev_press.gamepad.buttons & a_bit);
+
+    // Release trigger between iterations: in-flight tap-release flushes; no further taps.
+    const ev_release = try m.apply(.{ .buttons = 0 }, 4, t_restart1 + 2 * ns_per_ms);
+    try testing.expectEqual(@as(u64, 0), ev_release.gamepad.buttons & a_bit);
+
+    // Second restart timer expires after release: player completes, no tap emitted.
+    const t_restart2: i128 = t_restart1 + 50 * ns_per_ms;
+    _ = m.onMacroTimerExpired(t_restart2);
+    const ev_done = try m.apply(.{ .buttons = 0 }, 4, t_restart2 + ns_per_ms);
+    try testing.expectEqual(@as(u64, 0), ev_done.gamepad.buttons & a_bit);
+    try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
+}
+
+test "macro #119: non-repeat macro unaffected (single-shot completion)" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[[macro]]
+        \\name = "once"
+        \\steps = [
+        \\  { tap = "A" },
+        \\]
+        \\
+        \\[remap]
+        \\C = "macro:once"
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const c_mask = btnMask(.C);
+    const a_bit = btnMask(.A);
+    const t0: i128 = 1_000_000_000;
+    const ns_per_ms: i128 = std.time.ns_per_ms;
+
+    const ev0 = try m.apply(.{ .buttons = c_mask }, 16, t0);
+    try testing.expectEqual(a_bit, ev0.gamepad.buttons & a_bit);
+
+    // After tap_release frame, player should be removed (no repeat).
+    _ = try m.apply(.{ .buttons = c_mask }, 4, t0 + 4 * ns_per_ms);
+    try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
+}


### PR DESCRIPTION
## Summary

Adds an optional `repeat_delay_ms = N` field to `[[macro]]` blocks. While the macro's trigger button is held, the macro restarts `N` ms after the previous run finishes. Releasing the trigger lets the in-flight iteration finish naturally and stops further restarts. Macros without `repeat_delay_ms` keep their existing single-shot behaviour.

Issue: #119 (turbo / repeating combos while RM held)

## Design

Picked Option A (per-macro `repeat_delay_ms` field) over Option B (`repeat = true` boolean):
- Existing `delay = N` already covers intra-iteration timing inside `steps`, so a single `repeat_delay_ms` is enough to cover both reporter use cases (turbo single tap, multi-step combo).
- Declarative — restart cadence visible at the macro level, no surprise reruns when the macro author thinks they wrote a one-shot.
- Reuses the existing `TimerQueue` / `macro_timer_fd` machinery (PR #171, #157, #198) — no new fd, no new dispatch path. Same delay-step gating model: end-of-steps schedules a deadline, the next ppoll wakeup expires the timer, `step()` resets `step_index = 0` and runs again.

State machine additions on `MacroPlayer`:
- `trigger_held: bool` — refreshed by `Mapper.apply` each frame from `state.buttons & (1 << trigger_src_idx)`.
- `awaiting_restart_at_ns: ?i128` — set when end-of-steps is reached with `repeat_delay_ms != null` and `trigger_held == true`. The next `step()` call gates on `now_ns >= deadline`; if `trigger_held` is then false, the player completes (returns `true`); otherwise `step_index` resets to 0 and the macro replays.

## Changes

- `src/core/macro.zig` — add `repeat_delay_ms: ?u32 = null` to `Macro` struct.
- `src/core/macro_player.zig` — restart state machine + 3 unit tests covering held / mid-iteration release / non-repeat legacy path.
- `src/core/mapper.zig` — refresh `trigger_held` flag on each active player before the per-frame `step()` call (4 lines).
- `src/config/mapping.zig` — schema lint allowlist auto-derived; new parser test asserts the field round-trips.
- `src/test/macro_e2e_test.zig` — 2 integration tests through `Mapper.apply`: repeat fires multiple iterations while held; non-repeat macros remain single-shot.
- `docs/src/mapping-config.md`, `docs/src/mapping-guide.md` — document the new field with a turbo example and a multi-step combo example.

## Test plan

- [x] `zig build test -Dtest-filter=macro` — 53/53 macro tests pass (after iterating on the mid-release semantics in the second player unit test).
- [x] `zig fmt --check` clean on all touched files.
- [ ] Full `zig build test` — local run hung in unrelated `hidraw_open` D-state from concurrent test runs (kernel deadlock per project notes); CI will exercise the full suite.
- [ ] Reporter (@VaisVaisov) hardware verification with a turbo binding (e.g. `RM = "macro:spam_a"` + `repeat_delay_ms = 50`).
- [x] PR #198 issue #72 delay regression test left untouched and still part of the macro filter run.

refs #119