### PR TITLE
feat(release): publish versionless padctl_<arch>.deb assets, point docs at /latest/download/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,8 +191,12 @@ jobs:
       - name: Upload .deb
         env:
           TAG: ${{ github.ref_name }}
+          DEB_ARCH: ${{ matrix.deb_arch }}
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${TAG}" "${{ env.DEB }}" --clobber
+        run: |
+          gh release upload "${TAG}" "${{ env.DEB }}" --clobber
+          cp "${{ env.DEB }}" "padctl_${DEB_ARCH}.deb"
+          gh release upload "${TAG}" "padctl_${DEB_ARCH}.deb" --clobber
 
       - name: Upload .deb artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -100,11 +100,16 @@ yay -S padctl-git   # build from source
 ### Debian / Ubuntu
 
 ```sh
-curl -fLO https://github.com/BANANASJIM/padctl/releases/download/v0.1.2/padctl_0.1.2_amd64.deb
-sudo dpkg -i padctl_0.1.2_amd64.deb
+curl -fLO https://github.com/BANANASJIM/padctl/releases/latest/download/padctl_amd64.deb
+sudo dpkg -i padctl_amd64.deb
 ```
 
-For arm64, replace `amd64` with `arm64`.
+For arm64:
+
+```sh
+curl -fLO https://github.com/BANANASJIM/padctl/releases/latest/download/padctl_arm64.deb
+sudo dpkg -i padctl_arm64.deb
+```
 
 ### From Source
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -13,8 +13,15 @@ A prebuilt binary package (`padctl-bin`) is also available in the AUR.
 ### Debian / Ubuntu
 
 ```sh
-curl -fLO https://github.com/BANANASJIM/padctl/releases/download/v0.1.2/padctl_0.1.2_amd64.deb
-sudo dpkg -i padctl_0.1.2_amd64.deb
+curl -fLO https://github.com/BANANASJIM/padctl/releases/latest/download/padctl_amd64.deb
+sudo dpkg -i padctl_amd64.deb
+```
+
+For arm64:
+
+```sh
+curl -fLO https://github.com/BANANASJIM/padctl/releases/latest/download/padctl_arm64.deb
+sudo dpkg -i padctl_arm64.deb
 ```
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

- `build-deb` job now copies `padctl_${VERSION}_${DEB_ARCH}.deb` → `padctl_${DEB_ARCH}.deb` and uploads the versionless copy to the GitHub release alongside the versioned asset
- Applies to both `amd64` and `arm64` matrix entries
- `README.md` Debian/Ubuntu install section updated to use `/releases/latest/download/padctl_amd64.deb`; explicit `arm64` block added; all hardcoded `v0.1.2` references removed
- `docs/src/getting-started.md` updated identically
- GitHub auto-redirects `releases/latest/download/<asset>` to the most recent published release — the URL is now stable forever
- URL becomes functional as of the next release tag (v0.1.6+); `README.md`/docs change is forward-looking; users on v0.1.5 who follow the new URL before v0.1.6 is tagged will get a 404 (acceptable — v0.1.5 just shipped)

**Follow-up (out of band):** the maintainer can manually upload a copy of `padctl_0.1.5_amd64.deb` as `padctl_amd64.deb` on the v0.1.5 release page so the URL resolves immediately without waiting for v0.1.6.

refs: issue #220

## Test plan

- [ ] Verify `release.yml` diff: `Upload .deb` step now has a `cp` + second `gh release upload` call for the versionless name
- [ ] Verify `README.md` Debian/Ubuntu block shows `padctl_amd64.deb` and `padctl_arm64.deb` with `/latest/download/` URL
- [ ] Verify `docs/src/getting-started.md` shows the same updated URLs
- [ ] `git grep 'v0.1.2/padctl_0.1.2'` returns empty on this branch
- [ ] After next tag cut (v0.1.6), confirm `curl -fLO .../releases/latest/download/padctl_amd64.deb` succeeds