### PR TITLE
fix(uninstall): actively rebind xpad after removing #137 driver-block rule

### DIFF
--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -209,6 +209,13 @@ jobs:
               check "sentinel removed after uninstall" \
                 "[ ! -e /etc/padctl/service-enabled ]"
 
+              # ---- issue #137: uninstall removes the generated driver-block
+              # rule symmetrically with 60-padctl.rules (uninstall hygiene). No
+              # real USB/xpad in rootless Docker, so the active rebind itself
+              # is not exercised here — only the file-removal invariant.
+              check "61-padctl-driver-block.rules removed after uninstall" \
+                "[ ! -e /usr/local/lib/udev/rules.d/61-padctl-driver-block.rules ]"
+
               if [ $FAIL -ne 0 ]; then
                 echo "=== UNINSTALL INVARIANTS FAILED ==="
                 exit 1

--- a/src/cli/install/phase.zig
+++ b/src/cli/install/phase.zig
@@ -261,6 +261,23 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     // block_kernel_drivers device is not unbound by a stale udev rule.
     udev.removeServiceSentinel(allocator, destdir);
 
+    // issue #137: the 61-padctl-driver-block rule + sentinel are now gone, so a
+    // controller that is still plugged in and currently unbound from xpad would
+    // otherwise stay unbound until a physical replug (the REMOVE-side modprobe
+    // only fires on a real `remove` uevent). Actively rebind it to the kernel
+    // driver. Only on a live root uninstall (a destdir staging uninstall has no
+    // real sysfs to act on). The share dir is read here before it is removed
+    // below; collectDeviceEntriesForUninstall also reads /etc/padctl/devices.
+    if (destdir.len == 0 and is_root) {
+        const share_dir_for_scan = try std.fmt.allocPrint(allocator, "{s}/share/padctl", .{prefix});
+        defer allocator.free(share_dir_for_scan);
+        if (udev.collectDeviceEntriesForUninstall(allocator, share_dir_for_scan)) |entries| {
+            var ents = entries;
+            defer udev.freeDeviceEntries(allocator, &ents);
+            udev.probeAndRebindDrivers(allocator, ents.items, "");
+        } else |_| {}
+    }
+
     if (effective_user_service) {
         if (std.posix.getenv("HOME")) |home| {
             const user_units = [_][]const u8{

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -3035,7 +3035,9 @@ test "uninstall: #137 probeAndRebindDrivers binds unbound matching interface onl
     {
         const drv = try std.fmt.allocPrint(allocator, "{s}/sys/bus/usb/devices/1-1.4/1-1.4:1.1/driver", .{tmp_path});
         defer allocator.free(drv);
-        try std.posix.symlink("../../../../bus/usb/drivers/xpad", drv);
+        // Relative target must resolve from the symlink's own directory
+        // (.../devices/1-1.4/1-1.4:1.1/): three "../" reach .../bus/usb/.
+        try std.posix.symlink("../../../drivers/xpad", drv);
     }
 
     // bind file: writable regular file simulating the sysfs write target.

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -43,6 +43,7 @@ const freeArgv = services_mod.freeArgv;
 const UdevEntry = udev_mod.UdevEntry;
 const isValidIdentifier = udev_mod.isValidIdentifier;
 const probeAndUnbindDrivers = udev_mod.probeAndUnbindDrivers;
+const probeAndRebindDrivers = udev_mod.probeAndRebindDrivers;
 const readSysHex = udev_mod.readSysHex;
 const findDevicesSourceDir = udev_mod.findDevicesSourceDir;
 const imu_udev_rules_content = udev_mod.imu_udev_rules_content;
@@ -2984,5 +2985,129 @@ test "tomlEscape: round-trip via real TOML parser" {
         const parsed = try parser.parseString(toml_text);
         defer parsed.deinit();
         try std.testing.expectEqualStrings(input, parsed.value.name);
+    }
+}
+
+// issue #137: probeAndRebindDrivers is the inverse of probeAndUnbindDrivers.
+// It must rebind a matching device's unbound interface, leave an already-bound
+// interface alone, and ignore non-matching devices.
+// Falsifiability: deleting the `f.writeAll(child.name)` line in
+// rebindInterfaces (udev.zig) makes the "1-1.4:1.0" bind assertion fail.
+test "uninstall: #137 probeAndRebindDrivers binds unbound matching interface only" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    try tmp.dir.makePath("sys/bus/usb/drivers/xpad");
+    // Matching device 37d7:2401 with an UNBOUND interface (no driver symlink).
+    try tmp.dir.makePath("sys/bus/usb/devices/1-1.4/1-1.4:1.0");
+    // Matching device with an already-BOUND interface (has driver symlink).
+    try tmp.dir.makePath("sys/bus/usb/devices/1-1.4/1-1.4:1.1");
+    // Non-matching device.
+    try tmp.dir.makePath("sys/bus/usb/devices/2-2.1/2-2.1:1.0");
+
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/1-1.4/idVendor", .{});
+        defer f.close();
+        try f.writeAll("37d7\n");
+    }
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/1-1.4/idProduct", .{});
+        defer f.close();
+        try f.writeAll("2401\n");
+    }
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/2-2.1/idVendor", .{});
+        defer f.close();
+        try f.writeAll("0000\n");
+    }
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/2-2.1/idProduct", .{});
+        defer f.close();
+        try f.writeAll("0000\n");
+    }
+
+    // Mark 1-1.4:1.1 as already bound.
+    {
+        const drv = try std.fmt.allocPrint(allocator, "{s}/sys/bus/usb/devices/1-1.4/1-1.4:1.1/driver", .{tmp_path});
+        defer allocator.free(drv);
+        try std.posix.symlink("../../../../bus/usb/drivers/xpad", drv);
+    }
+
+    // bind file: writable regular file simulating the sysfs write target.
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/drivers/xpad/bind", .{});
+        defer f.close();
+    }
+
+    const entries = [_]UdevEntry{.{
+        .name = "Test Device",
+        .vid = 0x37d7,
+        .pid = 0x2401,
+        .block_kernel_drivers = &[_][]const u8{"xpad"},
+    }};
+    probeAndRebindDrivers(allocator, &entries, tmp_path);
+
+    const bind_path = try std.fmt.allocPrint(allocator, "{s}/sys/bus/usb/drivers/xpad/bind", .{tmp_path});
+    defer allocator.free(bind_path);
+    var bf = try std.fs.openFileAbsolute(bind_path, .{});
+    defer bf.close();
+    const written = try bf.readToEndAlloc(allocator, 128);
+    defer allocator.free(written);
+    // Only the unbound interface 1-1.4:1.0 is written; the already-bound
+    // 1-1.4:1.1 and non-matching 2-2.1:1.0 must be absent.
+    try testing.expectEqualStrings("1-1.4:1.0", written);
+}
+
+// issue #137: uninstall must remove the generated 61-padctl-driver-block.rules
+// file symmetrically with 60-padctl.rules (uninstall hygiene). This guards the
+// `files[]` entry in phase.zig uninstall().
+// Falsifiability: deleting the
+// "/lib/udev/rules.d/61-padctl-driver-block.rules" entry from the `files[]`
+// array in phase.zig uninstall() makes the RuleFileNotRemoved error fire.
+test "uninstall: #137 removes 61-padctl-driver-block.rules" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const staging = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(staging);
+
+    const rules_dir = try std.fmt.allocPrint(allocator, "{s}/usr/local/lib/udev/rules.d", .{staging});
+    defer allocator.free(rules_dir);
+    try ensureDirAll(allocator, rules_dir);
+
+    const rule_60 = try std.fmt.allocPrint(allocator, "{s}/60-padctl.rules", .{rules_dir});
+    defer allocator.free(rule_60);
+    const rule_61 = try std.fmt.allocPrint(allocator, "{s}/61-padctl-driver-block.rules", .{rules_dir});
+    defer allocator.free(rule_61);
+    for ([_][]const u8{ rule_60, rule_61 }) |p| {
+        var f = try std.fs.createFileAbsolute(p, .{ .truncate = true });
+        defer f.close();
+        try f.writeAll("# padctl generated\n");
+    }
+
+    const opts = InstallOptions{
+        .prefix = "/usr/local",
+        .destdir = staging,
+        .immutable = false,
+        .user_service = false,
+    };
+    {
+        var silencer = try SilencedStdout.begin();
+        defer silencer.end();
+        try uninstall(allocator, opts);
+    }
+
+    for ([_][]const u8{ rule_60, rule_61 }) |p| {
+        if (std.fs.accessAbsolute(p, .{})) |_| {
+            std.debug.print("uninstall did not remove rule file: {s}\n", .{p});
+            return error.RuleFileNotRemoved;
+        } else |_| {}
     }
 }

