### PR TITLE
fix(interpreter): align negate/abs single-point saturation with Lean oracle (#215)

### DIFF
--- a/src/core/interpreter.zig
+++ b/src/core/interpreter.zig
@@ -230,9 +230,16 @@ pub fn runTransformChain(initial: i64, chain: *const CompiledTransformChain) i64
     var val = initial;
     const t_max = typeMaxByTag(chain.type_tag);
     for (chain.items[0..chain.len]) |tr| {
+        // Lean oracle (formal/lean/Padctl/Transform.lean): negate/abs saturate
+        // at the single type-min point `val == Int.negSucc tMax` (= -(t_max+1))
+        // to t_max, otherwise raw -val / natAbs. This is a SINGLE-POINT guard,
+        // not a range clamp — broadening it would clamp scale→negate stick
+        // values to ±t_max (severe real-device regression). See ADR-017.
+        const type_min: i64 = -(t_max + 1);
         val = switch (tr.op) {
-            .negate => if (val == std.math.minInt(i64)) std.math.maxInt(i64) else -val,
+            .negate => if (val == type_min) t_max else if (val == std.math.minInt(i64)) std.math.maxInt(i64) else -val,
             .abs => blk: {
+                if (val == type_min) break :blk t_max;
                 const clamped = if (val == std.math.minInt(i64)) std.math.maxInt(i64) else val;
                 break :blk @intCast(@abs(clamped));
             },

--- a/src/test/properties/lean_drt_props.zig
+++ b/src/test/properties/lean_drt_props.zig
@@ -81,12 +81,6 @@ test "lean_drt: transform negate vectors" {
         if (!std.mem.eql(u8, f[0], "negate") and !std.mem.eql(u8, f[0], "abs")) continue;
         const input = parseInt(f[1]);
         const t_max_raw = parseUint(f[2]);
-        // TODO(lean-drt-saturation-debt): Lean oracle saturates negate/abs to t_max for
-        // out-of-range inputs (e.g. negate(-128, t_max=127) -> 127), production returns
-        // the raw arithmetic result (128). Skip out-of-range inputs until production
-        // gains a saturation pass — see lean_drt header comment about oracle truth.
-        const t_max_signed: i64 = @intCast(t_max_raw);
-        if (input < -t_max_signed or input > t_max_signed) continue;
         const expected = parseInt(f[3]);
         const op: interp.TransformOp = if (std.mem.eql(u8, f[0], "negate")) .negate else .abs;
         var chain = interp.CompiledTransformChain{ .type_tag = tMaxToFieldType(t_max_raw) };

--- a/src/test/transform_boundary_test.zig
+++ b/src/test/transform_boundary_test.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
 const testing = std.testing;
 const device = @import("../config/device.zig");
-const Interpreter = @import("../core/interpreter.zig").Interpreter;
+const interp = @import("../core/interpreter.zig");
+const Interpreter = interp.Interpreter;
 
 const boundary_i16 = [_]i16{ 0, 1, -1, std.math.maxInt(i16), std.math.minInt(i16), 16384 };
 
@@ -135,5 +136,31 @@ test "boundary: chain deadzone(1000), scale(-32768, 32767)" {
     const dead_vals = [_]i16{ 0, 999, -999 };
     inline for (dead_vals) |v| {
         try testing.expectEqual(scaled_zero, try runOne(&interp, v));
+    }
+}
+
+// issue #215 / ADR-017: production negate/abs MUST match the Lean oracle's
+// single-point saturation at the type-min boundary `val == -(t_max+1) -> t_max`.
+// Asserted directly via runTransformChain (DRT-independent). Reverting the
+// single-point guard in interpreter.zig makes this test FAIL.
+test "issue215: negate/abs single-point saturation matches Lean oracle" {
+    // i8: t_max = 127, type-min = -(127+1) = -128.
+    {
+        var neg = interp.compileTransformChain("negate", .i8);
+        try testing.expectEqual(@as(i64, 127), interp.runTransformChain(-128, &neg));
+        var abs_ = interp.compileTransformChain("abs", .i8);
+        try testing.expectEqual(@as(i64, 127), interp.runTransformChain(-128, &abs_));
+        // Non-minInt out-of-range input must NOT saturate (oracle: raw -val/natAbs).
+        try testing.expectEqual(@as(i64, 256), interp.runTransformChain(-256, &neg));
+        try testing.expectEqual(@as(i64, 256), interp.runTransformChain(-256, &abs_));
+        // In-range still raw.
+        try testing.expectEqual(@as(i64, 127), interp.runTransformChain(-127, &neg));
+    }
+    // Wider type i32le: t_max = 2147483647, type-min = -2147483648.
+    {
+        var neg = interp.compileTransformChain("negate", .i32le);
+        try testing.expectEqual(@as(i64, 2147483647), interp.runTransformChain(-2147483648, &neg));
+        var abs_ = interp.compileTransformChain("abs", .i32le);
+        try testing.expectEqual(@as(i64, 2147483647), interp.runTransformChain(-2147483648, &abs_));
     }
 }

--- a/src/test/transform_boundary_test.zig
+++ b/src/test/transform_boundary_test.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const testing = std.testing;
 const device = @import("../config/device.zig");
-const interp = @import("../core/interpreter.zig");
-const Interpreter = interp.Interpreter;
+const interpreter = @import("../core/interpreter.zig");
+const Interpreter = interpreter.Interpreter;
 
 const boundary_i16 = [_]i16{ 0, 1, -1, std.math.maxInt(i16), std.math.minInt(i16), 16384 };
 
@@ -146,21 +146,21 @@ test "boundary: chain deadzone(1000), scale(-32768, 32767)" {
 test "issue215: negate/abs single-point saturation matches Lean oracle" {
     // i8: t_max = 127, type-min = -(127+1) = -128.
     {
-        var neg = interp.compileTransformChain("negate", .i8);
-        try testing.expectEqual(@as(i64, 127), interp.runTransformChain(-128, &neg));
-        var abs_ = interp.compileTransformChain("abs", .i8);
-        try testing.expectEqual(@as(i64, 127), interp.runTransformChain(-128, &abs_));
+        var neg = interpreter.compileTransformChain("negate", .i8);
+        try testing.expectEqual(@as(i64, 127), interpreter.runTransformChain(-128, &neg));
+        var abs_ = interpreter.compileTransformChain("abs", .i8);
+        try testing.expectEqual(@as(i64, 127), interpreter.runTransformChain(-128, &abs_));
         // Non-minInt out-of-range input must NOT saturate (oracle: raw -val/natAbs).
-        try testing.expectEqual(@as(i64, 256), interp.runTransformChain(-256, &neg));
-        try testing.expectEqual(@as(i64, 256), interp.runTransformChain(-256, &abs_));
+        try testing.expectEqual(@as(i64, 256), interpreter.runTransformChain(-256, &neg));
+        try testing.expectEqual(@as(i64, 256), interpreter.runTransformChain(-256, &abs_));
         // In-range still raw.
-        try testing.expectEqual(@as(i64, 127), interp.runTransformChain(-127, &neg));
+        try testing.expectEqual(@as(i64, 127), interpreter.runTransformChain(-127, &neg));
     }
     // Wider type i32le: t_max = 2147483647, type-min = -2147483648.
     {
-        var neg = interp.compileTransformChain("negate", .i32le);
-        try testing.expectEqual(@as(i64, 2147483647), interp.runTransformChain(-2147483648, &neg));
-        var abs_ = interp.compileTransformChain("abs", .i32le);
-        try testing.expectEqual(@as(i64, 2147483647), interp.runTransformChain(-2147483648, &abs_));
+        var neg = interpreter.compileTransformChain("negate", .i32le);
+        try testing.expectEqual(@as(i64, 2147483647), interpreter.runTransformChain(-2147483648, &neg));
+        var abs_ = interpreter.compileTransformChain("abs", .i32le);
+        try testing.expectEqual(@as(i64, 2147483647), interpreter.runTransformChain(-2147483648, &abs_));
     }
 }


### PR DESCRIPTION
## What changed

- `src/core/interpreter.zig` `runTransformChain`: add a **single-point** guard for `negate`/`abs` so production matches the Lean formal oracle. When `val == -(t_max+1)` (the type-min boundary, Lean `Int.negSucc tMax`), return `t_max`; otherwise unchanged raw `-val` / `@abs`. The pre-existing i64-MIN guard is preserved (it never collides: max `t_max` is i32-max, so `-(t_max+1)` is far from i64 MIN).
- `src/test/properties/lean_drt_props.zig`: remove the obsolete `TODO(lean-drt-saturation-debt)` skip filter that bypassed out-of-range negate/abs vectors. The DRT now exercises these vectors against the now-aligned production code.
- `src/test/transform_boundary_test.zig`: add a DRT-independent unit test asserting the single point equals `t_max` for `i8` (t_max=127, -128 → 127) and the wider `i32le` (t_max=2147483647, -2147483648 → 2147483647), and asserting non-minInt out-of-range inputs (e.g. `negate(-256, i8)` → 256) are still raw arithmetic (proves this is NOT a range clamp).

This implements ADR-017 Option B (Lean oracle is canonical). The change is a single point per type only: it does NOT broaden to a range/window saturation, which would clamp DualSense/DS4 `scale(-32768,32767)→negate` stick values to ±t_max — a severe real-device regression explicitly avoided here.

Lean predicate mirrored (`formal/lean/Padctl/Transform.lean:9`): `if val == Int.negSucc tMax then tMax else -val`. Zig condition written: `if (val == type_min) t_max else ...` where `const type_min: i64 = -(t_max + 1)` and `Int.negSucc tMax == -(tMax+1)`.

## Falsifiability

Reverting the single-point guard — i.e. changing the negate arm back to `if (val == std.math.minInt(i64)) std.math.maxInt(i64) else -val` and removing the `if (val == type_min) break :blk t_max;` line in the abs arm — makes the new test `issue215: negate/abs single-point saturation matches Lean oracle` FAIL: `runTransformChain(-128, negate/i8)` would return `128` instead of the asserted `127` (and `-2147483648` → `2147483648` instead of `2147483647`). The DRT test `lean_drt: transform negate vectors` would also fail on the now-unfiltered out-of-range vectors. The non-minInt assertions (`-256 → 256`) guard against an over-broad range-clamp implementation.

## Test plan

- CI `zig build test` (Layer 0+1) is the oracle (host cannot build natively, #147).
- New unit test discovered via: `build.zig` → `test_root.zig` → `@import("src/main.zig")` → `refAllDeclsRecursive(@This())` (main.zig:1107) → `pub const transform_boundary_test = @import("test/transform_boundary_test.zig")` (main.zig:112).
- `lean_drt_props.zig` discovered via the same chain at main.zig:136.
- Existing `mutation audit: negate minInt guard` (i16le, input i64-MIN) unaffected: `-(32767+1) = -32768 ≠ i64 MIN`, still hits the preserved i64-MIN guard → `maxInt(i64)`.
- Existing `boundary: negate`/`boundary: abs` (i16le, only minInt point -32768) unaffected: prod 32768 and new-guard 32767 both collapse to 32767 via downstream `saturateCast(i16)`.

refs: #215