### PR TITLE
DELETEME mutation-proof #137b (do not merge)

### DIFF
--- a/src/cli/install/phase.zig
+++ b/src/cli/install/phase.zig
@@ -84,6 +84,17 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         mapping_failed = mapping_failed or binding_failed;
     }
 
+    // Sentinel gates the conditional driver-block udev rule (issue #137):
+    // present ⇒ unbind fires as before; absent ⇒ xpad keeps the device so a
+    // non-enabled install never leaves the controller ownerless. Always
+    // clear it on the non-enable path so a re-install with --no-enable over
+    // a previously-enabled install does not leave a stale sentinel.
+    if (udev.shouldProactiveUnbind(&plan)) {
+        udev.writeServiceSentinel(allocator, &plan) catch {};
+    } else {
+        udev.removeServiceSentinel(allocator, plan.opts.destdir);
+    }
+
     if (plan.do_enable_systemctl) {
         services.runSystemctlPhase(&plan);
     } else if (!plan.staging_mode) {
@@ -245,6 +256,10 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         _ = std.posix.write(std.posix.STDOUT_FILENO, path) catch {};
         _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
     }
+
+    // issue #137: drop the service-enabled sentinel so a future replug of a
+    // block_kernel_drivers device is not unbound by a stale udev rule.
+    udev.removeServiceSentinel(allocator, destdir);
 
     if (effective_user_service) {
         if (std.posix.getenv("HOME")) |home| {

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -55,6 +55,11 @@ const parseStringArray = _udev.parseStringArray;
 const parseHexOrDec = _udev.parseHexOrDec;
 const generateUdevRules = _udev.generateUdevRules;
 const generateDriverBlockRules = _udev.generateDriverBlockRules;
+const generateDriverBlockRulesFromEntries = _udev.generateDriverBlockRulesFromEntries;
+const sentinelPath = udev_mod.sentinelPath;
+const writeServiceSentinel = udev_mod.writeServiceSentinel;
+const removeServiceSentinel = udev_mod.removeServiceSentinel;
+const shouldProactiveUnbind = udev_mod.shouldProactiveUnbind;
 
 // migration.zig
 const ensureUserXdgDirs = migration_mod.ensureUserXdgDirs;
@@ -1286,6 +1291,199 @@ test "install: generateDriverBlockRules skips when no drivers configured" {
     };
     // File should not have been created — if it was, fail the test
     return error.TestUnexpectedResult;
+}
+
+// --- issue #137: conditional driver-block + service-enabled sentinel ---
+
+// Builds a single-driver entry list and generates the driver-block rules with
+// an explicit sentinel path. Caller owns nothing extra; entries are stack-lived.
+fn genIssue137Rules(allocator: std.mem.Allocator, rules_path: []const u8, sentinel: []const u8) !void {
+    const drivers = [_][]const u8{"xpad"};
+    const entries = [_]UdevEntry{.{
+        .name = "Test Pad",
+        .vid = 0x0f0d,
+        .pid = 0x00c1,
+        .block_kernel_drivers = &drivers,
+    }};
+    try generateDriverBlockRulesFromEntries(allocator, &entries, rules_path, sentinel);
+}
+
+fn readRulesFile(allocator: std.mem.Allocator, rules_path: []const u8) ![]u8 {
+    var file = try std.fs.openFileAbsolute(rules_path, .{});
+    defer file.close();
+    return file.readToEndAlloc(allocator, 8192);
+}
+
+// (1) MUTATION-CI-PROOF: every line that performs an `unbind` must be guarded
+// by a `test -e <sentinel> &&` predicate. FAILS if the sentinel predicate is
+// removed from the unbind RUN+= line in generateDriverBlockRulesFromEntries
+// (reverting to the unconditional `echo %k > .../unbind` shape).
+test "install: #137 every unbind line is sentinel-gated" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    const rules_path = try std.fmt.allocPrint(allocator, "{s}/61.rules", .{tmp_path});
+    defer allocator.free(rules_path);
+    const sentinel = "/etc/padctl/service-enabled";
+    try genIssue137Rules(allocator, rules_path, sentinel);
+
+    const content = try readRulesFile(allocator, rules_path);
+    defer allocator.free(content);
+
+    const guard = try std.fmt.allocPrint(allocator, "test -e {s} &&", .{sentinel});
+    defer allocator.free(guard);
+    try testing.expect(std.mem.indexOf(u8, content, guard) != null);
+
+    var it = std.mem.splitScalar(u8, content, '\n');
+    while (it.next()) |line| {
+        if (std.mem.indexOf(u8, line, "unbind") == null) continue;
+        try testing.expect(std.mem.indexOf(u8, line, "test -e ") != null);
+        try testing.expect(std.mem.indexOf(u8, line, sentinel) != null);
+    }
+}
+
+// (2) FAILS if the ACTION=="remove" rebind loop is deleted from
+// generateDriverBlockRulesFromEntries.
+test "install: #137 generates ACTION==remove rebind line" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    const rules_path = try std.fmt.allocPrint(allocator, "{s}/61.rules", .{tmp_path});
+    defer allocator.free(rules_path);
+    try genIssue137Rules(allocator, rules_path, "/etc/padctl/service-enabled");
+
+    const content = try readRulesFile(allocator, rules_path);
+    defer allocator.free(content);
+
+    try testing.expect(std.mem.indexOf(u8, content, "ACTION==\"remove\"") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "/bind") != null);
+}
+
+// (3) FAILS if writeServiceSentinel stops writing or sentinelPath diverges
+// from the file actually written when the plan is enabling & not --no-enable.
+test "install: #137 writeServiceSentinel creates the gating file" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(destdir);
+
+    const opts = InstallOptions{ .destdir = destdir };
+    const env = EnvSnapshot{ .uid = 1000, .home = "/home/alice", .sudo_user = null, .sudo_uid = null };
+    const plan = try InstallPlan.compute(allocator, opts, env);
+    defer plan.deinit(allocator);
+    // destdir set → staging → do_enable_systemctl=false; force the enabling
+    // shape this test is about by checking shouldProactiveUnbind precondition
+    // directly is covered by test (7); here we exercise the writer/path pair.
+    try writeServiceSentinel(allocator, &plan);
+
+    const path = try sentinelPath(allocator, destdir);
+    defer allocator.free(path);
+    try std.fs.accessAbsolute(path, .{});
+}
+
+// (4) FAILS if the install path writes a sentinel under --no-enable. Drives
+// the predicate that gates writeServiceSentinel in phase.zig.
+test "install: #137 no sentinel under --no-enable" {
+    const testing = std.testing;
+    const opts = InstallOptions{ .no_enable = true };
+    const env = EnvSnapshot{ .uid = 1000, .home = "/home/alice", .sudo_user = null, .sudo_uid = null };
+    const plan = try InstallPlan.compute(testing.allocator, opts, env);
+    defer plan.deinit(testing.allocator);
+    try testing.expect(!shouldProactiveUnbind(&plan));
+}
+
+// (5) FAILS if shouldProactiveUnbind returns true when do_enable_systemctl is
+// false (staged build), which would write a sentinel for a non-running install.
+test "install: #137 no sentinel when do_enable_systemctl false" {
+    const testing = std.testing;
+    const opts = InstallOptions{ .destdir = "/tmp/staging137" };
+    const env = EnvSnapshot{ .uid = 0, .home = "/root", .sudo_user = null, .sudo_uid = null };
+    const plan = try InstallPlan.compute(testing.allocator, opts, env);
+    defer plan.deinit(testing.allocator);
+    try testing.expect(!plan.do_enable_systemctl);
+    try testing.expect(!shouldProactiveUnbind(&plan));
+}
+
+// (6) FAILS if removeServiceSentinel does not delete the file, or is not
+// idempotent (panics / errors on the second call when already absent).
+test "install: #137 removeServiceSentinel deletes and is idempotent" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(destdir);
+
+    const opts = InstallOptions{ .destdir = destdir };
+    const env = EnvSnapshot{ .uid = 1000, .home = "/home/alice", .sudo_user = null, .sudo_uid = null };
+    const plan = try InstallPlan.compute(allocator, opts, env);
+    defer plan.deinit(allocator);
+    try writeServiceSentinel(allocator, &plan);
+
+    const path = try sentinelPath(allocator, destdir);
+    defer allocator.free(path);
+    try std.fs.accessAbsolute(path, .{});
+
+    removeServiceSentinel(allocator, destdir);
+    try testing.expectError(error.FileNotFound, std.fs.accessAbsolute(path, .{}));
+    removeServiceSentinel(allocator, destdir); // idempotent: must not error/panic
+    try testing.expectError(error.FileNotFound, std.fs.accessAbsolute(path, .{}));
+}
+
+// (7) FAILS if shouldProactiveUnbind is not exactly
+// (do_enable_systemctl && !no_enable). Table over both axes.
+test "install: #137 shouldProactiveUnbind truth table" {
+    const testing = std.testing;
+    const Case = struct {
+        opts: InstallOptions,
+        env: EnvSnapshot,
+        want: bool,
+    };
+    const cases = [_]Case{
+        // enabling, not --no-enable → true
+        .{
+            .opts = .{},
+            .env = .{ .uid = 1000, .home = "/home/a", .sudo_user = null, .sudo_uid = null },
+            .want = true,
+        },
+        // enabling but --no-enable → false
+        .{
+            .opts = .{ .no_enable = true },
+            .env = .{ .uid = 1000, .home = "/home/a", .sudo_user = null, .sudo_uid = null },
+            .want = false,
+        },
+        // staged (do_enable_systemctl=false), not --no-enable → false
+        .{
+            .opts = .{ .destdir = "/tmp/s137" },
+            .env = .{ .uid = 0, .home = "/root", .sudo_user = null, .sudo_uid = null },
+            .want = false,
+        },
+        // staged AND --no-enable → false
+        .{
+            .opts = .{ .destdir = "/tmp/s137", .no_enable = true },
+            .env = .{ .uid = 0, .home = "/root", .sudo_user = null, .sudo_uid = null },
+            .want = false,
+        },
+    };
+    for (cases) |c| {
+        const plan = try InstallPlan.compute(testing.allocator, c.opts, c.env);
+        defer plan.deinit(testing.allocator);
+        try testing.expectEqual(c.want, shouldProactiveUnbind(&plan));
+    }
 }
 
 // --- Phase 5: mapping installation ---

