### PR TITLE
test(ci): sentinel mechanism scenarios A/B/C in install-flow sandbox (issue #137 Wave 2)

### DIFF
--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -134,18 +134,27 @@ jobs:
               echo "=== sentinel mechanism invariants (Scenario A: enabled install) ==="
               FAIL=0
 
+              # Literal single quotes inside this docker -c argument (the whole
+              # script is single-quoted by the host runner shell) would prematurely
+              # close the host single-quote and corrupt parsing. Keep every check
+              # predicate single-quote-free: the sentinel-gate substring lives in a
+              # double-quoted variable and grep -F matches it verbatim.
+              SENTINEL=/etc/padctl/service-enabled
+              SENTINEL_GATE="test -e ${SENTINEL} && "
+              RULE=/usr/local/lib/udev/rules.d/61-padctl-driver-block.rules
+
               check "61 driver-block rule exists" \
-                "[ -f /usr/local/lib/udev/rules.d/61-padctl-driver-block.rules ]"
+                "[ -f \"\$RULE\" ]"
 
               check "61 rule unbind is sentinel-gated" \
-                "grep -q 'test -e /etc/padctl/service-enabled && ' /usr/local/lib/udev/rules.d/61-padctl-driver-block.rules"
+                "grep -qF -- \"\$SENTINEL_GATE\" \"\$RULE\""
 
               check "sentinel present after enabled install" \
-                "[ -e /etc/padctl/service-enabled ]"
+                "[ -e \"\$SENTINEL\" ]"
 
               mkdir -p /tmp/fakesys && : > /tmp/fakesys/unbind
               check "predicate-true reaches unbind" \
-                "/bin/sh -c 'test -e /etc/padctl/service-enabled && echo 1-1:1.0 > /tmp/fakesys/unbind'; [ -s /tmp/fakesys/unbind ]"
+                "{ [ -e \"\$SENTINEL\" ] && printf %s 1-1:1.0 > /tmp/fakesys/unbind; }; [ -s /tmp/fakesys/unbind ]"
 
               if [ $FAIL -ne 0 ]; then
                 echo "=== SCENARIO A FAILED ==="
@@ -161,14 +170,14 @@ jobs:
               FAIL=0
 
               check "61 rule still sentinel-gated after --no-enable" \
-                "grep -q 'test -e /etc/padctl/service-enabled && ' /usr/local/lib/udev/rules.d/61-padctl-driver-block.rules"
+                "grep -qF -- \"\$SENTINEL_GATE\" \"\$RULE\""
 
               check "NO sentinel under --no-enable" \
-                "[ ! -e /etc/padctl/service-enabled ]"
+                "[ ! -e \"\$SENTINEL\" ]"
 
               : > /tmp/fakesys/unbind
               check "predicate-false skips unbind" \
-                "/bin/sh -c 'test -e /etc/padctl/service-enabled && echo X > /tmp/fakesys/unbind'; [ ! -s /tmp/fakesys/unbind ]"
+                "{ [ -e \"\$SENTINEL\" ] && printf %s X > /tmp/fakesys/unbind; }; [ ! -s /tmp/fakesys/unbind ]"
 
               if [ $FAIL -ne 0 ]; then
                 echo "=== SCENARIO B FAILED ==="

--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -50,6 +50,20 @@ jobs:
               cp /opt/padctl/bin/padctl /usr/local/bin/padctl
               chmod +x /usr/local/bin/padctl
 
+              # Pre-stage device TOMLs at the installed-package share path.
+              # The binary lives at /usr/local/bin/padctl and the install runs
+              # from testuser HOME (su - login shell), so install.findDevicesSourceDir
+              # finds no source `devices/` near the binary or in cwd — exactly the
+              # real deb/AUR scenario where the package already shipped device
+              # configs into <prefix>/share/padctl/devices. installDeviceConfigs
+              # then takes the "package already shipped" branch and
+              # collectAllDeviceEntries scans share_dir, so vader5.toml
+              # (block_kernel_drivers=["xpad"]) drives generateDriverBlockRules
+              # to emit 61-padctl-driver-block.rules. Without this, no device
+              # TOMLs are scanned and the 61 rule is never written.
+              mkdir -p /usr/local/share/padctl/devices
+              cp -r /opt/padctl/devices/. /usr/local/share/padctl/devices/
+
               # ---- install ----
               # Run as testuser so SUDO_USER is set when they call sudo padctl install.
               # udevadm/systemctl calls inside padctl will fail silently (no daemon) —
@@ -104,6 +118,19 @@ jobs:
               fi
 
               # ---- Scenario A: enabled install => sentinel-gated rule + predicate-true reaches unbind ----
+              # Sandbox install: sudo SUDO_USER=testuser ... padctl install --prefix /usr/local
+              #   - is_root=true (sudo), destdir="" => staging_mode=false
+              #   - detectImmutableOs("")=.none in privileged debian:12 (writable /usr,
+              #     no /run/ostree-booted) => effective_immutable=false
+              #   - resolveUdevDir(destdir="",prefix="/usr/local",imm=false)
+              #     => /usr/local/lib/udev/rules.d  (plan.zig:65-70)
+              #   - installWillStartUserService(true,null,"","testuser")=true
+              #     => do_enable_systemctl = !staging && true = true  (plan.zig:383)
+              #   - shouldProactiveUnbind = do_enable_systemctl && !no_enable = true
+              #     => writeServiceSentinel runs (sentinelPath("")=/etc/padctl/service-enabled),
+              #        independent of the systemctl --user warn-fail (no user bus)
+              #   - device TOMLs pre-staged at /usr/local/share/padctl/devices => vader5
+              #     block_kernel_drivers=["xpad"] => 61 rule emitted, sentinel-gated.
               echo "=== sentinel mechanism invariants (Scenario A: enabled install) ==="
               FAIL=0
 

--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -103,6 +103,58 @@ jobs:
                 exit 1
               fi
 
+              # ---- Scenario A: enabled install => sentinel-gated rule + predicate-true reaches unbind ----
+              echo "=== sentinel mechanism invariants (Scenario A: enabled install) ==="
+              FAIL=0
+
+              check "61 driver-block rule exists" \
+                "[ -f /usr/local/lib/udev/rules.d/61-padctl-driver-block.rules ]"
+
+              check "61 rule unbind is sentinel-gated" \
+                "grep -q 'test -e /etc/padctl/service-enabled && ' /usr/local/lib/udev/rules.d/61-padctl-driver-block.rules"
+
+              check "sentinel present after enabled install" \
+                "[ -e /etc/padctl/service-enabled ]"
+
+              mkdir -p /tmp/fakesys && : > /tmp/fakesys/unbind
+              check "predicate-true reaches unbind" \
+                "/bin/sh -c 'test -e /etc/padctl/service-enabled && echo 1-1:1.0 > /tmp/fakesys/unbind'; [ -s /tmp/fakesys/unbind ]"
+
+              if [ $FAIL -ne 0 ]; then
+                echo "=== SCENARIO A FAILED ==="
+                exit 1
+              fi
+
+              # ---- Scenario B: --no-enable install => no sentinel => predicate-false skips unbind ----
+              su - testuser -c "sudo SUDO_USER=testuser SUDO_UID=$(id -u testuser) \
+                HOME=/home/testuser \
+                /usr/local/bin/padctl install --prefix /usr/local --no-enable 2>&1"
+
+              echo "=== sentinel mechanism invariants (Scenario B: --no-enable install) ==="
+              FAIL=0
+
+              check "61 rule still sentinel-gated after --no-enable" \
+                "grep -q 'test -e /etc/padctl/service-enabled && ' /usr/local/lib/udev/rules.d/61-padctl-driver-block.rules"
+
+              check "NO sentinel under --no-enable" \
+                "[ ! -e /etc/padctl/service-enabled ]"
+
+              : > /tmp/fakesys/unbind
+              check "predicate-false skips unbind" \
+                "/bin/sh -c 'test -e /etc/padctl/service-enabled && echo X > /tmp/fakesys/unbind'; [ ! -s /tmp/fakesys/unbind ]"
+
+              if [ $FAIL -ne 0 ]; then
+                echo "=== SCENARIO B FAILED ==="
+                exit 1
+              fi
+
+              rm -rf /tmp/fakesys
+
+              # Re-install with enabled so sentinel exists for uninstall to remove (Scenario C)
+              su - testuser -c "sudo SUDO_USER=testuser SUDO_UID=$(id -u testuser) \
+                HOME=/home/testuser \
+                /usr/local/bin/padctl install --prefix /usr/local 2>&1"
+
               # ---- uninstall ----
               su - testuser -c "sudo SUDO_USER=testuser SUDO_UID=$(id -u testuser) \
                 HOME=/home/testuser \
@@ -116,6 +168,10 @@ jobs:
 
               check "/etc/systemd/user/padctl.service removed after uninstall" \
                 "[ ! -f /etc/systemd/user/padctl.service ]"
+
+              # ---- Scenario C: uninstall removes the sentinel ----
+              check "sentinel removed after uninstall" \
+                "[ ! -e /etc/padctl/service-enabled ]"
 
               if [ $FAIL -ne 0 ]; then
                 echo "=== UNINSTALL INVARIANTS FAILED ==="


### PR DESCRIPTION
## What changed

- Extended `.github/workflows/install-flow.yml` `install-sandbox` job with three Wave-2 on-disk scenario checks for the Wave-1 sentinel mechanism (`99f7ad5`).

**Scenario A** (after existing post-install invariants):
- `61-padctl-driver-block.rules` exists at the expected path
- The rule contains the sentinel gate (`test -e /etc/padctl/service-enabled && `)
- `/etc/padctl/service-enabled` sentinel is present after an enabled install
- fakesys simulation: predicate-true (sentinel exists) → unbind path is reached (`echo 1-1:1.0 >`)

**Scenario B** (`--no-enable` reinstall mid-flow):
- The 61 rule is still sentinel-gated (rule content unchanged)
- `/etc/padctl/service-enabled` is absent after `--no-enable` install
- fakesys simulation: predicate-false (no sentinel) → unbind is skipped (file stays empty)

**Scenario C** (check appended to existing uninstall invariants block):
- A third enabled reinstall restores the sentinel before the existing uninstall runs
- After uninstall: `/etc/padctl/service-enabled` is absent

## Ordering preservation

All existing invariant checks are unmodified. Scenario A runs after the existing post-install `FAIL` guard. Scenario B is a mid-flow reinstall with `--no-enable`. A third enabled `install` call before the existing uninstall ensures the existing uninstall invariants (`padctl removed`, `padctl.service removed`) continue to pass. Scenario C's check is appended inside the existing uninstall `FAIL` block.

## Test plan

- [ ] CI `install / rootless-docker sandbox` job passes with all new `check` calls emitting `PASS`
- [ ] No existing checks removed or weakened
- [ ] Only `.github/workflows/install-flow.yml` changed

refs: `openspec/changes/issue-137-wave2/tasks.md`