### PR TITLE
docs: document implemented-but-undocumented config features

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ See the [getting started guide](https://bananasjim.github.io/padctl/getting-star
 | `padctl devices` | List detected HID/USB devices |
 | `padctl list-mappings` | Show available mapping profiles |
 | `padctl switch <name>` | Switch to a named mapping profile |
-| `padctl config init` | Interactively create a new mapping file in `~/.config/padctl/mappings/` |
+| `padctl config init [--preset <name>]` | Interactively create a new mapping file in `~/.config/padctl/mappings/`. Valid `--preset` values: `xbox-360`, `xbox-elite2`, `dualsense`, `switch-pro`. |
 | `padctl config edit <mapping>` | Open mapping in `$VISUAL` or `$EDITOR` |
 | `padctl config test <mapping>` | Live input preview against the mapping (no apply) |
 | `padctl scan` | Re-scan for connected devices |

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -33,6 +33,7 @@ Optional initialization sequence sent after device open.
 | `disable` | string | no | Hex byte string sent on shutdown |
 | `interface` | integer | no | Interface to send init commands on |
 | `report_size` | integer | no | Expected report size after init |
+| `feature_report` | integer[] | no | HID feature report sent via `HIDIOCSFEATURE` immediately after `commands`. Encoded as a list of byte values (0–255); `byte[0]` is the report ID. |
 
 ## `[[report]]`
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -198,7 +198,7 @@ padctl devices [--socket <path>]           # list connected devices
 padctl list-mappings [--config-dir <dir>]  # list available mapping profiles
 padctl reload [--pid <pid>]                # send SIGHUP to reload configs
 padctl config list                         # show XDG config search paths
-padctl config init [--device] [--preset]   # interactive mapping creator
+padctl config init [--device] [--preset <name>]  # interactive mapping creator; valid preset names: xbox-360, xbox-elite2, dualsense, switch-pro
 padctl config edit [name]                  # open mapping in $VISUAL/$EDITOR
 padctl config test [--config] [--mapping]  # live input preview
 padctl dump enable|disable                 # toggle diagnostic logging (persists)

--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -57,7 +57,7 @@ Without `trigger_threshold`, `LT` / `RT` emit analog axis events only and do not
 
 ## `[remap]`
 
-Top-level button remapping (active when no layer overrides). Keys are ButtonId names, values are target button names, `KEY_*` codes, `mouse_left`/`mouse_right`/`mouse_middle`/`mouse_side`/`mouse_forward`/`mouse_back`, `disabled`, or `macro:<name>`.
+Top-level button remapping (active when no layer overrides). Keys are ButtonId names, values are target button names, `KEY_*` codes, `mouse_left`/`mouse_right`/`mouse_middle`/`mouse_side`/`mouse_extra`/`mouse_forward`/`mouse_back`, `disabled`, or `macro:<name>`.
 
 ```toml
 [remap]
@@ -67,6 +67,8 @@ M3 = "disabled"
 A = "B"
 M4 = "macro:dodge_roll"
 ```
+
+Array values (e.g. `M1 = ["KEY_LEFTMETA", "KEY_1"]`) are parsed and resolved as chord targets (2–4 keys) but are not yet dispatched — chord output is planned for a future release.
 
 ## `[gyro]`
 
@@ -85,7 +87,8 @@ invert_y = true
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `mode` | string | `"off"` | `"off"` or `"mouse"` |
+| `mode` | string | `"off"` | `"off"`, `"mouse"`, or `"joystick"`. In `"joystick"` mode the processed gyro signal is routed to a virtual stick axis instead of mouse `REL_X/Y` events. |
+| `target` | string | `"right_stick"` | `"right_stick"` or `"left_stick"`. Selects which stick axis receives the gyro output. Only used when `mode = "joystick"`. |
 | `activate` | string | — | Button name to hold for activation (e.g. `"LS"`, `"hold_RB"`) |
 | `sensitivity` | float | — | Overall sensitivity multiplier |
 | `sensitivity_x` | float | — | X-axis sensitivity override |
@@ -204,6 +207,16 @@ suppress_gamepad = true
 ### `[layer.adaptive_trigger]`
 
 Per-layer adaptive trigger override. Same fields as top-level `[adaptive_trigger]`.
+
+```toml
+[layer.adaptive_trigger]
+mode = "weapon"
+
+[layer.adaptive_trigger.left]
+start    = 30
+end      = 120
+strength = 200
+```
 
 ## `[adaptive_trigger]`
 

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -140,7 +140,7 @@ Available button names: `A`, `B`, `X`, `Y`, `LB`, `RB`, `LT`, `RT`, `Start`, `Se
 
 ### Gyroscope (`[gyro]`)
 
-Translates gyroscope motion to mouse movement. Off by default.
+Translates gyroscope motion to mouse movement or a virtual stick. Off by default.
 
 ```toml
 [gyro]
@@ -153,6 +153,21 @@ invert_y    = true
 ```
 
 Omit `activate` to have gyro always active when mode is `"mouse"`.
+
+#### Joystick mode
+
+Set `mode = "joystick"` to route the gyro signal to a virtual stick axis instead of mouse events. Use `target` to choose which stick receives the output:
+
+```toml
+[gyro]
+mode   = "joystick"
+target = "right_stick"   # "right_stick" (default) or "left_stick"
+deadzone    = 200
+sensitivity = 1.5
+smoothing   = 0.3
+```
+
+This is useful for games that read the right stick for camera control but do not natively support gyro input. All other `[gyro]` fields (`sensitivity`, `deadzone`, `smoothing`, `curve`, `invert_x`, `invert_y`) apply in joystick mode the same way as in mouse mode.
 
 ### Sticks (`[stick.left]` / `[stick.right]`)
 

--- a/examples/mappings/comprehensive.toml
+++ b/examples/mappings/comprehensive.toml
@@ -47,7 +47,14 @@ suppress_gamepad = true   # suppress raw axis when mode is mouse/scroll
 # --- Gyroscope (off by default) ---
 
 [gyro]
-mode = "off"   # set to "mouse" to enable gyro-to-mouse
+mode = "off"   # "off" | "mouse" | "joystick"
+
+# Joystick mode: route gyro to a virtual stick axis instead of mouse events.
+# Useful for games that read right stick for camera but lack native gyro support.
+# target = "right_stick"   # "right_stick" (default) or "left_stick"
+# mode   = "joystick"
+# deadzone    = 200
+# sensitivity = 1.5
 
 # --- Macros (referenced by "macro:<name>" in remap values) ---
 


### PR DESCRIPTION
## What

Documents config/CLI features that are implemented on `main` but absent
from user-facing docs (found by a feature-vs-docs audit).

- `[gyro] mode = "joystick"` + `target = "right_stick"|"left_stick"`
  (default `right_stick`) — gyro drives a virtual stick instead of mouse.
  Added to `mapping-config.md` table, `mapping-guide.md` prose+example,
  and a commented block in `examples/mappings/comprehensive.toml`.
- `config init --preset` valid values listed (`xbox-360`, `xbox-elite2`,
  `dualsense`, `switch-pro`) in `getting-started.md` + README CLI table.
- `[remap]` array values noted as parsed-but-not-yet-dispatched (preview),
  not presented as working.
- `[device.init] feature_report` row added to `device-config.md`.
- `mouse_extra` added to the `[remap]` mouse-target list in
  `mapping-config.md` (was missing; valid in code + already in guide).
- `[layer.adaptive_trigger]` example snippet added.

## Scope

Docs only — 6 files (`README.md`, `docs/src/*`, `examples/mappings/*`),
zero `src/**`. Every statement verified against the implementing code.
Gyro `activate` `hold_`/bare-name semantics intentionally deferred to the
behavioral fix PR for issue #271 to keep docs and behavior in sync.

## Test plan

Docs-only; no code paths affected. CI runs for branch hygiene.