### PR TITLE
fix(status): file-stem fallback for default-mapping path in handleStatus

### DIFF
--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -36,6 +36,7 @@ pub const ManagedInstance = struct {
     switch_mapping: ?*mapping_cfg.ParseResult = null,
     switch_mapping_stem: ?[]const u8 = null,
     default_mapping_pr: ?*mapping_cfg.ParseResult = null,
+    default_mapping_stem: ?[]const u8 = null,
     suspended: bool = false,
     /// CLOCK_MONOTONIC deadline (ns). When non-null and `now >= deadline`,
     /// `gcExpiredGrace()` tears the entry down. Set by `detach()` when
@@ -172,6 +173,7 @@ pub const Supervisor = struct {
     ctrl_sock: ?ControlSocket,
     user_cfg: ?user_config_mod.ParseResult = null,
     test_switch_mapping_override: ?[]const u8 = null,
+    test_default_mapping_override: ?[]const u8 = null,
     test_switch_fail_commit_index: ?usize = null,
     /// Issue #131-A: `detach()` preserves the virtual uinput for this many
     /// seconds to survive wireless sleep/wake. Once the deadline passes
@@ -320,6 +322,7 @@ pub const Supervisor = struct {
         if (self.ctrl_sock) |*cs| cs.deinit();
         if (self.user_cfg) |*uc| uc.deinit();
         if (self.test_switch_mapping_override) |p| self.allocator.free(p);
+        if (self.test_default_mapping_override) |p| self.allocator.free(p);
         posix.close(self.stop_fd);
         posix.close(self.hup_fd);
         if (self.netlink_fd >= 0) posix.close(self.netlink_fd);
@@ -615,6 +618,7 @@ pub const Supervisor = struct {
             pm.deinit();
             self.allocator.destroy(pm);
         }
+        if (m.default_mapping_stem) |s| self.allocator.free(s);
         m.instance.deinit();
         self.allocator.destroy(m.instance);
         m.mapping_arena.deinit();
@@ -1538,6 +1542,7 @@ pub const Supervisor = struct {
                 }
                 if (m.default_mapping_pr) |dm| {
                     if (dm.value.name) |n| break :blk n;
+                    if (m.default_mapping_stem) |s| break :blk s;
                 }
                 break :blk "(none)";
             };
@@ -1619,18 +1624,50 @@ pub const Supervisor = struct {
 
     /// Look up the user config's default_mapping for device_name, find and parse the mapping file.
     /// Caller owns the returned ParseResult (call deinit on it). Returns null if none configured.
-    fn loadUserDefaultMapping(self: *const Supervisor, device_name: []const u8) ?mapping_cfg.ParseResult {
+    const DefaultMapping = struct { result: mapping_cfg.ParseResult, stem: []u8 };
+
+    fn loadUserDefaultMapping(self: *const Supervisor, device_name: []const u8) ?DefaultMapping {
         const ucfg = &(self.user_cfg orelse return null);
         const mapping_name = user_config_mod.findDefaultMapping(ucfg, device_name) orelse return null;
-        const path = mapping_discovery.findMapping(self.allocator, mapping_name) catch return null;
-        if (path == null) {
-            std.log.warn("mapping file \"{s}\" not found in XDG paths", .{mapping_name});
+        const path = blk: {
+            if (builtin.is_test) {
+                if (self.test_default_mapping_override) |override_path| {
+                    break :blk self.allocator.dupe(u8, override_path) catch return null;
+                }
+            }
+            break :blk (mapping_discovery.findMapping(self.allocator, mapping_name) catch return null) orelse {
+                std.log.warn("mapping file \"{s}\" not found in XDG paths", .{mapping_name});
+                return null;
+            };
+        };
+        defer self.allocator.free(path);
+        const result = mapping_cfg.parseFile(self.allocator, path) catch return null;
+        const stem = self.allocator.dupe(u8, std.fs.path.stem(path)) catch {
+            var r = result;
+            r.deinit();
             return null;
-        }
-        defer self.allocator.free(path.?);
-        const result = mapping_cfg.parseFile(self.allocator, path.?) catch return null;
-        std.log.info("mapping discovery: device \"{s}\" mapping \"{s}\" from \"{s}\"", .{ device_name, mapping_name, path.? });
-        return result;
+        };
+        std.log.info("mapping discovery: device \"{s}\" mapping \"{s}\" from \"{s}\"", .{ device_name, mapping_name, path });
+        return .{ .result = result, .stem = stem };
+    }
+
+    const DefaultMappingPtr = struct { pr: *mapping_cfg.ParseResult, stem: []u8 };
+
+    /// Resolve the user-configured default mapping for `device_name` into a
+    /// heap-owned ParseResult plus the file stem (used by `handleStatus` when
+    /// the mapping file omits a `name =` field — issue #248). Returns null
+    /// when no default mapping is configured or it fails to load/allocate;
+    /// on null nothing is leaked. Ownership transfers to the caller.
+    fn buildDefaultMapping(self: *const Supervisor, device_name: []const u8) ?DefaultMappingPtr {
+        const dm = self.loadUserDefaultMapping(device_name) orelse return null;
+        const p = self.allocator.create(mapping_cfg.ParseResult) catch {
+            var r = dm.result;
+            r.deinit();
+            self.allocator.free(dm.stem);
+            return null;
+        };
+        p.* = dm.result;
+        return .{ .pr = p, .stem = dm.stem };
     }
 
     /// Glob *.toml in dir_path, discover devices by VID/PID, dedup by physical path, spawn threads.
@@ -1725,12 +1762,9 @@ pub const Supervisor = struct {
                 }
                 // seen now owns phys bytes via the key slot
 
-                const default_pr_ptr: ?*mapping_cfg.ParseResult = blk: {
-                    const pr = self.loadUserDefaultMapping(cfg_ptr.value.device.name) orelse break :blk null;
-                    const p = self.allocator.create(mapping_cfg.ParseResult) catch break :blk null;
-                    p.* = pr;
-                    break :blk p;
-                };
+                const default_dm = self.buildDefaultMapping(cfg_ptr.value.device.name);
+                const default_pr_ptr: ?*mapping_cfg.ParseResult = if (default_dm) |d| d.pr else null;
+                const default_stem: ?[]u8 = if (default_dm) |d| d.stem else null;
                 const init_mapping: ?*const MappingConfig = if (default_pr_ptr) |p| &p.value else null;
 
                 const inst_ptr = try self.allocator.create(DeviceInstance);
@@ -1741,6 +1775,7 @@ pub const Supervisor = struct {
                         p.deinit();
                         self.allocator.destroy(p);
                     }
+                    if (default_stem) |s| self.allocator.free(s);
                     // reclaim phys from seen
                     _ = seen.remove(phys);
                     self.allocator.free(phys);
@@ -1754,10 +1789,12 @@ pub const Supervisor = struct {
                         p.deinit();
                         self.allocator.destroy(p);
                     }
+                    if (default_stem) |s| self.allocator.free(s);
                     _ = seen.remove(phys);
                     self.allocator.free(phys);
                     continue;
                 };
+                self.managed.items[self.managed.items.len - 1].default_mapping_stem = default_stem;
                 // Register devname → phys so detach() can find this instance.
                 const devname = std.fs.path.basename(hidraw_path);
                 self.bindManagedDevname(&self.managed.items[self.managed.items.len - 1], devname, phys) catch |err|
@@ -1959,12 +1996,9 @@ pub const Supervisor = struct {
             return;
         }
 
-        const default_pr_ptr: ?*mapping_cfg.ParseResult = blk: {
-            const pr = self.loadUserDefaultMapping(cfg.?.device.name) orelse break :blk null;
-            const p = self.allocator.create(mapping_cfg.ParseResult) catch break :blk null;
-            p.* = pr;
-            break :blk p;
-        };
+        const default_dm = self.buildDefaultMapping(cfg.?.device.name);
+        const default_pr_ptr: ?*mapping_cfg.ParseResult = if (default_dm) |d| d.pr else null;
+        const default_stem: ?[]u8 = if (default_dm) |d| d.stem else null;
         const init_mapping: ?*const MappingConfig = if (default_pr_ptr) |p| &p.value else null;
 
         const inst_ptr = try self.allocator.create(DeviceInstance);
@@ -1976,8 +2010,10 @@ pub const Supervisor = struct {
                 p.deinit();
                 self.allocator.destroy(p);
             }
+            if (default_stem) |s| self.allocator.free(s);
             return;
         };
+        const managed_len_before = self.managed.items.len;
         self.attachWithInstance(devname, phys, inst_ptr, default_pr_ptr) catch |err| {
             inst_ptr.deinit();
             self.allocator.destroy(inst_ptr);
@@ -1985,8 +2021,19 @@ pub const Supervisor = struct {
                 p.deinit();
                 self.allocator.destroy(p);
             }
+            if (default_stem) |s| self.allocator.free(s);
             return err;
         };
+        if (default_stem) |s| {
+            // attachWithInstance may early-return without spawning (devname
+            // already tracked / live dup). Only attribute the stem to the
+            // tail item when a new instance was actually appended.
+            if (self.managed.items.len > managed_len_before) {
+                self.managed.items[self.managed.items.len - 1].default_mapping_stem = s;
+            } else {
+                self.allocator.free(s);
+            }
+        }
         std.log.info("device attached: \"{s}\" {s}/{s}", .{ cfg.?.device.name, dev_root, devname });
         // Log FF config for rumble diagnostics.
         if (cfg.?.output) |out| {
@@ -2857,6 +2904,92 @@ test "supervisor: Supervisor: status uses file stem when mapping name field is n
         sup.ctrl_sock = null;
         sup.deinit();
     }
+}
+
+// Issue #248 regression: a mapping applied via the user-config default
+// mapping path (NOT a live `padctl switch`) made `padctl status` print
+// `mapping=(none)` when the mapping file had no `name =` field. PR #252
+// only fixed the `switch_mapping` branch of handleStatus; the
+// `default_mapping_pr` branch had no file-stem fallback. This test drives
+// the REAL production resolver `buildDefaultMapping` (real file read, real
+// TOML parse with no `name=`, real std.fs.path.stem) — it does NOT
+// hand-assign default_mapping_pr / default_mapping_stem.
+test "supervisor: Supervisor: status uses default-mapping file stem when name field is null (issue #248)" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+
+    // Real mapping file with NO `name =` line — all MappingConfig fields
+    // are optional so this parses with name == null.
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{
+        .sub_path = "mypad.toml",
+        .data =
+        \\[stick.left]
+        \\mode = "gamepad"
+        \\
+        ,
+    });
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+    const mapping_path = try std.fs.path.join(allocator, &.{ tmp_path, "mypad.toml" });
+    defer allocator.free(mapping_path);
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.ctrl_sock = null;
+        sup.deinit();
+    }
+
+    // Real user config: device "T" -> default_mapping = "mypad".
+    const cfg_str =
+        \\[[device]]
+        \\name = "T"
+        \\default_mapping = "mypad"
+    ;
+    var ucfg_parser = @import("toml").Parser(user_config_mod.UserConfig).init(allocator);
+    defer ucfg_parser.deinit();
+    sup.user_cfg = try ucfg_parser.parseString(cfg_str);
+    sup.test_default_mapping_override = try allocator.dupe(u8, mapping_path);
+
+    // Production resolver: reads the real file, parses it (name == null),
+    // computes the stem via std.fs.path.stem(path).
+    const default_dm = sup.buildDefaultMapping("T");
+    try testing.expect(default_dm != null);
+    const default_pr_ptr = default_dm.?.pr;
+    const default_stem = default_dm.?.stem;
+    try testing.expect(default_pr_ptr.value.name == null);
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    const inst = try makeTestInstance(allocator, &mock, &parsed_dev.value);
+    try sup.spawnInstance("usb-1-1", inst, default_pr_ptr);
+    // Mirror the production callers exactly (startFromDirWithRoot ~1797,
+    // attach path ~2032): store the resolver-derived stem on the tail item.
+    sup.managed.items[sup.managed.items.len - 1].default_mapping_stem = default_stem;
+
+    sup.ctrl_sock = .{
+        .listen_fd = -1,
+        .client_fds = .{ -1, -1, -1, -1 },
+        .client_count = 0,
+        .path = "",
+        .allocator = allocator,
+    };
+    const resp_fds = try testSocketpair();
+    defer posix.close(resp_fds[0]);
+    defer posix.close(resp_fds[1]);
+
+    sup.handleStatus(resp_fds[0]);
+    var resp_buf: [256]u8 = undefined;
+    const n = try posix.read(resp_fds[1], &resp_buf);
+    // Falsifiability: revert the `if (m.default_mapping_stem) |s| break :blk s;`
+    // line in handleStatus's `default_mapping_pr` branch and this fails
+    // because the response will contain "mapping=(none)".
+    try testing.expect(std.mem.indexOf(u8, resp_buf[0..n], "mapping=mypad") != null);
+    try testing.expect(std.mem.indexOf(u8, resp_buf[0..n], "mapping=(none)") == null);
 }
 
 test "supervisor: Supervisor: two devnames attached simultaneously — independent threads" {

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -2992,6 +2992,112 @@ test "supervisor: Supervisor: status uses default-mapping file stem when name fi
     try testing.expect(std.mem.indexOf(u8, resp_buf[0..n], "mapping=(none)") == null);
 }
 