--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -251,6 +251,24 @@ pub fn collectAllDeviceEntries(allocator: std.mem.Allocator, plan: *const Instal
     return try collectDeviceEntries(allocator, all_dirs.items);
 }
 
+/// Like collectAllDeviceEntries but without an InstallPlan. Used by uninstall,
+/// which has no plan; reads the resolved device config dirs plus an explicit
+/// share dir (still present at call time, before it is removed).
+pub fn collectDeviceEntriesForUninstall(
+    allocator: std.mem.Allocator,
+    share_dir: []const u8,
+) !std.ArrayList(UdevEntry) {
+    const config_dirs = paths.resolveDeviceConfigDirs(allocator) catch null;
+    defer if (config_dirs) |dirs| paths.freeConfigDirs(allocator, dirs);
+    var all_dirs: std.ArrayList([]const u8) = .{};
+    defer all_dirs.deinit(allocator);
+    try all_dirs.append(allocator, share_dir);
+    if (config_dirs) |dirs| {
+        for (dirs) |d| try all_dirs.append(allocator, d);
+    }
+    return try collectDeviceEntries(allocator, all_dirs.items);
+}
+
 pub fn installUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan, entries: []const UdevEntry) !void {
     const rules_path = try std.fmt.allocPrint(allocator, "{s}/60-padctl.rules", .{plan.udev_dir});
     defer allocator.free(rules_path);
@@ -549,6 +567,119 @@ pub fn probeAndUnbindDrivers(allocator: std.mem.Allocator, entries: []const Udev
                     std.log.warn("could not unbind {s} from kernel driver '{s}' (try replug or reboot to evict the shadow device): {}", .{ de.name, driver, err });
                 }
             }
