### PR TITLE
docs: feature-coverage audit + close gaps for v0.1.4..main

### DIFF
--- a/docs/src/contributing/code-contributions.md
+++ b/docs/src/contributing/code-contributions.md
@@ -53,9 +53,11 @@ than declaring an inline TOML literal.
 Inline literals drift away from the canonical files over time: a field
 gets renamed, a transform is added, or a fixture grows a new
 `[output.imu]` block, and the inline copy keeps testing the old shape.
-PR #193 retired the last set of inline `vader5_toml` literals after
-exactly this drift was observed (the inline copy had `gyro_y` / `gyro_z`
-swapped relative to `devices/flydigi/vader5.toml`).
+PR #193 began retiring inline `vader5_toml` literals after exactly this
+drift was observed (the inline copy had `gyro_y` / `gyro_z` swapped
+relative to `devices/flydigi/vader5.toml`). The last remaining inline copy
+in `interpreter_e2e_test.zig` was removed in PR #209; no inline device
+literals remain in the test suite.
 
 When you add a new e2e test, prefer one of these patterns:
 

--- a/docs/src/contributing/code-contributions.md
+++ b/docs/src/contributing/code-contributions.md
@@ -41,3 +41,32 @@ zig build check-all
 - **FieldTag coverage**: all field names map to known FieldTag values
 - **ButtonId coverage**: all button_group keys are valid ButtonId enum values
 - **VID/PID validity**: all device configs contain valid VID/PID
+
+## Test Fixtures Are Single-Source
+
+Files in `devices/` and `examples/mappings/` are the canonical source of
+truth for both the user-facing manual and the e2e test suite. End-to-end
+tests under `src/test/*_e2e_test.zig` MUST consume these fixtures via
+`device_mod.parseFile(...)` (or `@embedFile` for non-TOML payloads) rather
+than declaring an inline TOML literal.
+
+Inline literals drift away from the canonical files over time: a field
+gets renamed, a transform is added, or a fixture grows a new
+`[output.imu]` block, and the inline copy keeps testing the old shape.
+PR #193 retired the last set of inline `vader5_toml` literals after
+exactly this drift was observed (the inline copy had `gyro_y` / `gyro_z`
+swapped relative to `devices/flydigi/vader5.toml`).
+
+When you add a new e2e test, prefer one of these patterns:
+
+```zig
+// device-config-driven test
+const parsed = try device_mod.parseFile(allocator, "devices/flydigi/vader5.toml");
+
+// mapping-config-driven test
+const parsed = try mapping_mod.parseFile(allocator, "examples/mappings/comprehensive.toml");
+```
+
+If the test genuinely needs a config shape that no shipped fixture
+provides, add a new fixture under `src/test/fixtures/` and consume it via
+`@embedFile` — do not paste the TOML into the test source.

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -106,7 +106,7 @@ map = { A = 5, B = 6, X = 4, Y = 7, LB = 8, RB = 9 }
 | Field | Type | Description |
 |-------|------|-------------|
 | `source.offset` | integer | Starting byte offset within the report |
-| `source.size` | integer | Group width in bytes; must be `1..=8` (the interpreter packs the group into a u64; values above 8 are rejected at compile time) |
+| `source.size` | integer | Group width in bytes; must be `1..=8` (the interpreter packs the group into a u64; values above 8 are skipped at parse time with a warning logged to stderr and the report group falls back to all buttons unmapped) |
 | `map` | table | `Button = bit_index`. Bit indexes must satisfy `0 <= bit_index < size * 8`. |
 
 Button names must be valid `ButtonId` values:

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -103,6 +103,12 @@ source = { offset = 8, size = 3 }
 map = { A = 5, B = 6, X = 4, Y = 7, LB = 8, RB = 9 }
 ```
 
+| Field | Type | Description |
+|-------|------|-------------|
+| `source.offset` | integer | Starting byte offset within the report |
+| `source.size` | integer | Group width in bytes; must be `1..=8` (the interpreter packs the group into a u64; values above 8 are rejected at compile time) |
+| `map` | table | `Button = bit_index`. Bit indexes must satisfy `0 <= bit_index < size * 8`. |
+
 Button names must be valid `ButtonId` values:
 
 `A` `B` `X` `Y` `LB` `RB` `LT` `RT` `Start` `Select` `Home` `Capture` `LS` `RS` `DPadUp` `DPadDown` `DPadLeft` `DPadRight` `M1` `M2` `M3` `M4` `Paddle1` `Paddle2` `Paddle3` `Paddle4` `TouchPad` `Mic` `C` `Z` `LM` `RM` `O`
@@ -186,6 +192,13 @@ type = "hat"   # or "buttons"
 
 ### `[output.force_feedback]`
 
+Two backends are supported: legacy rumble via uinput (default), and HID PID
+passthrough via UHID for devices whose firmware speaks the
+[USB HID PID class spec](https://www.usb.org/document-library/device-class-definition-pid-10)
+directly (most racing wheels).
+
+#### Rumble (uinput, default)
+
 ```toml
 [output.force_feedback]
 type = "rumble"
