### PR TITLE
chore(hooks): add SKIP_BUILD escape to pre-commit (host #147 workaround)

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+if ! zig fmt --check src/ tools/ 2>/dev/null; then
+    echo "ERROR: zig fmt check failed. Run 'zig fmt src/ tools/' to fix."
+    exit 1
+fi
+
+if [ "${SKIP_BUILD:-0}" = "1" ]; then
+    echo "pre-commit: SKIP_BUILD=1 set, skipping zig build (host #147 workaround; CI still gates)"
+else
+    if ! zig build --cache-dir /tmp/zig-hook-cache 2>/dev/null; then
+        echo "ERROR: zig build failed."
+        exit 1
+    fi
+fi


### PR DESCRIPTION
## Problem

On hosts with glibc 2.43+ / GCC 16, `zig build` fails with `R_X86_64_PC64` relocation errors regardless of code correctness (issue #147). This makes the `hooks/pre-commit` step 2 always fail on affected hosts, blocking all commits even for trivially correct changes.

## Change

- Wrap only the `zig build` step (step 2) in `if [ "${SKIP_BUILD:-0}" = "1" ]`
- `zig fmt --check` (step 1) remains unconditional — style gate always runs
- `pre-push` TSan gate is unaffected
- CI (`zig build` in ubuntu-22.04) still gates every push — this is not a correctness bypass

## Test plan

- `bash -n hooks/pre-commit` — shell syntax check passes
- `SKIP_BUILD=1 git commit` — hook prints skip message, `zig fmt` still runs (no `--no-verify`)
- `SKIP_BUILD=0 git commit` (or unset) — original `zig build` path executes unchanged
- CI matrix runs `zig build test` on push — correctness gate unaffected

refs: issue #147