### PR TITLE
docs(install): document /etc/padctl/mappings is runtime-fixed regardless of --prefix

### DIFF
--- a/src/cli/install/services.zig
+++ b/src/cli/install/services.zig
@@ -79,6 +79,8 @@ pub fn generateReconnectScript(allocator: std.mem.Allocator, prefix: []const u8)
         \\
         \\# Re-apply mapping after hotplug (device reconnects in passthrough mode).
         \\# Apply the first mapping found (sorted for deterministic selection).
+        \\# /etc/padctl/mappings is the FHS sysconfdir — fixed at /etc regardless
+        \\# of --prefix. systemConfigDir() in src/config/paths.zig is the SSOT.
         \\sleep 2
         \\for f in $(ls /etc/padctl/mappings/*.toml 2>/dev/null | sort); do
         \\    [ -f "$f" ] || continue

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -766,6 +766,20 @@ test "install: generateReconnectScript has required commands" {
     try testing.expect(std.mem.indexOf(u8, script, "/etc/padctl/mappings/") != null);
 }
 
+test "services: generateReconnectScript embeds correct mappings dir for prefix=/usr/local" {
+    // Convention: sysconfdir is always /etc regardless of --prefix.
+    // systemConfigDir() in src/config/paths.zig is the SSOT.
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const script = try generateReconnectScript(allocator, "/usr/local");
+    defer allocator.free(script);
+    // Binary path uses prefix
+    try testing.expect(std.mem.indexOf(u8, script, "/usr/local/bin/padctl") != null);
+    // Mappings dir is always /etc — not /usr/local/etc
+    try testing.expect(std.mem.indexOf(u8, script, "/etc/padctl/mappings") != null);
+    try testing.expect(std.mem.indexOf(u8, script, "/usr/local/etc") == null);
+}
+
 test "install: generateUdevRules includes hotplug reconnect rules" {
     const testing = std.testing;
     const allocator = testing.allocator;

--- a/src/io/uhid.zig
+++ b/src/io/uhid.zig
@@ -92,7 +92,7 @@ pub const UhidDestroyEvent = extern struct {
 /// or the caller lacks permission so tests relying on a real UHID device
 /// skip cleanly on CI hosts without the capability.
 pub fn openUhid() !posix.fd_t {
-    return posix.open("/dev/uhid", .{ .ACCMODE = .RDWR }, 0) catch |err| switch (err) {
+    return posix.open("/dev/uhid", .{ .ACCMODE = .RDWR, .NONBLOCK = true }, 0) catch |err| switch (err) {
         error.AccessDenied, error.FileNotFound => return error.SkipZigTest,
         else => return err,
     };
@@ -1020,4 +1020,15 @@ test "uhid: pollOutputReport returns null on WouldBlock (empty pipe)" {
     var read_buf: [UHID_EVENT_SIZE]u8 = undefined;
     const report = try dev.pollOutputReport(&read_buf);
     try testing.expectEqual(@as(?OutputReport, null), report);
+}
+
+test "uhid: openUhid sets O_NONBLOCK on the fd" {
+    const fd = openUhid() catch |err| switch (err) {
+        error.SkipZigTest => return error.SkipZigTest,
+        else => return err,
+    };
+    defer posix.close(fd);
+    const flags: i32 = @intCast(try posix.fcntl(fd, posix.F.GETFL, 0));
+    const O_NONBLOCK_BIT: i32 = 0o4000;
+    try std.testing.expect((flags & O_NONBLOCK_BIT) != 0);
 }


### PR DESCRIPTION
## Summary
- Reviewer audit flagged `generateReconnectScript`'s literal `/etc/padctl/mappings/*.toml` as a possible bug ("ignores --prefix"). Investigation confirms: this is the canonical FHS sysconfdir, fixed at `/etc` regardless of `--prefix`. All install + runtime use-sites agree.
- This PR documents the invariant in `services.zig` (2-line comment) and adds a regression test asserting:
  - The binary path DOES use prefix (`/usr/local/bin/padctl`)
  - The mappings path is `/etc/padctl/mappings` (NOT `/usr/local/etc/...`) — negative assertion guards against future prefix-leakage refactors

## Stack note
This branch is stacked on `fix/uhid-nonblock` (PR #230). After #230 merges, this PR's diff will narrow naturally to the docs+test delta. GitHub UI will rebase cleanly.

## Test plan
- [ ] CI green
- [x] New test `services: generateReconnectScript embeds correct mappings dir for prefix=/usr/local` (lines 769-781)
- [x] `zig build test` passes locally
- [x] `zig build test-tsan` passes locally

## Refs
- Audit finding D-H1 from 2026-05-12 5-agent code review on main `fe6166f`
- Implementer verified via grep of all `etc/padctl/mappings` use-sites: `services.zig:85`, `phase.zig:330`, `mappings.zig:95`, `main.zig:1223-1229` all use literal path
- `systemConfigDir()` in `src/config/paths.zig` is the SSOT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added verification for mappings directory configuration with custom installation paths.

* **Documentation**
  * Clarified mappings directory location in code documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/234)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->