### PR TITLE
chore(release): bump 0.1.7

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.6",
+    .version = "0.1.7",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
Bump build.zig.zon 0.1.6 -> 0.1.7 to cut the v0.1.7 release. Carries #137 Wave 1 (conditional xpad driver-block via service-enabled sentinel) + Wave 2 (install-flow scenarios), #248 status-stem fix, #215 negate single-point saturation, wave6-probe cleanup, and the release.yml verify/idempotent root-fixes (#250/#251).

Test plan: CI; release.yml asserts the v0.1.7 tag matches build.zig.zon before building (version single-sourced since #218).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.1.7

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->