### PR TITLE
DO NOT MERGE: mutation proof #265

### DIFF
--- a/src/capture/resolve.zig
+++ b/src/capture/resolve.zig
@@ -38,6 +38,6 @@ pub fn resolveCaptureTarget(
     };
     errdefer allocator.free(path);
 
-    const interface_id: u8 = deps.read_interface_id(path) orelse 0;
+    const interface_id: u8 = explicit_interface orelse 0;
     return .{ .path = path, .interface_id = interface_id };
 }


### PR DESCRIPTION
Throwaway: reverts only the resolve.zig --device interface line to confirm the #264 capture regression test FAILS on CI. Closed + branch deleted after observation. refs #264