### PR TITLE
fix(install): add input group to hidraw udev rule + SupplementaryGroups to user service

### DIFF
--- a/src/cli/install/services.zig
+++ b/src/cli/install/services.zig
@@ -24,6 +24,7 @@ pub fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8) 
         \\[Service]
         \\Type=simple
         \\ExecStart={s}
+        \\SupplementaryGroups=input
         \\Restart=on-failure
         \\RestartSec=3
         \\# Canonical state/log dir: $XDG_STATE_HOME/padctl on user services,

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -272,6 +272,21 @@ test "install: generateServiceContent is user unit" {
     try testing.expect(std.mem.indexOf(u8, content, "User=") == null);
 }
 
+test "install: generateServiceContent user unit has SupplementaryGroups=input" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const content = try generateServiceContent(allocator, "/usr");
+    defer allocator.free(content);
+    // ADR-008 Update 2026-05-17 / ADR-014:24 consumer half: the headless/linger
+    // user daemon needs the 'input' GID to reach group-owned hidraw nodes.
+    // Strict newline boundaries pin it as its own directive line.
+    // Falsifiability: revert services.zig generateServiceContent
+    // SupplementaryGroups=input line → this fails.
+    try testing.expect(std.mem.indexOf(u8, content, "\nSupplementaryGroups=input\n") != null);
+    // Coexists with the user-unit invariant: still no User= directive.
+    try testing.expect(std.mem.indexOf(u8, content, "User=") == null);
+}
+
 test "install: generateUdevRules produces valid output" {
     const testing = std.testing;
     const allocator = testing.allocator;
@@ -311,7 +326,10 @@ test "install: generateUdevRules produces valid output" {
     try testing.expect(std.mem.indexOf(u8, content, "2401") != null);
     try testing.expect(std.mem.indexOf(u8, content, "SUBSYSTEM==\"hidraw\"") != null);
     try testing.expect(std.mem.indexOf(u8, content, "SUBSYSTEM==\"input\"") != null);
-    try testing.expect(std.mem.indexOf(u8, content, "TAG+=\"uaccess\"") != null); // hidraw rule
+    // ADR-008 Update 2026-05-17 / ADR-014:24: hidraw line keeps uaccess and
+    // adds GROUP="input", MODE="0660" for headless/linger fallback, VID/PID-scoped.
+    // Falsifiability: revert udev.zig hidraw format-string append → this fails.
+    try testing.expect(std.mem.indexOf(u8, content, "SUBSYSTEM==\"hidraw\", ATTRS{idVendor}==\"37d7\", ATTRS{idProduct}==\"2401\", TAG+=\"uaccess\", GROUP=\"input\", MODE=\"0660\"") != null);
     try testing.expect(std.mem.indexOf(u8, content, "GROUP=\"input\", MODE=\"0660\"") != null);
     try testing.expect(std.mem.indexOf(u8, content, "KERNEL==\"uinput\"") != null);
     // ADR-015: /dev/uhid must get uaccess so the user service can create
@@ -1982,7 +2000,10 @@ test "install: user unit has no systemd 257+ incompatible hardening (issue #216)
     try testing.expect(std.mem.indexOf(u8, content, "NoNewPrivileges=") == null);
     try testing.expect(std.mem.indexOf(u8, content, "LockPersonality=") == null);
     try testing.expect(std.mem.indexOf(u8, content, "ProtectClock=") == null);
-    try testing.expect(std.mem.indexOf(u8, content, "SupplementaryGroups") == null);
+    // SupplementaryGroups=input is required (ADR-008 Update 2026-05-17 /
+    // ADR-014:24) and is NOT a systemd 257+ incompatible directive, so it
+    // intentionally stays in the user unit; only the hardening triad above
+    // is forbidden.
     try testing.expect(std.mem.indexOf(u8, content, "StateDirectory=padctl") != null);
 }
 

--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -375,7 +375,7 @@ pub fn generateUdevRulesFromEntries(allocator: std.mem.Allocator, entries: []con
     for (entries) |e| {
         const line = try std.fmt.allocPrint(
             allocator,
-            "ACTION==\"add\", SUBSYSTEM==\"hidraw\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", TAG+=\"uaccess\"\nACTION==\"add\", SUBSYSTEM==\"input\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", GROUP=\"input\", MODE=\"0660\"\n# {s}\n",
+            "ACTION==\"add\", SUBSYSTEM==\"hidraw\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", TAG+=\"uaccess\", GROUP=\"input\", MODE=\"0660\"\nACTION==\"add\", SUBSYSTEM==\"input\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", GROUP=\"input\", MODE=\"0660\"\n# {s}\n",
             .{ e.vid, e.pid, e.vid, e.pid, e.name },
         );
         defer allocator.free(line);


### PR DESCRIPTION
## What changed

- **udev.zig** `generateUdevRulesFromEntries`: append `GROUP="input", MODE="0660"` to the per-device hidraw rule. `TAG+="uaccess"` is preserved; the rule stays VID/PID-scoped and never degrades to a blanket `KERNEL=="hidraw*"`. The evdev `SUBSYSTEM=="input"` line, the trailing comment, and the `#137` driver-block generator are untouched.
- **services.zig** `generateServiceContent`: add `SupplementaryGroups=input` to the user unit `[Service]` (previously only present on the system unit). No `User=` directive added.
- **tests.zig**:
  - Strengthened the udev valid-output test to assert the exact hidraw-line substring `SUBSYSTEM=="hidraw", ATTRS{idVendor}=="37d7", ATTRS{idProduct}=="2401", TAG+="uaccess", GROUP="input", MODE="0660"` (falsifiable: revert udev.zig append → fails).
  - New `generateServiceContent` test pinning `\nSupplementaryGroups=input\n` with strict newline boundaries, coexisting with the existing "user template has no `User=`" invariant.
  - Updated the issue #216 test: `SupplementaryGroups` is not a systemd 257+ incompatible directive, so it is intentionally retained on the user unit; only the `NoNewPrivileges`/`LockPersonality`/`ProtectClock` triad remains forbidden.

## Why

Headless / no-graphical-seat / linger `systemd --user` padctl gets persistent EACCES on `/dev/hidrawN`: the per-device hidraw rule had only `TAG+="uaccess"` (seat-only) and the user service template lacked `SupplementaryGroups=input`. This completes the ADR-014:24 `input`-group producer (`GROUP="input"`) + consumer (`SupplementaryGroups=input`) contract on the hidraw path — a conformance completion, not a new decision. Exposure stays VID/PID-scoped and equivalent to the already-shipped uhid rule.

## Test plan

- New/strengthened unit tests in `src/cli/install/tests.zig` (udev hidraw-line substring + user-unit `SupplementaryGroups=input` newline-pinned).
- `zig build test` blocked locally only by the known #147 host `R_X86_64_PC64` crt1.o/libc_nonshared.a linker error (host glibc/binutils toolchain, not source); all changed files pass `zig ast-check`. CI is the oracle.

## Refs

- refs #264 (A.2 structural fix)
- ADR-008 Update 2026-05-17 / ADR-014:24