### PR TITLE
fix(mapper): gyro activate accepts bare button names + validate gyro config

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -89,7 +89,7 @@ invert_y = true
 |-------|------|---------|-------------|
 | `mode` | string | `"off"` | `"off"`, `"mouse"`, or `"joystick"`. In `"joystick"` mode the processed gyro signal is routed to a virtual stick axis instead of mouse `REL_X/Y` events. |
 | `target` | string | `"right_stick"` | `"right_stick"` or `"left_stick"`. Selects which stick axis receives the gyro output. Only used when `mode = "joystick"`. |
-| `activate` | string | — | Button name to hold for activation (e.g. `"LS"`, `"hold_RB"`) |
+| `activate` | string | — | Gate button: bare name (`"LS"`) or `hold_<BTN>` form (`"hold_RB"`) — both are equivalent. For analog triggers (`LT`/`RT`), also set `trigger_threshold`. Omit for always-active. |
 | `sensitivity` | float | — | Overall sensitivity multiplier |
 | `sensitivity_x` | float | — | X-axis sensitivity override |
 | `sensitivity_y` | float | — | Y-axis sensitivity override |

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -154,6 +154,8 @@ invert_y    = true
 
 Omit `activate` to have gyro always active when mode is `"mouse"`.
 
+`activate` accepts a bare button name (`"LS"`) or the `hold_<BTN>` form (`"hold_RB"`) — both behave identically. For analog triggers (`LT`/`RT`) you must also declare `trigger_threshold` at the top level, otherwise the trigger axis is never converted to a button press and the gyro gate never fires.
+
 #### Joystick mode
 
 Set `mode = "joystick"` to route the gyro signal to a virtual stick axis instead of mouse events. Use `target` to choose which stick receives the output:

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -2,8 +2,11 @@ const std = @import("std");
 const toml = @import("toml");
 const input_codes = @import("input_codes.zig");
 const remap_mod = @import("../core/remap.zig");
+const state = @import("../core/state.zig");
 pub const MacroStep = @import("../core/macro.zig").MacroStep;
 pub const Macro = @import("../core/macro.zig").Macro;
+
+const ButtonId = state.ButtonId;
 
 // `[remap]` value is either a single string ("KEY_F13", "macro:dodge_roll",
 // "BTN_LEFT", gamepad-button name) or an array of KEY_* strings (chord output).
@@ -359,6 +362,45 @@ fn remapHasTriggerKey(map: *const RemapMap) bool {
     return false;
 }
 
+const valid_gyro_modes = [_][]const u8{ "off", "mouse", "joystick" };
+const valid_gyro_targets = [_][]const u8{ "right_stick", "left_stick" };
+
+fn validateGyroConfig(g: *const GyroConfig, trigger_threshold: ?u8) !void {
+    var mode_ok = false;
+    for (valid_gyro_modes) |v| {
+        if (std.mem.eql(u8, g.mode, v)) {
+            mode_ok = true;
+            break;
+        }
+    }
+    if (!mode_ok) return error.InvalidConfig;
+
+    if (g.target) |t| {
+        var target_ok = false;
+        for (valid_gyro_targets) |v| {
+            if (std.mem.eql(u8, t, v)) {
+                target_ok = true;
+                break;
+            }
+        }
+        if (!target_ok) return error.InvalidConfig;
+    }
+
+    if (g.activate) |spec| {
+        const btn_name = if (std.mem.startsWith(u8, spec, "hold_"))
+            spec["hold_".len..]
+        else
+            spec;
+        if (!std.mem.eql(u8, spec, "always")) {
+            if (std.meta.stringToEnum(ButtonId, btn_name) == null) {
+                std.log.warn("config: gyro activate '{s}' is not a recognized button name — gyro will be disabled", .{spec});
+            } else if ((std.mem.eql(u8, btn_name, "LT") or std.mem.eql(u8, btn_name, "RT")) and trigger_threshold == null) {
+                std.log.warn("config: gyro activate '{s}' uses an analog trigger but trigger_threshold is not set — gate will never fire; add trigger_threshold = 128", .{spec});
+            }
+        }
+    }
+}
+
 // Returns true when LT/RT appear in any remap but trigger_threshold is not set.
 // Exposed for testing; warn at validate time so users see the failure mode before runtime.
 pub fn needsTriggerThresholdWarn(cfg: *const MappingConfig) bool {
@@ -617,6 +659,7 @@ pub fn validate(cfg: *const MappingConfig) !void {
         try checkRemapChords(m);
     }
     if (cfg.adaptive_trigger) |*at| try validateAdaptiveTrigger(at);
+    if (cfg.gyro) |*g| try validateGyroConfig(g, cfg.trigger_threshold);
 
     if (needsTriggerThresholdWarn(cfg)) {
         std.log.warn("config: LT/RT used in [remap] or [layer.remap] without trigger_threshold — analog triggers are not synthesized into button events; add trigger_threshold = 128 (or your preferred 0-255 value) to enable", .{});
@@ -654,6 +697,7 @@ pub fn validate(cfg: *const MappingConfig) !void {
             try checkRemapChords(m);
         }
         if (layer.adaptive_trigger) |*at| try validateAdaptiveTrigger(at);
+        if (layer.gyro) |*g| try validateGyroConfig(g, cfg.trigger_threshold);
     }
 }
 
