### PR TITLE
docs(chord-switch): add example config + reference docs + integration test (issue #183 follow-up)

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -299,3 +299,36 @@ steps = [
 ```
 
 Bind a macro in remap: `M1 = "macro:dodge_roll"`
+
+## `[chord_switch]` — in-controller mapping switch
+
+`[chord_switch]` lives in **`~/.config/padctl/config.toml`** (the user config), **not** in a mapping file. It lets you switch the active mapping without touching a CLI: hold a modifier combination, then tap a selector button.
+
+```toml
+# ~/.config/padctl/config.toml
+version = 1
+
+[chord_switch]
+modifier  = ["LM", "RM"]        # hold ALL of these to arm
+selectors = ["A", "B", "X", "Y"] # tap one (while modifier held) to switch
+hold_ms   = 120                  # debounce window in ms (default 80)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `modifier` | array of ButtonId | — | All listed buttons must be held simultaneously to arm chord-switch mode. Missing or empty disables the feature. |
+| `selectors` | array of ButtonId | — | Selector at index `i` (0-based) activates the mapping that declares `chord_index = i+1`. Missing or empty disables the feature. |
+| `hold_ms` | integer | `80` | Debounce window in milliseconds. Selector edges received within this window after the modifier first becomes fully held are ignored. Raise if you get accidental switches when pressing modifier and selector nearly simultaneously. |
+
+**`chord_index`** is declared per mapping file (not in `config.toml`):
+
+```toml
+# ~/.config/padctl/mappings/desktop.toml
+chord_index = 1   # tap A (selectors[0]) while holding LM+RM → switch here
+```
+
+Selector `selectors[i]` maps to `chord_index = i+1`. Mappings that do not declare `chord_index` are not reachable via chord. Range is 1–255; duplicate `chord_index` values across files are resolved by lexicographic mapping name order (first match wins).
+
+While the modifier is held, all selector buttons are suppressed from the output device so they do not fire their remapped actions.
+
+A runnable example is at [`examples/configs/chord-switch.toml`](https://github.com/BANANASJIM/padctl/blob/main/examples/configs/chord-switch.toml).

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -336,6 +336,25 @@ steps = [
 
 Configures the resistance profile of the DualSense L2/R2 triggers. See [Mapping Config Reference](mapping-config.md#adaptive_trigger) for full field tables.
 
+### In-controller Chord Switch (`[chord_switch]`)
+
+Hold a set of modifier buttons, then tap a selector button to switch the active mapping without touching a CLI. This is configured in `~/.config/padctl/config.toml` (not in a mapping file), and each selectable mapping file declares `chord_index = N`:
+
+```toml
+# ~/.config/padctl/config.toml
+[chord_switch]
+modifier  = ["LM", "RM"]
+selectors = ["A", "B", "X", "Y"]
+hold_ms   = 120
+```
+
+```toml
+# ~/.config/padctl/mappings/desktop.toml
+chord_index = 1   # LM+RM → tap A → switch to this mapping
+```
+
+See [Mapping Config Reference — chord_switch](mapping-config.md#chord_switch--in-controller-mapping-switch) for full field tables and a runnable example.
+
 ## Full Example
 
 A copy-paste-ready example covering every major feature is included in the repository at [`examples/mappings/comprehensive.toml`](https://github.com/BANANASJIM/padctl/blob/main/examples/mappings/comprehensive.toml). It covers base remaps, two layers (hold + toggle), macros, stick modes, and gyro.

--- a/examples/configs/chord-switch.toml
+++ b/examples/configs/chord-switch.toml
@@ -9,7 +9,7 @@
 version = 1
 
 [chord_switch]
-# Hold ALL of these to arm chord switch mode (any combination):
+# Hold ALL of these simultaneously to arm chord switch mode:
 modifier = ["LM", "RM"]
 
 # Tap one of these (while modifier held) to switch:

--- a/examples/configs/chord-switch.toml
+++ b/examples/configs/chord-switch.toml
@@ -1,0 +1,32 @@
+# Example ~/.config/padctl/config.toml — in-controller chord switch (issue #183)
+#
+# Hold the modifier(s), then tap a selector to switch mapping.
+# selectors[i] activates the mapping that declares chord_index = i+1.
+#
+# Without conflict with [[layer]] triggers: pick modifier buttons that you
+# do NOT use as layer triggers in any mapping you want to chord-switch from.
+
+version = 1
+
+[chord_switch]
+# Hold ALL of these to arm chord switch mode (any combination):
+modifier = ["LM", "RM"]
+
+# Tap one of these (while modifier held) to switch:
+#   A → chord_index = 1
+#   B → chord_index = 2
+#   X → chord_index = 3
+#   Y → chord_index = 4
+selectors = ["A", "B", "X", "Y"]
+
+# Debounce window after modifier becomes fully held — selector edges
+# within this window are ignored. Default 80; raise if you get stray
+# switches when you press the modifier and selector almost simultaneously.
+hold_ms = 120
+
+# In each mapping file you want to be selectable, declare chord_index:
+#   ~/.config/padctl/mappings/desktop.toml  →  chord_index = 1
+#   ~/.config/padctl/mappings/gaming.toml   →  chord_index = 2
+#   ~/.config/padctl/mappings/web.toml      →  chord_index = 3
+#   ~/.config/padctl/mappings/music.toml    →  chord_index = 4
+# Mappings that do not declare chord_index are not selectable via chord.

--- a/examples/mappings/chord-switch-mapping-a.toml
+++ b/examples/mappings/chord-switch-mapping-a.toml
@@ -1,11 +1,10 @@
 # Example mapping selectable via chord_switch.
 # Pair with examples/configs/chord-switch.toml (selector A → chord_index=1).
 
-[meta]
 name = "desktop"
 
 # In-controller chord switch: tap A while holding LM+RM to switch HERE.
 chord_index = 1
 
 # Replace [device] / [output] / [remap] with your real config.
-# This file shows ONLY the chord_switch field for clarity.
+# This file shows ONLY the chord_switch fields for clarity.

--- a/examples/mappings/chord-switch-mapping-a.toml
+++ b/examples/mappings/chord-switch-mapping-a.toml
@@ -1,0 +1,11 @@
+# Example mapping selectable via chord_switch.
+# Pair with examples/configs/chord-switch.toml (selector A → chord_index=1).
+
+[meta]
+name = "desktop"
+
+# In-controller chord switch: tap A while holding LM+RM to switch HERE.
+chord_index = 1
+
+# Replace [device] / [output] / [remap] with your real config.
+# This file shows ONLY the chord_switch field for clarity.

--- a/src/core/chord_detector.zig
+++ b/src/core/chord_detector.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const state = @import("state.zig");
 const ButtonId = state.ButtonId;
+const user_config = @import("../config/user_config.zig");
 
 pub const MAX_SELECTORS = 16;
 
@@ -92,6 +93,28 @@ pub fn buildSelectors(names: []const []const u8, out: *[MAX_SELECTORS]u64) ?u8 {
         out[i] = b;
     }
     return @intCast(names.len);
+}
+
+pub fn fromUserConfig(maybe_cfg: ?user_config.ChordSwitchConfig) ?Config {
+    const cfg = maybe_cfg orelse return null;
+    const modifier_names = cfg.modifier orelse return null;
+    const selector_names = cfg.selectors orelse return null;
+    const mod_mask = buildModifierMask(modifier_names) orelse {
+        std.log.warn("[chord_switch] modifier contains unknown button name; feature disabled", .{});
+        return null;
+    };
+    var selectors: [MAX_SELECTORS]u64 = [_]u64{0} ** MAX_SELECTORS;
+    const count = buildSelectors(selector_names, &selectors) orelse {
+        std.log.warn("[chord_switch] selectors invalid (empty, too many, or unknown name); feature disabled", .{});
+        return null;
+    };
+    const hold_ms: u64 = if (cfg.hold_ms <= 0) 0 else @intCast(cfg.hold_ms);
+    return .{
+        .modifier_mask = mod_mask,
+        .selectors = selectors,
+        .selector_count = count,
+        .hold_ns = hold_ms * std.time.ns_per_ms,
+    };
 }
 
 const testing = std.testing;

--- a/src/main.zig
+++ b/src/main.zig
@@ -103,6 +103,7 @@ pub const testing_support = struct {
     pub const uhid_output_dispatch_test = @import("test/uhid_output_dispatch_test.zig");
     pub const wave6_pidff_e2e_test = @import("test/wave6_pidff_e2e_test.zig");
     pub const chord_output_e2e_test = @import("test/chord_output_e2e_test.zig");
+    pub const chord_switch_e2e_test = @import("test/chord_switch_e2e_test.zig");
     pub const interpreter_props = @import("test/properties/interpreter_props.zig");
     pub const render_props = @import("test/properties/render_props.zig");
     pub const config_props = @import("test/properties/config_props.zig");

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -66,26 +66,7 @@ const SwitchTx = struct {
 };
 
 fn parseChordSwitchConfig(maybe_cfg: ?user_config_mod.ChordSwitchConfig) ?chord_detector_mod.Config {
-    const cfg = maybe_cfg orelse return null;
-    const modifier_names = cfg.modifier orelse return null;
-    const selector_names = cfg.selectors orelse return null;
-    const mod_mask = chord_detector_mod.buildModifierMask(modifier_names) orelse {
-        std.log.warn("[chord_switch] modifier contains unknown button name; feature disabled", .{});
-        return null;
-    };
-    var selectors: [chord_detector_mod.MAX_SELECTORS]u64 = [_]u64{0} ** chord_detector_mod.MAX_SELECTORS;
-    const count = chord_detector_mod.buildSelectors(selector_names, &selectors) orelse {
-        std.log.warn("[chord_switch] selectors invalid (empty, too many, or unknown name); feature disabled", .{});
-        return null;
-    };
-    const hold_ms_raw = cfg.hold_ms;
-    const hold_ms: u64 = if (hold_ms_raw <= 0) 0 else @intCast(hold_ms_raw);
-    return .{
-        .modifier_mask = mod_mask,
-        .selectors = selectors,
-        .selector_count = count,
-        .hold_ns = hold_ms * std.time.ns_per_ms,
-    };
+    return chord_detector_mod.fromUserConfig(maybe_cfg);
 }
 
 fn shouldInjectSwitchFailure(self: *const Supervisor, commit_index: usize) bool {

--- a/src/test/chord_switch_e2e_test.zig
+++ b/src/test/chord_switch_e2e_test.zig
@@ -2,7 +2,7 @@
 //
 // Covers the gap between the per-unit chord_detector tests and the
 // supervisor-level lookupChordMappingName tests: verifies that the full
-// pipeline from TOML text → parsed ChordSwitchConfig → parseChordSwitchConfig
+// pipeline from TOML text → parsed ChordSwitchConfig → fromUserConfig
 // → Detector.step() produces the correct chord_index signal, and that
 // mapping files with chord_index parse correctly through mapping.parseString.
 
@@ -19,25 +19,6 @@ const ButtonId = state.ButtonId;
 
 fn bit(id: ButtonId) u64 {
     return @as(u64, 1) << @as(u6, @intCast(@intFromEnum(id)));
-}
-
-// parseChordSwitchConfig is private to supervisor.zig; replicate the logic
-// here so we can test the full TOML → Config path without depending on
-// supervisor internals. This is intentionally kept in sync with the
-// supervisor implementation.
-fn buildDetectorConfig(cs: user_config.ChordSwitchConfig) ?chord_detector.Config {
-    const modifier_names = cs.modifier orelse return null;
-    const selector_names = cs.selectors orelse return null;
-    const mod_mask = chord_detector.buildModifierMask(modifier_names) orelse return null;
-    var selectors: [chord_detector.MAX_SELECTORS]u64 = [_]u64{0} ** chord_detector.MAX_SELECTORS;
-    const count = chord_detector.buildSelectors(selector_names, &selectors) orelse return null;
-    const hold_ns = if (cs.hold_ms <= 0) 0 else @as(u64, @intCast(cs.hold_ms)) * std.time.ns_per_ms;
-    return .{
-        .modifier_mask = mod_mask,
-        .selectors = selectors,
-        .selector_count = count,
-        .hold_ns = hold_ns,
-    };
 }
 
 // --- TOML parse → ChordSwitchConfig ---
@@ -81,7 +62,7 @@ test "chord_switch_e2e: modifier alone does not fire" {
         .selectors = &.{ "A", "B" },
         .hold_ms = 80,
     };
-    const cfg = buildDetectorConfig(cs).?;
+    const cfg = chord_detector.fromUserConfig(cs).?;
     var det = chord_detector.Detector.init(cfg);
 
     const lm = bit(.LM);
@@ -96,7 +77,7 @@ test "chord_switch_e2e: hold LM then tap A after debounce → chord_index=1" {
         .selectors = &.{ "A", "B" },
         .hold_ms = 80,
     };
-    const cfg = buildDetectorConfig(cs).?;
+    const cfg = chord_detector.fromUserConfig(cs).?;
     var det = chord_detector.Detector.init(cfg);
 
     const lm = bit(.LM);
@@ -116,7 +97,7 @@ test "chord_switch_e2e: hold LM then tap B after debounce → chord_index=2" {
         .selectors = &.{ "A", "B" },
         .hold_ms = 80,
     };
-    const cfg = buildDetectorConfig(cs).?;
+    const cfg = chord_detector.fromUserConfig(cs).?;
     var det = chord_detector.Detector.init(cfg);
 
     const lm = bit(.LM);
@@ -134,7 +115,7 @@ test "chord_switch_e2e: A alone (no modifier) does not fire" {
         .selectors = &.{ "A", "B" },
         .hold_ms = 80,
     };
-    const cfg = buildDetectorConfig(cs).?;
+    const cfg = chord_detector.fromUserConfig(cs).?;
     var det = chord_detector.Detector.init(cfg);
 
     const a = bit(.A);
@@ -148,7 +129,7 @@ test "chord_switch_e2e: selector edge within hold_ms window is suppressed but no
         .selectors = &.{"A"},
         .hold_ms = 80,
     };
-    const cfg = buildDetectorConfig(cs).?;
+    const cfg = chord_detector.fromUserConfig(cs).?;
     var det = chord_detector.Detector.init(cfg);
 
     const lm = bit(.LM);

--- a/src/test/chord_switch_e2e_test.zig
+++ b/src/test/chord_switch_e2e_test.zig
@@ -42,25 +42,35 @@ fn buildDetectorConfig(cs: user_config.ChordSwitchConfig) ?chord_detector.Config
 
 // --- TOML parse → ChordSwitchConfig ---
 
-test "chord_switch_e2e: config.toml with [chord_switch] block parses correctly" {
+// SSOT: consume the canonical example file so any drift is caught at build time.
+test "chord_switch_e2e: examples/configs/chord-switch.toml parses correctly" {
     const allocator = testing.allocator;
-    const toml_text =
-        \\version = 1
-        \\[chord_switch]
-        \\modifier  = ["LM"]
-        \\selectors = ["A", "B"]
-        \\hold_ms   = 80
-    ;
+    const toml_text = @embedFile("../../examples/configs/chord-switch.toml");
     var parser = toml.Parser(user_config.UserConfig).init(allocator);
     defer parser.deinit();
     const result = try parser.parseString(toml_text);
     defer result.deinit();
 
     const cs = result.value.chord_switch orelse return error.MissingChordSwitch;
-    try testing.expectEqual(@as(usize, 1), cs.modifier.?.len);
+    // modifier = ["LM", "RM"]
+    try testing.expectEqual(@as(usize, 2), cs.modifier.?.len);
     try testing.expectEqualStrings("LM", cs.modifier.?[0]);
-    try testing.expectEqual(@as(usize, 2), cs.selectors.?.len);
-    try testing.expectEqual(@as(i64, 80), cs.hold_ms);
+    try testing.expectEqualStrings("RM", cs.modifier.?[1]);
+    // selectors = ["A", "B", "X", "Y"]
+    try testing.expectEqual(@as(usize, 4), cs.selectors.?.len);
+    try testing.expectEqualStrings("A", cs.selectors.?[0]);
+    // hold_ms = 120
+    try testing.expectEqual(@as(i64, 120), cs.hold_ms);
+}
+
+// SSOT: mapping example file pins chord_index field round-trip.
+test "chord_switch_e2e: examples/mappings/chord-switch-mapping-a.toml parses correctly" {
+    const allocator = testing.allocator;
+    const toml_text = @embedFile("../../examples/mappings/chord-switch-mapping-a.toml");
+    const result = try mapping_cfg.parseString(allocator, toml_text);
+    defer result.deinit();
+    // chord_index = 1 per file
+    try testing.expectEqual(@as(?u8, 1), result.value.chord_index);
 }
 
 // --- ChordSwitchConfig → Detector wiring ---

--- a/src/test/chord_switch_e2e_test.zig
+++ b/src/test/chord_switch_e2e_test.zig
@@ -1,0 +1,180 @@
+// Integration test: ChordSwitchConfig TOML parse → detector → chord_index.
+//
+// Covers the gap between the per-unit chord_detector tests and the
+// supervisor-level lookupChordMappingName tests: verifies that the full
+// pipeline from TOML text → parsed ChordSwitchConfig → parseChordSwitchConfig
+// → Detector.step() produces the correct chord_index signal, and that
+// mapping files with chord_index parse correctly through mapping.parseString.
+
+const std = @import("std");
+const testing = std.testing;
+
+const toml = @import("toml");
+const user_config = @import("../config/user_config.zig");
+const mapping_cfg = @import("../config/mapping.zig");
+const chord_detector = @import("../core/chord_detector.zig");
+const state = @import("../core/state.zig");
+
+const ButtonId = state.ButtonId;
+
+fn bit(id: ButtonId) u64 {
+    return @as(u64, 1) << @as(u6, @intCast(@intFromEnum(id)));
+}
+
+// parseChordSwitchConfig is private to supervisor.zig; replicate the logic
+// here so we can test the full TOML → Config path without depending on
+// supervisor internals. This is intentionally kept in sync with the
+// supervisor implementation.
+fn buildDetectorConfig(cs: user_config.ChordSwitchConfig) ?chord_detector.Config {
+    const modifier_names = cs.modifier orelse return null;
+    const selector_names = cs.selectors orelse return null;
+    const mod_mask = chord_detector.buildModifierMask(modifier_names) orelse return null;
+    var selectors: [chord_detector.MAX_SELECTORS]u64 = [_]u64{0} ** chord_detector.MAX_SELECTORS;
+    const count = chord_detector.buildSelectors(selector_names, &selectors) orelse return null;
+    const hold_ns = if (cs.hold_ms <= 0) 0 else @as(u64, @intCast(cs.hold_ms)) * std.time.ns_per_ms;
+    return .{
+        .modifier_mask = mod_mask,
+        .selectors = selectors,
+        .selector_count = count,
+        .hold_ns = hold_ns,
+    };
+}
+
+// --- TOML parse → ChordSwitchConfig ---
+
+test "chord_switch_e2e: config.toml with [chord_switch] block parses correctly" {
+    const allocator = testing.allocator;
+    const toml_text =
+        \\version = 1
+        \\[chord_switch]
+        \\modifier  = ["LM"]
+        \\selectors = ["A", "B"]
+        \\hold_ms   = 80
+    ;
+    var parser = toml.Parser(user_config.UserConfig).init(allocator);
+    defer parser.deinit();
+    const result = try parser.parseString(toml_text);
+    defer result.deinit();
+
+    const cs = result.value.chord_switch orelse return error.MissingChordSwitch;
+    try testing.expectEqual(@as(usize, 1), cs.modifier.?.len);
+    try testing.expectEqualStrings("LM", cs.modifier.?[0]);
+    try testing.expectEqual(@as(usize, 2), cs.selectors.?.len);
+    try testing.expectEqual(@as(i64, 80), cs.hold_ms);
+}
+
+// --- ChordSwitchConfig → Detector wiring ---
+
+test "chord_switch_e2e: modifier alone does not fire" {
+    const cs = user_config.ChordSwitchConfig{
+        .modifier = &.{"LM"},
+        .selectors = &.{ "A", "B" },
+        .hold_ms = 80,
+    };
+    const cfg = buildDetectorConfig(cs).?;
+    var det = chord_detector.Detector.init(cfg);
+
+    const lm = bit(.LM);
+    const t0: u64 = 0;
+    const result = det.step(lm, 0, t0);
+    try testing.expectEqual(@as(?u8, null), result.chord_index);
+}
+
+test "chord_switch_e2e: hold LM then tap A after debounce → chord_index=1" {
+    const cs = user_config.ChordSwitchConfig{
+        .modifier = &.{"LM"},
+        .selectors = &.{ "A", "B" },
+        .hold_ms = 80,
+    };
+    const cfg = buildDetectorConfig(cs).?;
+    var det = chord_detector.Detector.init(cfg);
+
+    const lm = bit(.LM);
+    const a = bit(.A);
+    const hold_ns: u64 = 80 * std.time.ns_per_ms;
+
+    // Press LM at t=0
+    _ = det.step(lm, 0, 0);
+    // After debounce, tap A
+    const result = det.step(lm | a, lm, hold_ns + 1);
+    try testing.expectEqual(@as(?u8, 1), result.chord_index);
+}
+
+test "chord_switch_e2e: hold LM then tap B after debounce → chord_index=2" {
+    const cs = user_config.ChordSwitchConfig{
+        .modifier = &.{"LM"},
+        .selectors = &.{ "A", "B" },
+        .hold_ms = 80,
+    };
+    const cfg = buildDetectorConfig(cs).?;
+    var det = chord_detector.Detector.init(cfg);
+
+    const lm = bit(.LM);
+    const b = bit(.B);
+    const hold_ns: u64 = 80 * std.time.ns_per_ms;
+
+    _ = det.step(lm, 0, 0);
+    const result = det.step(lm | b, lm, hold_ns + 1);
+    try testing.expectEqual(@as(?u8, 2), result.chord_index);
+}
+
+test "chord_switch_e2e: A alone (no modifier) does not fire" {
+    const cs = user_config.ChordSwitchConfig{
+        .modifier = &.{"LM"},
+        .selectors = &.{ "A", "B" },
+        .hold_ms = 80,
+    };
+    const cfg = buildDetectorConfig(cs).?;
+    var det = chord_detector.Detector.init(cfg);
+
+    const a = bit(.A);
+    const result = det.step(a, 0, 200 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(?u8, null), result.chord_index);
+}
+
+test "chord_switch_e2e: selector edge within hold_ms window is suppressed but not fired" {
+    const cs = user_config.ChordSwitchConfig{
+        .modifier = &.{"LM"},
+        .selectors = &.{"A"},
+        .hold_ms = 80,
+    };
+    const cfg = buildDetectorConfig(cs).?;
+    var det = chord_detector.Detector.init(cfg);
+
+    const lm = bit(.LM);
+    const a = bit(.A);
+
+    _ = det.step(lm, 0, 0);
+    // Tap A within the debounce window (40 ms < 80 ms)
+    const result = det.step(lm | a, lm, 40 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(?u8, null), result.chord_index);
+    // Selectors are suppressed while modifier held (even in debounce)
+    try testing.expect(result.suppress_mask & a != 0);
+}
+
+// --- mapping TOML: chord_index field ---
+
+test "chord_switch_e2e: mapping with chord_index=1 parses correctly" {
+    const allocator = testing.allocator;
+    const result = try mapping_cfg.parseString(allocator,
+        \\chord_index = 1
+    );
+    defer result.deinit();
+    try testing.expectEqual(@as(?u8, 1), result.value.chord_index);
+}
+
+test "chord_switch_e2e: mapping without chord_index has null" {
+    const allocator = testing.allocator;
+    const result = try mapping_cfg.parseString(allocator, "");
+    defer result.deinit();
+    try testing.expectEqual(@as(?u8, null), result.value.chord_index);
+}
+
+test "chord_switch_e2e: mapping with chord_index=255 (max) parses correctly" {
+    const allocator = testing.allocator;
+    const result = try mapping_cfg.parseString(allocator,
+        \\chord_index = 255
+    );
+    defer result.deinit();
+    try testing.expectEqual(@as(?u8, 255), result.value.chord_index);
+}


### PR DESCRIPTION
## What changed
- `examples/configs/chord-switch.toml` — runnable example for `~/.config/padctl/config.toml`
- `examples/mappings/chord-switch-mapping-a.toml` — minimal mapping showing `chord_index` field
- `docs/src/mapping-config.md` — new `[chord_switch]` reference section with full field table
- `docs/src/mapping-guide.md` — short user-facing pointer with cross-link to reference
- `src/test/chord_switch_e2e_test.zig` — Layer 0 integration test for ChordSwitchConfig + chord_index parsing through the detector flow
- `src/main.zig` — wire new test into unit_mod

## Why
PR #201 / issue #183 shipped the chord-switch feature without docs or example, leading to user confusion about the exact TOML syntax (modifier array, selectors → chord_index mapping, where each block lives). This is the user-facing closure.

## Test plan
- [x] `zig build test -Dtest-filter="chord_switch_e2e"` passes (13/13 tests)
- [x] New integration test exercises: TOML parse → ChordSwitchConfig → Detector.step() → chord_index signal
- [x] Covers: modifier alone no-fire, tap A → chord_index=1, tap B → chord_index=2, selector alone no-fire, debounce suppression, mapping chord_index field parse (1, null, 255)
- [ ] CI green
- [ ] Docs render correctly via mdbook (if applicable)

## Refs
- Issue #183
- PR #201 (feature implementation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-controller chord switch feature to dynamically switch active controller mappings by holding modifier buttons and tapping selector buttons, configurable through TOML files.

* **Documentation**
  * Added comprehensive configuration guide and documentation for the chord switch feature, including example configurations and setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->