### PR TITLE
fix(install): staging mode suppresses user-service auto-detect

### DIFF
--- a/src/cli/install/plan.zig
+++ b/src/cli/install/plan.zig
@@ -352,7 +352,8 @@ pub const InstallPlan = struct {
         const destdir = opts.destdir;
         const staging_mode = destdir.len != 0;
 
-        // staging mode (--destdir set, packaging build) always writes to system path
+        // staging mode (--destdir set, packaging build) defaults to system path;
+        // explicit --user-service still routes to user HOME.
         const effective_user_service = opts.user_service orelse (!is_root and !staging_mode);
 
         const immutable_kind = detectImmutableOs(allocator, if (staging_mode) destdir else "");

--- a/src/cli/install/plan.zig
+++ b/src/cli/install/plan.zig
@@ -352,7 +352,8 @@ pub const InstallPlan = struct {
         const destdir = opts.destdir;
         const staging_mode = destdir.len != 0;
 
-        const effective_user_service = opts.user_service orelse !is_root;
+        // staging mode (--destdir set, packaging build) always writes to system path
+        const effective_user_service = opts.user_service orelse (!is_root and !staging_mode);
 
         const immutable_kind = detectImmutableOs(allocator, if (staging_mode) destdir else "");
         const effective_immutable = opts.immutable or (immutable_kind != .none and !opts.no_immutable);

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -2162,6 +2162,17 @@ test "install: InstallPlan service_dir routes by user_service + immutable" {
     try testing.expect(std.mem.endsWith(u8, plan.service_dir, "/.config/systemd/user"));
 }
 
+test "install: InstallPlan staging non-root uses system service path" {
+    const testing = std.testing;
+    const opts = InstallOptions{ .destdir = "/tmp/staging", .prefix = "/usr", .user_service = null };
+    const env = EnvSnapshot{ .uid = 1000, .home = "/home/builder", .sudo_user = null, .sudo_uid = null };
+    const plan = try InstallPlan.compute(testing.allocator, opts, env);
+    defer plan.deinit(testing.allocator);
+    try testing.expect(plan.staging_mode);
+    try testing.expect(!plan.effective_user_service);
+    try testing.expect(std.mem.endsWith(u8, plan.service_dir, "/usr/lib/systemd/user"));
+}
+
 test "install: ensureUserXdgDirs chown path opens dir with iterate flag (no BADF)" {
     // Zig std.posix.fchown panics with BADF on a Dir fd opened without
     // .iterate = true. Verify ensureUserXdgDirs creates dirs that can be

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -2164,10 +2164,15 @@ test "install: InstallPlan service_dir routes by user_service + immutable" {
 
 test "install: InstallPlan staging non-root uses system service path" {
     const testing = std.testing;
-    const opts = InstallOptions{ .destdir = "/tmp/staging", .prefix = "/usr", .user_service = null };
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+    const opts = InstallOptions{ .destdir = tmp_path, .prefix = "/usr", .user_service = null };
     const env = EnvSnapshot{ .uid = 1000, .home = "/home/builder", .sudo_user = null, .sudo_uid = null };
-    const plan = try InstallPlan.compute(testing.allocator, opts, env);
-    defer plan.deinit(testing.allocator);
+    const plan = try InstallPlan.compute(allocator, opts, env);
+    defer plan.deinit(allocator);
     try testing.expect(plan.staging_mode);
     try testing.expect(!plan.effective_user_service);
     try testing.expect(std.mem.endsWith(u8, plan.service_dir, "/usr/lib/systemd/user"));


### PR DESCRIPTION
## What changed
- `src/cli/install/plan.zig` — `effective_user_service` now also gates on `staging_mode`
- `src/cli/install/tests.zig` — new regression test for uid=1000 + destdir + prefix=/usr

## Why
When `--destdir` is set, the install is a packaging build (AUR makepkg, deb pbuilder, RPM mock). The unit must land at the system path (`$pkgdir/usr/lib/systemd/user/`), not the build user's home directory. `installWillStartUserService` already had this gate; `effective_user_service` was missing the same guard.

## Test plan
- [x] Existing install tests pass (no behavior change for uid=0 or explicit --user-service flags)
- [x] New regression test pins the exact failing scenario (uid=1000 non-root + destdir + no flag → system path)
- [ ] CI green

## Refs
- External user reported the broken AUR install during v0.1.4 testing
- PR #207 (`fix/aur-pkgbuild-no-user-service`) adds `--no-user-service` defensively to AUR PKGBUILD; that flag becomes redundant but harmless after this PR