### PR TITLE
test(ci): extend pkg-deb-smoke with full v0.1.5 verification matrix

### DIFF
--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -275,7 +275,7 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::static linkage (no glibc dep)"
-            ldd /usr/bin/padctl 2>&1 | grep -q "not a dynamic executable" || { echo FAIL not statically linked; ldd /usr/bin/padctl; exit 1; }
+            file /usr/bin/padctl | grep -q "statically linked" || { echo FAIL not statically linked; file /usr/bin/padctl; ldd /usr/bin/padctl 2>&1 || true; exit 1; }
             echo "::endgroup::"
 
             echo "::group::uninstall removes everything"

--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -237,8 +237,8 @@ jobs:
 
             echo "::group::version sync (zon=${ZON_VER})"
             BIN_VER=$(/usr/bin/padctl --version | awk "{print \$2}")
-            if [ "${BIN_VER}" != "0.0.0-ci" ]; then
-              echo "FAIL: --version reported ${BIN_VER}, expected 0.0.0-ci (build.zig.zon override should propagate via build_options.version)"
+            if [ "${BIN_VER}" != "${ZON_VER}" ]; then
+              echo "FAIL: --version reported ${BIN_VER}, expected ${ZON_VER} from build.zig.zon (SSOT path build_options.version is broken)"
               exit 1
             fi
             echo "::endgroup::"

--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Install .deb in Debian 12 + runtime invariants
         run: |
           ZON_VER=$(grep -E '^\s*\.version\s*=' build.zig.zon | sed -E 's/.*"([^"]+)".*/\1/')
-          docker run --rm -v "$PWD:/work:ro" -e ZON_VER debian:12 /bin/bash -euo pipefail -c '
+          docker run --rm -v "$PWD:/work:ro" -e ZON_VER="${ZON_VER}" debian:12 /bin/bash -euo pipefail -c '
             apt-get update -qq
             DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd 2>/dev/null
 

--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -217,7 +217,7 @@ jobs:
           ZON_VER=$(grep -E '^\s*\.version\s*=' build.zig.zon | sed -E 's/.*"([^"]+)".*/\1/')
           docker run --rm -v "$PWD:/work:ro" -e ZON_VER="${ZON_VER}" debian:12 /bin/bash -euo pipefail -c '
             apt-get update -qq
-            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd 2>/dev/null
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd file 2>/dev/null
 
             echo "::group::install"
             dpkg -i /work/padctl_0.0.0-ci_amd64.deb || (apt-get install -fy && dpkg -i /work/padctl_0.0.0-ci_amd64.deb)

--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -200,21 +200,95 @@ jobs:
             || { echo "FAIL: /usr/bin/padctl missing"; echo "${OUT}"; exit 1; }
           echo "${OUT}" | grep -q ' \./usr/lib/systemd/user/padctl\.service$' \
             || { echo "FAIL: padctl.service missing"; echo "${OUT}"; exit 1; }
+          echo "${OUT}" | grep -q ' \./usr/lib/udev/rules\.d/60-padctl\.rules$' \
+            || { echo "FAIL: 60-padctl.rules missing"; echo "${OUT}"; exit 1; }
           echo "${OUT}" | grep -q ' \./usr/share/padctl/devices/flydigi/vader5\.toml$' \
             || { echo "FAIL: vader5.toml not under /usr/share/padctl/devices/"; echo "${OUT}"; exit 1; }
           DEVICES=$(echo "${OUT}" | grep -c '^.* \./usr/share/padctl/devices/.\+/.\+\.toml$' || true)
           [ "${DEVICES}" -ge 5 ] \
             || { echo "FAIL: expected >=5 .toml under devices/, got ${DEVICES}"; echo "${OUT}"; exit 1; }
-          echo "PASS: .deb structure invariants (${DEVICES} device TOMLs under devices/)"
+          BROKEN=$(echo "${OUT}" | grep -c '^.* \./usr/share/padctl/[^/]\+/[^/]\+\.toml$' || true)
+          [ "${BROKEN}" -eq 0 ] \
+            || { echo "FAIL: ${BROKEN} TOMLs at broken layout /usr/share/padctl/<vendor>/ (pre-#217 regression)"; echo "${OUT}"; exit 1; }
+          echo "PASS: .deb structure invariants (${DEVICES} device TOMLs under devices/, 0 at broken layout)"
 
