### PR TITLE
test: isolate UHID kernel-touching tests from test/test-tsan/test-safe

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,3 +39,8 @@ jobs:
         env:
           PADCTL_TEST_REQUIRE_UHID: "1"
         run: zig build test-integration
+      - name: Run UHID kernel-touching unit tests (test-uhid)
+        if: steps.uhid_probe.outputs.uhid_ok == 'true'
+        env:
+          PADCTL_TEST_REQUIRE_UHID: "1"
+        run: zig build test-uhid

--- a/build.zig
+++ b/build.zig
@@ -335,37 +335,27 @@ pub fn build(b: *std.Build) void {
     gen_e2e_tests.linkLibC();
     e2e_step.dependOn(&b.addRunArtifact(gen_e2e_tests).step);
 
-    // test-uhid-uniq: Phase 13 Wave 5 canary — run ONLY the
-    // `src/test/uhid_uniq_pairing_test.zig` file as a standalone test binary.
-    // Split from `test` so the privileged Docker canary doesn't accidentally
-    // trigger other tests that probe real hidraw devices on the host and
-    // deadlock in `hid_hw_open`.
-    const uniq_step = b.step("test-uhid-uniq", "Run UHID uniq pairing test only (Wave 5 canary)");
-    // Root at src/ so the test's relative imports (../io/uhid.zig etc.)
-    // stay inside the module path. The `addTest` will still run the tests
-    // defined in `test/uhid_uniq_pairing_test.zig` via `test-filter`.
-    const uniq_mod = b.createModule(.{
-        .root_source_file = b.path("test_root.zig"),
+    // test-uhid: UHID kernel-touching tests. Excluded from test/test-safe/test-tsan
+    // because opening /dev/uhid triggers hid_hw_open in the kernel; a leaked device
+    // parks subsequent runs in D-state indefinitely (SIGKILL has no userspace handler).
+    // Requires /dev/uhid + CAP_SYS_ADMIN or input group membership.
+    // Do NOT add to check-all — run explicitly before merging UHID-affecting changes.
+    const uhid_step = b.step("test-uhid", "Run UHID kernel-touching tests (requires /dev/uhid + privilege)");
+    const uhid_mod = b.createModule(.{
+        .root_source_file = b.path("test_root_uhid.zig"),
         .target = target,
         .optimize = optimize,
         .sanitize_c = .trap,
     });
-    uniq_mod.addImport("toml", toml_mod);
-    uniq_mod.addImport("analyse", capture_analyse_mod);
-    uniq_mod.addImport("toml_gen", capture_toml_gen_mod);
-    uniq_mod.addImport("build_options", build_opts.createModule());
-    if (use_wasm) addWasm3(b, uniq_mod, wasm3_c_flags);
-    const uniq_tests = b.addTest(.{
-        .root_module = uniq_mod,
-        .filters = &.{"uhid_uniq_pairing_test"},
-    });
+    uhid_mod.addImport("toml", toml_mod);
+    const uhid_tests = b.addTest(.{ .root_module = uhid_mod });
     if (use_libusb) {
-        uniq_tests.linkSystemLibrary("usb-1.0");
+        uhid_tests.linkSystemLibrary("usb-1.0");
     } else {
-        uniq_tests.addIncludePath(b.path("compat"));
+        uhid_tests.addIncludePath(b.path("compat"));
     }
-    uniq_tests.linkLibC();
-    uniq_step.dependOn(&b.addRunArtifact(uniq_tests).step);
+    uhid_tests.linkLibC();
+    uhid_step.dependOn(&b.addRunArtifact(uhid_tests).step);
 
     // spike (only available when spike/toml_spike.zig exists)
     if (std.fs.cwd().access("spike/toml_spike.zig", .{})) |_| {

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,4 +1,8 @@
 #!/bin/sh
+# test-uhid is excluded from pre-push: it opens /dev/uhid and the Wave A4
+# SIGTERM/SIGINT handler has no SIGKILL path — a leaked device parks subsequent
+# runs in kernel D-state indefinitely. Run manually before merging any change
+# that touches UHID paths: PADCTL_TEST_REQUIRE_UHID=1 zig build test-uhid
 set -e
 
 if [ "$SKIP_TSAN" = "1" ]; then

--- a/src/cli/config/test.zig
+++ b/src/cli/config/test.zig
@@ -181,11 +181,6 @@ test "test: mappingLabel with no remap returns null" {
     try std.testing.expectEqual(@as(?[]const u8, null), mappingLabel(&m, "A"));
 }
 
-test "test: openFirstHidraw returns error when no device" {
-    // In CI there are no hidraw devices; ensure it returns an error cleanly.
-    const result = openFirstHidraw();
-    // May succeed or fail depending on environment; just ensure no panic.
-    if (result) |fd| {
-        posix.close(fd);
-    } else |_| {}
-}
+// "openFirstHidraw returns error when no device" test removed: openFirstHidraw
+// scans /dev/hidraw0..63 and on dev machines an orphaned UHID device causes
+// hid_hw_open D-state even with O_NONBLOCK. The function is exercised via run().

--- a/src/main.zig
+++ b/src/main.zig
@@ -1106,7 +1106,9 @@ test {
     _ = @import("core/rumble_scheduler.zig");
     _ = @import("io/uniq.zig");
     _ = @import("test/bugfix_regression_test.zig");
-    _ = @import("test/uhid_uniq_pairing_test.zig");
+    // uhid_uniq_pairing_test is EXCLUDED: it opens /dev/uhid and triggers
+    // hid_hw_open in the kernel, which can deadlock under SIGKILL/OOM (Wave A4
+    // SIGTERM handler has no SIGKILL path). Run via: zig build test-uhid
     _ = @import("test/macro_gamepad_button_test.zig");
     _ = @import("test/macro_e2e_test.zig");
     _ = @import("test/properties/config_props.zig");

--- a/src/test/harness/uhid_simulator.zig
+++ b/src/test/harness/uhid_simulator.zig
@@ -225,34 +225,8 @@ fn findHidrawPath(vid: u16, pid: u16, expect_uniq: []const u8) !?HidrawEntry {
     return null;
 }
 
-// --- Tests -----------------------------------------------------------------
-
-const testing = std.testing;
-
-test "uhid_simulator: non-linux host skips cleanly" {
-    if (builtin.os.tag == .linux) return error.SkipZigTest;
-    try testing.expectError(error.SkipZigTest, UhidSimulator.create(.{
-        .vid = 0xFADE,
-        .pid = 0xCAFE,
-        .descriptor = &[_]u8{ 0x05, 0x01, 0xC0 },
-    }));
-}
-
-test "uhid_simulator: linux host without /dev/uhid or caps skips cleanly" {
-    if (builtin.os.tag != .linux) return error.SkipZigTest;
-    // `/dev/uhid` may exist but not be writable under test runners. We accept
-    // either outcome: the device either came up, in which case we tear it
-    // down, or we see SkipZigTest — both are "no CI failure".
-    var sim = UhidSimulator.create(.{
-        .vid = 0xFADE,
-        .pid = 0xCAFE,
-        .name = "padctl-sim-test",
-        .descriptor = &[_]u8{ 0x05, 0x01, 0xC0 },
-        .hidraw_timeout_ms = 50,
-    }) catch |err| switch (err) {
-        error.SkipZigTest, error.HidrawNotFound, error.AccessDenied => return error.SkipZigTest,
-        else => |e| return e,
-    };
-    defer sim.destroy();
-    try testing.expect(sim.fd >= 0);
-}
+// Self-tests removed: UhidSimulator.create opens /dev/uhid and findHidrawPath
+// scans /dev/hidraw*. On a host with an orphaned UHID device, posix.open with
+// O_NONBLOCK still blocks in hid_hw_open (kernel limitation). Coverage via
+// steam_deck_uhid_e2e_test and supervisor_uhid_grace_integration_test under
+// `zig build test-integration`, where /dev/uhid access is intentional.

--- a/test_root_uhid.zig
+++ b/test_root_uhid.zig
@@ -1,0 +1,6 @@
+// Kernel-touching UHID tests. Requires /dev/uhid + CAP_SYS_ADMIN (or input group).
+// Run with: zig build test-uhid
+// NOT included in test, test-safe, test-tsan — those are pure userspace.
+comptime {
+    _ = @import("src/test/uhid_uniq_pairing_test.zig");
+}


### PR DESCRIPTION
## Summary

- Move `uhid_uniq_pairing_test` out of `src/main.zig` test block into new `test_root_uhid.zig` + new `zig build test-uhid` step
- Delete 2 self-tests in `src/test/harness/uhid_simulator.zig` that called `UhidSimulator.create` (opens `/dev/uhid`) — coverage retained via existing `test-integration` step
- Delete `openFirstHidraw` test in `src/cli/config/test.zig` — function had no assertions, scanned `/dev/hidraw0..63` triggering D-state when an orphaned UHID device is present
- Replace existing `test-uhid-uniq` Wave 5 canary step with `test-uhid` (broader scope name)
- Add `zig build test-uhid` invocation in `.github/workflows/e2e.yml` gated on `[ -r /dev/uhid -a -w /dev/uhid ]`
- Document exclusion rationale in `hooks/pre-push`

## Why

Wave A4 SIGTERM cleanup hook (PR #136) only handles SIGTERM/SIGINT — SIGKILL/OOM/segfault paths leave UHID devices orphaned in `/sys/devices/virtual/misc/uhid/`. Subsequent `test-tsan` runs that touch `/dev/hidraw*` park indefinitely in `hid_hw_open` D-state. ThreadSanitizer is for userspace race detection; kernel-touching tests are Layer 2 (per `design/testing.md`) and should be invoked separately.

## Test plan

- [x] `timeout 300 zig build test-tsan` completes EXIT:0 in ~90s on a host with an orphaned UHID device (1286/1301 passed, 15 skipped)
- [x] `zig build test-tsan --summary all 2>&1 | grep -iE 'uhid|hidraw'` returns empty
- [x] `zig build test-uhid` runs the UHID test, gracefully skips when `/dev/uhid` unavailable, exits 0
- [x] `zig build --help | grep test-uhid` shows the new step
- [x] `ps -ef | grep zig` shows zero zombies after `test-tsan` completes
- [ ] CI green on PR (distro-check / fedora-41 may still be red until PR #227 mount-Zig fix lands)

## Follow-up (not blocking)

- `test-uhid` and `test-integration` are both Layer 2 entry points — consolidate when Zig issue #22453 (cache flock) is resolved upstream, or update `design/testing.md` to acknowledge the dual-step pattern as load-bearing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized privileged kernel-level tests into a dedicated build target for better isolation.
  * Updated CI workflow to conditionally run kernel-level tests based on system capabilities.
* **Chores**
  * Improved build and testing infrastructure documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->