### PR TITLE
fix(ci): apt-get update before .deb install in release verify step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,7 +225,8 @@ jobs:
           DEB=$(ls padctl_*_${{ matrix.deb_arch }}.deb | head -1)
           docker run --rm -v "$PWD/$DEB:/pkg/$DEB" debian:12 bash -c "
             set -e
-            apt-get install -y /pkg/$DEB >/dev/null 2>&1
+            apt-get update -qq
+            apt-get install -y /pkg/$DEB
             padctl --version | grep -F '${VERSION}'
             padctl list-mappings
             padctl --validate /usr/share/padctl/devices/sony/dualsense.toml


### PR DESCRIPTION
release.yml verify-release-artifact installed the .deb in a bare debian:12 with no preceding apt-get update, so the package Depends (systemd) could not be resolved and apt exited 100 — failing the job and skipping checksums + update-aur. Add `apt-get update -qq` before install (matching install-flow.yml / ci.yml convention) and drop the `>/dev/null 2>&1` so apt errors are visible.

Test plan: release.yml runs on tag push; verified after the v0.1.6 tag is re-pushed (full release re-run including SHA256SUMS + AUR).