### PR TITLE
fix(ci): release.yml AUR update — match builder UID to host runner UID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,8 +273,9 @@ jobs:
           sed -i "s/^sha256sums_x86_64=.*/sha256sums_x86_64=('${X86_HASH}')/" PKGBUILD
           sed -i "s/^sha256sums_aarch64=.*/sha256sums_aarch64=('${ARM_HASH}')/" PKGBUILD
 
+          HOST_UID=$(id -u)
           docker run --rm -v "$PWD:/pkg" archlinux:latest bash -c \
-            "pacman -Sy --noconfirm pacman-contrib && useradd -m builder && chown -R builder /pkg && su builder -c 'cd /pkg && makepkg --printsrcinfo > .SRCINFO'"
+            "pacman -Sy --noconfirm pacman-contrib && useradd -m -u ${HOST_UID} builder && su builder -c 'cd /pkg && makepkg --printsrcinfo > .SRCINFO'"
 
           git config user.name "bananasjim"
           git config user.email "bananasjim1@gmail.com"


### PR DESCRIPTION
## Summary

- v0.1.1 / v0.1.2 / v0.1.4 release.yml runs all failed at the same step (\`update-aur\` → \`git config user.name\`) with \`could not lock config file .git/config: Permission denied\`
- Root cause: \`docker run ... chown -R builder /pkg\` re-owned the host-mounted \`/tmp/padctl-bin/.git/config\` to container's \`builder\` UID (1000), but the host runner is UID 1001
- After docker exits, host \`git config\` cannot lock the file → AUR push never happens
- Fix: \`useradd -m -u \$(id -u) builder\` so builder UID matches host runner; drop the now-unnecessary \`chown -R\`

## Test plan

- Cannot dry-run on PR (release.yml only triggers on tag push). Will validate on next tag (\`v0.1.6\`).
- v0.1.5's update-aur step ran with the old buggy version and is expected to fail; the .deb / tarball / SHA256SUMS uploads (issue #216 fix path) are NOT gated on AUR and ship regardless.

## Refs

- refs: v0.1.4 release.yml run #25111955701 (representative AUR failure log)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release automation workflow to better handle file permissions during Arch Linux repository build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->