-      - name: Install .deb in Debian 12 + post-install structural check
+      - name: Install .deb in Debian 12 + runtime invariants
         run: |
-          docker run --rm -v "$PWD:/work:ro" debian:12 /bin/bash -euo pipefail -c '
+          ZON_VER=$(grep -E '^\s*\.version\s*=' build.zig.zon | sed -E 's/.*"([^"]+)".*/\1/')
+          docker run --rm -v "$PWD:/work:ro" -e ZON_VER debian:12 /bin/bash -euo pipefail -c '
             apt-get update -qq
             DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd 2>/dev/null
+
+            echo "::group::install"
             dpkg -i /work/padctl_0.0.0-ci_amd64.deb || (apt-get install -fy && dpkg -i /work/padctl_0.0.0-ci_amd64.deb)
-            test -d /usr/share/padctl/devices
-            test -f /usr/share/padctl/devices/flydigi/vader5.toml
-            test -x /usr/bin/padctl
-            /usr/bin/padctl --help >/dev/null
+            echo "::endgroup::"
+
+            echo "::group::reinstall idempotent"
+            dpkg -i /work/padctl_0.0.0-ci_amd64.deb
+            echo "::endgroup::"
+
+            echo "::group::file layout"
+            test -d /usr/share/padctl/devices || { echo FAIL devices dir missing; exit 1; }
+            test -f /usr/share/padctl/devices/flydigi/vader5.toml || { echo FAIL vader5.toml missing; exit 1; }
+            test -x /usr/bin/padctl || { echo FAIL padctl bin not executable; exit 1; }
+            test -f /usr/lib/systemd/user/padctl.service || { echo FAIL service unit missing; exit 1; }
+            test -f /usr/lib/udev/rules.d/60-padctl.rules || { echo FAIL udev rules missing; exit 1; }
+            echo "::endgroup::"
+
+            echo "::group::version sync (zon=${ZON_VER})"
+            BIN_VER=$(/usr/bin/padctl --version | awk "{print \$2}")
+            if [ "${BIN_VER}" != "0.0.0-ci" ]; then
+              echo "FAIL: --version reported ${BIN_VER}, expected 0.0.0-ci (build.zig.zon override should propagate via build_options.version)"
+              exit 1
+            fi
+            echo "::endgroup::"
+
+            echo "::group::shipped device TOMLs all parse"
+            FAIL=0; TOTAL=0
+            for toml in $(find /usr/share/padctl/devices -name "*.toml"); do
+              TOTAL=$((TOTAL+1))
+              /usr/bin/padctl --validate "$toml" 2>&1 | grep -q ": OK$" || { echo "FAIL validate: $toml"; FAIL=$((FAIL+1)); }
+            done
+            [ "$FAIL" -eq 0 ] || { echo "FAIL: ${FAIL}/${TOTAL} TOMLs failed --validate"; exit 1; }
+            echo "PASS validated ${TOTAL}/${TOTAL}"
+            echo "::endgroup::"
+
+            echo "::group::udev rules content (Vader 5 Pro / 8BitDo / input-group fallback)"
+            grep -q "37d7.*2401" /usr/lib/udev/rules.d/60-padctl.rules || { echo FAIL vader5 USB VID/PID rule missing; exit 1; }
+            grep -q "GROUP=\"input\"" /usr/lib/udev/rules.d/60-padctl.rules || { echo FAIL input-group fallback missing; exit 1; }
+            grep -q "TAG+=\"uaccess\"" /usr/lib/udev/rules.d/60-padctl.rules || { echo FAIL uaccess tag missing; exit 1; }
+            echo "::endgroup::"
+
+            echo "::group::systemd unit critical fields"
+            grep -qE "^ExecStart=/usr/bin/padctl" /usr/lib/systemd/user/padctl.service || { echo FAIL ExecStart wrong; exit 1; }
+            grep -qE "^StateDirectory=padctl$" /usr/lib/systemd/user/padctl.service || { echo FAIL StateDirectory wrong; exit 1; }
+            grep -qE "^NoNewPrivileges=true$" /usr/lib/systemd/user/padctl.service || { echo FAIL NoNewPrivileges missing; exit 1; }
+            echo "::endgroup::"
+
+            echo "::group::dump subcommand recognized (issue #216 symptom 3)"
+            /usr/bin/padctl dump 2>&1 | grep -qiE "unknown argument" && { echo FAIL dump still unknown; exit 1; } || echo "PASS dump recognized"
+            echo "::endgroup::"
+
+            echo "::group::scan + list-mappings smoke"
+            /usr/bin/padctl scan >/dev/null 2>&1 || { echo FAIL scan crashed; exit 1; }
+            /usr/bin/padctl list-mappings >/dev/null 2>&1 || { echo FAIL list-mappings crashed; exit 1; }
+            echo "::endgroup::"
+
+            echo "::group::static linkage (no glibc dep)"
+            ldd /usr/bin/padctl 2>&1 | grep -q "not a dynamic executable" || { echo FAIL not statically linked; ldd /usr/bin/padctl; exit 1; }
+            echo "::endgroup::"
+
+            echo "::group::uninstall removes everything"
+            apt-get remove -y padctl
+            test ! -f /usr/bin/padctl || { echo FAIL bin still present; exit 1; }
+            test ! -f /usr/lib/systemd/user/padctl.service || { echo FAIL service still present; exit 1; }
+            test ! -f /usr/lib/udev/rules.d/60-padctl.rules || { echo FAIL udev still present; exit 1; }
+            echo "::endgroup::"
+
+            echo "::group::purge cleans residual share dir"
+            apt-get purge -y padctl
+            test ! -d /usr/share/padctl || { echo FAIL share dir not cleaned: $(ls /usr/share/padctl); exit 1; }
+            echo "::endgroup::"
+
+            echo "ALL INVARIANTS PASS"
           '


