### PR TITLE
feat(deck): send 0x81 feature report on attach to unlock button reports (issue #126)

### DIFF
--- a/devices/valve/steam-deck.toml
+++ b/devices/valve/steam-deck.toml
@@ -7,6 +7,14 @@ pid = 0x1205
 id = 2
 class = "hid"
 
+# Send 0x81 ID_CLEAR_DIGITAL_MAPPINGS feature report on attach to exit lizard
+# mode (Steam Deck ships in lizard mode when Steam client has not run since boot;
+# bytes 8-15 of 0x09 reports are all zero until this report is sent).
+# Reference: Linux kernel drivers/hid/hid-steam.c steam_clear_mappings()
+[device.init]
+interface = 2
+feature_report = [0x81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
 # --- Input report (Report type 0x09, 64 bytes) ---
 # Reference: Linux kernel drivers/hid/hid-steam.c :1748-1766 (envelope),
 #            :1597 steam_do_deck_input_event (bit mapping)

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -334,6 +334,13 @@ pub fn validate(cfg: *const DeviceConfig) !void {
         }
     }
 
+    // feature_report byte-range validation
+    if (cfg.device.init) |init_cfg| {
+        if (init_cfg.feature_report) |fr| {
+            for (fr) |b| if (b < 0 or b > 255) return error.InvalidConfig;
+        }
+    }
+
     // IMU backend validation (Phase 13 Wave 3 T1c).
     // ADR-015 §Alternatives forbids "uinput primary + [output.imu] present":
     // uinput's EVIOCGUNIQ always returns -ENOENT, so SDL's strcmp pairing
@@ -1129,6 +1136,46 @@ test "device: generic mode: ABS event missing range returns error" {
         \\wheel = { event = "ABS_WHEEL" }
     ;
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, toml_str));
+}
+
+test "device: feature_report rejects byte > 255" {
+    const allocator = std.testing.allocator;
+    const bad =
+        \\[device]
+        \\name = "Test"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[device.init]
+        \\feature_report = [256]
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad));
+}
+
+test "device: feature_report rejects byte < 0" {
+    const allocator = std.testing.allocator;
+    const bad =
+        \\[device]
+        \\name = "Test"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[device.init]
+        \\feature_report = [-1]
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad));
 }
 
 test "device: fuzz parseString: no panic on arbitrary input" {

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -14,12 +14,15 @@ pub const InterfaceConfig = struct {
 };
 
 pub const InitConfig = struct {
-    commands: []const []const u8,
-    response_prefix: []const i64,
+    commands: ?[]const []const u8 = null,
+    response_prefix: ?[]const i64 = null,
     enable: ?[]const u8 = null,
     disable: ?[]const u8 = null,
     interface: ?i64 = null,
     report_size: ?i64 = null,
+    /// HID feature report to send via HIDIOCSFEATURE immediately after commands.
+    /// Encoded as a list of byte values (0–255); report ID is byte[0].
+    feature_report: ?[]const i64 = null,
 };
 
 pub const DeviceInfo = struct {
@@ -456,6 +459,20 @@ const test_toml =
     \\type = "rumble"
     \\max_effects = 16
 ;
+
+test "device: load devices/valve/steam-deck.toml has feature_report init" {
+    const allocator = std.testing.allocator;
+    const result = try parseFile(allocator, "devices/valve/steam-deck.toml");
+    defer result.deinit();
+
+    const cfg = result.value;
+    try std.testing.expectEqualStrings("Valve Steam Deck", cfg.device.name);
+    const init_cfg = cfg.device.init orelse return error.MissingInit;
+    const fr = init_cfg.feature_report orelse return error.MissingFeatureReport;
+    try std.testing.expectEqual(@as(usize, 64), fr.len);
+    try std.testing.expectEqual(@as(i64, 0x81), fr[0]);
+    for (fr[1..]) |b| try std.testing.expectEqual(@as(i64, 0), b);
+}
 
 test "device: load flydigi/vader5.toml succeeds" {
     const allocator = std.testing.allocator;

--- a/src/init.zig
+++ b/src/init.zig
@@ -54,34 +54,37 @@ fn sendAndWaitPrefix(device: DeviceIO, bytes: []const u8, prefix: []const u8, re
 }
 
 /// Run device init handshake for a single DeviceIO.
-/// For each command hex string: write bytes, then retry up to 10 times (5ms apart)
-/// waiting for a response whose prefix matches response_prefix.
+/// For each command hex string: write bytes, then retry waiting for response_prefix.
+/// If feature_report is set, send it via HIDIOCSFEATURE after all commands.
 pub fn runInitSequence(
     allocator: std.mem.Allocator,
     device: DeviceIO,
     init_config: device_mod.InitConfig,
 ) !void {
     const prefix: []const u8 = blk: {
-        const raw = init_config.response_prefix;
+        const raw = init_config.response_prefix orelse break :blk &[_]u8{};
         var buf = try allocator.alloc(u8, raw.len);
         for (raw, 0..) |b, j| buf[j] = @intCast(b);
         break :blk buf;
     };
-    defer allocator.free(prefix);
+    defer if (init_config.response_prefix != null) allocator.free(prefix);
 
     const report_size: usize = if (init_config.report_size) |rs| @intCast(rs) else 0;
 
-    for (init_config.commands) |cmd| {
-        const bytes = try parseHexBytes(allocator, cmd);
-        defer allocator.free(bytes);
-        sendAndWaitPrefix(device, bytes, prefix, 50, report_size) catch |err| {
-            if (err == error.InitFailed) {
-                std.log.debug("init command got no ack, continuing", .{});
-            } else return err;
-        };
-    }
+    var total: usize = 0;
 
-    var total: usize = init_config.commands.len;
+    if (init_config.commands) |cmds| {
+        for (cmds) |cmd| {
+            const bytes = try parseHexBytes(allocator, cmd);
+            defer allocator.free(bytes);
+            sendAndWaitPrefix(device, bytes, prefix, 50, report_size) catch |err| {
+                if (err == error.InitFailed) {
+                    std.log.debug("init command got no ack, continuing", .{});
+                } else return err;
+            };
+        }
+        total += cmds.len;
+    }
 
     if (init_config.enable) |enable_cmd| {
         const bytes = try parseHexBytes(allocator, enable_cmd);
@@ -90,6 +93,16 @@ pub fn runInitSequence(
             if (err == error.InitFailed) {
                 std.log.debug("enable command got no ack, continuing", .{});
             } else return err;
+        };
+        total += 1;
+    }
+
+    if (init_config.feature_report) |fr| {
+        var buf: [64]u8 = .{0} ** 64;
+        const n = @min(fr.len, buf.len);
+        for (fr[0..n], 0..) |b, i| buf[i] = @intCast(b);
+        device.featureReport(buf[0..n]) catch |err| {
+            std.log.debug("feature_report ioctl failed: {}, continuing", .{err});
         };
         total += 1;
     }
@@ -210,4 +223,50 @@ test "init: runInitSequence: wrong prefix after retries logs warning and continu
     };
 
     try runInitSequence(allocator, dev, init_cfg);
+}
+
+test "init: runInitSequence: feature_report sent via featureReport path (no commands)" {
+    const allocator = std.testing.allocator;
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    const dev = mock.deviceIO();
+
+    // Steam Deck lizard-mode unlock: 0x81 + 63 zero bytes
+    const init_cfg = device_mod.InitConfig{
+        .feature_report = &[_]i64{ 0x81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    };
+
+    try runInitSequence(allocator, dev, init_cfg);
+
+    // Nothing written via output report path
+    try std.testing.expectEqual(@as(usize, 0), mock.write_log.items.len);
+    // 64 bytes sent via featureReport path; first byte is report ID 0x81
+    try std.testing.expectEqual(@as(usize, 64), mock.feature_report_log.items.len);
+    try std.testing.expectEqual(@as(u8, 0x81), mock.feature_report_log.items[0]);
+    // remaining 63 bytes must be zero
+    for (mock.feature_report_log.items[1..]) |b| {
+        try std.testing.expectEqual(@as(u8, 0), b);
+    }
+}
+
+test "init: runInitSequence: feature_report after commands" {
+    const allocator = std.testing.allocator;
+
+    const resp = [_]u8{ 0x5a, 0xa5 };
+    var mock = try MockDeviceIO.init(allocator, &.{&resp});
+    defer mock.deinit();
+    const dev = mock.deviceIO();
+
+    const init_cfg = device_mod.InitConfig{
+        .commands = &[_][]const u8{"aa"},
+        .response_prefix = &[_]i64{ 0x5a, 0xa5 },
+        .feature_report = &[_]i64{ 0x81, 0, 0 },
+    };
+
+    try runInitSequence(allocator, dev, init_cfg);
+
+    try std.testing.expectEqualSlices(u8, &[_]u8{0xaa}, mock.write_log.items);
+    try std.testing.expectEqual(@as(usize, 3), mock.feature_report_log.items.len);
+    try std.testing.expectEqual(@as(u8, 0x81), mock.feature_report_log.items[0]);
 }

--- a/src/init.zig
+++ b/src/init.zig
@@ -102,7 +102,7 @@ pub fn runInitSequence(
         const n = @min(fr.len, buf.len);
         for (fr[0..n], 0..) |b, i| buf[i] = @intCast(b);
         device.featureReport(buf[0..n]) catch |err| {
-            std.log.debug("feature_report ioctl failed: {}, continuing", .{err});
+            std.log.warn("feature_report ioctl failed: {}, continuing", .{err});
         };
         total += 1;
     }

--- a/src/io/device_io.zig
+++ b/src/io/device_io.zig
@@ -7,6 +7,7 @@ pub const DeviceIO = struct {
     pub const VTable = struct {
         read: *const fn (ptr: *anyopaque, buf: []u8) ReadError!usize,
         write: *const fn (ptr: *anyopaque, data: []const u8) WriteError!void,
+        feature_report: *const fn (ptr: *anyopaque, data: []const u8) WriteError!void,
         pollfd: *const fn (ptr: *anyopaque) std.posix.pollfd,
         close: *const fn (ptr: *anyopaque) void,
     };
@@ -20,6 +21,13 @@ pub const DeviceIO = struct {
 
     pub fn write(self: DeviceIO, data: []const u8) WriteError!void {
         return self.vtable.write(self.ptr, data);
+    }
+
+    /// Send a HID feature report via HIDIOCSFEATURE ioctl. Falls back to a
+    /// no-op write error on device types that don't support feature reports
+    /// (e.g. USB bulk endpoints).
+    pub fn featureReport(self: DeviceIO, data: []const u8) WriteError!void {
+        return self.vtable.feature_report(self.ptr, data);
     }
 
     pub fn pollfd(self: DeviceIO) std.posix.pollfd {

--- a/src/io/hidraw.zig
+++ b/src/io/hidraw.zig
@@ -199,6 +199,7 @@ pub const HidrawDevice = struct {
     const vtable = DeviceIO.VTable{
         .read = read,
         .write = write,
+        .feature_report = featureReport,
         .pollfd = pollfd,
         .close = close,
     };
@@ -220,6 +221,18 @@ pub const HidrawDevice = struct {
             error.BrokenPipe, error.ConnectionResetByPeer => return DeviceIO.WriteError.Disconnected,
             else => return DeviceIO.WriteError.Io,
         };
+    }
+
+    fn featureReport(ptr: *anyopaque, data: []const u8) DeviceIO.WriteError!void {
+        const self: *HidrawDevice = @ptrCast(@alignCast(ptr));
+        const len: u14 = @intCast(@min(data.len, 0x3fff));
+        const req = ioctl.HIDIOCSFEATURE(len);
+        const rc = linux.ioctl(self.fd, req, @intFromPtr(data.ptr));
+        if (rc < 0) {
+            const errno = posix.errno(rc);
+            if (errno == .NODEV or errno == .PIPE) return DeviceIO.WriteError.Disconnected;
+            return DeviceIO.WriteError.Io;
+        }
     }
 
     fn pollfd(ptr: *anyopaque) posix.pollfd {

--- a/src/io/ioctl_constants.zig
+++ b/src/io/ioctl_constants.zig
@@ -20,6 +20,13 @@ pub fn HIDIOCGRAWUNIQ(len: u14) u32 {
     return @bitCast(req);
 }
 
+/// HIDIOCSFEATURE(len): send a HID feature report (report ID byte + payload).
+/// dir = _IOC_WRITE|_IOC_READ = 3, nr = 0x06.
+pub fn HIDIOCSFEATURE(len: u14) u32 {
+    const req = IOCTL.Request{ .dir = 3, .io_type = 'H', .nr = 0x06, .size = len };
+    return @bitCast(req);
+}
+
 // evdev
 pub const EVIOCGRAB = IOCTL.IOW('E', 0x90, c_int);
 

--- a/src/io/usbraw.zig
+++ b/src/io/usbraw.zig
@@ -175,6 +175,7 @@ pub const UsbrawDevice = struct {
     const vtable = DeviceIO.VTable{
         .read = read,
         .write = write,
+        .feature_report = featureReportUnsupported,
         .pollfd = pollfd,
         .close = close,
     };
@@ -187,6 +188,10 @@ pub const UsbrawDevice = struct {
         const n = self.ring.pop(buf);
         if (n == 0) return DeviceIO.ReadError.Again;
         return n;
+    }
+
+    fn featureReportUnsupported(_: *anyopaque, _: []const u8) DeviceIO.WriteError!void {
+        return DeviceIO.WriteError.Io;
     }
 
     fn write(ptr: *anyopaque, data: []const u8) DeviceIO.WriteError!void {

--- a/src/test/mock_device_io.zig
+++ b/src/test/mock_device_io.zig
@@ -12,6 +12,7 @@ pub const MockDeviceIO = struct {
     frame_idx: usize,
     allocator: std.mem.Allocator,
     write_log: std.ArrayList(u8),
+    feature_report_log: std.ArrayList(u8),
     pipe_r: posix.fd_t,
     pipe_w: posix.fd_t,
     disconnected: bool,
@@ -31,6 +32,7 @@ pub const MockDeviceIO = struct {
             .frame_idx = 0,
             .allocator = allocator,
             .write_log = .{},
+            .feature_report_log = .{},
             .pipe_r = fds[0],
             .pipe_w = fds[1],
             .disconnected = false,
@@ -39,6 +41,7 @@ pub const MockDeviceIO = struct {
 
     pub fn deinit(self: *MockDeviceIO) void {
         self.write_log.deinit(self.allocator);
+        self.feature_report_log.deinit(self.allocator);
         posix.close(self.pipe_r);
         self.closeWriteEnd();
     }
@@ -73,6 +76,7 @@ pub const MockDeviceIO = struct {
     const vtable = DeviceIO.VTable{
         .read = read,
         .write = write,
+        .feature_report = featureReport,
         .pollfd = pollfd,
         .close = close,
     };
@@ -98,6 +102,11 @@ pub const MockDeviceIO = struct {
     fn write(ptr: *anyopaque, data: []const u8) DeviceIO.WriteError!void {
         const self: *MockDeviceIO = @ptrCast(@alignCast(ptr));
         self.write_log.appendSlice(self.allocator, data) catch return DeviceIO.WriteError.Io;
+    }
+
+    fn featureReport(ptr: *anyopaque, data: []const u8) DeviceIO.WriteError!void {
+        const self: *MockDeviceIO = @ptrCast(@alignCast(ptr));
+        self.feature_report_log.appendSlice(self.allocator, data) catch return DeviceIO.WriteError.Io;
     }
 
     fn pollfd(ptr: *anyopaque) posix.pollfd {


### PR DESCRIPTION
## What changed

- `src/io/ioctl_constants.zig`: add `HIDIOCSFEATURE(len)` function (dynamic-size ioctl, dir=3, nr=0x06)
- `src/io/device_io.zig`: add `feature_report` slot to `DeviceIO.VTable` and `featureReport()` helper
- `src/io/hidraw.zig`: implement `featureReport` via `HIDIOCSFEATURE` ioctl on the hidraw fd
- `src/io/usbraw.zig`: stub `featureReportUnsupported` returning `WriteError.Io`
- `src/test/mock_device_io.zig`: add `feature_report_log` field; `featureReport` appends to it (separate from `write_log`)
- `src/config/device.zig`: `InitConfig.commands` and `InitConfig.response_prefix` become optional (null-default); add `feature_report: ?[]const i64` field
- `src/init.zig`: `runInitSequence` handles optional commands/prefix and calls `device.featureReport` when `feature_report` is set
- `devices/valve/steam-deck.toml`: add `[device.init]` with `interface = 2` and a 64-byte `feature_report` (0x81 + 63 zeros)

## Why

Steam Deck ships in lizard mode when Steam client has not run since boot. In lizard mode the 0x09 input report bytes 8–15 (button bitfield) are always zero. The kernel driver (`hid-steam.c` `steam_clear_mappings()`) exits lizard mode by sending report ID 0x81 via `HIDIOCSFEATURE`. Without this, padctl sees no button events on a freshly booted console.

## Test plan

- `zig build test -Dtest-filter="init"` — covers `feature_report` path (no-command-only, after-commands cases)
- `zig build test -Dtest-filter="deck"` — covers steam-deck.toml parse; asserts `init.feature_report[0] == 0x81` and `len == 64`
- `zig build test -Dtest-filter="vader5"` — regression: existing `[device.init]` with commands still parses correctly
- Hardware verification: issue #126 reporter to attach a freshly booted Steam Deck and confirm button events arrive without running Steam first

refs: issue #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HID feature report support to device initialization sequence.
  * Steam Deck now automatically clears digital mappings on startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->