### PR TITLE
chore(release): bump 0.1.8

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.7",
+    .version = "0.1.8",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
## Changes shipped in 0.1.8

- #262 — fix status display stem regression
- #266 — remove dead code paths
- #267 — fix (#137) uninstall rebind handling
- #268 — fix (#264 A.2) hidraw input-group udev rule
- #265 — fix (#264 B.6) capture falls back to any-interface discovery

Release tag v0.1.8 to follow after CI green.