@@ -1609,6 +1653,78 @@ test "chord remap: deriveAuxFromMapping flags needs_keyboard for chord array" {
     const caps = deriveAuxFromMapping(&result.value);
     try std.testing.expect(caps.needs_keyboard);
     try std.testing.expect(caps.needsAux());
+}
+
+// --- validateGyroConfig tests ---
+
+test "validate: gyro mode invalid case returns error" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[gyro]
+        \\mode = "Joystick"
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "validate: gyro mode unknown string returns error" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[gyro]
+        \\mode = "stick"
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "validate: gyro target invalid returns error" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[gyro]
+        \\mode = "joystick"
+        \\target = "center_stick"
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "validate: gyro mode=joystick target=left_stick is valid" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[gyro]
+        \\mode = "joystick"
+        \\target = "left_stick"
+    );
+    defer result.deinit();
+    try validate(&result.value);
+}
+
+test "validate: layer gyro mode bogus returns error" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[[layer]]
+        \\name = "aim"
+        \\trigger = "LM"
+        \\
+        \\[layer.gyro]
+        \\mode = "bogus"
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "validate: layer gyro valid mode passes" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[[layer]]
+        \\name = "aim"
+        \\trigger = "LM"
+        \\
+        \\[layer.gyro]
+        \\mode = "mouse"
+    );
+    defer result.deinit();
+    try validate(&result.value);
 }
 
 test "chord remap: layer-level chord too long is rejected by validate" {

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -618,11 +618,12 @@ fn buttonBit(name: []const u8) u64 {
 
 fn checkGyroActivate(activate: ?[]const u8, buttons: u64) bool {
     const spec = activate orelse return true;
+    if (std.mem.eql(u8, spec, "always")) return true;
     if (std.mem.startsWith(u8, spec, "hold_")) {
         const btn_name = spec["hold_".len..];
         return buttons & buttonBit(btn_name) != 0;
     }
-    return true; // "always" or unrecognized
+    return buttons & buttonBit(spec) != 0;
 }
 
 // --- tests ---
@@ -1100,6 +1101,151 @@ test "mapper: checkGyroActivate: hold_RB not pressed" {
 
 test "mapper: checkGyroActivate: unknown button name returns false" {
     try testing.expect(!checkGyroActivate("hold_UNKNOWN", 0xFFFFFFFF));
+}
+
+test "mapper: checkGyroActivate: bare LS gates correctly" {
+    const ls_idx: u6 = @intCast(@intFromEnum(ButtonId.LS));
+    const ls_mask: u64 = @as(u64, 1) << ls_idx;
+    // LS bit set → active
+    try testing.expect(checkGyroActivate("LS", ls_mask));
+    // LS bit clear → inactive
+    try testing.expect(!checkGyroActivate("LS", 0));
+    // Other button set, LS clear → inactive
+    const rb_idx: u6 = @intCast(@intFromEnum(ButtonId.RB));
+    try testing.expect(!checkGyroActivate("LS", @as(u64, 1) << rb_idx));
+}
+
+test "mapper: checkGyroActivate: bare LT gates correctly" {
+    const lt_idx: u6 = @intCast(@intFromEnum(ButtonId.LT));
+    const lt_mask: u64 = @as(u64, 1) << lt_idx;
+    try testing.expect(checkGyroActivate("LT", lt_mask));
+    try testing.expect(!checkGyroActivate("LT", 0));
+}
+
+test "mapper: checkGyroActivate: bogus bare name returns false (not true)" {
+    // Regression: before fix this returned true, making gyro always-on.
+    try testing.expect(!checkGyroActivate("BOGUS_NOT_A_BUTTON", 0xFFFFFFFF));
+}
+
+test "e2e: gyro activate bare LS — no output when LS not pressed, output when pressed" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[gyro]
+        \\mode = "mouse"
+        \\sensitivity = 1000.0
+        \\smoothing = 0.0
+        \\activate = "LS"
+    , allocator);
+    defer parsed.deinit();
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const ls_idx: u6 = @intCast(@intFromEnum(ButtonId.LS));
+    const ls_mask: u64 = @as(u64, 1) << ls_idx;
+
+    // LS not pressed → no gyro output
+    const ev_off = try m.apply(.{ .buttons = 0, .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
+    for (ev_off.aux.slice()) |e| switch (e) {
+        .rel => return error.UnexpectedRelEvent,
+        else => {},
+    };
+
+    // LS pressed → gyro output
+    const ev_on = try m.apply(.{ .buttons = ls_mask, .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
+    var has_rel = false;
+    for (ev_on.aux.slice()) |e| switch (e) {
+        .rel => {
+            has_rel = true;
+        },
+        else => {},
+    };
+    try testing.expect(has_rel);
+
+    // LS released → gyro output stops
+    const ev_off2 = try m.apply(.{ .buttons = 0, .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
+    for (ev_off2.aux.slice()) |e| switch (e) {
+        .rel => return error.UnexpectedRelEvent,
+        else => {},
+    };
+}
+
+test "e2e: gyro activate bare LT — gated through trigger_threshold LT synthesis" {
+    // End-to-end: the analog LT axis crossing trigger_threshold synthesizes the
+    // LT button bit, which the bare-name activate gate then consumes.
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\trigger_threshold = 128
+        \\[gyro]
+        \\mode = "mouse"
+        \\sensitivity = 1000.0
+        \\smoothing = 0.0
+        \\activate = "LT"
+    , allocator);
+    defer parsed.deinit();
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    // LT below threshold → no LT bit synthesized → gyro gated off
+    const ev_off = try m.apply(.{ .lt = 0, .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
+    for (ev_off.aux.slice()) |e| switch (e) {
+        .rel => return error.UnexpectedRelEvent,
+        else => {},
+    };
+
+    // LT above threshold → LT bit synthesized → gyro fires
+    const ev_on = try m.apply(.{ .lt = 200, .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
+    var has_rel = false;
+    for (ev_on.aux.slice()) |e| switch (e) {
+        .rel => {
+            has_rel = true;
+        },
+        else => {},
+    };
+    try testing.expect(has_rel);
+}
+
+test "e2e: gyro activate bogus name — gyro always disabled" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[gyro]
+        \\mode = "mouse"
+        \\sensitivity = 1000.0
+        \\smoothing = 0.0
+        \\activate = "BOGUS_NOT_A_BUTTON"
+    , allocator);
+    defer parsed.deinit();
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    // Even with all bits set, unknown name resolves to 0 via buttonBit → gyro off
+    const ev = try m.apply(.{ .buttons = 0xFFFFFFFFFFFFFFFF, .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
+    for (ev.aux.slice()) |e| switch (e) {
+        .rel => return error.UnexpectedRelEvent,
+        else => {},
+    };
+}
+
+test "e2e: gyro activate hold_LT no trigger_threshold — LT bit never synthesized, gyro stays off" {
+    // Documents the analog-trigger trap: without trigger_threshold the LT bit is
+    // never set in buttons, so hold_LT (and bare LT) never fires.
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[gyro]
+        \\mode = "mouse"
+        \\sensitivity = 1000.0
+        \\smoothing = 0.0
+        \\activate = "hold_LT"
+    , allocator);
+    defer parsed.deinit();
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    // Simulate LT axis fully pressed (lt=255) but no trigger_threshold → bit never set
+    const ev = try m.apply(.{ .lt = 255, .buttons = 0, .gyro_x = 10000, .gyro_y = 10000 }, 16, 0);
+    for (ev.aux.slice()) |e| switch (e) {
+        .rel => return error.UnexpectedRelEvent,
+        else => {},
+    };
 }
 
 // --- OOM path tests ---


### PR DESCRIPTION
## Problem (issue #271)

`[gyro] activate = "LT"` (or any bare button name like `"LS"`) had no
effect — gyro was always active. `checkGyroActivate` only handled the
`hold_<BTN>` prefix form and fell through to `return true` for everything
else, so a bare button name silently disabled the gate entirely.

## Fix

- `src/core/mapper.zig` `checkGyroActivate`: bare button names now gate
  via `buttonBit` exactly like `hold_<BTN>`. Explicit `"always"` and
  omitted `activate` still return true (unchanged). An unrecognized name
  resolves to bit 0 → gate is false (gyro disabled), which is safer than
  the previous always-on behavior.
- `src/config/mapping.zig`: new `validateGyroConfig`, called for the
  top-level `[gyro]` and every `[layer.gyro]`. Rejects invalid `mode`
  (not off/mouse/joystick) and `target` (not right_stick/left_stick) with
  the existing `error.InvalidConfig`. Emits `std.log.warn` (not a hard
  error, not `std.log.err`) for an unknown `activate` button name and for
  `LT`/`RT` activate without `trigger_threshold` (the analog-trigger trap).
- Docs: `mapping-config.md` / `mapping-guide.md` now explain the bare vs
  `hold_<BTN>` equivalence and the `LT`/`RT` + `trigger_threshold`
  requirement.

Also hardens config validation for the gyro joystick `mode`/`target`
introduced earlier (catches typos like `mode = "Joystick"` that would
otherwise silently fall back to off).

## Test plan

L0 regression tests (zero privilege, run under `zig build test`):
- `checkGyroActivate` bare `LS`/`LT` gate correctly; bogus bare name → false.
- e2e: bare-`LS` gyro suppressed when not pressed, active when pressed,
  stops on release; bogus name → always disabled.
- `hold_LT` without `trigger_threshold` → gyro stays off (documents trap).
- `validate`: bad `mode`/`target` (incl. wrong case, in `[[layer]]`) →
  `error.InvalidConfig`; valid `mode="joystick" target="left_stick"` ok.
Each test fails if the one-line gate fix is reverted.

CI (zig 0.15.2) is the build/test gate — host cannot build (#147).

refs #271