@@ -195,9 +208,52 @@ auto_stop = true     # default; set false to disable userspace auto-stop
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `type` | string | — | Force-feedback type: `"rumble"` |
+| `type` | string | `"rumble"` | Force-feedback type. `"rumble"` is the only legacy value. |
 | `max_effects` | int | 16 | Maximum number of concurrent FF effect slots |
 | `auto_stop` | bool | `true` | Enable userspace rumble auto-stop. When `true`, padctl emits a stop frame to the HID device after each effect's `replay.length` elapses — compensating for the fact that uinput does not use the kernel's `ff-memless` auto-stop timer. Set to `false` only for devices whose firmware handles auto-stop internally. |
+| `backend` | string | `"uinput"` | `"uinput"` (rumble) or `"uhid"` (PID passthrough — see below). |
+| `kind` | string | `"rumble"` | `"rumble"` or `"pid"`. |
+
+#### HID PID passthrough (UHID, racing wheels)
+
+For devices that already implement HID PID effects in firmware (constant
+force, spring, damper, friction, sine periodic, etc.), padctl can publish a
+UHID node with the device's own PID descriptor and forward `UHID_OUTPUT`
+events back to the physical wheel. The kernel's `hid-pidff` driver then
+exposes the standard evdev FF interface to games and SDL — no userspace
+effect synthesis.
+
+Phase 13 Wave 6 introduced this path; closes issue #82 (Moza, Logitech G-series,
+Thrustmaster T-series, Fanatec ClubSport).
+
+```toml
+[output.force_feedback]
+backend       = "uhid"
+kind          = "pid"
+clone_vid_pid = true   # publish the UHID node with the wheel's real VID/PID
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `backend` | string | `"uinput"` | Set to `"uhid"` for PID passthrough. |
+| `kind` | string | `"rumble"` | Set to `"pid"` for PID passthrough. |
+| `clone_vid_pid` | bool | `false` | When `true`, the emitted UHID node uses `[device].vid` / `[device].pid` so games and `hid-pidff` recognize the wheel by its real identifiers. Requires non-zero VID and PID in `[device]`. |
+
+**Validation matrix** — the parser rejects illegal combinations at config load:
+
+| `backend` | `kind` | Result |
+|-----------|--------|--------|
+| `"uinput"` | `"rumble"` | OK (default; legacy uinput rumble) |
+| `"uinput"` | `"pid"` | rejected |
+| `"uhid"`   | `"rumble"` | rejected |
+| `"uhid"`   | `"pid"` | OK — also requires `[output.imu]` to be declared (UHID routing gate) |
+
+`clone_vid_pid = true` requires `[device].vid` and `[device].pid` to be non-zero.
+
+> **Kernel requirement:** the `hid-pidff` driver must be loaded, and the
+> `hid-universal-pidff` quirk module is recommended for non-Logitech wheels.
+> See the [Bazzite / Immutable Distros guide](immutable-install.md) for
+> distro-specific notes.
 
 ### `[output.aux]`
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -111,8 +111,14 @@ The service runs padctl in daemon mode, scanning all config directories (user, s
 Check the daemon is running:
 
 ```sh
-padctl status
+$ padctl status
+STATUS device=Flydigi Vader 5 Pro state=active mapping=fps
 ```
+
+Each managed device prints one space-separated triple: `device=<name>`,
+`state=<active|suspended>`, `mapping=<active mapping name|(none)>`. Multiple
+devices appear on the same line. Exit code is 0 when the daemon answered
+and 1 when the response begins with `ERR` or the socket is unreachable.
 
 ## Run Manually
 
@@ -135,10 +141,18 @@ padctl --config-dir /usr/share/padctl/devices/
 ## Validate a Config
 
 ```sh
