### PR TITLE
fix(build): pin toml dependency to immutable commit SHA

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .version = "0.1.5",
     .dependencies = .{
         .toml = .{
-            .url = "https://github.com/sam701/zig-toml/archive/refs/heads/main.tar.gz",
-            .hash = "toml-0.3.0-bV14Be6EAQDr0fkyURz4jYFyTAMPcwlNN0FEPVjDnXTR",
+            .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",
+            .hash = "toml-0.3.0-bV14BVqIAQANb68hDuVPZ72hrcIhT-fv_fcIbetQIAyg",
         },
     },
     .minimum_zig_version = "0.15.0",


### PR DESCRIPTION
## What changed

- `build.zig.zon`: replace rolling `refs/heads/main.tar.gz` URL with immutable commit-SHA archive URL (`24e0deec`) + updated hash

## Problem

The `toml` dependency was declared against a branch HEAD tarball. Every upstream push to `sam701/zig-toml` changes the tarball content, invalidating the declared hash. This caused hash mismatch errors on every CI re-run and is the root cause of PR #237 being red:

```
build.zig.zon:8:21: error: hash mismatch: manifest declares 'toml-0.3.0-bV14Be6EAQDr0fkyURz4jYFyTAMPcwlNN0FEPVjDnXTR'
  but the fetched package has 'toml-0.3.0-bV14BVqIAQANb68hDuVPZ72hrcIhT-fv_fcIbetQIAyg'
```

## Fix

Pin to commit `24e0deeceaad1b7f1b12027ebae1c65ff1d86e33` (latest `main` HEAD as of 2026-05-15). No semver release tags exist on the upstream repo; commit SHA is the only immutable ref. The pinned tree is API-compatible — `Parser(T)`, `Parsed(T)`, `HashMap(T)` are all present.

## Test plan

- [x] `zig build` from clean cache succeeds (no hash mismatch)
- [x] `zig build test` exits 0 (all Layer 0+1 tests pass)
- [x] `git show --stat` shows exactly 1 file changed (`build.zig.zon`)
- [x] Pre-push tsan hook passed

refs: `build.zig.zon@89a6522`