### PR TITLE
fix(interpreter): bound-check src_off+src_size against raw.len

### DIFF
--- a/src/core/interpreter.zig
+++ b/src/core/interpreter.zig
@@ -522,6 +522,7 @@ fn extractAndFillCompiled(cr: *const CompiledReport, raw: []const u8, delta: *Ga
     }
 
     if (cr.button_group) |*cbg| {
+        if (cbg.src_off + cbg.src_size > raw.len) return;
         const src_val = readUintBytes(raw, cbg.src_off, cbg.src_size);
         var bits: u64 = delta.buttons orelse 0;
         for (cbg.entries[0..cbg.count]) |entry| {
@@ -1924,4 +1925,33 @@ test "readUintBytes: clamps size to 8" {
     const buf = [_]u8{0x01} ** 16;
     const result = readUintBytes(&buf, 0, 12);
     try testing.expectEqual(@as(u64, 0x0101010101010101), result);
+}
+
+test "interpreter: readUintBytes rejects src_off+src_size > raw.len" {
+    // Directly construct a CompiledReport with button_group { src_off=6, src_size=4 }
+    // and call extractAndFillCompiled with an 8-byte buffer.
+    // cbg.src_off(6) + cbg.src_size(4) = 10 > 8 = raw.len.
+    // Without the bounds check, readUintBytes panics in ReleaseSafe (OOB slice).
+    // With the check, the button_group is skipped gracefully and delta.buttons stays null.
+    const dummy_report = device.ReportConfig{
+        .name = "dummy",
+        .interface = 0,
+        .size = 8,
+    };
+    var cr = CompiledReport{
+        .src = &dummy_report,
+        .checksum = null,
+        .fields = undefined,
+        .field_count = 0,
+        .button_group = CompiledButtonGroup{
+            .src_off = 6,
+            .src_size = 4,
+            .entries = undefined,
+            .count = 0,
+        },
+    };
+    const raw = [_]u8{0} ** 8;
+    var delta = GamepadStateDelta{};
+    extractAndFillCompiled(&cr, &raw, &delta);
+    try testing.expectEqual(@as(?u64, null), delta.buttons);
 }


### PR DESCRIPTION
## Summary
- `extractAndFillCompiled` now guards `if (cbg.src_off + cbg.src_size > raw.len) return;` before calling `readUintBytes`.
- PR-X6 added the `size > 8` guard (necessary, not sufficient): a TOML `button_group` with `source.offset + source.size > report.size` passed PR-X6 but caused `readUintBytes` to slice past `raw.len`, panicking in ReleaseSafe / UB in ReleaseFast.
- Defense-in-depth: `device.parseString` already validates `bg.source.offset + bg.source.size <= report.size` at parse time, so OOB is unreachable via the public API. The fix protects any caller constructing `CompiledReport` directly.
- Standard fields: covered by the existing outer guard `raw.len >= cr.src.size` + parser-time `offset + sizeof(type_tag) <= report.size`. No further change needed.

## Test plan
- [ ] CI green
- [x] New test `interpreter: readUintBytes rejects src_off+src_size > raw.len`: directly constructs `CompiledButtonGroup` with `src_off=6, src_size=4`, calls `extractAndFillCompiled` with an 8-byte buffer, asserts no panic + `delta.buttons` stays null
- [x] Pre-fix: panic in ReleaseSafe; post-fix: graceful skip
- [x] `zig build test` passes locally
- [x] `zig build test-tsan` passes locally

## Refs
- Audit finding A-M3 from 2026-05-12 5-agent code review on main `fe6166f`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur when processing malformed report data with invalid button configuration bounds. The interpreter now gracefully skips button extraction instead of panicking when encountering out-of-range data.

* **Tests**
  * Added regression test to ensure out-of-bounds button configuration is handled safely.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/233)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->