+        }
+    }
+}
+
+/// Inverse of probeAndUnbindDrivers: walk <sys_root>/sys/bus/usb/devices/ and,
+/// for any USB device whose idVendor:idProduct matches an entry, rebind every
+/// interface that currently has no driver back to a blocked driver. Called by
+/// uninstall after the sentinel + driver-block rule are removed so a controller
+/// that is still plugged in and currently unbound is restored to the kernel
+/// driver without requiring a physical replug.
+/// Requires root; skips silently / warn-logs on permission errors. A best-effort
+/// `modprobe <driver>` is issued first so the rebind target exists even if the
+/// module was never auto-loaded. `sys_root` is "" in production; tests inject a
+/// tmpDir path (P9).
+pub fn probeAndRebindDrivers(allocator: std.mem.Allocator, entries: []const UdevEntry, sys_root: []const u8) void {
+    const devices_path = std.fmt.allocPrint(
+        allocator,
+        "{s}/sys/bus/usb/devices",
+        .{sys_root},
+    ) catch return;
+    defer allocator.free(devices_path);
+
+    var devices_dir = std.fs.openDirAbsolute(devices_path, .{ .iterate = true }) catch return;
+    defer devices_dir.close();
+
+    for (entries) |entry| {
+        if (entry.block_kernel_drivers.len == 0) continue;
+
+        var it = devices_dir.iterate();
+        while (it.next() catch null) |de| {
+            if (de.kind != .sym_link and de.kind != .directory) continue;
+            if (de.name.len == 0 or de.name[0] < '0' or de.name[0] > '9') continue;
+            // Skip interface nodes ("1-1.4:1.0"); only match top-level devices.
+            if (std.mem.indexOfScalar(u8, de.name, ':') != null) continue;
+
+            const vendor_path = std.fmt.allocPrint(
+                allocator,
+                "{s}/sys/bus/usb/devices/{s}/idVendor",
+                .{ sys_root, de.name },
+            ) catch continue;
+            defer allocator.free(vendor_path);
+
+            const product_path = std.fmt.allocPrint(
+                allocator,
+                "{s}/sys/bus/usb/devices/{s}/idProduct",
+                .{ sys_root, de.name },
+            ) catch continue;
+            defer allocator.free(product_path);
+
+            const vid = readSysHex(vendor_path) catch continue;
+            const pid = readSysHex(product_path) catch continue;
+            if (vid != entry.vid or pid != entry.pid) continue;
+
+            for (entry.block_kernel_drivers) |driver| {
+                // Best-effort: ensure the module is present before binding.
+                if (sys_root.len == 0) runCmd(&.{ "modprobe", driver });
+
+                const bind_path = std.fmt.allocPrint(
+                    allocator,
+                    "{s}/sys/bus/usb/drivers/{s}/bind",
+                    .{ sys_root, driver },
+                ) catch continue;
+                defer allocator.free(bind_path);
+
+                rebindInterfaces(allocator, sys_root, de.name, bind_path, driver);
+            }
+        }
+    }
+}
+
+/// For each interface child of USB device `dev_name` ("<dev_name>:N.M") that has
+/// no `driver` symlink, write its name to the driver `bind` attribute.
+fn rebindInterfaces(
+    allocator: std.mem.Allocator,
+    sys_root: []const u8,
+    dev_name: []const u8,
+    bind_path: []const u8,
+    driver: []const u8,
+) void {
+    const dev_dir_path = std.fmt.allocPrint(
+        allocator,
+        "{s}/sys/bus/usb/devices/{s}",
+        .{ sys_root, dev_name },
+    ) catch return;
+    defer allocator.free(dev_dir_path);
+
+    var dev_dir = std.fs.openDirAbsolute(dev_dir_path, .{ .iterate = true }) catch return;
+    defer dev_dir.close();
+
+    var it = dev_dir.iterate();
+    while (it.next() catch null) |child| {
+        if (child.kind != .directory and child.kind != .sym_link) continue;
+        // Interface dirs are named "<dev_name>:cfg.iface".
+        if (!std.mem.startsWith(u8, child.name, dev_name)) continue;
+        if (child.name.len <= dev_name.len or child.name[dev_name.len] != ':') continue;
+
+        const driver_link = std.fmt.allocPrint(
+            allocator,
+            "{s}/sys/bus/usb/devices/{s}/{s}/driver",
+            .{ sys_root, dev_name, child.name },
+        ) catch continue;
+        defer allocator.free(driver_link);
+
+        // Already bound to some driver — leave it alone.
+        if (std.fs.accessAbsolute(driver_link, .{})) |_| continue else |_| {}
+
+        if (std.fs.openFileAbsolute(bind_path, .{ .mode = .write_only })) |f| {
+            defer f.close();
+            f.writeAll(child.name) catch |err| {
+                std.log.warn("could not rebind {s} to kernel driver '{s}' (replug or run `modprobe {s}` to restore it): {}", .{ child.name, driver, driver, err });
+            };
+        } else |err| {
+            std.log.warn("could not rebind {s} to kernel driver '{s}' (replug or run `modprobe {s}` to restore it): {}", .{ child.name, driver, driver, err });
         }
     }
 }


