### PR TITLE
fix(install): apply destdir prefix to runtime-state cleanup paths

### DIFF
--- a/src/cli/install/phase.zig
+++ b/src/cli/install/phase.zig
@@ -335,8 +335,16 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
     }
 
-    std.fs.deleteFileAbsolute("/run/padctl/padctl.pid") catch {};
-    std.fs.deleteFileAbsolute("/run/padctl/padctl.sock") catch {};
+    {
+        const path = try std.fmt.allocPrint(allocator, "{s}/run/padctl/padctl.pid", .{destdir});
+        defer allocator.free(path);
+        std.fs.deleteFileAbsolute(path) catch {};
+    }
+    {
+        const path = try std.fmt.allocPrint(allocator, "{s}/run/padctl/padctl.sock", .{destdir});
+        defer allocator.free(path);
+        std.fs.deleteFileAbsolute(path) catch {};
+    }
 
     if (destdir.len == 0) {
         const reload_plan = services.currentPlanFromEnv();

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -751,6 +751,57 @@ test "uninstall: legacy padctl-resume.service is removed (non-immutable)" {
     } else |_| {}
 }
 
+test "install: uninstall applies destdir to runtime state paths" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const staging = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(staging);
+
+    const run_dir = try std.fmt.allocPrint(allocator, "{s}/run/padctl", .{staging});
+    defer allocator.free(run_dir);
+    try ensureDirAll(allocator, run_dir);
+
+    const pid_path = try std.fmt.allocPrint(allocator, "{s}/padctl.pid", .{run_dir});
+    defer allocator.free(pid_path);
+    const sock_path = try std.fmt.allocPrint(allocator, "{s}/padctl.sock", .{run_dir});
+    defer allocator.free(sock_path);
+
+    {
+        var f = try std.fs.createFileAbsolute(pid_path, .{ .truncate = true });
+        defer f.close();
+        try f.writeAll("12345\n");
+    }
+    {
+        var f = try std.fs.createFileAbsolute(sock_path, .{ .truncate = true });
+        defer f.close();
+    }
+
+    const opts = InstallOptions{
+        .prefix = "/usr/local",
+        .destdir = staging,
+        .immutable = false,
+        .user_service = false,
+    };
+    {
+        var silencer = try SilencedStdout.begin();
+        defer silencer.end();
+        try uninstall(allocator, opts);
+    }
+
+    if (std.fs.accessAbsolute(pid_path, .{})) |_| {
+        std.debug.print("padctl.pid not cleaned up under destdir: {s}\n", .{pid_path});
+        return error.RuntimePidNotRemoved;
+    } else |_| {}
+
+    if (std.fs.accessAbsolute(sock_path, .{})) |_| {
+        std.debug.print("padctl.sock not cleaned up under destdir: {s}\n", .{sock_path});
+        return error.RuntimeSockNotRemoved;
+    } else |_| {}
+}
+
 test "install: generateReconnectScript has required commands" {
     const testing = std.testing;
     const allocator = testing.allocator;


### PR DESCRIPTION
## Summary
- `uninstall` previously deleted `/run/padctl/padctl.pid` and `/run/padctl/padctl.sock` unconditionally, ignoring `--destdir`.
- Packager staging install (`padctl uninstall --destdir /tmp/staging`) would attempt to delete LIVE system files instead of staging files; if the staging host had a running daemon, its IPC socket got nuked.
- Both lines now wrap in `allocPrint("{s}/run/padctl/padctl.{pid,sock}", .{destdir})` matching the surrounding pattern (lines 276-336 already use this idiom).
- Live uninstall (no destdir, destdir.len == 0) still works: empty prefix collapses to `/run/padctl/...`.
- Audit confirmed via grep: only these two `deleteFileAbsolute("/...")` literals existed; no other absolute-path leaks.

## Test plan
- [ ] CI green
- [x] New test `install: uninstall applies destdir to runtime state paths`: creates `<tmp>/run/padctl/padctl.{pid,sock}`, calls `uninstall(destdir=<tmp>)`, asserts files removed
- [x] Test uses `.user_service = false` to avoid touching `$HOME/.config/systemd/user/...`
- [x] `zig build test` passes locally
- [x] `zig build test-tsan` passes locally

## Refs
- Audit finding D-H2 from 2026-05-12 5-agent code review on main `fe6166f`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed uninstall procedure to correctly remove runtime files under the configured destination directory instead of absolute system paths, improving installation path handling.

* **Tests**
  * Added test to verify proper cleanup of runtime files when uninstalling with a configured destination directory.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/232)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->