### PR DESCRIPTION
## Summary

Sinks the 12-step manual verification I ran on the v0.1.5 .deb into the existing \`pkg-deb-smoke\` job, so future releases are auto-validated.

## Added invariants

All run inside Debian 12 Docker after \`dpkg -i\`:

- broken-layout regression: 0 TOMLs at \`/usr/share/padctl/<vendor>/\` (catches the pre-#217 layout bug)
- \`60-padctl.rules\` ships in the .deb
- reinstall idempotent (\`dpkg -i\` twice)
- \`--version\` matches \`build.zig.zon\` (catches VERSION SSOT drift; uses \`-Dversion=0.0.0-ci\` smoke override)
- \`padctl --validate\` clean on every shipped device TOML (15 currently)
- udev rule contains Vader 5 Pro VID:PID, input-group fallback, \`uaccess\` tag
- systemd unit has \`ExecStart\`, \`StateDirectory=padctl\`, \`NoNewPrivileges=true\`
- \`padctl dump\` no longer \"unknown argument\" (issue #216 symptom 3 regression check)
- \`padctl scan\` + \`list-mappings\` do not crash on shipped DB
- binary is statically linked (no glibc dep)
- \`apt remove\` removes bin/service/udev
- \`apt purge\` cleans \`/usr/share/padctl/\`

## Test plan

- pkg-deb-smoke job now exercises all 12 invariants
- intentionally leaves out the 218/CAPABILITIES check (Ubuntu 26.04 systemd issue, not a padctl regression)

## Refs

- refs: v0.1.5 manual verification rundown caught zero regressions but exercised these checks
- refs: PR #217 (.deb layout fix), PR #218 (VERSION SSOT)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened Debian 12 installation pipeline with comprehensive validation checks for package structure, device configuration files, system components, filesystem structure, and extensive runtime validation including scanning, mapping verification, and uninstall cleanup to ensure consistent and reliable package installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->