### PR TITLE
fix(aur): force system-scope service unit path with --no-user-service

### DIFF
--- a/contrib/aur/PKGBUILD
+++ b/contrib/aur/PKGBUILD
@@ -38,7 +38,7 @@ build() {
 
 package() {
     cd padctl
-    ./zig-out/bin/padctl install --destdir "$pkgdir" --prefix /usr
+    ./zig-out/bin/padctl install --destdir "$pkgdir" --prefix /usr --no-user-service
 
     install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }


### PR DESCRIPTION
## What changed
- `contrib/aur/PKGBUILD` `package()`: add `--no-user-service` to `padctl install` invocation

## Why
makepkg runs as a non-root build user. Without the flag, `padctl install` auto-detects user-scope and writes the unit to `$pkgdir$HOME/.config/systemd/user/padctl.service` — a path that does not exist on the installed system. With the flag, the unit lands at `$pkgdir/usr/lib/systemd/user/padctl.service`, which is the path systemd `--user` actually scans.

Matches the manual install path used in `contrib/aur/padctl-bin/PKGBUILD`.

## Test plan
- [ ] `makepkg --noconfirm` in clean Arch container produces `pkg/padctl-git/usr/lib/systemd/user/padctl.service` (not `pkg/padctl-git/build/.config/...`)
- [ ] `systemctl --user enable padctl.service` succeeds after install

## Refs
- Reported by external user during v0.1.4 testing
- Structural fix tracked separately (gates `effective_user_service` on `staging_mode` in `plan.zig`)