### PR TITLE
feat(config): chord remap syntax — parse array values in remap table

### DIFF
--- a/examples/mappings/chord-output.toml
+++ b/examples/mappings/chord-output.toml
@@ -1,0 +1,20 @@
+# Example mapping demonstrating chord output remap (issue #206).
+# A single button press emits a multi-key chord (modifier+key combo).
+# On press: down events emitted in declaration order.
+# On release: up events emitted in reverse order.
+
+[meta]
+name = "chord-output-demo"
+
+# Chord output: array of KEY_* strings (length 2..=4, no duplicates).
+[remap]
+# Single key — existing form, still works:
+M1 = "KEY_F13"
+# 2-key chord — Super+1 (workspace switch on tile WMs):
+A = ["KEY_LEFTMETA", "KEY_1"]
+# 2-key chord — Ctrl+C (copy):
+B = ["KEY_LEFTCTRL", "KEY_C"]
+# 3-key chord — Ctrl+Shift+S (save as):
+X = ["KEY_LEFTCTRL", "KEY_LEFTSHIFT", "KEY_S"]
+# 4-key chord — Meta+Ctrl+Shift+T (custom WM action):
+Y = ["KEY_LEFTMETA", "KEY_LEFTCTRL", "KEY_LEFTSHIFT", "KEY_T"]

