### PR TITLE
T1: fix distro-check post-job cache-save EACCES from root-owned .zig-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,15 @@ jobs:
               timeout 600 /opt/zig/zig build -Dlibusb=false test-safe --summary all
               timeout 600 /opt/zig/zig build -Dlibusb=false check-fmt
             " 2>&1 | tee distro-check.log
+      # The container above runs as root (apt-get/dnf require it), so any
+      # .zig-cache / zig-out files it writes are root-owned on the host.
+      # The subsequent host build step and the setup-zig post-job cache-save
+      # trim both run as the unprivileged `runner` user; root-owned files make
+      # the post-job `unlink` trim fail with EACCES once the cache exceeds the
+      # 2 GiB limit. Reclaim ownership so runner-side steps can manage them.
+      - name: Reclaim container-written cache ownership
+        if: always()
+        run: sudo chown -R "$(id -u):$(id -g)" .zig-cache zig-out 2>/dev/null || true
       - name: Build musl binary (host)
         run: zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-musl -Dlibusb=false
       - name: Smoke-test musl binary in container


### PR DESCRIPTION
## Problem

`distro-check` is deterministically red on PR branches even when the PR is
otherwise correct. All build/test steps pass; the only `##[error]` is in
**Post job cleanup**:

```
Cache directory reached <2.2GB> bytes, exceeding limit of 2147483648; clearing cache
##[error]EACCES: permission denied, unlink '.../.zig-cache/o/.../test'
```

### Mechanism (ci.yml line cites, origin/main 160a8ca)

- L132: `distro-check` uses `mlugg/setup-zig@v2` with default caching (restores/saves `.zig-cache`).
- L148-159: the first `docker run` mounts the whole workspace (`-v "$PWD:/work"`, L149) and runs **as root** — it has to, because `${DISTRO_SETUP}` (L155) is `apt-get update && apt-get install ...` (debian-12) / `dnf install -y ...` (fedora-41), both of which require root inside the container. Zig writes `.zig-cache` / `zig-out` files there → those files are **root-owned on the host**.
- Post-job: the `setup-zig` cache-save runs as the unprivileged `runner` user. When `.zig-cache` exceeds the 2 GiB limit it trims via `unlink`, which fails with `EACCES` on the root-owned files.

### Why latent on main

On `main` the cache happens to stay just under 2 GiB, so the trim path is never exercised and distro-check is green by luck. PR branches push the cache ~300-430 MB over the limit, hitting the trim → deterministic red. This currently blocks **#240** and **#241** (both correct; every other CI job green).

Other jobs are unaffected because they never write `.zig-cache` from docker-as-root: `check-matrix` (L30-50) and `tsan` (L76-81) build directly on the host as `runner`; `tsan` additionally `rm -rf .zig-cache` first. The second `docker run` in distro-check (L168-177) only mounts the binary, not the cache.

## Fix

Add a `distro-check`-scoped step right after the container build that runs
`sudo chown -R "$(id -u):$(id -g)" .zig-cache zig-out` (with `if: always()`,
errors ignored). This makes the cache files runner-owned so both the
subsequent host musl-build step and the `setup-zig` post-job trim — both
unprivileged — can manage them. Root cause fixed: no more root-owned cache
files reaching the post-job trim.

### Options considered

- **Option 1 — `docker run --user "$(id -u):$(id -g)"`**: rejected. The container legitimately needs root for `apt-get`/`dnf install` in `${DISTRO_SETUP}`; a non-root container user cannot write `/var/lib/apt` or `/var/cache/dnf`, breaking distro-check for all PRs.
- **Option 2 — runner-side `sudo chown` (chosen)**: minimal (+9 lines, single hunk), scoped to `distro-check`, fixes the ownership root cause, preserves caching. `sudo` is already used in this workflow (L37, L75) and is passwordless on GitHub-hosted `ubuntu-22.04`.
- **Option 3 — disable cache for distro-check**: rejected; avoids the trim but loses caching for the job.
- Raising the 2 GiB cap: rejected — does not fix the root cause, only delays it.

## Test plan

CI itself is the proof (host cannot build, see #147 — but this is a `.yml`-only change with no zig to compile):

- [ ] `distro-check / debian-12` and `distro-check / fedora-41` go green on this PR.
- [ ] The **Post job cleanup** for both no longer emits `EACCES ... unlink '.../.zig-cache/...'` (cache files are runner-owned after the new chown step).
- [ ] `check-matrix`, `check`, `tsan` behaviour unchanged (diff is scoped entirely within the `distro-check` job; YAML parses, all 4 jobs intact).
- [ ] After merge, rebasing #240 / #241 onto main clears their `distro-check` failures.

refs: `.github/workflows/ci.yml@160a8ca`