### PR TITLE
fix(io): open /dev/uhid with O_NONBLOCK to avoid event-loop drain hang

### DIFF
--- a/src/io/uhid.zig
+++ b/src/io/uhid.zig
@@ -92,7 +92,7 @@ pub const UhidDestroyEvent = extern struct {
 /// or the caller lacks permission so tests relying on a real UHID device
 /// skip cleanly on CI hosts without the capability.
 pub fn openUhid() !posix.fd_t {
-    return posix.open("/dev/uhid", .{ .ACCMODE = .RDWR }, 0) catch |err| switch (err) {
+    return posix.open("/dev/uhid", .{ .ACCMODE = .RDWR, .NONBLOCK = true }, 0) catch |err| switch (err) {
         error.AccessDenied, error.FileNotFound => return error.SkipZigTest,
         else => return err,
     };
@@ -1020,4 +1020,15 @@ test "uhid: pollOutputReport returns null on WouldBlock (empty pipe)" {
     var read_buf: [UHID_EVENT_SIZE]u8 = undefined;
     const report = try dev.pollOutputReport(&read_buf);
     try testing.expectEqual(@as(?OutputReport, null), report);
+}
+
+test "uhid: openUhid sets O_NONBLOCK on the fd" {
+    const fd = openUhid() catch |err| switch (err) {
+        error.SkipZigTest => return error.SkipZigTest,
+        else => return err,
+    };
+    defer posix.close(fd);
+    const flags: i32 = @intCast(try posix.fcntl(fd, posix.F.GETFL, 0));
+    const O_NONBLOCK_BIT: i32 = 0o4000;
+    try std.testing.expect((flags & O_NONBLOCK_BIT) != 0);
 }


### PR DESCRIPTION
## Summary
- `openUhid()` now opens `/dev/uhid` with `.NONBLOCK = true`. Previously it was blocking.
- Production `UhidDevice.init()` uses `openUhid()`. `pollOutputReport()` catches `error.WouldBlock => return null`, but on a blocking fd that case is unreachable, so the `event_loop` drain `while (true)` loop blocked indefinitely on the second iteration after consuming the last queued UHID_OUTPUT event — stalling the entire device thread until a new event arrived.
- This fixes a real production hang on Wave 6 PIDFF racing wheels.

## Test plan
- [ ] CI green
- [x] New regression test `uhid: openUhid sets O_NONBLOCK on the fd` asserts `fcntl(fd, F_GETFL) & O_NONBLOCK != 0` (skips on hosts without `/dev/uhid`)
- [x] `zig build test` passes locally
- [ ] `zig build test-uhid` (Layer 2, requires `/dev/uhid`) — green on hosts with kernel UHID

## Refs
- Audit finding B-M4 from 2026-05-12 5-agent code review on main `fe6166f`
- Independently dispatcher-verified: `git show origin/main:src/io/uhid.zig:94-100` confirmed `.NONBLOCK` flag missing pre-fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * UHID device initialization now operates in non-blocking mode.

* **Tests**
  * New unit test added to verify the non-blocking flag is properly configured when the device is opened.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/230)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->