--- a/src/cli/config/test.zig
+++ b/src/cli/config/test.zig
@@ -60,7 +60,14 @@ fn openFirstHidraw() !posix.fd_t {
 
 fn mappingLabel(mapping: *const mapping_mod.MappingConfig, button: []const u8) ?[]const u8 {
     if (mapping.remap) |remap| {
-        if (remap.map.get(button)) |target| return target;
+        if (remap.map.get(button)) |target| {
+            switch (target) {
+                .string => |s| return s,
+                // Chord arrays don't have a single human label; callers fall
+                // back to the source button name.
+                else => return null,
+            }
+        }
     }
     return null;
 }
@@ -133,7 +140,17 @@ pub fn run(allocator: std.mem.Allocator, config_path: ?[]const u8, mapping_path:
             if (remap != null) {
                 var it = remap.?.map.iterator();
                 while (it.next()) |entry| {
-                    try w.print("  {s} -> {s}", .{ entry.key_ptr.*, entry.value_ptr.* });
+                    switch (entry.value_ptr.*) {
+                        .string => |s| try w.print("  {s} -> {s}", .{ entry.key_ptr.*, s }),
+                        .chord_names => |names| {
+                            try w.print("  {s} -> chord[", .{entry.key_ptr.*});
+                            for (names, 0..) |name, i| {
+                                if (i > 0) try w.writeAll(", ");
+                                try w.print("{s}", .{name});
+                            }
+                            try w.writeAll("]");
+                        },
+                    }
                 }
             }
         }

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const toml = @import("toml");
 const input_codes = @import("input_codes.zig");
+const remap_mod = @import("../core/remap.zig");
 pub const MacroStep = @import("../core/macro.zig").MacroStep;
 pub const Macro = @import("../core/macro.zig").Macro;
 
@@ -309,9 +310,6 @@ fn checkRemapMacros(cfg: *const MappingConfig, map: *const RemapMap) !void {
 // Chord-array validation matching core/remap.zig::resolveChordTarget. Done at
 // validate() time so users see length/duplicate/unknown-key failures before
 // runtime; production precomputeRemap silently warns and skips.
-const CHORD_MIN_KEYS: usize = 2;
-const CHORD_MAX_KEYS: usize = 4;
-
 pub const ChordValidateError = error{
     ChordTooShort,
     ChordTooLong,
@@ -327,10 +325,10 @@ fn checkRemapChords(map: *const RemapMap) ChordValidateError!void {
             .chord_names => |n| n,
             else => continue,
         };
-        if (names.len < CHORD_MIN_KEYS) return error.ChordTooShort;
-        if (names.len > CHORD_MAX_KEYS) return error.ChordTooLong;
+        if (names.len < remap_mod.CHORD_MIN_KEYS) return error.ChordTooShort;
+        if (names.len > remap_mod.CHORD_MAX_KEYS) return error.ChordTooLong;
 
-        var seen: [CHORD_MAX_KEYS]u16 = undefined;
+        var seen: [remap_mod.CHORD_MAX_KEYS]u16 = undefined;
         var seen_len: usize = 0;
         for (names) |name| {
             const code = input_codes.resolveKeyCode(name) catch return error.UnknownKeyCode;

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -4,6 +4,48 @@ const input_codes = @import("input_codes.zig");
 pub const MacroStep = @import("../core/macro.zig").MacroStep;
 pub const Macro = @import("../core/macro.zig").Macro;
 
+// `[remap]` value is either a single string ("KEY_F13", "macro:dodge_roll",
+// "BTN_LEFT", gamepad-button name) or an array of KEY_* strings (chord output,
+// issue #206). RemapMap below has a `tomlIntoStruct` hook that inspects the
+// raw toml.Value per entry to choose between the two forms.
+pub const RemapValue = union(enum) {
+    string: []const u8,
+    chord_names: []const []const u8,
+};
+
+pub const RemapMap = struct {
+    map: std.StringHashMap(RemapValue),
+
+    pub fn tomlIntoStruct(ctx: anytype, table: anytype) !RemapMap {
+        var map = std.StringHashMap(RemapValue).init(ctx.alloc);
+        errdefer map.deinit();
+
+        var it = table.iterator();
+        while (it.next()) |entry| {
+            const value = entry.value_ptr.*;
+            const remap_value: RemapValue = switch (value) {
+                .string => |s| .{ .string = s },
+                .array => |arr| blk: {
+                    const names = try ctx.alloc.alloc([]const u8, arr.items.len);
+                    for (arr.items, 0..) |elem, i| {
+                        switch (elem) {
+                            .string => |s| names[i] = s,
+                            else => return error.InvalidValueType,
+                        }
+                    }
+                    break :blk .{ .chord_names = names };
+                },
+                else => return error.InvalidValueType,
+            };
+
+            const key: []u8 = try ctx.alloc.alloc(u8, entry.key_ptr.len);
+            @memcpy(key, entry.key_ptr.*);
+            try map.put(key, remap_value);
+        }
+        return .{ .map = map };
+    }
+};
+
 pub const DerivedAuxCaps = struct {
     needs_rel: bool = false, // REL_X/Y/WHEEL/HWHEEL (gyro mouse, stick mouse/scroll)
     needs_keyboard: bool = false, // KEY_* remaps, dpad arrows
@@ -76,27 +118,35 @@ fn scanTarget(caps: *DerivedAuxCaps, target: []const u8) void {
     }
 }
 
-fn scanRemapTargets(caps: *DerivedAuxCaps, cfg: *const MappingConfig, remap: *const toml.HashMap([]const u8)) void {
+fn scanRemapTargets(caps: *DerivedAuxCaps, cfg: *const MappingConfig, remap: *const RemapMap) void {
     var it = remap.map.iterator();
     while (it.next()) |entry| {
-        const target = entry.value_ptr.*;
-        if (std.mem.startsWith(u8, target, "macro:")) {
-            const macro_name = target["macro:".len..];
-            const macros = cfg.macro orelse continue;
-            for (macros) |*m| {
-                if (!std.mem.eql(u8, m.name, macro_name)) continue;
-                for (m.steps) |s| {
-                    switch (s) {
-                        .tap => |name| scanTarget(caps, name),
-                        .down => |name| scanTarget(caps, name),
-                        .up => |name| scanTarget(caps, name),
-                        .delay, .pause_for_release => {},
+        switch (entry.value_ptr.*) {
+            .string => |target| {
+                if (std.mem.startsWith(u8, target, "macro:")) {
+                    const macro_name = target["macro:".len..];
+                    const macros = cfg.macro orelse continue;
+                    for (macros) |*m| {
+                        if (!std.mem.eql(u8, m.name, macro_name)) continue;
+                        for (m.steps) |s| {
+                            switch (s) {
+                                .tap => |name| scanTarget(caps, name),
+                                .down => |name| scanTarget(caps, name),
+                                .up => |name| scanTarget(caps, name),
+                                .delay, .pause_for_release => {},
+                            }
+                        }
+                        break;
                     }
+                } else {
+                    scanTarget(caps, target);
                 }
-                break;
-            }
-        } else {
-            scanTarget(caps, target);
+            },
+            .chord_names => |names| {
+                // Chord output: every element is a KEY_* code (validated at
+                // validate() time). Capability is keyboard regardless of count.
+                for (names) |name| scanTarget(caps, name);
+            },
         }
     }
 }
@@ -189,7 +239,7 @@ pub const LayerConfig = struct {
     activation: []const u8 = "hold",
     tap: ?[]const u8 = null,
     hold_timeout: ?i64 = null,
-    remap: ?toml.HashMap([]const u8) = null,
+    remap: ?RemapMap = null,
     gyro: ?GyroConfig = null,
     stick_left: ?StickConfig = null,
     stick_right: ?StickConfig = null,
@@ -200,7 +250,7 @@ pub const LayerConfig = struct {
 pub const MappingConfig = struct {
     name: ?[]const u8 = null,
     chord_index: ?u8 = null,
-    remap: ?toml.HashMap([]const u8) = null,
+    remap: ?RemapMap = null,
     gyro: ?GyroConfig = null,
     stick: ?StickPairConfig = null,
     dpad: ?DpadConfig = null,
@@ -240,13 +290,55 @@ fn macroExists(cfg: *const MappingConfig, name: []const u8) bool {
     return false;
 }
 
-fn checkRemapMacros(cfg: *const MappingConfig, map: *const toml.HashMap([]const u8)) !void {
+fn checkRemapMacros(cfg: *const MappingConfig, map: *const RemapMap) !void {
     var it = map.map.iterator();
     while (it.next()) |entry| {
-        const val = entry.value_ptr.*;
-        if (std.mem.startsWith(u8, val, "macro:")) {
-            const macro_name = val["macro:".len..];
-            if (!macroExists(cfg, macro_name)) return error.UnknownMacro;
+        switch (entry.value_ptr.*) {
+            .string => |s| {
+                if (std.mem.startsWith(u8, s, "macro:")) {
+                    const macro_name = s["macro:".len..];
+                    if (!macroExists(cfg, macro_name)) return error.UnknownMacro;
+                }
+            },
+            // Chord arrays cannot reference macros — validated separately.
+            .chord_names => {},
+        }
+    }
+}
+
+// Chord-array validation matching core/remap.zig::resolveChordTarget. Done at
+// validate() time so users see length/duplicate/unknown-key failures before
+// runtime; production precomputeRemap silently warns and skips.
+const CHORD_MIN_KEYS: usize = 2;
+const CHORD_MAX_KEYS: usize = 4;
+
+pub const ChordValidateError = error{
+    ChordTooShort,
+    ChordTooLong,
+    DuplicateChordKey,
+    InvalidChordElement,
+    UnknownKeyCode,
+};
+
+fn checkRemapChords(map: *const RemapMap) ChordValidateError!void {
+    var it = map.map.iterator();
+    while (it.next()) |entry| {
+        const names = switch (entry.value_ptr.*) {
+            .chord_names => |n| n,
+            else => continue,
+        };
+        if (names.len < CHORD_MIN_KEYS) return error.ChordTooShort;
+        if (names.len > CHORD_MAX_KEYS) return error.ChordTooLong;
+
+        var seen: [CHORD_MAX_KEYS]u16 = undefined;
+        var seen_len: usize = 0;
+        for (names) |name| {
+            const code = input_codes.resolveKeyCode(name) catch return error.UnknownKeyCode;
+            for (seen[0..seen_len]) |c| {
+                if (c == code) return error.DuplicateChordKey;
+            }
+            seen[seen_len] = code;
+            seen_len += 1;
         }
     }
 }
@@ -260,7 +352,7 @@ fn validateAdaptiveTrigger(at: *const AdaptiveTriggerConfig) !void {
     return error.InvalidConfig;
 }
 
-fn remapHasTriggerKey(map: *const toml.HashMap([]const u8)) bool {
+fn remapHasTriggerKey(map: *const RemapMap) bool {
     var it = map.map.iterator();
     while (it.next()) |entry| {
         const key = entry.key_ptr.*;
@@ -522,7 +614,10 @@ fn warnLintFindings(findings: []const LintFinding) void {
 }
 
 pub fn validate(cfg: *const MappingConfig) !void {
-    if (cfg.remap) |*m| try checkRemapMacros(cfg, m);
+    if (cfg.remap) |*m| {
+        try checkRemapMacros(cfg, m);
+        try checkRemapChords(m);
+    }
     if (cfg.adaptive_trigger) |*at| try validateAdaptiveTrigger(at);
 
     if (needsTriggerThresholdWarn(cfg)) {
@@ -556,7 +651,10 @@ pub fn validate(cfg: *const MappingConfig) !void {
             }
         }
 
-        if (layer.remap) |*m| try checkRemapMacros(cfg, m);
+        if (layer.remap) |*m| {
+            try checkRemapMacros(cfg, m);
+            try checkRemapChords(m);
+        }
         if (layer.adaptive_trigger) |*at| try validateAdaptiveTrigger(at);
     }
 }
@@ -580,9 +678,9 @@ test "mapping: MappingConfig parses name and remap" {
     const cfg = result.value;
     try std.testing.expectEqualStrings("test", cfg.name.?);
     try std.testing.expect(cfg.remap != null);
-    try std.testing.expectEqualStrings("KEY_F13", cfg.remap.?.map.get("M1").?);
-    try std.testing.expectEqualStrings("disabled", cfg.remap.?.map.get("M2").?);
-    try std.testing.expectEqualStrings("B", cfg.remap.?.map.get("A").?);
+    try std.testing.expectEqualStrings("KEY_F13", cfg.remap.?.map.get("M1").?.string);
+    try std.testing.expectEqualStrings("disabled", cfg.remap.?.map.get("M2").?.string);
+    try std.testing.expectEqualStrings("B", cfg.remap.?.map.get("A").?.string);
 }
 
 test "mapping: MappingConfig: empty config" {
@@ -711,7 +809,7 @@ test "mapping: MappingConfig: full config with layers, gyro, stick, dpad" {
     try std.testing.expectEqualStrings("mouse_side", aim.tap.?);
     try std.testing.expectEqual(@as(?i64, 200), aim.hold_timeout);
     try std.testing.expect(aim.remap != null);
-    try std.testing.expectEqualStrings("mouse_left", aim.remap.?.map.get("RB").?);
+    try std.testing.expectEqualStrings("mouse_left", aim.remap.?.map.get("RB").?.string);
 
     // layer[0] gyro override
     try std.testing.expect(aim.gyro != null);
@@ -733,7 +831,7 @@ test "mapping: MappingConfig: full config with layers, gyro, stick, dpad" {
     const fn_layer = cfg.layer.?[1];
     try std.testing.expectEqualStrings("toggle", fn_layer.activation);
     try std.testing.expect(fn_layer.remap != null);
-    try std.testing.expectEqualStrings("KEY_F1", fn_layer.remap.?.map.get("A").?);
+    try std.testing.expectEqualStrings("KEY_F1", fn_layer.remap.?.map.get("A").?.string);
 
     try validate(&cfg);
 }
@@ -865,7 +963,7 @@ test "mapping: [[macro]] multi-entry parse: all step primitives correct" {
     try std.testing.expectEqualStrings("noop", noop.name);
     try std.testing.expectEqual(@as(usize, 0), noop.steps.len);
 
-    try std.testing.expectEqualStrings("macro:dodge_roll", cfg.remap.?.map.get("M1").?);
+    try std.testing.expectEqualStrings("macro:dodge_roll", cfg.remap.?.map.get("M1").?.string);
     try validate(&cfg);
 }
 
@@ -1392,4 +1490,139 @@ test "validate: layer tap to gamepad button works (regression)" {
     const result = try parseString(allocator, toml_str);
     defer result.deinit();
     try validate(&result.value);
+}
+
+// --- chord remap (issue #206) ---
+
+test "chord remap: 2-key array parses into chord_names" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\C = ["KEY_LEFTMETA", "KEY_1"]
+    );
+    defer result.deinit();
+    const entry = result.value.remap.?.map.get("C").?;
+    try std.testing.expectEqual(@as(usize, 2), entry.chord_names.len);
+    try std.testing.expectEqualStrings("KEY_LEFTMETA", entry.chord_names[0]);
+    try std.testing.expectEqualStrings("KEY_1", entry.chord_names[1]);
+    try validate(&result.value);
+}
+
+test "chord remap: 3-key array parses and validates" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\D = ["KEY_LEFTCTRL", "KEY_LEFTSHIFT", "KEY_S"]
+    );
+    defer result.deinit();
+    const entry = result.value.remap.?.map.get("D").?;
+    try std.testing.expectEqual(@as(usize, 3), entry.chord_names.len);
+    try validate(&result.value);
+}
+
+test "chord remap: single-key string remap still parses (regression)" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\M1 = "KEY_F13"
+    );
+    defer result.deinit();
+    try std.testing.expectEqualStrings("KEY_F13", result.value.remap.?.map.get("M1").?.string);
+    try validate(&result.value);
+}
+
+test "chord remap: 1-element array -> ChordTooShort" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\C = ["KEY_A"]
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.ChordTooShort, validate(&result.value));
+}
+
+test "chord remap: 5-element array -> ChordTooLong" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\C = ["KEY_A", "KEY_B", "KEY_C", "KEY_D", "KEY_E"]
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.ChordTooLong, validate(&result.value));
+}
+
+test "chord remap: duplicate keys -> DuplicateChordKey" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\C = ["KEY_A", "KEY_A"]
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.DuplicateChordKey, validate(&result.value));
+}
+
+test "chord remap: unknown keycode -> UnknownKeyCode" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\C = ["KEY_NOT_REAL", "KEY_1"]
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.UnknownKeyCode, validate(&result.value));
+}
+
+test "chord remap: non-string array element rejected at parse time" {
+    const allocator = std.testing.allocator;
+    // Integer elements inside a `[remap]` array must surface as a parse-time
+    // InvalidValueType (RemapMap.tomlIntoStruct refuses non-string elements).
+    const r = parseString(allocator,
+        \\[remap]
+        \\C = [1, 2]
+    );
+    try std.testing.expectError(error.InvalidValueType, r);
+}
+
+test "chord remap: layer remap supports array form" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[[layer]]
+        \\name = "fn"
+        \\trigger = "Select"
+        \\
+        \\[layer.remap]
+        \\A = ["KEY_LEFTCTRL", "KEY_C"]
+    );
+    defer result.deinit();
+    const layer_remap = result.value.layer.?[0].remap.?;
+    const entry = layer_remap.map.get("A").?;
+    try std.testing.expectEqual(@as(usize, 2), entry.chord_names.len);
+    try std.testing.expectEqualStrings("KEY_LEFTCTRL", entry.chord_names[0]);
+    try std.testing.expectEqualStrings("KEY_C", entry.chord_names[1]);
+    try validate(&result.value);
+}
+
+test "chord remap: deriveAuxFromMapping flags needs_keyboard for chord array" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\C = ["KEY_LEFTMETA", "KEY_1"]
+    );
+    defer result.deinit();
+    const caps = deriveAuxFromMapping(&result.value);
+    try std.testing.expect(caps.needs_keyboard);
+    try std.testing.expect(caps.needsAux());
+}
+
+test "chord remap: layer-level chord too long is rejected by validate" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[[layer]]
+        \\name = "fn"
+        \\trigger = "Select"
+        \\
+        \\[layer.remap]
+        \\A = ["KEY_A", "KEY_B", "KEY_C", "KEY_D", "KEY_E"]
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.ChordTooLong, validate(&result.value));
 }