--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -47,6 +47,70 @@ pub const UdevEntry = struct {
     clone_vid_pid: bool = false,
 };
 
+/// Path to the service-enabled sentinel. `/etc/padctl` is the fixed FHS
+/// sysconfdir (consistent with the reconnect-script `/etc/padctl/mappings`
+/// path in services.zig), so only `destdir` is prefixed — never `prefix`.
+pub fn sentinelPath(allocator: std.mem.Allocator, destdir: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{s}/etc/padctl/service-enabled", .{destdir});
+}
+
+/// Proactive unbind / sentinel write is performed only when this install
+/// actually enables and starts a runnable user service. Pure predicate so
+/// tests can table-drive it; the absence of the sentinel is what makes the
+/// generated udev rule fail-safe (issue #137).
+pub fn shouldProactiveUnbind(plan: *const InstallPlan) bool {
+    return plan.do_enable_systemctl and !plan.opts.no_enable;
+}
+
+/// Write the service-enabled sentinel. Only its existence is load-bearing for
+/// the udev `test -e` predicate; the body is provenance for debugging.
+pub fn writeServiceSentinel(allocator: std.mem.Allocator, plan: *const InstallPlan) !void {
+    const dir_path = try std.fmt.allocPrint(allocator, "{s}/etc/padctl", .{plan.opts.destdir});
+    defer allocator.free(dir_path);
+    try ensureDirAll(allocator, dir_path);
+
+    const path = try sentinelPath(allocator, plan.opts.destdir);
+    defer allocator.free(path);
+
+    var buf: [64]u8 = undefined;
+    const now = std.time.timestamp();
+    const es = std.time.epoch.EpochSeconds{ .secs = @intCast(@max(now, 0)) };
+    const yd = es.getEpochDay().calculateYearDay();
+    const md = yd.calculateMonthDay();
+    const ds = es.getDaySeconds();
+    const iso = std.fmt.bufPrint(&buf, "{d:0>4}-{d:0>2}-{d:0>2}T{d:0>2}:{d:0>2}:{d:0>2}Z", .{
+        yd.year,
+        @as(u32, @intFromEnum(md.month)) + 1,
+        @as(u32, md.day_index) + 1,
+        ds.getHoursIntoDay(),
+        ds.getMinutesIntoHour(),
+        ds.getSecondsIntoMinute(),
+    }) catch "unknown";
+
+    const content = try std.fmt.allocPrint(
+        allocator,
+        "padctl service-enabled sentinel v1\nprefix={s}\nwritten-by=padctl install\ndate={s}\n",
+        .{ plan.prefix, iso },
+    );
+    defer allocator.free(content);
+
+    var f = try std.fs.createFileAbsolute(path, .{ .truncate = true });
+    defer f.close();
+    try f.writeAll(content);
+    _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
+    _ = std.posix.write(std.posix.STDOUT_FILENO, path) catch {};
+    _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
+}
+
+/// Remove the service-enabled sentinel. Idempotent: a missing file is success
+/// so `--no-enable` re-install over a previously-enabled install and uninstall
+/// can both call this unconditionally.
+pub fn removeServiceSentinel(allocator: std.mem.Allocator, destdir: []const u8) void {
+    const path = sentinelPath(allocator, destdir) catch return;
+    defer allocator.free(path);
+    std.fs.deleteFileAbsolute(path) catch {};
+}
+
 pub fn writeImuUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan) !void {
     const rules_path = try std.fmt.allocPrint(allocator, "{s}/90-padctl.rules", .{plan.udev_dir});
     defer allocator.free(rules_path);
@@ -200,7 +264,9 @@ pub fn installUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan, 
 
     const driver_rules_path = try std.fmt.allocPrint(allocator, "{s}/61-padctl-driver-block.rules", .{plan.udev_dir});
     defer allocator.free(driver_rules_path);
-    generateDriverBlockRulesFromEntries(allocator, entries, driver_rules_path) catch |err| {
+    const sentinel = try sentinelPath(allocator, plan.opts.destdir);
+    defer allocator.free(sentinel);
+    generateDriverBlockRulesFromEntries(allocator, entries, driver_rules_path, sentinel) catch |err| {
         var errbuf: [256]u8 = undefined;
         const msg = std.fmt.bufPrint(&errbuf, "warning: driver block rules not generated: {}\n", .{err}) catch "warning: driver block rules error\n";
         _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch {};
@@ -209,8 +275,10 @@ pub fn installUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan, 
     // Evict already-attached devices without waiting for reboot.
     // udevadm trigger only sends add events; bind rules fire on the next
     // plug cycle. Proactively writing to sysfs unbind covers devices that
-    // are already claimed by a blocking driver at install time.
-    if (!plan.staging_mode and plan.is_root) {
+    // are already claimed by a blocking driver at install time — but only
+    // when this install actually starts a runnable service (issue #137),
+    // otherwise an unbound device would be left ownerless.
+    if (!plan.staging_mode and plan.is_root and shouldProactiveUnbind(plan)) {
         probeAndUnbindDrivers(allocator, entries, "");
     }
 }
@@ -358,7 +426,7 @@ fn generateUdevRulesFromDirs(allocator: std.mem.Allocator, dirs: []const []const
     try generateUdevRulesFromEntries(allocator, entries.items, rules_path, prefix);
 }
 
-pub fn generateDriverBlockRulesFromEntries(allocator: std.mem.Allocator, entries: []const UdevEntry, rules_path: []const u8) !void {
+pub fn generateDriverBlockRulesFromEntries(allocator: std.mem.Allocator, entries: []const UdevEntry, rules_path: []const u8, sentinel_path: []const u8) !void {
     var has_blocks = false;
     for (entries) |e| {
         if (e.block_kernel_drivers.len > 0) {
@@ -378,10 +446,28 @@ pub fn generateDriverBlockRulesFromEntries(allocator: std.mem.Allocator, entries
 
     for (entries) |e| {
         for (e.block_kernel_drivers) |driver| {
+            // Unbind only when the service-enabled sentinel exists. If padctl
+            // is not deployed/enabled the sentinel is absent, `test -e` fails,
+            // `&&` short-circuits, and xpad keeps the device so the controller
+            // still works as a plain kernel gamepad (issue #137 fail-safe).
             const line = try std.fmt.allocPrint(
                 allocator,
-                "ACTION==\"add|bind\", SUBSYSTEM==\"usb\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", DRIVER==\"{s}\", RUN+=\"/bin/sh -c 'echo %k > /sys/bus/usb/drivers/{s}/unbind'\"\n# {s}\n",
-                .{ e.vid, e.pid, driver, driver, e.name },
+                "ACTION==\"add|bind\", SUBSYSTEM==\"usb\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", DRIVER==\"{s}\", RUN+=\"/bin/sh -c 'test -e {s} && echo %k > /sys/bus/usb/drivers/{s}/unbind'\"\n# {s}\n",
+                .{ e.vid, e.pid, driver, sentinel_path, driver, e.name },
+            );
+            defer allocator.free(line);
+            try buf.appendSlice(allocator, line);
+        }
+    }
+
+    // On device removal, rebind the kernel driver (or modprobe it) so a stale
+    // unbind never persists across replug when padctl is no longer enabled.
+    for (entries) |e| {
+        for (e.block_kernel_drivers) |driver| {
+            const line = try std.fmt.allocPrint(
+                allocator,
+                "ACTION==\"remove\", SUBSYSTEM==\"usb\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", RUN+=\"/bin/sh -c 'test -e {s} && echo %k > /sys/bus/usb/drivers/{s}/bind || /sbin/modprobe {s}'\"\n",
+                .{ e.vid, e.pid, sentinel_path, driver, driver },
             );
             defer allocator.free(line);
             try buf.appendSlice(allocator, line);
@@ -397,7 +483,7 @@ pub fn generateDriverBlockRulesFromEntries(allocator: std.mem.Allocator, entries
 fn generateDriverBlockRules(allocator: std.mem.Allocator, dirs: []const []const u8, rules_path: []const u8) !void {
     var entries = try collectDeviceEntries(allocator, dirs);
     defer freeDeviceEntries(allocator, &entries);
-    try generateDriverBlockRulesFromEntries(allocator, entries.items, rules_path);
+    try generateDriverBlockRulesFromEntries(allocator, entries.items, rules_path, "/etc/padctl/service-enabled");
 }
 
 /// Walk <sys_root>/sys/bus/usb/drivers/<driver>/ and synchronously unbind any
@@ -598,6 +684,7 @@ pub const _internals_for_tests = struct {
     pub const collectDeviceEntries = @import("udev.zig").collectDeviceEntries;
     pub const generateUdevRules = @import("udev.zig").generateUdevRules;
     pub const generateDriverBlockRules = @import("udev.zig").generateDriverBlockRules;
+    pub const generateDriverBlockRulesFromEntries = @import("udev.zig").generateDriverBlockRulesFromEntries;
 };
 
 // setupTestUdev writes a udev rule that grants world-read access to UHID virtual

--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -97,9 +97,6 @@ pub fn writeServiceSentinel(allocator: std.mem.Allocator, plan: *const InstallPl
     var f = try std.fs.createFileAbsolute(path, .{ .truncate = true });
     defer f.close();
     try f.writeAll(content);
-    _ = std.posix.write(std.posix.STDOUT_FILENO, "  ") catch {};
-    _ = std.posix.write(std.posix.STDOUT_FILENO, path) catch {};
-    _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
 }
 
 /// Remove the service-enabled sentinel. Idempotent: a missing file is success

--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -449,8 +449,8 @@ pub fn generateDriverBlockRulesFromEntries(allocator: std.mem.Allocator, entries
             // still works as a plain kernel gamepad (issue #137 fail-safe).
             const line = try std.fmt.allocPrint(
                 allocator,
-                "ACTION==\"add|bind\", SUBSYSTEM==\"usb\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", DRIVER==\"{s}\", RUN+=\"/bin/sh -c 'test -e {s} && echo %k > /sys/bus/usb/drivers/{s}/unbind'\"\n# {s}\n",
-                .{ e.vid, e.pid, driver, sentinel_path, driver, e.name },
+                "ACTION==\"add|bind\", SUBSYSTEM==\"usb\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", DRIVER==\"{s}\", RUN+=\"/bin/sh -c 'echo %k > /sys/bus/usb/drivers/{s}/unbind'\"\n# {s}\n",
+                .{ e.vid, e.pid, driver, driver, e.name },
             );
             defer allocator.free(line);
             try buf.appendSlice(allocator, line);


### PR DESCRIPTION
Throwaway: #256 with sentinel gate dropped from add|bind unbind line (compiles; reintroduces #137 bug). Expect test 'install: #137 every unbind line is sentinel-gated' FAILS. Auto-closed by dispatcher.