### PR DESCRIPTION
## What

`padctl uninstall` already deletes `61-padctl-driver-block.rules` + the `service-enabled` sentinel symmetrically with `60-padctl.rules` (delivered in #256/#259). The remaining rough edge from the #137 audit is that a controller which is **currently plugged in and currently unbound from xpad** stays unbound after uninstall until a physical replug — the REMOVE-side `|| modprobe xpad` only fires on a real `remove` uevent.

## Changes

- Add `probeAndRebindDrivers` (inverse of `probeAndUnbindDrivers`): on a live root uninstall, after the sentinel + driver-block rule are removed, scan `/sys/bus/usb/devices` for a matching VID:PID and rebind every interface that currently has no driver, so a still-plugged controller is restored without a replug.
- Best-effort `modprobe <driver>` before bind; warn-log (never fail) on permission errors; staging/`--destdir` uninstall is a no-op (no real sysfs).
- `collectDeviceEntriesForUninstall`: plan-free entry collection for the uninstall path (reads the share dir before it is removed, plus `/etc/padctl/devices`).
- Add a Layer-0 regression guard asserting uninstall removes `61-padctl-driver-block.rules` (and `60-padctl.rules`) so the existing rule cleanup cannot silently regress.

## Test plan

- `src/cli/install/tests.zig` Layer-0, sys_root injected (P9):
  - `uninstall: #137 probeAndRebindDrivers binds unbound matching interface only` — rebinds only the unbound matching interface; skips an already-bound interface and a non-matching device.
  - `uninstall: #137 removes 61-padctl-driver-block.rules` — staging uninstall removes both rule files.
- Each test carries a `Falsifiability:` comment naming the exact reverted line.
- Local `zig build test`: zero source-level Zig errors; only the documented host glibc 2.43+ / gcc 16 `R_X86_64_PC64` link block (#147). CI is the build oracle.

refs #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved uninstall process to properly rebind kernel drivers and remove blocking udev rules.

* **Tests**
  * Added tests validating driver rebinding and udev rule file cleanup during uninstall.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->