### PR TITLE
chore(release): bump 0.1.5 + sync VERSION from build.zig.zon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify tag matches build.zig.zon version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          TAG_VER="${TAG#v}"
+          ZON_VER=$(grep -E '^\s*\.version\s*=' build.zig.zon | sed -E 's/.*"([^"]+)".*/\1/')
+          if [ "$TAG_VER" != "$ZON_VER" ]; then
+            echo "::error::Tag $TAG (version $TAG_VER) does not match build.zig.zon version $ZON_VER. Bump build.zig.zon before tagging."
+            exit 1
+          fi
+          echo "tag $TAG matches build.zig.zon version $ZON_VER"
+
       - name: Generate changelog
         env:
           TAG: ${{ github.ref_name }}

--- a/build.zig
+++ b/build.zig
@@ -12,8 +12,13 @@ pub fn build(b: *std.Build) void {
 
     const wasm3_c_flags: []const []const u8 = &.{ "-std=c99", "-DDEBUG=0", "-Dd_m3HasWASI=0" };
 
+    const zon = @import("build.zig.zon");
+    const version_override = b.option([]const u8, "version", "Override version string (default: build.zig.zon)");
+    const version = version_override orelse zon.version;
+
     const build_opts = b.addOptions();
     build_opts.addOption(bool, "use_wasm", use_wasm);
+    build_opts.addOption([]const u8, "version", version);
 
     const toml_dep = b.dependency("toml", .{ .target = target, .optimize = optimize });
     const toml_mod = toml_dep.module("toml");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.4",
+    .version = "0.1.5",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/refs/heads/main.tar.gz",

--- a/examples/mappings/chord-output.toml
+++ b/examples/mappings/chord-output.toml
@@ -2,6 +2,12 @@
 # A single button press emits a multi-key chord (modifier+key combo).
 # On press: down events emitted in declaration order.
 # On release: up events emitted in reverse order.
+#
+# PREVIEW — As of v0.1.5 the array syntax parses and validates, and the
+# source button is suppressed, but no key events are dispatched yet.
+# Chord output dispatch lands in a follow-up release. Buttons remapped to
+# arrays in this file currently emit nothing on press; do not deploy this
+# example as your daily mapping.
 
 [meta]
 name = "chord-output-demo"

--- a/src/main.zig
+++ b/src/main.zig
@@ -172,7 +172,7 @@ const DeviceInstance = device_instance.DeviceInstance;
 const Supervisor = supervisor.Supervisor;
 const Interpreter = core.interpreter.Interpreter;
 const DeviceIO = io.device_io.DeviceIO;
-const VERSION = "0.1.0";
+const VERSION = @import("build_options").version;
 
 pub const DumpAction = enum { enable, disable, status, @"export", clear };
 


### PR DESCRIPTION
## Summary

- `build.zig.zon` 0.1.4 -> 0.1.5
- `src/main.zig` VERSION was hardcoded `0.1.0` since v0.1.0; now reads `@import("build_options").version` (build-time SSOT)
- `build.zig` imports zon as SSOT, exposes as `build_options.version` with `-Dversion=` override
- `release.yml` asserts tag matches `build.zig.zon` before building (forces pre-tag bump; release fails fast on mismatch)
- `examples/mappings/chord-output.toml` PREVIEW disclaimer (chord dispatch is no-op pre-PR-B-2, parser-only)

## Test plan

- Local: `zig build && ./zig-out/bin/padctl --version` -> `padctl 0.1.5`
- Local: `zig build -Dversion=99.0.0-rc1 && ./zig-out/bin/padctl --version` -> `padctl 99.0.0-rc1` (override works)
- CI: `pkg-deb-smoke` should remain green (the .deb fix from PR #217 still applies)
- CI: `tag-vs-zon` assertion exercises only on tag push; verified by hand on this branch (zon=0.1.5)

## Refs

- refs: pre-release audit on v0.1.4..main found `--version` reporter pre-existing bug
- refs: PR #217 (.deb packaging fix that this release ships)
- refs: code-reviewer flagged chord-output example as preview-only

## Followups

- PR B-2 (issue #206) lands chord output dispatch; disclaimer can be removed then

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Preview support for chord-output array syntax (parsing and validation enabled; key event dispatch planned for a future release)

* **Chores**
  - Version bumped to 0.1.5
  - Improved release process with automated version verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->