### PR TITLE
test: build Lean oracle in ci.yml so DRT formal-spec coverage actually runs (F2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Build the Lean formal-spec oracle once and publish it as an artifact.
+  # The interactive-Lean-oracle DRT suite in src/test/properties/drt_props.zig
+  # only runs when formal/lean/.lake/build/bin/oracle exists; without this job
+  # every DRT oracle test silently SkipZigTest's in CI (audit F2). The Lean
+  # toolchain (elan + lake build) is heavy, so it is built once here and
+  # downloaded by the zig-test jobs rather than rebuilt per matrix leg.
+  # Cross-workflow artifacts are not reachable via `needs:`, so the oracle is
+  # built inside this workflow (not reused from lean.yml).
+  lean-oracle:
+    name: lean-oracle
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install elan
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+      - name: Build Lean oracle
+        working-directory: formal/lean
+        run: lake build oracle
+      - name: Verify oracle binary exists
+        run: test -x formal/lean/.lake/build/bin/oracle
+      - name: Upload oracle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lean-oracle
+          path: formal/lean/.lake/build/bin/oracle
+          if-no-files-found: error
+          retention-days: 1
+
   check-matrix:
     name: check / ${{ matrix.os }} / ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    needs: [lean-oracle]
     strategy:
       fail-fast: false
       matrix:
@@ -26,6 +57,11 @@ jobs:
             zig_args: -Dwasm=false
           - name: libusb-false
             zig_args: -Dlibusb=false
+    env:
+      # Turn a missing oracle into a hard failure (no silent SkipZigTest) so
+      # the formal-spec differential coverage can never regress to skip again.
+      # Mirrors the existing PADCTL_TEST_REQUIRE_UHID pattern (e2e.yml).
+      PADCTL_TEST_REQUIRE_LEAN: "1"
     steps:
       - uses: actions/checkout@v4
       - name: Install Zig
@@ -35,6 +71,16 @@ jobs:
       - name: Install system dependencies
         if: matrix.name != 'libusb-false'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libusb-1.0-0-dev
+      - name: Download Lean oracle artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: lean-oracle
+          path: formal/lean/.lake/build/bin
+      - name: Restore oracle executable bit
+        run: |
+          set -eo pipefail
+          chmod +x formal/lean/.lake/build/bin/oracle
+          test -x formal/lean/.lake/build/bin/oracle
       # Three separate `zig build` processes (Option C from PR #166 fc4937b)
       # to avoid Zig issue #22453 inter-step flock contention. Each process
       # has its own .zig-cache lock space.
@@ -52,11 +98,15 @@ jobs:
   check:
     name: check
     runs-on: ubuntu-22.04
-    needs: [check-matrix]
+    needs: [lean-oracle, check-matrix]
     if: ${{ always() }}
     steps:
-      - name: Require check matrix success
+      - name: Require lean-oracle and check matrix success
         run: |
+          if [ "${{ needs.lean-oracle.result }}" != "success" ]; then
+            echo "lean-oracle result: ${{ needs.lean-oracle.result }}"
+            exit 1
+          fi
           if [ "${{ needs.check-matrix.result }}" != "success" ]; then
             echo "check-matrix result: ${{ needs.check-matrix.result }}"
             exit 1

--- a/src/test/properties/drt_props.zig
+++ b/src/test/properties/drt_props.zig
@@ -155,13 +155,33 @@ fn compareDelta(fr: lean.FieldResult, delta: anytype) !void {
     }
 }
 