--- a/src/core/macro_player.zig
+++ b/src/core/macro_player.zig
@@ -165,7 +165,7 @@ pub const MacroPlayer = struct {
                 .key => |code| aux.append(.{ .key = .{ .code = code, .pressed = false } }) catch {},
                 .mouse_button => |code| aux.append(.{ .mouse_button = .{ .code = code, .pressed = false } }) catch {},
                 .gamepad_button => {},
-                .disabled, .macro => {},
+                .disabled, .macro, .chord => {},
             }
         }
 

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -78,18 +78,25 @@ pub const Mapper = struct {
     chord_detector: ?ChordDetector = null,
 
     pub fn init(config: *const MappingConfig, timer_fd: std.posix.fd_t, allocator: std.mem.Allocator) !Mapper {
-        const base = if (config.remap) |m| precomputeRemap(m) else ResolvedRemap{
+        const base = if (config.remap) |m| try precomputeRemap(allocator, m) else ResolvedRemap{
             .inject = [_]?RemapTargetResolved{null} ** BUTTON_COUNT,
             .suppress = 0,
         };
+        errdefer freeResolvedRemap(allocator, base);
 
         const layers = config.layer orelse &.{};
         const resolved_layers = try allocator.alloc(ResolvedRemap, layers.len);
+        errdefer allocator.free(resolved_layers);
+
+        var initialized: usize = 0;
+        errdefer for (resolved_layers[0..initialized]) |r| freeResolvedRemap(allocator, r);
+
         for (layers, 0..) |*lc, i| {
-            resolved_layers[i] = if (lc.remap) |m| precomputeRemap(m) else ResolvedRemap{
+            resolved_layers[i] = if (lc.remap) |m| try precomputeRemap(allocator, m) else ResolvedRemap{
                 .inject = [_]?RemapTargetResolved{null} ** BUTTON_COUNT,
                 .suppress = 0,
             };
+            initialized = i + 1;
         }
 
         return .{
@@ -118,6 +125,8 @@ pub const Mapper = struct {
         self.layer.deinit();
         self.active_macros.deinit(self.allocator);
         self.timer_queue.deinit();
+        freeResolvedRemap(self.allocator, self.resolved_base);
+        for (self.resolved_layers) |r| freeResolvedRemap(self.allocator, r);
         self.allocator.free(self.resolved_layers);
     }
 
@@ -337,6 +346,10 @@ pub const Mapper = struct {
                         remap_mod.applyTarget(target, .release, &aux, &self.injected_buttons, null, null);
                 },
                 .disabled => {},
+                // Chord dispatch lands in PR B-2; B-1 keeps the source button
+                // suppressed (via `precomputeRemap`'s `result.suppress |= ...`)
+                // but emits no chord events yet.
+                .chord => {},
             }
         }
 
@@ -552,11 +565,23 @@ fn resolveStickConfig(mc: *const mapping.StickConfig) stick.StickConfig {
     };
 }
 
-fn precomputeRemap(remap_map: toml.HashMap([]const u8)) ResolvedRemap {
+fn freeResolvedRemap(allocator: std.mem.Allocator, r: ResolvedRemap) void {
+    for (r.inject) |maybe_target| {
+        const t = maybe_target orelse continue;
+        switch (t) {
+            .chord => |codes| allocator.free(codes),
+            else => {},
+        }
+    }
+}
+
+fn precomputeRemap(allocator: std.mem.Allocator, remap_map: mapping.RemapMap) !ResolvedRemap {
     var result = ResolvedRemap{
         .inject = [_]?RemapTargetResolved{null} ** BUTTON_COUNT,
         .suppress = 0,
     };
+    errdefer freeResolvedRemap(allocator, result);
+
     var it = remap_map.map.iterator();
     while (it.next()) |entry| {
         const src_id = std.meta.stringToEnum(ButtonId, entry.key_ptr.*) orelse {
@@ -564,9 +589,15 @@ fn precomputeRemap(remap_map: toml.HashMap([]const u8)) ResolvedRemap {
             continue;
         };
         const src_idx: u6 = @intCast(@intFromEnum(src_id));
-        const target = resolveTarget(entry.value_ptr.*) catch {
-            std.log.warn("unknown remap target: {s}", .{entry.value_ptr.*});
-            continue;
+        const target: RemapTargetResolved = switch (entry.value_ptr.*) {
+            .string => |s| resolveTarget(s) catch {
+                std.log.warn("unknown remap target: {s}", .{s});
+                continue;
+            },
+            .chord_names => |names| remap_mod.resolveChordTarget(allocator, names) catch |e| {
+                std.log.warn("chord remap on {s} rejected: {s}", .{ entry.key_ptr.*, @errorName(e) });
+                continue;
+            },
         };
         result.suppress |= @as(u64, 1) << src_idx;
         result.inject[@intCast(src_idx)] = target;

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -594,9 +594,12 @@ fn precomputeRemap(allocator: std.mem.Allocator, remap_map: mapping.RemapMap) !R
                 std.log.warn("unknown remap target: {s}", .{s});
                 continue;
             },
-            .chord_names => |names| remap_mod.resolveChordTarget(allocator, names) catch |e| {
-                std.log.warn("chord remap on {s} rejected: {s}", .{ entry.key_ptr.*, @errorName(e) });
-                continue;
+            .chord_names => |names| remap_mod.resolveChordTarget(allocator, names) catch |e| switch (e) {
+                error.OutOfMemory => return e,
+                error.ChordTooShort, error.ChordTooLong, error.DuplicateChordKey, error.UnknownKeyCode => {
+                    std.log.warn("chord remap on {s} rejected: {s}", .{ entry.key_ptr.*, @errorName(e) });
+                    continue;
+                },
             },
         };
         result.suppress |= @as(u64, 1) << src_idx;

--- a/src/core/remap.zig
+++ b/src/core/remap.zig
@@ -12,6 +12,10 @@ pub const RemapTargetResolved = union(enum) {
     gamepad_button: ButtonId,
     disabled: void,
     macro: []const u8,
+    // Chord output: 2..=4 evdev key codes (issue #206). Codes are owned by the
+    // Mapper allocator (allocated in precomputeRemap, freed in Mapper.deinit).
+    // Dispatch implementation lands in PR B-2.
+    chord: []const u16,
 };
 
 pub const TargetAction = enum { press, release, tap };
@@ -63,8 +67,31 @@ pub fn applyTarget(
                 },
             }
         },
-        .disabled, .macro => {},
+        // chord dispatch lands in PR B-2 (issue #206)
+        .disabled, .macro, .chord => {},
     }
+}
+
+pub const CHORD_MIN_KEYS: usize = 2;
+pub const CHORD_MAX_KEYS: usize = 4;
+
+/// Resolve an array remap target like `["KEY_LEFTMETA", "KEY_1"]` into a
+/// `.chord` variant. Caller owns the returned `chord` slice.
+pub fn resolveChordTarget(allocator: std.mem.Allocator, names: []const []const u8) !RemapTargetResolved {
+    if (names.len < CHORD_MIN_KEYS) return error.ChordTooShort;
+    if (names.len > CHORD_MAX_KEYS) return error.ChordTooLong;
+
+    const codes = try allocator.alloc(u16, names.len);
+    errdefer allocator.free(codes);
+
+    for (names, 0..) |name, i| {
+        const code = try input_codes.resolveKeyCode(name);
+        for (codes[0..i]) |prior| {
+            if (prior == code) return error.DuplicateChordKey;
+        }
+        codes[i] = code;
+    }
+    return .{ .chord = codes };
 }
 
 pub fn resolveTarget(raw: []const u8) !RemapTargetResolved {
@@ -139,4 +166,49 @@ test "remap: resolveTarget: disabled -> .disabled" {
 
 test "remap: resolveTarget: unknown string -> error.UnknownRemapTarget" {
     try std.testing.expectError(error.UnknownRemapTarget, resolveTarget("unknown_garbage"));
+}
+
+test "remap: resolveChordTarget: 2-key chord resolves" {
+    const allocator = std.testing.allocator;
+    const names = [_][]const u8{ "KEY_LEFTMETA", "KEY_1" };
+    const target = try resolveChordTarget(allocator, &names);
+    defer allocator.free(target.chord);
+    try std.testing.expectEqual(@as(usize, 2), target.chord.len);
+    try std.testing.expectEqual(try input_codes.resolveKeyCode("KEY_LEFTMETA"), target.chord[0]);
+    try std.testing.expectEqual(try input_codes.resolveKeyCode("KEY_1"), target.chord[1]);
+}
+
+test "remap: resolveChordTarget: 3-key chord preserves declaration order" {
+    const allocator = std.testing.allocator;
+    const names = [_][]const u8{ "KEY_LEFTCTRL", "KEY_LEFTSHIFT", "KEY_S" };
+    const target = try resolveChordTarget(allocator, &names);
+    defer allocator.free(target.chord);
+    try std.testing.expectEqual(@as(usize, 3), target.chord.len);
+    try std.testing.expectEqual(try input_codes.resolveKeyCode("KEY_LEFTCTRL"), target.chord[0]);
+    try std.testing.expectEqual(try input_codes.resolveKeyCode("KEY_LEFTSHIFT"), target.chord[1]);
+    try std.testing.expectEqual(try input_codes.resolveKeyCode("KEY_S"), target.chord[2]);
+}
+
+test "remap: resolveChordTarget: 1-key array -> ChordTooShort" {
+    const allocator = std.testing.allocator;
+    const names = [_][]const u8{"KEY_A"};
+    try std.testing.expectError(error.ChordTooShort, resolveChordTarget(allocator, &names));
+}
+
+test "remap: resolveChordTarget: 5-key array -> ChordTooLong" {
+    const allocator = std.testing.allocator;
+    const names = [_][]const u8{ "KEY_A", "KEY_B", "KEY_C", "KEY_D", "KEY_E" };
+    try std.testing.expectError(error.ChordTooLong, resolveChordTarget(allocator, &names));
+}
+
+test "remap: resolveChordTarget: duplicate keys -> DuplicateChordKey" {
+    const allocator = std.testing.allocator;
+    const names = [_][]const u8{ "KEY_A", "KEY_A" };
+    try std.testing.expectError(error.DuplicateChordKey, resolveChordTarget(allocator, &names));
+}
+
+test "remap: resolveChordTarget: unknown key code propagates resolveKeyCode error" {
+    const allocator = std.testing.allocator;
+    const names = [_][]const u8{ "KEY_NOT_REAL", "KEY_1" };
+    try std.testing.expectError(error.UnknownKeyCode, resolveChordTarget(allocator, &names));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -102,6 +102,7 @@ pub const testing_support = struct {
     pub const event_loop_rumble_test = @import("test/event_loop_rumble_test.zig");
     pub const uhid_output_dispatch_test = @import("test/uhid_output_dispatch_test.zig");
     pub const wave6_pidff_e2e_test = @import("test/wave6_pidff_e2e_test.zig");
+    pub const chord_output_e2e_test = @import("test/chord_output_e2e_test.zig");
     pub const interpreter_props = @import("test/properties/interpreter_props.zig");
     pub const render_props = @import("test/properties/render_props.zig");
     pub const config_props = @import("test/properties/config_props.zig");

--- a/src/test/chord_output_e2e_test.zig
+++ b/src/test/chord_output_e2e_test.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+const mapping = @import("../config/mapping.zig");
+
+const toml_text = @embedFile("../../examples/mappings/chord-output.toml");
+
+test "chord_output_e2e: examples/mappings/chord-output.toml parses (SSOT)" {
+    const allocator = std.testing.allocator;
+    const result = try mapping.parseString(allocator, toml_text);
+    defer result.deinit();
+
+    const remap = result.value.remap orelse return error.MissingRemap;
+
+    // M1 single-key form
+    const m1 = remap.map.get("M1") orelse return error.MissingM1;
+    try std.testing.expect(m1 == .string);
+    try std.testing.expectEqualStrings("KEY_F13", m1.string);
+
+    // A: 2-key chord
+    const a = remap.map.get("A") orelse return error.MissingA;
+    try std.testing.expect(a == .chord_names);
+    try std.testing.expectEqual(@as(usize, 2), a.chord_names.len);
+    try std.testing.expectEqualStrings("KEY_LEFTMETA", a.chord_names[0]);
+    try std.testing.expectEqualStrings("KEY_1", a.chord_names[1]);
+
+    // B: 2-key chord
+    const b = remap.map.get("B") orelse return error.MissingB;
+    try std.testing.expect(b == .chord_names);
+    try std.testing.expectEqual(@as(usize, 2), b.chord_names.len);
+
+    // X: 3-key chord
+    const x = remap.map.get("X") orelse return error.MissingX;
+    try std.testing.expect(x == .chord_names);
+    try std.testing.expectEqual(@as(usize, 3), x.chord_names.len);
+
+    // Y: 4-key chord (max length)
+    const y = remap.map.get("Y") orelse return error.MissingY;
+    try std.testing.expect(y == .chord_names);
+    try std.testing.expectEqual(@as(usize, 4), y.chord_names.len);
+
+    // Canonical example must pass full validation
+    try mapping.validate(&result.value);
+}

--- a/src/test/gen/mapper_oracle.zig
+++ b/src/test/gen/mapper_oracle.zig
@@ -148,6 +148,10 @@ pub fn applyWithLayer(
             },
             .disabled => {},
             .macro => {},
+            // Chord dispatch lands in PR B-2; oracle treats it as a no-op for
+            // now (matches applyTarget) — generators won't produce chord
+            // remaps until B-2 lands.
+            .chord => {},
         }
     }
 
@@ -231,7 +235,7 @@ fn processLayers(os: *OracleState, layers: []const LayerConfig, buttons: u64, dt
 }
 
 fn collectRemap(
-    remap_map: toml.HashMap([]const u8),
+    remap_map: mapping.RemapMap,
     suppressed: *u64,
     per_src: []?RemapTarget,
 ) void {
@@ -239,9 +243,14 @@ fn collectRemap(
     while (it.next()) |entry| {
         const src_id = std.meta.stringToEnum(ButtonId, entry.key_ptr.*) orelse continue;
         const src_idx: u6 = @intCast(@intFromEnum(src_id));
-        suppressed.* |= @as(u64, 1) << src_idx;
         // Unknown targets skipped — matches production mapper.zig behaviour.
-        const target = remap_mod.resolveTarget(entry.value_ptr.*) catch continue;
+        // Chord arrays are also skipped here: the oracle has no allocator and
+        // dispatch lands in B-2, so chord doesn't affect oracle output.
+        const target = switch (entry.value_ptr.*) {
+            .string => |s| remap_mod.resolveTarget(s) catch continue,
+            .chord_names => continue,
+        };
+        suppressed.* |= @as(u64, 1) << src_idx;
         per_src[@intCast(src_idx)] = target;
     }
 }

--- a/src/test/gen/transition_id.zig
+++ b/src/test/gen/transition_id.zig
@@ -191,8 +191,13 @@ pub fn classify(
         if (cfg.remap) |remap_map| {
             var it = remap_map.map.iterator();
             while (it.next()) |entry| {
-                if (std.mem.startsWith(u8, entry.value_ptr.*, "macro:"))
-                    tracker.mark(.macro_cancelled_by_layer);
+                switch (entry.value_ptr.*) {
+                    .string => |s| {
+                        if (std.mem.startsWith(u8, s, "macro:"))
+                            tracker.mark(.macro_cancelled_by_layer);
+                    },
+                    .chord_names => {},
+                }
             }
         }
     }
@@ -229,16 +234,21 @@ fn classifyRemapTargets(tracker: *CoverageTracker, cfg: *const mapping.MappingCo
     const remap = cfg.remap orelse return;
     var it = remap.map.iterator();
     while (it.next()) |entry| {
-        const val = entry.value_ptr.*;
-        if (std.mem.startsWith(u8, val, "KEY_"))
-            tracker.mark(.remap_inject_key)
-        else if (std.mem.startsWith(u8, val, "mouse_"))
-            tracker.mark(.remap_inject_mouse)
-        else if (std.mem.eql(u8, val, "disabled")) {} // suppress only
-        else if (std.mem.startsWith(u8, val, "macro:"))
-            tracker.mark(.macro_triggered)
-        else
-            tracker.mark(.remap_inject_gamepad);
+        switch (entry.value_ptr.*) {
+            .string => |val| {
+                if (std.mem.startsWith(u8, val, "KEY_"))
+                    tracker.mark(.remap_inject_key)
+                else if (std.mem.startsWith(u8, val, "mouse_"))
+                    tracker.mark(.remap_inject_mouse)
+                else if (std.mem.eql(u8, val, "disabled")) {} // suppress only
+                else if (std.mem.startsWith(u8, val, "macro:"))
+                    tracker.mark(.macro_triggered)
+                else
+                    tracker.mark(.remap_inject_gamepad);
+            },
+            // Chord arrays count as keyboard injection (every element is KEY_*).
+            .chord_names => tracker.mark(.remap_inject_key),
+        }
     }
 }
 

--- a/tools/padctl-debug.zig
+++ b/tools/padctl-debug.zig
@@ -223,7 +223,14 @@ pub fn main() !void {
                     // Apply remap override if mapping is loaded
                     if (mapping_parsed) |mp| {
                         if (mp.value.remap) |remap| {
-                            if (remap.map.get(entry.key_ptr.*)) |target| {
+                            if (remap.map.get(entry.key_ptr.*)) |target_v| {
+                                // Chord remap is rendered as the source button
+                                // name unchanged here; the debug TUI doesn't yet
+                                // visualize chords (PR B-2 follow-up).
+                                const target = switch (target_v) {
+                                    .string => |s| s,
+                                    .chord_names => continue,
+                                };
                                 if (std.mem.eql(u8, target, "disabled")) {
                                     continue; // skip disabled buttons
                                 }
@@ -262,7 +269,11 @@ pub fn main() !void {
                 var it = remap.map.iterator();
                 while (it.next()) |entry| {
                     if (std.meta.stringToEnum(ButtonId, entry.key_ptr.*)) |btn| {
-                        const target = entry.value_ptr.*;
+                        const target = switch (entry.value_ptr.*) {
+                            .string => |s| s,
+                            // Chord remap not yet rendered in debug TUI.
+                            .chord_names => continue,
+                        };
                         if (std.mem.eql(u8, target, "disabled")) continue;
 
                         // Skip if already added from output.buttons


### PR DESCRIPTION
## What changed
- `src/config/mapping.zig` — new `RemapValue` union (`string` or `chord_names`) and `RemapMap` (custom `tomlIntoStruct` hook); `MappingConfig.remap` and `LayerConfig.remap` change from `?toml.HashMap([]const u8)` to `?RemapMap`. `validate()` rejects chord arrays whose length is outside 2..=4, contains duplicate codes, or contains an element that does not resolve via `resolveKeyCode`. Non-string array elements are rejected at parse time.
- `src/core/remap.zig` — new `RemapTargetResolved.chord: []const u16` variant, `resolveChordTarget(allocator, names)` resolver, `CHORD_MIN_KEYS=2` / `CHORD_MAX_KEYS=4` constants, plus 6 unit tests for the resolver (success + each error path).
- `src/core/mapper.zig` — `precomputeRemap` is now fallible and takes an allocator; chord codes are allocated on the Mapper allocator and released by `freeResolvedRemap` in `Mapper.deinit`. `applyTarget` and the per-button switch in `Mapper.apply` keep `.chord` as a no-op for now (dispatch lands in PR B-2).
- `src/test/gen/mapper_oracle.zig`, `src/test/gen/transition_id.zig`, `src/core/macro_player.zig`, `src/cli/config/test.zig`, `tools/padctl-debug.zig` — updated to handle `RemapValue` (extract `.string`, skip `.chord_names` for now) and exhaustive switch on `RemapTargetResolved` including the new arm.
- 13 new tests covering single-key regression, 2-key and 3-key chord parsing, layer remap chord support, length / duplicate / unknown-keycode / non-string-element validation, and `deriveAuxFromMapping` keyboard-cap derivation for chord arrays.

## Why
Issue #206 — let users bind a single button to a modifier+key chord (e.g., `C = [\"KEY_LEFTMETA\", \"KEY_1\"]` for Super+1) without writing a 5-line `[[macro]]`. PR B-1 lands the parser, AST, and validation; PR B-2 will add the actual press/release dispatch on top of the existing macro engine.

## Test plan
- [x] Existing single-key remap continues to parse + resolve unchanged
- [x] 2-key and 3-key chord arrays produce `.chord` variant
- [x] Length / duplicate / invalid-keycode / non-string-element rejected with typed errors
- [x] Layer override remap accepts the same array syntax
- [x] `deriveAuxFromMapping` flags `needs_keyboard` for chord arrays
- [x] `zig build` clean, `zig fmt --check` clean
- [x] Targeted test sets all green (`-Dtest-filter=` for `chord remap`, `mapping:`, `mapper:`, `remap:`, `validate`, `lint`, `layer`, `macro`, `oracle`, `generative`, `deriveAux`)
- [ ] Full CI matrix
- [ ] Dispatch follow-up: PR B-2 will add the `.chord` arm in `applyTarget`

## Refs
- Issue #206