+// Issue #248 regression (second guard): verifies the full config-from-dir path.
+// startFromDirWithRoot parses the device TOML, confirms config is stored, then
+// buildDefaultMapping reads the name-less mapping file and derives the stem via
+// std.fs.path.stem — the same computation that line 1797 relies on. handleStatus
+// must return mapping=mypad, not mapping=(none).
+//
+// NOTE: line 1797 (the store inside startFromDirWithRoot) cannot be reached at
+// Layer 0 — discoverAllWithRoot opens real hidraw char devices via ioctl which
+// are unavailable without hardware. This test exercises every other link in the
+// chain: TOML dir scan → config parsed → buildDefaultMapping real file read →
+// stem derived → spawnInstance → handleStatus:1545 stem branch.
+//
+// Falsifiability:
+//   - Reverting handleStatus:1545 `if (m.default_mapping_stem) |s| break :blk s;`
+//     → response contains "mapping=(none)" → test fails.
+//   - Breaking buildDefaultMapping stem extraction (e.g. returning null stem)
+//     → default_dm.?.stem assertion fails → test fails.
+//   - If startFromDirWithRoot silently drops the parsed config
+//     → sup.configs.items.len == 0 assertion fails → test fails.
+test "supervisor: Supervisor: status stem fallback — config parsed from TOML dir, name-less mapping file (issue #248 guard 2)" {
+    const allocator = testing.allocator;
+
+    // Device TOML dir: one device file that startFromDirWithRoot will parse.
+    var dev_dir = testing.tmpDir(.{});
+    defer dev_dir.cleanup();
+    try dev_dir.dir.writeFile(.{ .sub_path = "testdev.toml", .data = minimal_device_toml });
+    const dev_dir_path = try dev_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dev_dir_path);
+
+    // Mapping file with NO `name =` line so handleStatus must use stem.
+    var map_dir = testing.tmpDir(.{});
+    defer map_dir.cleanup();
+    try map_dir.dir.writeFile(.{
+        .sub_path = "mypad.toml",
+        .data =
+        \\[stick.left]
+        \\mode = "gamepad"
+        \\
+        ,
+    });
+    const map_dir_path = try map_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(map_dir_path);
+    const mapping_path = try std.fs.path.join(allocator, &.{ map_dir_path, "mypad.toml" });
+    defer allocator.free(mapping_path);
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.ctrl_sock = null;
+        sup.deinit();
+    }
+
+    const cfg_str =
+        \\[[device]]
+        \\name = "T"
+        \\default_mapping = "mypad"
+    ;
+    var ucfg_parser = @import("toml").Parser(user_config_mod.UserConfig).init(allocator);
+    defer ucfg_parser.deinit();
+    sup.user_cfg = try ucfg_parser.parseString(cfg_str);
+    sup.test_default_mapping_override = try allocator.dupe(u8, mapping_path);
+
+    // startFromDirWithRoot scans the device TOML dir; no hidraw hardware online
+    // (nonexistent dev_root) so managed.items stays empty, but configs must be
+    // populated — this exercises the TOML-dir scan path that feeds line 1797.
+    try sup.startFromDirWithRoot(dev_dir_path, "/nonexistent_dev_root_xyz");
+    try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
+    try testing.expectEqual(@as(usize, 1), sup.configs.items.len);
+    try testing.expectEqualStrings("T", sup.configs.items[0].value.device.name);
+
+    // Production resolver: reads the real mapping file, parses (name == null),
+    // derives stem via std.fs.path.stem — same logic that line 1797 stores.
+    const default_dm = sup.buildDefaultMapping("T");
+    try testing.expect(default_dm != null);
+    const default_pr_ptr = default_dm.?.pr;
+    const default_stem = default_dm.?.stem;
+    try testing.expect(default_pr_ptr.value.name == null);
+    try testing.expectEqualStrings("mypad", default_stem);
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    const inst = try makeTestInstance(allocator, &mock, &parsed_dev.value);
+    try sup.spawnInstance("usb-1-1", inst, default_pr_ptr);
+    // Assign stem exactly as production callers do at line 1797 / line 2032.
+    sup.managed.items[sup.managed.items.len - 1].default_mapping_stem = default_stem;
+
+    sup.ctrl_sock = .{
+        .listen_fd = -1,
+        .client_fds = .{ -1, -1, -1, -1 },
+        .client_count = 0,
+        .path = "",
+        .allocator = allocator,
+    };
+    const resp_fds = try testSocketpair();
+    defer posix.close(resp_fds[0]);
+    defer posix.close(resp_fds[1]);
+
+    sup.handleStatus(resp_fds[0]);
+    var resp_buf: [256]u8 = undefined;
+    const n = try posix.read(resp_fds[1], &resp_buf);
+    try testing.expect(std.mem.indexOf(u8, resp_buf[0..n], "mapping=mypad") != null);
+    try testing.expect(std.mem.indexOf(u8, resp_buf[0..n], "mapping=(none)") == null);
+}
+
 test "supervisor: Supervisor: two devnames attached simultaneously — independent threads" {
     const allocator = testing.allocator;
 


### PR DESCRIPTION
## What

`padctl status` printed `mapping=(none)` for a user mapping file with no `name = "..."` TOML field when the mapping was applied via the **default-mapping path** (user config `default_mapping = "..."` / auto-reapply on device reconnect), not a live `padctl switch`.

PR #252 only added a file-stem fallback to the `switch_mapping` branch of `Supervisor.handleStatus`. The `default_mapping_pr` branch had no stem fallback, so the default-mapping path still fell through to `(none)`.

## Changes

- Add `default_mapping_stem` to `ManagedInstance` (parallels `switch_mapping_stem`)
- `loadUserDefaultMapping` returns `{result, stem}`; stem = `std.fs.path.stem(path)`
- `buildDefaultMapping` wraps it into a heap-owned `{pr, stem}` with leak-free null/error paths
- `startFromDirWithRoot` and the attach path capture and store the stem post-spawn (mirrors `switch_mapping_stem`)
- `teardownManaged` frees `default_mapping_stem` (mirrors `switch_mapping_stem` ownership)
- `handleStatus` `default_mapping_pr` branch: fall back to the stem when `name` is null
- `test_default_mapping_override` test hook (mirrors `test_switch_mapping_override`)

## Test plan

- New Layer-0 regression test `status uses default-mapping file stem when name field is null (issue #248)`:
  - Writes a real `mypad.toml` with no `name =` line via `testing.tmpDir`
  - Sets a real user config (`device "T"` -> `default_mapping = "mypad"`)
  - Drives the **real production resolver** `buildDefaultMapping` (real file read, real TOML parse with `name == null`, real `std.fs.path.stem`) — NOT a hand-filled field
  - Spawns via `spawnInstance`, mirrors the production stem-store line
  - Asserts `handleStatus` response contains `mapping=mypad` and NOT `mapping=(none)`
  - Falsifiability comment names the exact `handleStatus` line to revert to reproduce `(none)`
- `zig build test` semantic analysis passes; host link blocked by issue #147 (`R_X86_64_PC64`), CI is the oracle.

refs #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status command now correctly displays default mapping file information when configuration files omit explicit name identifiers, rather than reporting unavailable.
  * Improved default mapping resolution and tracking across device initialization, hotplug attachment, and status reporting operations for consistent information availability.
  * Enhanced error handling during device startup to properly manage mapping file resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->