-fn initOracle() error{SkipZigTest}!*lean.LeanOracle {
-    var oracle = lean.LeanOracle.init() catch {
-        return error.SkipZigTest;
+// PADCTL_TEST_REQUIRE_LEAN=1 turns a missing/broken Lean oracle into a hard
+// failure instead of a silent skip. CI sets this so the formal-spec
+// differential coverage can never regress to SkipZigTest unnoticed (audit F2).
+// Mirrors requireUhid() in src/test/uhid_uniq_pairing_test.zig.
+fn requireLean() bool {
+    const v = std.posix.getenv("PADCTL_TEST_REQUIRE_LEAN") orelse return false;
+    return std.mem.eql(u8, v, "1") or std.mem.eql(u8, v, "true");
+}
+
+fn reportMissingOracle(reason: []const u8) error{ SkipZigTest, LeanOracleRequired } {
+    std.log.warn(
+        "DRT: Lean oracle unavailable ({s}) — formal-spec differential coverage is SILENT. " ++
+            "Build it via 'cd formal/lean && lake build oracle', " ++
+            "or set PADCTL_TEST_REQUIRE_LEAN=1 to turn this into a hard failure.",
+        .{reason},
+    );
+    if (requireLean()) return error.LeanOracleRequired;
+    return error.SkipZigTest;
+}
+
+fn initOracle() error{ SkipZigTest, LeanOracleRequired }!*lean.LeanOracle {
+    var oracle = lean.LeanOracle.init() catch |err| {
+        return reportMissingOracle(@errorName(err));
     };
     const heap_oracle = std.heap.page_allocator.create(lean.LeanOracle) catch {
         oracle.deinit();
-        return error.SkipZigTest;
+        return reportMissingOracle("oracle heap allocation failed");
     };
     heap_oracle.* = oracle;
     std.log.info("DRT: using Lean subprocess oracle", .{});
@@ -181,9 +201,7 @@ test "DRT: production interpreter matches reference oracle on random packets" {
     var rng = std.Random.DefaultPrng.init(0xC0FFEE_42);
     const random = rng.random();
 
-    const oracle = initOracle() catch |err| switch (err) {
-        error.SkipZigTest => return error.SkipZigTest,
-    };
+    const oracle = try initOracle();
     defer deinitOracle(oracle);
 
     for (paths.items) |path| {
@@ -233,9 +251,7 @@ test "DRT: structured random packets — valid field values at correct offsets" 
     var rng = std.Random.DefaultPrng.init(0xABCD_EF01);
     const random = rng.random();
 
-    const oracle = initOracle() catch |err| switch (err) {
-        error.SkipZigTest => return error.SkipZigTest,
-    };
+    const oracle = try initOracle();
     defer deinitOracle(oracle);
 
     for (paths.items) |path| {


### PR DESCRIPTION
## Problem (audit F2, CRITICAL)

`.github/workflows/ci.yml` — the only workflow that runs `zig build test` — never built the Lean oracle binary.

- `src/test/lean_oracle_client.zig` does `access("formal/lean/.lake/build/bin/oracle")`; on CI that path is absent, so `LeanOracle.init` returns `FileNotFound`.
- `src/test/properties/drt_props.zig` `initOracle()` then `return error.SkipZigTest`, so the entire interactive-Lean-oracle DRT suite (the authoritative formal-spec differential coverage, TP5) silently skipped on **every** CI run. Any interpreter field-extraction bug would not fail CI.
- `lean.yml` builds Lean in a *separate workflow*; its artifact is unreachable from `ci.yml` (`needs:` only spans a single workflow).

## Approach + rationale

Chosen: approach (a) — build the oracle once, publish as an artifact, consume in the zig-test jobs. The Lean toolchain (elan + `lake build`) is heavy and is already a dedicated job in `lean.yml`, so building it inside each of the 3 `check-matrix` legs would be wasteful. Cross-workflow artifacts cannot be reached via `needs:`, so the oracle is built **inside `ci.yml`** (a new `lean-oracle` job) rather than reused from `lean.yml`.

- New `lean-oracle` job: `elan` + `lake build oracle`, uploads `formal/lean/.lake/build/bin/oracle` as an intra-workflow artifact (`if-no-files-found: error`, `retention-days: 1`).
- `check-matrix` gains `needs: [lean-oracle]`, downloads the artifact to `formal/lean/.lake/build/bin`, and restores the executable bit (`actions/upload-artifact` drops `+x`) before `zig build test`.
- `check` aggregator job now also requires `lean-oracle` success.

## New hard-fail guard

Mirrors the existing `PADCTL_TEST_REQUIRE_UHID` pattern (`src/test/uhid_uniq_pairing_test.zig` / `e2e.yml`):

- `drt_props.zig`: new `requireLean()` + `reportMissingOracle()`. The `check-matrix` job sets `PADCTL_TEST_REQUIRE_LEAN=1`; when set, a missing/broken oracle yields `error.LeanOracleRequired` (hard test failure) instead of `error.SkipZigTest`. So the suite can never silently regress to skip again.

## Test plan

- [ ] CI `lean-oracle` job builds the oracle and uploads the artifact.
- [ ] `check-matrix` legs download the artifact and the DRT oracle tests (`DRT: production interpreter matches reference oracle on random packets`, `DRT: structured random packets — valid field values at correct offsets`) appear as **run/passed**, not skipped, in `test.log` / `--summary all`.
- [ ] Falsifiability: with `PADCTL_TEST_REQUIRE_LEAN=1` set in the job env, a missing oracle would fail the job (not skip) — verified by the guard logic.
- [ ] `tsan` / `distro-check` unchanged (no `PADCTL_TEST_REQUIRE_LEAN`, so they still skip the oracle gracefully — out of scope for F2).

refs: `research/test-code-audit-2026-05-15.md@a8c6187`