### PR TITLE
test: cli_smoke_test + sealed-binary release verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,8 +200,36 @@ jobs:
           name: deb-${{ matrix.deb_arch }}
           path: ${{ env.DEB }}
 
+  verify-release-artifact:
+    needs: [build-deb]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - deb_arch: amd64
+    steps:
+      - name: Download .deb
+        uses: actions/download-artifact@v4
+        with:
+          name: deb-${{ matrix.deb_arch }}
+
+      - name: Install and smoke-test inside debian:12
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          DEB=$(ls padctl_*_${{ matrix.deb_arch }}.deb | head -1)
+          docker run --rm -v "$PWD/$DEB:/pkg/$DEB" debian:12 bash -c "
+            set -e
+            apt-get install -y /pkg/$DEB >/dev/null 2>&1
+            padctl --version | grep -F '${VERSION}'
+            padctl list-mappings
+            padctl --validate /usr/share/padctl/devices/sony/dualsense.toml
+            test -d /usr/share/padctl/devices/
+          "
+
   checksums:
-    needs: [build, build-deb]
+    needs: [build, build-deb, verify-release-artifact]
     runs-on: ubuntu-latest
 
     steps:

--- a/build.zig
+++ b/build.zig
@@ -185,6 +185,18 @@ pub fn build(b: *std.Build) void {
     if (coverage) capture_tests.setExecCmd(&.{ "kcov", "--include-path=src/", "kcov-output", null });
     test_step.dependOn(&b.addRunArtifact(capture_tests).step);
 
+    // cli_smoke: spawn zig-out/bin/padctl as subprocess; skips if binary absent.
+    const smoke_mod = b.createModule(.{
+        .root_source_file = b.path("src/test/cli_smoke_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    smoke_mod.addImport("build_options", build_opts.createModule());
+    const smoke_tests = b.addTest(.{ .root_module = smoke_mod });
+    const run_smoke = b.addRunArtifact(smoke_tests);
+    run_smoke.step.dependOn(&exe.step);
+    test_step.dependOn(&run_smoke.step);
+
     // test-integration: Layer 2 (UHID, requires privilege)
     const integration_step = b.step("test-integration", "Run Layer 2 integration tests (UHID, local)");
     const integ_mod = b.createModule(.{

--- a/src/test/cli_smoke_test.zig
+++ b/src/test/cli_smoke_test.zig
@@ -1,0 +1,66 @@
+// cli_smoke_test: assert the produced binary (zig-out/bin/padctl) behaves correctly.
+// Skips gracefully if the binary is absent (e.g. isolated test run without prior build).
+
+const std = @import("std");
+const testing = std.testing;
+const build_options = @import("build_options");
+
+const BIN = "zig-out/bin/padctl";
+const DUALSENSE = "devices/sony/dualsense.toml";
+
+fn run(allocator: std.mem.Allocator, argv: []const []const u8) !std.process.Child.RunResult {
+    return std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = argv,
+        .max_output_bytes = 64 * 1024,
+    });
+}
+
+fn binExists() bool {
+    std.fs.cwd().access(BIN, .{}) catch return false;
+    return true;
+}
+
+test "smoke: padctl --version exits 0 and reports correct version" {
+    if (!binExists()) return error.SkipZigTest;
+    const allocator = testing.allocator;
+    const result = try run(allocator, &.{ BIN, "--version" });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    try testing.expectEqual(@as(u8, 0), result.term.Exited);
+    try testing.expect(std.mem.startsWith(u8, result.stdout, "padctl "));
+    try testing.expect(std.mem.indexOf(u8, result.stdout, build_options.version) != null);
+}
+
+test "smoke: padctl --help exits 0 and lists all subcommands" {
+    if (!binExists()) return error.SkipZigTest;
+    const allocator = testing.allocator;
+    const result = try run(allocator, &.{ BIN, "--help" });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    try testing.expectEqual(@as(u8, 0), result.term.Exited);
+    const out = result.stdout;
+    for (&[_][]const u8{
+        "install", "uninstall", "scan",   "list-mappings",
+        "reload",  "switch",    "status", "devices",
+        "dump",
+    }) |cmd| {
+        if (std.mem.indexOf(u8, out, cmd) == null) {
+            std.debug.print("--help output missing subcommand: {s}\n", .{cmd});
+            return error.TestFailed;
+        }
+    }
+}
+
+test "smoke: padctl --validate dualsense exits 0 with OK" {
+    if (!binExists()) return error.SkipZigTest;
+    std.fs.cwd().access(DUALSENSE, .{}) catch return error.SkipZigTest;
+    const allocator = testing.allocator;
+    const result = try run(allocator, &.{ BIN, "--validate", DUALSENSE });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    try testing.expectEqual(@as(u8, 0), result.term.Exited);
+    const combined = try std.fmt.allocPrint(allocator, "{s}{s}", .{ result.stdout, result.stderr });
+    defer allocator.free(combined);
+    try testing.expect(std.mem.indexOf(u8, combined, ": OK") != null);
+}


### PR DESCRIPTION
## What changed

- **`src/test/cli_smoke_test.zig`** (new): spawns `zig-out/bin/padctl` as a subprocess via `std.process.Child.run` and asserts:
  - `--version` exits 0, output starts with `"padctl "`, and contains the version string from `build_options.version` (validates zon → build_options → binary stdout end-to-end)
  - `--help` exits 0 and contains all 9 top-level subcommands: `install`, `uninstall`, `scan`, `list-mappings`, `reload`, `switch`, `status`, `devices`, `dump`
  - `--validate devices/sony/dualsense.toml` exits 0 and produces `": OK"` in stdout/stderr
  - Skips gracefully (`SkipZigTest`) if binary absent (e.g. isolated test run)

- **`build.zig`**: adds `smoke_mod` + `smoke_tests` wired into `test_step` via `run_smoke.step.dependOn(&exe.step)` so `zig build test` always builds the binary before running the smoke tests

- **`.github/workflows/release.yml`**: adds `verify-release-artifact` job (runs after `build-deb`, before `checksums` and `update-aur`):
  - downloads amd64 `.deb` artifact
  - installs inside `debian:12` Docker container
  - asserts: `padctl --version | grep -F "${VERSION}"`, `padctl list-mappings`, `padctl --validate /usr/share/padctl/devices/sony/dualsense.toml`, `test -d /usr/share/padctl/devices/`
  - if verify fails the release stops; tarballs/debs already uploaded to GH releases remain and the release is recoverable by fixing + re-tagging
  - updates `checksums` and `update-aur` `needs:` to include `verify-release-artifact`

## Test plan

- [ ] `zig build` succeeds (binary built to `zig-out/bin/padctl`)
- [ ] `zig build test -Dtest-filter=smoke` passes all 3 smoke tests
- [ ] `zig build test` includes smoke tests without breaking existing tests
- [ ] CI green on this PR

## refs

Closes maintainability audit Top-5 #1 (cli_smoke catches source-not-artifact pattern) and #4 (release.yml sealed-binary verification).
refs: `156add1`