-padctl --validate devices/sony/dualsense.toml
+padctl --validate devices/sony/dualsense.toml      # device config
+padctl --validate ~/.config/padctl/mappings/fps.toml  # mapping config
 ```
 
+`--validate` auto-detects which schema to apply by scanning for a `[device]`
+section header — files containing `[device]`, `[device.*]`, or `[[device.*]]`
+are validated as device configs; everything else (including bare `name = ...`
+mapping files) is validated against the mapping schema.
+
 Exit 0 = valid. Exit 1 = validation errors printed to stderr. Exit 2 = file not found or parse failure.
+
+The flag is repeatable: `padctl --validate a.toml --validate b.toml` validates both files and exits with the worst code seen.
 
 ## Generate Device Docs
 

--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -13,6 +13,7 @@ trigger_threshold = 100
 |-------|------|---------|-------------|
 | `name` | string | — | Mapping profile name. Used by `padctl switch <name>` and `default_mapping` in user config to identify this profile. |
 | `trigger_threshold` | integer (0–255) | null | Threshold for synthesizing digital `LT` / `RT` button events from the analog trigger axes. **Top-level only** — placing this inside `[[layer]]` is silently ignored. See below. |
+| `chord_index` | integer (≥1) | null | Selector index used by the in-controller `[chord_switch]` quick-switch. Each selectable mapping declares a unique `chord_index`; the value is matched against `[chord_switch].selectors` in `~/.config/padctl/config.toml`. See [Diagnostic Logging — Chord switch](diagnostic-logging.md#chord-switch-issue-183) for the full setup. |
 
 ## Validation behaviour
 
@@ -152,7 +153,7 @@ hold_timeout = 200
 | `name` | string | yes | Unique layer identifier |
 | `trigger` | string | yes | Button name that activates this layer |
 | `activation` | string | no | `"hold"` (default) or `"toggle"` |
-| `tap` | string | no | Button/key emitted on short press (when using hold activation) |
+| `tap` | string | no | Button/key emitted on short press (when using hold activation). May be a `ButtonId`, `KEY_*`, `mouse_*`, or `disabled`. **Cannot be `macro:<name>`** — the layer tap dispatch path does not run macros, so `tap = "macro:foo"` is rejected at validate time (`error.LayerTapCannotBeMacro`). Use `macro:<name>` from `[remap]` / `[layer.remap]` instead. |
 | `hold_timeout` | integer | no | Hold detection threshold in ms (1–5000) |
 
 ### `[layer.remap]`

--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -13,7 +13,7 @@ trigger_threshold = 100
 |-------|------|---------|-------------|
 | `name` | string | — | Mapping profile name. Used by `padctl switch <name>` and `default_mapping` in user config to identify this profile. |
 | `trigger_threshold` | integer (0–255) | null | Threshold for synthesizing digital `LT` / `RT` button events from the analog trigger axes. **Top-level only** — placing this inside `[[layer]]` is silently ignored. See below. |
-| `chord_index` | integer (≥1) | null | Selector index used by the in-controller `[chord_switch]` quick-switch. Each selectable mapping declares a unique `chord_index`; the value is matched against `[chord_switch].selectors` in `~/.config/padctl/config.toml`. See [Diagnostic Logging — Chord switch](diagnostic-logging.md#chord-switch-issue-183) for the full setup. |
+| `chord_index` | integer (0–255) | null | Selector index used by the in-controller `[chord_switch]` quick-switch. The value is matched against the position of `[chord_switch].selectors`: `chord_index = i+1` activates when `selectors[i]` is pressed. Set `chord_index = 0` (or omit) to leave a mapping unselectable via chord. See [Diagnostic Logging — Chord switch](diagnostic-logging.md#chord-switch-issue-183) for the full setup. |
 
 ## Validation behaviour
 

--- a/src/test/interpreter_e2e_test.zig
+++ b/src/test/interpreter_e2e_test.zig
@@ -25,36 +25,6 @@ const ButtonId = state_mod.ButtonId;
 //   [16]    rt u8
 //   [17..28] IMU fields
 
-const vader5_toml =
-    \\[device]
-    \\name = "Flydigi Vader 5 Pro"
-    \\vid = 0x37d7
-    \\pid = 0x2401
-    \\[[device.interface]]
-    \\id = 1
-    \\class = "hid"
-    \\[device.init]
-    \\commands = ["5aa5 0102 03"]
-    \\response_prefix = [0x5a, 0xa5]
-    \\[[report]]
-    \\name = "extended"
-    \\interface = 1
-    \\size = 32
-    \\[report.match]
-    \\offset = 0
-    \\expect = [0x5a, 0xa5, 0xef]
-    \\[report.fields]
-    \\left_x  = { offset = 3,  type = "i16le" }
-    \\left_y  = { offset = 5,  type = "i16le", transform = "negate" }
-    \\right_x = { offset = 7,  type = "i16le" }
-    \\right_y = { offset = 9,  type = "i16le", transform = "negate" }
-    \\lt      = { offset = 15, type = "u8" }
-    \\rt      = { offset = 16, type = "u8" }
-    \\[report.button_group]
-    \\source = { offset = 11, size = 4 }
-    \\map = { DPadUp = 0, DPadRight = 1, DPadDown = 2, DPadLeft = 3, A = 4, B = 5, Select = 6, X = 7, Y = 8, Start = 9, LB = 10, RB = 11, LS = 14, RS = 15, C = 16, Z = 17, M1 = 18, M2 = 19, M3 = 20, M4 = 21, LM = 22, RM = 23, O = 24, Home = 27 }
-;
-
 fn makeIf1Sample() [32]u8 {
     var raw = [_]u8{0} ** 32;
     raw[0] = 0x5a;
@@ -68,24 +38,6 @@ fn makeIf1Sample() [32]u8 {
 }
 
 // --- Layer 1: raw bytes → GamepadState ---
-
-test "interpreter_e2e: Vader5 IF1 — axes, button A, lt" {
-    const allocator = testing.allocator;
-    const parsed = try device_mod.parseString(allocator, vader5_toml);
-    defer parsed.deinit();
-    const interp = Interpreter.init(&parsed.value);
-
-    const raw = makeIf1Sample();
-    const delta = (try interp.processReport(1, &raw)) orelse return error.NoMatch;
-
-    try testing.expectEqual(@as(?i16, 1000), delta.ax);
-    try testing.expectEqual(@as(?i16, 500), delta.ay); // negated
-    try testing.expectEqual(@as(?u8, 128), delta.lt);
-
-    const btns = delta.buttons orelse return error.NoBtns;
-    const a_bit: u6 = @intCast(@intFromEnum(ButtonId.A));
-    try testing.expect(btns & (@as(u64, 1) << a_bit) != 0);
-}
 
 test "interpreter_e2e: Vader5 IF1 — load from file and process" {
     const allocator = testing.allocator;


### PR DESCRIPTION
## What changed

Closes user-facing doc gaps for every feature merged since the last drift sync (PR #184, 2026-04-28).

- `docs/src/device-config.md`
  - `[output.force_feedback]` extended with the Wave 6 PID-passthrough fields (`backend`, `kind`, `clone_vid_pid`)
  - new validation matrix (uinput/uhid × rumble/pid) and the `[output.imu]` routing-gate requirement
  - racing-wheel TOML example + `hid-pidff` / `hid-universal-pidff` kernel requirement note
  - `[report.button_group]` documents `source.size` 1..=8 limit and `bit_index < size * 8`
- `docs/src/mapping-config.md`
  - `chord_index` field cross-linked to `[chord_switch]` setup in diagnostic-logging.md
  - `[[layer]]` `tap` field documents the `error.LayerTapCannotBeMacro` validate-time rejection
- `docs/src/getting-started.md`
  - `padctl status` documents the `STATUS device=... state=... mapping=...` response triple
  - `padctl --validate` documents auto-detection of mapping vs device files (`[device]` header heuristic) and the repeatable flag
- `docs/src/contributing/code-contributions.md`
  - new "Test Fixtures Are Single-Source" section: e2e tests must consume `devices/` and `examples/mappings/` via `parseFile` / `@embedFile`, never inline TOML literals (carries forward the drift-proofing rationale from PR #193)

## Why

Several user reports during v0.1.4 testing showed "this feature exists but I cannot find it documented" cases. This PR audits every code-side change merged from PR #176 (2026-04-28) through PR #205 (2026-05-01) and closes every doc gap that surfaced in that audit.

## Test plan

- [x] `zig build` clean (no code changes; doc-only PR)
- [x] `mdbook build docs/` renders with no warnings
- [x] All TOML examples cross-checked against `src/config/device.zig` (`ForceFeedbackConfig`), `src/tools/validate.zig` (`detectFileKind`), `src/supervisor.zig` (`handleStatus`), `src/config/mapping.zig` (`LayerTapCannotBeMacro`), and `src/test/wave6_pidff_e2e_test.zig` (PID passthrough fixture)
- [ ] CI green

## Refs

- PRs documented: #166, #176, #177, #199, #202, #204
- `chord_switch` (PR #201) docs are in sibling PR `docs/chord-switch-example-and-docs`
- Last full doc sync: PR #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced getting-started guide with clarified daemon status examples and multi-schema validation workflows.
  * Expanded configuration reference with selectable force-feedback backends/kinds, UHID PID passthrough details, and button-group/bit-size semantics.
  * Added `chord_index` mapping key and tightened layer `tap` validation rules.
  * New rule: e2e tests must use single-source on-disk fixtures instead of inline configuration literals.
* **Tests**
  * Removed an embedded inline-config e2e test in favor of canonical fixture-driven tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->