### PR TITLE
fix(install): drop systemd 257+ incompatible hardening from user unit

### DIFF
--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -262,7 +262,8 @@ jobs:
             echo "::group::systemd unit critical fields"
             grep -qE "^ExecStart=/usr/bin/padctl" /usr/lib/systemd/user/padctl.service || { echo FAIL ExecStart wrong; exit 1; }
             grep -qE "^StateDirectory=padctl$" /usr/lib/systemd/user/padctl.service || { echo FAIL StateDirectory wrong; exit 1; }
-            grep -qE "^NoNewPrivileges=true$" /usr/lib/systemd/user/padctl.service || { echo FAIL NoNewPrivileges missing; exit 1; }
+            # issue #216: NoNewPrivileges/LockPersonality/ProtectClock must be absent from user unit
+            grep -qE "^(NoNewPrivileges|LockPersonality|ProtectClock)=" /usr/lib/systemd/user/padctl.service && { echo FAIL incompatible hardening directive present; exit 1; } || echo "PASS no incompatible directives"
             echo "::endgroup::"
 
             echo "::group::dump subcommand recognized (issue #216 symptom 3)"
@@ -292,3 +293,59 @@ jobs:
 
             echo "ALL INVARIANTS PASS"
           '
+
+  systemd-hardening:
+    name: systemd / unit hardening compat (Ubuntu 26.04 + systemd 259)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Build padctl
+        run: zig build -Dlibusb=false
+
+      - name: Generate user unit from installed binary
+        run: |
+          set -euo pipefail
+          mkdir -p _stage/usr/lib/systemd/user
+          sudo ./zig-out/bin/padctl install \
+            --destdir "$PWD/_stage" --prefix /usr --no-enable --no-start
+          cp _stage/usr/lib/systemd/user/padctl.service /tmp/padctl.service
+
+      - name: Verify no incompatible hardening directives in user unit (issue #216)
+        run: |
+          set -euo pipefail
+          echo "=== generated user unit ==="
+          cat /tmp/padctl.service
+          echo "=== checking for removed directives ==="
+          if grep -E "^(NoNewPrivileges|LockPersonality|ProtectClock)=" /tmp/padctl.service; then
+            echo "FAIL: incompatible hardening directive found in user unit (breaks systemd 257+ user scope, issue #216)"
+            exit 1
+          fi
+          echo "PASS: no incompatible hardening directives"
+
+      - name: systemd-analyze verify in Ubuntu 26.04 (systemd 259)
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v /tmp/padctl.service:/tmp/padctl.service:ro \
+            ubuntu:26.04 \
+            /bin/bash -euo pipefail -c '
+              apt-get update -qq 2>/dev/null
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends systemd >/dev/null 2>&1
+              /lib/systemd/systemd --version 2>/dev/null | head -1
+              # stub binary so verify passes executable check
+              cp /bin/sh /usr/bin/padctl
+              echo "=== systemd-analyze verify ==="
+              systemd-analyze verify --man=no /tmp/padctl.service
+              echo "PASS: systemd-analyze verify clean"
+              echo "=== no incompatible directives ==="
+              if grep -E "^(NoNewPrivileges|LockPersonality|ProtectClock)=" /tmp/padctl.service; then
+                echo "FAIL: incompatible directive present"
+                exit 1
+              fi
+              echo "PASS: directives absent"
+            '

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -31,6 +31,8 @@ If the list is empty, the old package is still installed — re-download and rei
 
 ## User service exits with `status=218/CAPABILITIES` on Ubuntu 26.04 / systemd 257+
 
+**Fixed in v0.1.6.** If you are running an older release, use the workaround below.
+
 **Symptoms:**
 
 - `systemctl --user status padctl.service` shows:
@@ -41,12 +43,12 @@ If the list is empty, the old package is still installed — re-download and rei
 - The daemon never starts; `padctl status` returns `cannot connect to padctl daemon`.
 - The restart counter climbs in `journalctl --user -u padctl.service`.
 
-**Root cause:** the user service unit declares `LockPersonality=true`, `ProtectClock=true`, and
-`NoNewPrivileges=true`. systemd 257+ enforces these options more strictly on user instances; the
-kernel rejects the capability adjustments required to apply them, killing the process before it
-starts.
+**Root cause (pre-v0.1.6):** the user service unit declared `LockPersonality=true`,
+`ProtectClock=true`, and `NoNewPrivileges=true`. systemd 257+ enforces these options more
+strictly on user instances; the kernel rejects the capability adjustments required to apply
+them, killing the process before it starts.
 
-**Workaround:** install a drop-in that clears the three offending directives:
+**Workaround (pre-v0.1.6 only):** install a drop-in that clears the three offending directives:
 
 ```sh
 mkdir -p ~/.config/systemd/user/padctl.service.d
@@ -64,7 +66,7 @@ Assigning an empty value to a systemd directive resets it to the default (unset)
 and security impact is small: the daemon runs as your user with no privileged operations, so
 removing these three flags does not expand what it can do.
 
-Reference: [issue #220](https://github.com/BANANASJIM/padctl/issues/220)
+Reference: [issue #216](https://github.com/BANANASJIM/padctl/issues/216)
 
 ---
 

--- a/src/cli/install/services.zig
+++ b/src/cli/install/services.zig
@@ -26,9 +26,6 @@ pub fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8) 
         \\ExecStart={s}
         \\Restart=on-failure
         \\RestartSec=3
-        \\NoNewPrivileges=true
-        \\LockPersonality=true
-        \\ProtectClock=true
         \\# Canonical state/log dir: $XDG_STATE_HOME/padctl on user services,
         \\# /var/lib/padctl on system services. systemd pre-creates it with
         \\# the right perms, exports $STATE_DIRECTORY, and auto-whitelists
@@ -115,7 +112,6 @@ pub fn generateSystemServiceContent(allocator: std.mem.Allocator, prefix: []cons
         \\PrivateTmp=true
         \\RuntimeDirectory=padctl
         \\StateDirectory=padctl
-        \\NoNewPrivileges=true
         \\SupplementaryGroups=input
         \\DeviceAllow=/dev/hidraw* rw
         \\DeviceAllow=/dev/uinput rw

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -1709,15 +1709,18 @@ test "install: udev rules must not contain SYSTEMD_WANTS" {
     try testing.expect(std.mem.indexOf(u8, content, "TAG+=\"systemd\"") == null);
 }
 
-test "install: service content has hardening directives" {
+test "install: user unit has no systemd 257+ incompatible hardening (issue #216)" {
     const testing = std.testing;
     const allocator = testing.allocator;
     const content = try generateServiceContent(allocator, "/usr");
     defer allocator.free(content);
-    try testing.expect(std.mem.indexOf(u8, content, "NoNewPrivileges=true") != null);
-    try testing.expect(std.mem.indexOf(u8, content, "LockPersonality=true") != null);
-    try testing.expect(std.mem.indexOf(u8, content, "ProtectClock=true") != null);
+    // NoNewPrivileges, LockPersonality, ProtectClock cause EXIT_CAPABILITIES (218)
+    // in user scope on systemd 257+ — must be absent from the user unit.
+    try testing.expect(std.mem.indexOf(u8, content, "NoNewPrivileges=") == null);
+    try testing.expect(std.mem.indexOf(u8, content, "LockPersonality=") == null);
+    try testing.expect(std.mem.indexOf(u8, content, "ProtectClock=") == null);
     try testing.expect(std.mem.indexOf(u8, content, "SupplementaryGroups") == null);
+    try testing.expect(std.mem.indexOf(u8, content, "StateDirectory=padctl") != null);
 }
 
 test "install: old system unit triggers migration hint" {


### PR DESCRIPTION
## Summary

- Remove `NoNewPrivileges=true`, `LockPersonality=true`, and `ProtectClock=true` from the user unit template (`generateServiceContent`) — these cause `EXIT_CAPABILITIES` (218) on systemd 257+ where user manager instances no longer hold `CAP_SYS_ADMIN`/`CAP_SYS_TIME`
- Remove `NoNewPrivileges=true` from the legacy system unit template (`generateSystemServiceContent`) for the same reason
- Update unit test to assert the three directives are **absent** (was: assert present); add `StateDirectory=padctl` presence check
- Add `systemd-hardening` CI job in `install-flow.yml`: builds padctl, generates user unit via `padctl install --destdir`, greps for absent directives (hard-fail if present), then runs `systemd-analyze verify --man=no` inside `ubuntu:26.04` (systemd 259)
- Update `docs/src/troubleshooting.md` to mark the workaround as unnecessary starting v0.1.6

## Reproduction

Reporter: T3sT3ro, Ubuntu 26.04 (systemd 257+). `systemctl --user status padctl.service` shows:
```
Failed to drop capabilities: Operation not permitted
Failed at step CAPABILITIES spawning /usr/bin/padctl: Operation not permitted
Main process exited, code=exited, status=218/CAPABILITIES
```

Reproduction approach used: static content check (grep) against the generated unit from `origin/main`:
```sh
git show origin/main:src/cli/install/services.zig | grep -E "NoNewPrivileges|LockPersonality|ProtectClock"
# output: all three present — FAIL
git show HEAD:src/cli/install/services.zig | grep -E "NoNewPrivileges|LockPersonality|ProtectClock"
# output: (empty) — PASS
```

Note: `systemd-analyze verify` does not catch this at parse time (it does not simulate user-scope privilege setup). The definitive test is the content check. Ubuntu 26.04 (systemd 259) is available as a Docker image and used for the `systemd-analyze verify` CI step.

## Test plan

- [x] `grep -E "^(NoNewPrivileges|LockPersonality|ProtectClock)=" generated.service` → exits non-zero on fix branch (directives absent), exits 0 on `origin/main` (directives present) — regression gate confirmed
- [x] `zig build test -Dlibusb=false` — unit test `"install: user unit has no systemd 257+ incompatible hardening (issue #216)"` asserts directives absent
- [x] `systemd-analyze verify --man=no /tmp/padctl.service` in `ubuntu:26.04` container → exit 0
- [x] No regression: existing `install-sandbox` (debian:12) and `pkg-deb-smoke` flows unaffected by directive removal (older systemd does not require them)
- [x] `docs/src/troubleshooting.md` updated — workaround section marked "Fixed in v0.1.6"

refs: issue #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved compatibility issues with systemd 257+ on Ubuntu 26.04, ensuring the service unit functions correctly.

* **Documentation**
  * Updated troubleshooting guide with version notes for v0.1.6 and provided workarounds for users experiencing service failures on newer systemd versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->