### PR TITLE
refactor(supervisor): delete dead applySwitchMapping fn

### DIFF
--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -845,6 +845,9 @@ pub const Supervisor = struct {
             return err;
         };
         m.switch_mapping = tx.parsed_ptr;
+        // Invariant (issue #248): switch_mapping_stem must always be set together
+        // with switch_mapping so handleStatus can report the mapping name. Any new
+        // apply-mapping path must derive and assign switch_mapping_stem here.
         m.switch_mapping_stem = tx.path_stem;
         tx.parsed_ptr = null;
         tx.path_stem = null;
@@ -1359,30 +1362,6 @@ pub const Supervisor = struct {
         if (dup and found != null)
             std.log.warn("chord_switch: chord_index={d} matches multiple mappings; using '{s}' (first by name)", .{ chord_index, found.? });
         return found;
-    }
-
-    fn applySwitchMapping(self: *Supervisor, m: *ManagedInstance, parsed_ptr: *mapping_cfg.ParseResult) !void {
-        const new_mapper = try Mapper.init(&parsed_ptr.value, m.instance.loop.macro_timer_fd, self.allocator);
-        m.instance.stop();
-        m.thread.join();
-        self.clearSwitchMapping(m);
-        const old_mcfg = m.instance.mapping_cfg;
-        if (m.instance.mapper) |*old| old.deinit();
-        m.instance.mapper = new_mapper;
-        m.instance.mapping_cfg = &parsed_ptr.value;
-        self.installChordDetector(m);
-        m.instance.rebuildAuxIfChanged(&parsed_ptr.value, old_mcfg) catch |err| {
-            std.log.warn("rebuildAuxIfChanged: {}", .{err});
-        };
-        restartManagedThread(m) catch |err| {
-            if (m.instance.mapper) |*mapper| {
-                mapper.deinit();
-                m.instance.mapper = null;
-            }
-            m.instance.mapping_cfg = null;
-            return err;
-        };
-        m.switch_mapping = parsed_ptr;
     }
 
     fn handleSwitch(self: *Supervisor, fd: posix.fd_t, name: []const u8, device_id: ?[]const u8) void {


### PR DESCRIPTION
## Changes

- Delete `applySwitchMapping` from `src/supervisor.zig` — confirmed zero call sites (exhaustive grep of all src/ and test files on origin/main; only occurrence was the definition itself at line 1364)
- The function had a latent #248-class bug: it called `clearSwitchMapping` (which nulls `switch_mapping_stem`) then set `switch_mapping` without restoring the stem field — if ever wired into a live path, `handleStatus` would regress to reporting `mapping=(none)` for named mappings, exactly the class of regression fixed in #248
- Add an invariant comment at the sole live apply site (`commitSwitchTarget`, line 848) documenting that `switch_mapping` and `switch_mapping_stem` must be set together — guards against a future contributor reintroducing a stem-clearing path that would bypass review

## Test plan

- [ ] `zig build test` on CI (host blocked by #147 `R_X86_64_PC64` linker error; 4/4 compiled tests passed locally)
- [ ] No compile errors introduced — deleting an unused private fn cannot break callers
- [ ] Zig does NOT error on unused private functions (unlike unused variables), so the compiler alone cannot guard against reintroduction; the invariant comment at `commitSwitchTarget` is the best available static guard

## Note on Zig unused-fn behaviour

Zig emits `unused local variable` errors but does **not** error on unused private functions. The compiler therefore cannot prevent a future dead apply path from being reintroduced silently. The guard comment documents the required invariant at the one authoritative call site.

refs #248 #262