### PR TITLE
fix(ci): make release create-release job idempotent for re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,12 @@ jobs:
         env:
           TAG: ${{ github.ref_name }}
           GH_TOKEN: ${{ github.token }}
-        run: >
-          gh release create "${TAG}"
-          --title "${TAG}"
-          --notes-file CHANGELOG.md
-          --draft=false
+        run: |
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "release ${TAG} already exists — skipping create (idempotent re-run)"
+          else
+            gh release create "${TAG}" --title "${TAG}" --notes-file CHANGELOG.md --draft=false
+          fi
 
   gen-install-artifacts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
release.yml create-release ran \`gh release create\` unconditionally, so re-running a tag whose release already exists failed the job and skipped all downstream jobs (build/build-deb/verify/checksums/update-aur) — making a release pipeline non-re-entrant without destructively deleting the public release. Guard with \`gh release view || gh release create\` so an existing release is a no-op and the rest of the pipeline (checksums, update-aur) runs on re-push.

Test plan: release.yml runs on tag push; verified by force-moving the v0.1.6 tag onto this commit and observing the full pipeline (incl update-aur) complete without deleting the existing release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release creation process reliability by adding a check to prevent duplicate releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->