### PR TITLE
test: falsifiable #216 client-connect error-specificity regression guard

### DIFF
--- a/src/cli/socket_client.zig
+++ b/src/cli/socket_client.zig
@@ -136,3 +136,43 @@ test "sendCommand: empty response returns EndOfStream" {
     const result = sendCommand(fds[0], "STATUS\n", &buf);
     try testing.expectError(error.BrokenPipe, result);
 }
+
+// Issue #216 (partial): "cannot connect to padctl daemon". The systemd
+// capabilities / SupplementaryGroups / hidraw-permission half is an
+// environment-layer concern (NOT-UNIT-TESTABLE; the install-side guard lives
+// in src/cli/install/tests.zig "issue #216"). The padctl-side testable slice
+// (research/issue-regression-coverage-audit-2026-05-15.md §D.6) is: the client
+// connect path must surface a *specific*, diagnosable error rather than a
+// catch-all, so callers can distinguish a malformed socket path from a
+// genuinely-unreachable daemon. `connectToSocket` is the exact function every
+// CLI client (status/devices/switch/dump) calls before printing "cannot
+// connect to padctl daemon".
+//
+// Falsifiability contract (audit §D.6): the explicit validation branch
+//   `if (path.len == 0 or path[0] != '/' or indexOf(path, "..") != null)
+//        return error.InvalidPath;`
+// is what makes the error specific. If that guard is removed/weakened (errors
+// "mapped back to catch-all"), an empty or relative or "..":-traversal path
+// instead falls through to posix.socket/posix.connect and fails with a generic
+// posix errno (e.g. error.FileNotFound / AddressNotAvailable) — NOT
+// error.InvalidPath. Under that mutation every `expectError(error.InvalidPath,
+// ...)` below fails. Independently provable by deleting that `if` line.
+test "socket_client: connectToSocket: malformed paths return specific InvalidPath (issue #216)" {
+    // Empty path — must not be a generic socket/connect failure.
+    try testing.expectError(error.InvalidPath, connectToSocket(""));
+
+    // Relative (non-absolute) path — daemon sockets are always absolute.
+    try testing.expectError(error.InvalidPath, connectToSocket("relative/padctl.sock"));
+
+    // Path-traversal attempt — must be rejected before any syscall.
+    try testing.expectError(error.InvalidPath, connectToSocket("/run/padctl/../padctl.sock"));
+}
+
+// Companion guard: a well-formed but absent absolute socket path must return a
+// concrete posix ConnectError member (FileNotFound for a missing AF_UNIX
+// node), never an opaque/unexpected error. This pins the "daemon not running"
+// diagnostic to a specific, actionable error variant.
+test "socket_client: connectToSocket: nonexistent absolute socket yields concrete posix error (issue #216)" {
+    const result = connectToSocket("/run/padctl-issue216-nonexistent/padctl.sock");
+    try testing.expectError(error.FileNotFound, result);
+}


### PR DESCRIPTION
## What

Adds falsifiable regression coverage for the unit-testable slice of open issue
**#216** ("cannot connect to padctl daemon"), per the audit's PR-ready spec in
`research/issue-regression-coverage-audit-2026-05-15.md` §D.6.

Scope assessed across the three requested issues; only #216 yielded a genuine,
non-duplicate, falsifiable unit slice (see Notes).

## Tests added (`src/cli/socket_client.zig`, inline L0)

Both tests exercise the exact production function `connectToSocket` — the
function every CLI client (status/devices/switch/dump) calls immediately before
printing "cannot connect to padctl daemon". No new `src/test/` file; the file
is already registered under `main.zig` `testing_support`, so no
`testing_support` edit is required (the `_meta_wiring_check` canary covers
discovery).

1. `connectToSocket: malformed paths return specific InvalidPath (issue #216)`
   - Asserts empty / relative / `..`-traversal paths return `error.InvalidPath`.
   - **Falsifiability contract:** delete the explicit validation branch
     `if (path.len == 0 or path[0] != '/' or indexOf(path, "..") != null) return error.InvalidPath;`
     → those paths fall through to `posix.socket`/`posix.connect` and fail with
     a generic posix errno (e.g. `FileNotFound`/`AddressNotAvailable`), **not**
     `error.InvalidPath` → all three `expectError` assertions fail.

2. `connectToSocket: nonexistent absolute socket yields concrete posix error (issue #216)`
   - Asserts a well-formed but absent absolute socket path returns the concrete
     `error.FileNotFound` (Zig `ConnectError`: ENOENT for a missing AF_UNIX
     node), never an opaque/unexpected error.
   - **Falsifiability contract:** map the connect error back to a catch-all
     (e.g. `error.Unexpected`) → `expectError(error.FileNotFound, ...)` fails.

## Notes / deferred follow-ups

- **#137** (real HID exclusive-grab slice, audit §D.5): **already covered** —
  STOPPED, no duplicate added. `src/cli/install/tests.zig`
  `"install: generateDriverBlockRules produces unbind rules"` already uses
  Vader5 Pro's exact real VID/PID `0x37d7`/`0x2401` + `block_kernel_drivers=["xpad"]`
  (verified against `devices/flydigi/vader5.toml`) and is falsifiable under
  §D.5's mutation (skip entry / drop `block_kernel_drivers` handling →
  `has_blocks=false` → rules file empty/deleted → assertion fails).
- **#65** (cold-start `default_mapping` slice, audit §D.4): **STOPPED with
  finding**. The config-resolution half (`findDefaultMapping`) is already
  falsifiably covered by 5 tests in `src/config/user_config.zig`
  (exact/case-insensitive/no-match/no-devices/no-default, incl. the literal
  "Flydigi Vader 5 Pro"→"fps" case). The remaining half — `findMapping`
  XDG-path discovery wiring inside `loadUserDefaultMapping` — has **no test
  injection seam** (hard XDG dependency, no `dev_root`-style override; Zig
  0.15.2 `std.c` does not expose `setenv`). A hermetic falsifiable test there
  needs a production seam (a `findMappingWithRoot`-style override), which is a
  structural follow-up outside test-only implementer scope — not fabricated
  here.
- **#215** (negate `t_max` saturation): **deferred follow-up**, intentionally
  NOT implemented. Audit §D.3 classifies it ADR-blocked — the
  "production saturates vs Lean oracle saturates" semantic divergence is
  undecided; any test would conflict with the undecided behavior until an ADR
  selects Spec-A or Spec-B.

## Test plan

- [ ] CI `ci.yml` / `e2e.yml` / `lean.yml` / `coverage.yml` green on this branch
- [ ] (reviewer) re-prove falsifiability: delete the `InvalidPath` guard line
      in `connectToSocket` → test 1 fails; remap connect error to catch-all →
      test 2 fails

refs: `research/issue-regression-coverage-audit-2026-05-15.md`