### PR TITLE
fix(layer): do not signal active_changed on Hold PENDING entry

### DIFF
--- a/src/core/layer.zig
+++ b/src/core/layer.zig
@@ -100,7 +100,6 @@ pub const LayerState = struct {
                     const res = self.onTriggerPress(cfg.name, timeout, now_ns);
                     if (res.arm_timer_ms) |ms| {
                         action.arm_timer_ms = ms;
-                        action.active_changed = true;
                     }
                 } else if (!pressed and was_pressed) {
                     // Only process release for the layer that owns tap_hold.
@@ -443,9 +442,38 @@ test "layer: processLayerTriggers: Hold press → PENDING, arm timer" {
     const action = ls.processLayerTriggers(&configs, lt, 0, 0);
     try testing.expect(action.arm_timer_ms != null);
     try testing.expectEqual(@as(?u64, 200), action.arm_timer_ms);
-    try testing.expect(action.active_changed);
     try testing.expect(ls.tap_hold != null);
     try testing.expectEqual(TapHoldPhase.pending, ls.tap_hold.?.phase);
+}
+
+test "layer: hold PENDING entry does not signal active_changed" {
+    // Regression: PENDING entry must not trigger mapper's active_changed reset
+    // path (gyro/stick reset + macro release emission). Only real transitions
+    // (PENDING→ACTIVE, ACTIVE→IDLE, tap-resolve, toggle) signal active_changed.
+    // Candidate root cause for issue #79.
+    const hold_cfg = LayerConfig{ .name = "aim", .trigger = "LM", .activation = "hold", .hold_timeout = 200 };
+    var ls = LayerState.init(testing.allocator);
+    defer ls.deinit();
+    const configs = [_]LayerConfig{hold_cfg};
+    const lm = @as(u64, 1) << @as(u6, @intCast(@intFromEnum(@import("state.zig").ButtonId.LM)));
+
+    const action = ls.processLayerTriggers(&configs, lm, 0, 0);
+    try testing.expect(action.arm_timer_ms != null);
+    try testing.expect(!action.active_changed);
+}
+
+test "layer: hold PENDING -> ACTIVE transition signals active_changed" {
+    // Guard against over-aggressive removal: the timer-fire path must still
+    // mark the layer state as changed so callers refresh getActive().
+    const hold_cfg = LayerConfig{ .name = "aim", .trigger = "LM", .activation = "hold", .hold_timeout = 200 };
+    var ls = LayerState.init(testing.allocator);
+    defer ls.deinit();
+    const configs = [_]LayerConfig{hold_cfg};
+    const lm = @as(u64, 1) << @as(u6, @intCast(@intFromEnum(@import("state.zig").ButtonId.LM)));
+
+    _ = ls.processLayerTriggers(&configs, lm, 0, 0);
+    const res = ls.onTimerExpired();
+    try testing.expect(res.layer_activated);
 }
 
 test "layer: processLayerTriggers: Hold PENDING + timer → ACTIVE, getActive returns layer" {

--- a/src/test/macro_e2e_test.zig
+++ b/src/test/macro_e2e_test.zig
@@ -296,12 +296,17 @@ test "macro: layer switch while macro active — held keys released, macros clea
     _ = try m.apply(.{ .buttons = m1_mask }, 16, 0);
     try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
 
-    // Press LT — processLayerTriggers fires action.active_changed on the rising
-    // edge of a hold trigger, which clears active_macros and emits releases.
+    // Press LT — PENDING entry alone must not clear macros (issue #79 fix).
     const lt_mask = btnMask(.LT);
-    const ev = try m.apply(.{ .buttons = m1_mask | lt_mask }, 16, 0);
+    _ = try m.apply(.{ .buttons = m1_mask | lt_mask }, 16, 0);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
 
-    // active_macros must be empty after layer switch.
+    // Advance to ACTIVE then release LT → real layer transition → active_changed
+    // fires through processLayerTriggers → active_macros cleared, releases emitted.
+    _ = m.layer.onTimerExpired();
+    const ev = try m.apply(.{ .buttons = m1_mask }, 16, 0);
+
+    // active_macros must be empty after the layer truly deactivates.
     try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
 
     // At least one release event for KEY_LEFTSHIFT should be in aux.


### PR DESCRIPTION
## Summary
- When a Hold-activation layer trigger is pressed and enters PENDING (timer armed, not yet ACTIVE), `processLayerTriggers` no longer sets `action.active_changed = true`.
- Previously, PENDING entry caused `mapper.apply()` to: reset gyro/stick/dpad accumulators, emit pending macro releases, and clear `active_macros` — before tap-vs-hold was decided. If the user tapped within `hold_timeout`, all in-flight macro state was wiped silently.
- The 4 legitimate `active_changed` sites are unchanged: PENDING→ACTIVE (`onTimerExpired`), tap-resolve / ACTIVE→IDLE (release), toggle on, toggle off.
- Candidate root cause for issue #79.

## Test plan
- [ ] CI green
- [x] New test `layer: hold PENDING entry does not signal active_changed`
- [x] New test `layer: hold PENDING -> ACTIVE transition signals active_changed` (guards against over-aggressive removal)
- [x] `src/test/macro_e2e_test.zig` test adapted: PENDING alone preserves in-flight macros; only real PENDING→ACTIVE→IDLE cycle clears them
- [x] Existing test `Hold press → PENDING, arm timer` updated (removed assertion of buggy behavior)
- [x] `zig build test` passes locally

## Refs
- Audit finding A-H1 from 2026-05-12 5-agent code review on main `fe6166f`
- Related to user-reported issue #79 (xl666, Vader 5 Pro, Bazzite, "tapped button is sometimes triggered but most of the time not")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hold-layer behavior to prevent incorrectly clearing active macros during the initial trigger press; macros now persist until the hold-layer fully activates.
  * Corrected layer state signaling to occur only when a hold-layer fully activates, not during the pending state.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/231)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->