### PR TITLE
feat(mapper): per-button tap/hold/double-press gesture bindings

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -70,6 +70,40 @@ M4 = "macro:dodge_roll"
 
 Array values (e.g. `M1 = ["KEY_LEFTMETA", "KEY_1"]`) are parsed and resolved as chord targets (2–4 keys) but are not yet dispatched — chord output is planned for a future release.
 
+### Gesture bindings (tap / hold / double-press)
+
+A `[remap]` value may also be an inline table that binds different actions to
+short press, long press, and double press of the same button:
+
+```toml
+[remap]
+A  = { tap = "KEY_X", hold = "KEY_Y", double = "KEY_Z" }
+B  = { tap = "B", hold = "KEY_LEFTSHIFT" }
+Y  = { tap = "Y", double = "KEY_F" }
+RB = { tap = "RB", hold = "KEY_TAB", hold_ms = 400, double_ms = 200 }
+```
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `tap` | string | — | Action for a short press (fired on release). |
+| `hold` | string | — | Action fired once the button is held past `hold_ms`. |
+| `double` | string | — | Action fired when a second press starts within `double_ms` of the first release. |
+| `hold_ms` | integer (1–5000) | 300 | Hold threshold in milliseconds. |
+| `double_ms` | integer (1–5000) | 250 | Double-press window in milliseconds. |
+
+At least one of `tap` / `hold` / `double` must be set. Each leg is a single
+target (`ButtonId`, `KEY_*`, `mouse_*`, or `disabled`); `macro:<name>` and chord
+arrays are not allowed inside a gesture. An empty table `{}` or an unknown key
+is rejected at parse time; out-of-range thresholds and a base-`[remap]` gesture
+key that collides with a `[[layer]]` `trigger` are rejected at validate time.
+Absent legs simply do nothing.
+
+Latency trade-off: when `double` is set, `tap` cannot fire until the
+double-press window has elapsed (the engine must wait to see whether a second
+press arrives). Without `double`, `tap` fires immediately on release with zero
+added latency. Plain string and chord-array remap forms are unaffected and
+incur no extra latency.
+
 ## `[gyro]`
 
 Global gyro-to-mouse configuration.

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -138,6 +138,29 @@ Available target types:
 
 Available button names: `A`, `B`, `X`, `Y`, `LB`, `RB`, `LT`, `RT`, `Start`, `Select`, `LS`, `RS`, `M1`, `M2`, `M3`, `M4`, `LM`, `RM`, `C`, `Z`
 
+#### Tap / hold / double-press on one button
+
+Bind separate actions to a short press, a long press, and a double press of the
+same button by using an inline table instead of a string:
+
+```toml
+[remap]
+A  = { tap = "KEY_X", hold = "KEY_Y", double = "KEY_Z" }
+B  = { tap = "B", hold = "KEY_LEFTSHIFT" }           # tap passes B through, hold = shift
+RB = { tap = "RB", hold = "KEY_TAB", hold_ms = 400, double_ms = 200 }
+```
+
+- `tap` fires on release (short press), `hold` fires once held past `hold_ms`
+  (default 300 ms), `double` fires on a second press within `double_ms` (default
+  250 ms) of the first release.
+- At least one leg is required; absent legs do nothing. Legs are single targets
+  only — `macro:<name>` and chord arrays are not allowed inside a gesture.
+- Works the same in `[layer.remap]`.
+- Trade-off: when `double` is set, `tap` is delayed until the double-press
+  window closes (the only way to tell a single press from the first of a
+  double). Omit `double` to keep `tap` instant. Plain string and chord remaps
+  are unchanged and never add latency.
+
 ### Gyroscope (`[gyro]`)
 
 Translates gyroscope motion to mouse movement or a virtual stick. Off by default.

--- a/src/cli/config/test.zig
+++ b/src/cli/config/test.zig
@@ -150,6 +150,7 @@ pub fn run(allocator: std.mem.Allocator, config_path: ?[]const u8, mapping_path:
                             }
                             try w.writeAll("]");
                         },
+                        .gesture => try w.print("  {s} -> <gesture>", .{entry.key_ptr.*}),
                     }
                 }
             }

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -8,13 +8,22 @@ pub const Macro = @import("../core/macro.zig").Macro;
 
 const ButtonId = state.ButtonId;
 
-// `[remap]` value is either a single string ("KEY_F13", "macro:dodge_roll",
-// "BTN_LEFT", gamepad-button name) or an array of KEY_* strings (chord output).
-// RemapMap below has a `tomlIntoStruct` hook that inspects the raw toml.Value
-// per entry to choose between the two forms.
+// `[remap]` value is a single string ("KEY_F13", "macro:dodge_roll", "BTN_LEFT",
+// gamepad-button name), an array of KEY_* strings (chord output), or an inline
+// table describing tap/hold/double gesture legs. RemapMap below has a
+// `tomlIntoStruct` hook that inspects the raw toml.Value per entry.
+pub const GestureSpec = struct {
+    tap: ?[]const u8 = null,
+    hold: ?[]const u8 = null,
+    double: ?[]const u8 = null,
+    hold_ms: u32 = 300,
+    double_ms: u32 = 250,
+};
+
 pub const RemapValue = union(enum) {
     string: []const u8,
     chord_names: []const []const u8,
+    gesture: GestureSpec,
 };
 
 pub const RemapMap = struct {
@@ -38,6 +47,46 @@ pub const RemapMap = struct {
                         }
                     }
                     break :blk .{ .chord_names = names };
+                },
+                .table => |tbl| blk: {
+                    if (tbl.count() == 0) return error.InvalidValueType;
+                    var spec = GestureSpec{};
+                    var tit = tbl.iterator();
+                    while (tit.next()) |te| {
+                        const k = te.key_ptr.*;
+                        if (std.mem.eql(u8, k, "tap") or
+                            std.mem.eql(u8, k, "hold") or
+                            std.mem.eql(u8, k, "double"))
+                        {
+                            const s = switch (te.value_ptr.*) {
+                                .string => |sv| sv,
+                                else => return error.InvalidValueType,
+                            };
+                            const dup: []u8 = try ctx.alloc.alloc(u8, s.len);
+                            @memcpy(dup, s);
+                            if (std.mem.eql(u8, k, "tap")) {
+                                spec.tap = dup;
+                            } else if (std.mem.eql(u8, k, "hold")) {
+                                spec.hold = dup;
+                            } else {
+                                spec.double = dup;
+                            }
+                        } else if (std.mem.eql(u8, k, "hold_ms") or std.mem.eql(u8, k, "double_ms")) {
+                            const iv = switch (te.value_ptr.*) {
+                                .integer => |i| i,
+                                else => return error.InvalidValueType,
+                            };
+                            if (iv < 0 or iv > std.math.maxInt(u32)) return error.InvalidValueType;
+                            if (std.mem.eql(u8, k, "hold_ms")) {
+                                spec.hold_ms = @intCast(iv);
+                            } else {
+                                spec.double_ms = @intCast(iv);
+                            }
+                        } else {
+                            return error.InvalidValueType;
+                        }
+                    }
+                    break :blk .{ .gesture = spec };
                 },
                 else => return error.InvalidValueType,
             };
@@ -150,6 +199,11 @@ fn scanRemapTargets(caps: *DerivedAuxCaps, cfg: *const MappingConfig, remap: *co
                 // Chord output: every element is a KEY_* code (validated at
                 // validate() time). Capability is keyboard regardless of count.
                 for (names) |name| scanTarget(caps, name);
+            },
+            .gesture => |g| {
+                if (g.tap) |t| scanTarget(caps, t);
+                if (g.hold) |t| scanTarget(caps, t);
+                if (g.double) |t| scanTarget(caps, t);
             },
         }
     }
@@ -306,6 +360,37 @@ fn checkRemapMacros(cfg: *const MappingConfig, map: *const RemapMap) !void {
             },
             // Chord arrays cannot reference macros — validated separately.
             .chord_names => {},
+            // Gesture legs cannot be macros — enforced in checkRemapGestures.
+            .gesture => {},
+        }
+    }
+}
+
+fn gestureLegInvalid(target: []const u8) bool {
+    if (std.mem.startsWith(u8, target, "macro:")) return true;
+    _ = remap_mod.resolveTarget(target) catch return true;
+    return false;
+}
+
+fn checkRemapGestures(cfg: *const MappingConfig, map: *const RemapMap, is_base: bool) !void {
+    var it = map.map.iterator();
+    while (it.next()) |entry| {
+        const g = switch (entry.value_ptr.*) {
+            .gesture => |gv| gv,
+            else => continue,
+        };
+        if (g.tap == null and g.hold == null and g.double == null) return error.InvalidConfig;
+        if (g.hold_ms < 1 or g.hold_ms > 5000) return error.InvalidConfig;
+        if (g.double_ms < 1 or g.double_ms > 5000) return error.InvalidConfig;
+        if (g.tap) |t| if (gestureLegInvalid(t)) return error.InvalidConfig;
+        if (g.hold) |t| if (gestureLegInvalid(t)) return error.InvalidConfig;
+        if (g.double) |t| if (gestureLegInvalid(t)) return error.InvalidConfig;
+
+        if (is_base) {
+            const layers = cfg.layer orelse continue;
+            for (layers) |*lc| {
+                if (std.mem.eql(u8, lc.trigger, entry.key_ptr.*)) return error.InvalidConfig;
+            }
         }
     }
 }
@@ -657,6 +742,7 @@ pub fn validate(cfg: *const MappingConfig) !void {
     if (cfg.remap) |*m| {
         try checkRemapMacros(cfg, m);
         try checkRemapChords(m);
+        try checkRemapGestures(cfg, m, true);
     }
     if (cfg.adaptive_trigger) |*at| try validateAdaptiveTrigger(at);
     if (cfg.gyro) |*g| try validateGyroConfig(g, cfg.trigger_threshold);
@@ -695,6 +781,7 @@ pub fn validate(cfg: *const MappingConfig) !void {
         if (layer.remap) |*m| {
             try checkRemapMacros(cfg, m);
             try checkRemapChords(m);
+            try checkRemapGestures(cfg, m, false);
         }
         if (layer.adaptive_trigger) |*at| try validateAdaptiveTrigger(at);
         if (layer.gyro) |*g| try validateGyroConfig(g, cfg.trigger_threshold);
@@ -1739,4 +1826,146 @@ test "chord remap: layer-level chord too long is rejected by validate" {
     );
     defer result.deinit();
     try std.testing.expectError(error.ChordTooLong, validate(&result.value));
+}
+
+test "gesture parse: full tap/hold/double with custom thresholds" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\A = { tap = "KEY_X", hold = "KEY_Y", double = "KEY_Z", hold_ms = 400, double_ms = 200 }
+    );
+    defer result.deinit();
+    const g = result.value.remap.?.map.get("A").?.gesture;
+    try std.testing.expectEqualStrings("KEY_X", g.tap.?);
+    try std.testing.expectEqualStrings("KEY_Y", g.hold.?);
+    try std.testing.expectEqualStrings("KEY_Z", g.double.?);
+    try std.testing.expectEqual(@as(u32, 400), g.hold_ms);
+    try std.testing.expectEqual(@as(u32, 200), g.double_ms);
+}
+
+test "gesture parse: partial legs default thresholds" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\B = { tap = "B", hold = "KEY_LEFTSHIFT" }
+        \\Y = { tap = "Y", double = "KEY_F" }
+    );
+    defer result.deinit();
+    const gb = result.value.remap.?.map.get("B").?.gesture;
+    try std.testing.expectEqualStrings("KEY_LEFTSHIFT", gb.hold.?);
+    try std.testing.expect(gb.double == null);
+    try std.testing.expectEqual(@as(u32, 300), gb.hold_ms);
+    try std.testing.expectEqual(@as(u32, 250), gb.double_ms);
+    const gy = result.value.remap.?.map.get("Y").?.gesture;
+    try std.testing.expect(gy.hold == null);
+    try std.testing.expectEqualStrings("KEY_F", gy.double.?);
+}
+
+test "gesture parse: empty inline table rejected" {
+    const allocator = std.testing.allocator;
+    if (parseString(allocator,
+        \\[remap]
+        \\A = {}
+    )) |r| {
+        var rr = r;
+        rr.deinit();
+        return error.EmptyGestureTableAccepted;
+    } else |_| {}
+}
+
+test "gesture parse: unknown key in inline table rejected" {
+    const allocator = std.testing.allocator;
+    try std.testing.expectError(error.InvalidValueType, parseString(allocator,
+        \\[remap]
+        \\A = { tap = "KEY_X", bogus = "KEY_Y" }
+    ));
+}
+
+test "gesture validate: at least one leg required" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\A = { hold_ms = 400 }
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "gesture validate: threshold out of range rejected" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\A = { tap = "KEY_X", hold_ms = 9000 }
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "gesture validate: macro leg rejected" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\A = { tap = "macro:foo" }
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "gesture validate: base gesture key equal to a layer trigger rejected" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\Select = { tap = "KEY_X" }
+        \\
+        \\[[layer]]
+        \\name = "fn"
+        \\trigger = "Select"
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "gesture validate: valid full gesture passes" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\A = { tap = "KEY_X", hold = "KEY_Y", double = "KEY_Z" }
+    );
+    defer result.deinit();
+    try validate(&result.value);
+}
+
+test "gesture deriveAux: legs contribute keyboard and mouse caps" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\A = { tap = "KEY_X", hold = "mouse_left", double = "KEY_Z" }
+    );
+    defer result.deinit();
+    const caps = deriveAuxFromMapping(&result.value);
+    try std.testing.expect(caps.needs_keyboard);
+    try std.testing.expect(caps.mouse_buttons & 1 != 0);
+}
+
+test "gesture back-compat: plain string remap still parses as string" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\X = "KEY_SPACE"
+    );
+    defer result.deinit();
+    try std.testing.expectEqualStrings("KEY_SPACE", result.value.remap.?.map.get("X").?.string);
+}
+
+test "gesture back-compat: chord array remap still parses as chord_names" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[remap]
+        \\C = ["KEY_K", "KEY_L"]
+    );
+    defer result.deinit();
+    const names = result.value.remap.?.map.get("C").?.chord_names;
+    try std.testing.expectEqual(@as(usize, 2), names.len);
+    try std.testing.expectEqualStrings("KEY_K", names[0]);
+    try std.testing.expectEqualStrings("KEY_L", names[1]);
 }

--- a/src/core/gesture.zig
+++ b/src/core/gesture.zig
@@ -1,0 +1,402 @@
+const std = @import("std");
+const remap_mod = @import("remap.zig");
+
+const RemapTargetResolved = remap_mod.RemapTargetResolved;
+const ResolvedGesture = remap_mod.ResolvedGesture;
+
+pub const GESTURE_SLOTS = 16;
+
+pub const GestureLeg = enum { hold, double };
+
+pub const EmitAction = enum { press, release, tap };
+
+pub const Emit = struct {
+    target: RemapTargetResolved,
+    action: EmitAction,
+};
+
+pub const Arm = struct {
+    leg: GestureLeg,
+    deadline_ns: i128,
+};
+
+// Result of one engine step. The mapper performs the emits via applyTarget and
+// owns the shared timer_queue: it allocates a token for `arm`, records it back
+// into the slot via setArmToken, and drains expiry by token.
+pub const Outcome = struct {
+    emits: [3]Emit = undefined,
+    emit_len: usize = 0,
+    arm: ?Arm = null,
+    cancel_hold: bool = false,
+    cancel_double: bool = false,
+
+    fn push(self: *Outcome, target: RemapTargetResolved, action: EmitAction) void {
+        if (self.emit_len >= self.emits.len) return;
+        self.emits[self.emit_len] = .{ .target = target, .action = action };
+        self.emit_len += 1;
+    }
+
+    pub fn slice(self: *const Outcome) []const Emit {
+        return self.emits[0..self.emit_len];
+    }
+};
+
+const Phase = enum { idle, wait_decide, hold_active };
+
+const Slot = struct {
+    src_idx: u6,
+    gesture: *const ResolvedGesture,
+    phase: Phase = .idle,
+    press_ns: i128 = 0,
+    release_ns: i128 = 0,
+    hold_token: ?u32 = null,
+    double_token: ?u32 = null,
+    first_release_seen: bool = false,
+};
+
+pub const GestureEngine = struct {
+    slots: [GESTURE_SLOTS]?Slot = [_]?Slot{null} ** GESTURE_SLOTS,
+
+    pub fn reset(self: *GestureEngine) void {
+        self.slots = [_]?Slot{null} ** GESTURE_SLOTS;
+    }
+
+    fn findSlot(self: *GestureEngine, src_idx: u6) ?*Slot {
+        for (&self.slots) |*maybe| {
+            if (maybe.*) |*s| {
+                if (s.src_idx == src_idx) return s;
+            }
+        }
+        return null;
+    }
+
+    fn acquireSlot(self: *GestureEngine, src_idx: u6, gesture: *const ResolvedGesture) ?*Slot {
+        if (self.findSlot(src_idx)) |s| return s;
+        for (&self.slots) |*maybe| {
+            if (maybe.* == null) {
+                maybe.* = .{ .src_idx = src_idx, .gesture = gesture };
+                return &maybe.*.?;
+            }
+        }
+        return null;
+    }
+
+    fn releaseSlot(self: *GestureEngine, src_idx: u6) void {
+        for (&self.slots) |*maybe| {
+            if (maybe.*) |*s| {
+                if (s.src_idx == src_idx) {
+                    maybe.* = null;
+                    return;
+                }
+            }
+        }
+    }
+
+    // Called by the mapper after it allocates a timer token for `out.arm`.
+    pub fn setArmToken(self: *GestureEngine, src_idx: u6, leg: GestureLeg, token: u32) void {
+        const s = self.findSlot(src_idx) orelse return;
+        switch (leg) {
+            .hold => s.hold_token = token,
+            .double => s.double_token = token,
+        }
+    }
+
+    pub fn onButtonEdge(self: *GestureEngine, src_idx: u6, gesture: *const ResolvedGesture, pressed: bool, now_ns: i128) Outcome {
+        var out = Outcome{};
+        if (pressed) {
+            const s = self.acquireSlot(src_idx, gesture) orelse return out;
+            switch (s.phase) {
+                .idle => {
+                    s.press_ns = now_ns;
+                    s.first_release_seen = false;
+                    s.phase = .wait_decide;
+                    if (gesture.hold != null) {
+                        out.arm = .{ .leg = .hold, .deadline_ns = now_ns + gesture.hold_ns };
+                    }
+                },
+                .wait_decide => {
+                    // Second press inside the double window confirms double.
+                    if (gesture.has_double and s.first_release_seen) {
+                        if (gesture.double) |d| out.push(d, .tap);
+                        if (s.double_token != null) {
+                            out.cancel_double = true;
+                            s.double_token = null;
+                        }
+                        s.phase = .idle;
+                        self.releaseSlot(src_idx);
+                    }
+                },
+                .hold_active => {},
+            }
+            return out;
+        }
+
+        // release edge
+        const s = self.findSlot(src_idx) orelse return out;
+        switch (s.phase) {
+            .idle => {},
+            .wait_decide => {
+                if (!gesture.has_double) {
+                    if (gesture.tap) |t| out.push(t, .tap);
+                    if (s.hold_token != null) {
+                        out.cancel_hold = true;
+                        s.hold_token = null;
+                    }
+                    s.phase = .idle;
+                    self.releaseSlot(src_idx);
+                } else if (!s.first_release_seen) {
+                    s.first_release_seen = true;
+                    s.release_ns = now_ns;
+                    if (s.hold_token != null) {
+                        out.cancel_hold = true;
+                        s.hold_token = null;
+                    }
+                    out.arm = .{ .leg = .double, .deadline_ns = now_ns + gesture.double_ns };
+                }
+            },
+            .hold_active => {
+                if (gesture.hold) |hh| out.push(hh, .release);
+                s.phase = .idle;
+                self.releaseSlot(src_idx);
+            },
+        }
+        return out;
+    }
+
+    // `leg` is the timer's leg; resolved by the mapper from the expired token.
+    pub fn onTimerExpired(self: *GestureEngine, src_idx: u6, leg: GestureLeg, held: bool, _: i128) Outcome {
+        var out = Outcome{};
+        const s = self.findSlot(src_idx) orelse return out;
+        switch (leg) {
+            .hold => {
+                s.hold_token = null;
+                if (s.phase == .wait_decide and held) {
+                    if (s.gesture.hold) |hh| out.push(hh, .press);
+                    if (s.double_token != null) {
+                        out.cancel_double = true;
+                        s.double_token = null;
+                    }
+                    s.phase = .hold_active;
+                }
+            },
+            .double => {
+                s.double_token = null;
+                if (s.phase == .wait_decide and s.first_release_seen) {
+                    if (s.gesture.tap) |t| out.push(t, .tap);
+                    s.phase = .idle;
+                    self.releaseSlot(src_idx);
+                }
+            },
+        }
+        return out;
+    }
+};
+
+// --- tests ---
+
+const testing = std.testing;
+const input_codes = @import("../config/input_codes.zig");
+
+fn key(name: []const u8) RemapTargetResolved {
+    return .{ .key = input_codes.resolveKeyCode(name) catch unreachable };
+}
+
+const ns_ms: i128 = std.time.ns_per_ms;
+
+test "gesture: tap-only emits tap on release" {
+    var g = ResolvedGesture{
+        .tap = key("KEY_X"),
+        .hold = null,
+        .double = null,
+        .hold_ns = 300 * ns_ms,
+        .double_ns = 250 * ns_ms,
+        .has_double = false,
+    };
+    var e = GestureEngine{};
+
+    const o_press = e.onButtonEdge(0, &g, true, 0);
+    try testing.expectEqual(@as(usize, 0), o_press.emit_len);
+    try testing.expect(o_press.arm == null); // no hold leg -> no deadline armed
+
+    const o_rel = e.onButtonEdge(0, &g, false, 50 * ns_ms);
+    try testing.expectEqual(@as(usize, 1), o_rel.emit_len);
+    try testing.expectEqual(EmitAction.tap, o_rel.slice()[0].action);
+    try testing.expectEqual(key("KEY_X").key, o_rel.slice()[0].target.key);
+}
+
+test "gesture: hold fires at deadline while still held, then release on button up" {
+    var g = ResolvedGesture{
+        .tap = key("KEY_X"),
+        .hold = key("KEY_Y"),
+        .double = null,
+        .hold_ns = 300 * ns_ms,
+        .double_ns = 250 * ns_ms,
+        .has_double = false,
+    };
+    var e = GestureEngine{};
+
+    const o_press = e.onButtonEdge(0, &g, true, 0);
+    try testing.expect(o_press.arm != null);
+    try testing.expectEqual(GestureLeg.hold, o_press.arm.?.leg);
+    try testing.expectEqual(@as(i128, 300 * ns_ms), o_press.arm.?.deadline_ns);
+    e.setArmToken(0, .hold, 7);
+
+    const o_exp = e.onTimerExpired(0, .hold, true, 300 * ns_ms);
+    try testing.expectEqual(@as(usize, 1), o_exp.emit_len);
+    try testing.expectEqual(EmitAction.press, o_exp.slice()[0].action);
+    try testing.expectEqual(key("KEY_Y").key, o_exp.slice()[0].target.key);
+
+    const o_rel = e.onButtonEdge(0, &g, false, 500 * ns_ms);
+    try testing.expectEqual(@as(usize, 1), o_rel.emit_len);
+    try testing.expectEqual(EmitAction.release, o_rel.slice()[0].action);
+    try testing.expectEqual(key("KEY_Y").key, o_rel.slice()[0].target.key);
+}
+
+test "gesture: hold deadline ignored when button already released" {
+    var g = ResolvedGesture{
+        .tap = key("KEY_X"),
+        .hold = key("KEY_Y"),
+        .double = null,
+        .hold_ns = 300 * ns_ms,
+        .double_ns = 250 * ns_ms,
+        .has_double = false,
+    };
+    var e = GestureEngine{};
+    _ = e.onButtonEdge(0, &g, true, 0);
+    e.setArmToken(0, .hold, 7);
+    // released before hold deadline -> tap, slot freed
+    const o_rel = e.onButtonEdge(0, &g, false, 50 * ns_ms);
+    try testing.expect(o_rel.cancel_hold);
+    try testing.expectEqual(EmitAction.tap, o_rel.slice()[0].action);
+    // stale hold expiry must not emit
+    const o_exp = e.onTimerExpired(0, .hold, false, 300 * ns_ms);
+    try testing.expectEqual(@as(usize, 0), o_exp.emit_len);
+}
+
+test "gesture: double fires on second press inside window" {
+    var g = ResolvedGesture{
+        .tap = key("KEY_X"),
+        .hold = null,
+        .double = key("KEY_Z"),
+        .hold_ns = 300 * ns_ms,
+        .double_ns = 250 * ns_ms,
+        .has_double = true,
+    };
+    var e = GestureEngine{};
+
+    _ = e.onButtonEdge(0, &g, true, 0);
+    const o_r1 = e.onButtonEdge(0, &g, false, 40 * ns_ms);
+    try testing.expectEqual(@as(usize, 0), o_r1.emit_len); // tap deferred (has_double)
+    try testing.expect(o_r1.arm != null);
+    try testing.expectEqual(GestureLeg.double, o_r1.arm.?.leg);
+    e.setArmToken(0, .double, 9);
+
+    const o_p2 = e.onButtonEdge(0, &g, true, 100 * ns_ms);
+    try testing.expectEqual(@as(usize, 1), o_p2.emit_len);
+    try testing.expectEqual(key("KEY_Z").key, o_p2.slice()[0].target.key);
+    try testing.expect(o_p2.cancel_double);
+}
+
+test "gesture: double window timeout collapses to single tap" {
+    var g = ResolvedGesture{
+        .tap = key("KEY_X"),
+        .hold = null,
+        .double = key("KEY_Z"),
+        .hold_ns = 300 * ns_ms,
+        .double_ns = 250 * ns_ms,
+        .has_double = true,
+    };
+    var e = GestureEngine{};
+    _ = e.onButtonEdge(0, &g, true, 0);
+    _ = e.onButtonEdge(0, &g, false, 40 * ns_ms);
+    e.setArmToken(0, .double, 9);
+
+    const o_exp = e.onTimerExpired(0, .double, false, 290 * ns_ms);
+    try testing.expectEqual(@as(usize, 1), o_exp.emit_len);
+    try testing.expectEqual(EmitAction.tap, o_exp.slice()[0].action);
+    try testing.expectEqual(key("KEY_X").key, o_exp.slice()[0].target.key);
+}
+
+test "gesture: hold fires while held, no double pending to cancel" {
+    var g = ResolvedGesture{
+        .tap = key("KEY_X"),
+        .hold = key("KEY_Y"),
+        .double = key("KEY_Z"),
+        .hold_ns = 300 * ns_ms,
+        .double_ns = 250 * ns_ms,
+        .has_double = true,
+    };
+    var e = GestureEngine{};
+    _ = e.onButtonEdge(0, &g, true, 0);
+    e.setArmToken(0, .hold, 1);
+    const o_exp = e.onTimerExpired(0, .hold, true, 300 * ns_ms);
+    try testing.expectEqual(EmitAction.press, o_exp.slice()[0].action);
+    try testing.expectEqual(key("KEY_Y").key, o_exp.slice()[0].target.key);
+    // No release happened, so no double deadline was ever armed: nothing to cancel.
+    try testing.expect(!o_exp.cancel_double);
+}
+
+test "gesture: tap+hold (no double) emits tap immediately on release, no double armed" {
+    var g = ResolvedGesture{
+        .tap = key("KEY_X"),
+        .hold = key("KEY_Y"),
+        .double = null,
+        .hold_ns = 300 * ns_ms,
+        .double_ns = 250 * ns_ms,
+        .has_double = false,
+    };
+    var e = GestureEngine{};
+    _ = e.onButtonEdge(0, &g, true, 0);
+    e.setArmToken(0, .hold, 1);
+    const o_rel = e.onButtonEdge(0, &g, false, 30 * ns_ms);
+    try testing.expectEqual(EmitAction.tap, o_rel.slice()[0].action);
+    try testing.expectEqual(key("KEY_X").key, o_rel.slice()[0].target.key);
+    try testing.expect(o_rel.arm == null); // no double_token armed
+    try testing.expect(o_rel.cancel_hold);
+}
+
+test "gesture: multi-slot concurrency — two sources independent" {
+    var ga = ResolvedGesture{
+        .tap = key("KEY_X"),
+        .hold = null,
+        .double = null,
+        .hold_ns = 300 * ns_ms,
+        .double_ns = 250 * ns_ms,
+        .has_double = false,
+    };
+    var gb = ResolvedGesture{
+        .tap = key("KEY_Z"),
+        .hold = key("KEY_Y"),
+        .double = null,
+        .hold_ns = 300 * ns_ms,
+        .double_ns = 250 * ns_ms,
+        .has_double = false,
+    };
+    var e = GestureEngine{};
+    _ = e.onButtonEdge(3, &ga, true, 0);
+    _ = e.onButtonEdge(5, &gb, true, 0);
+    e.setArmToken(5, .hold, 2);
+
+    const o_b = e.onTimerExpired(5, .hold, true, 300 * ns_ms);
+    try testing.expectEqual(key("KEY_Y").key, o_b.slice()[0].target.key);
+
+    const o_a = e.onButtonEdge(3, &ga, false, 10 * ns_ms);
+    try testing.expectEqual(key("KEY_X").key, o_a.slice()[0].target.key);
+    try testing.expectEqual(EmitAction.tap, o_a.slice()[0].action);
+}
+
+test "gesture: reset clears all slots" {
+    var g = ResolvedGesture{
+        .tap = key("KEY_X"),
+        .hold = key("KEY_Y"),
+        .double = null,
+        .hold_ns = 300 * ns_ms,
+        .double_ns = 250 * ns_ms,
+        .has_double = false,
+    };
+    var e = GestureEngine{};
+    _ = e.onButtonEdge(0, &g, true, 0);
+    try testing.expect(e.findSlot(0) != null);
+    e.reset();
+    try testing.expect(e.findSlot(0) == null);
+}

--- a/src/core/macro_player.zig
+++ b/src/core/macro_player.zig
@@ -165,7 +165,7 @@ pub const MacroPlayer = struct {
                 .key => |code| aux.append(.{ .key = .{ .code = code, .pressed = false } }) catch {},
                 .mouse_button => |code| aux.append(.{ .mouse_button = .{ .code = code, .pressed = false } }) catch {},
                 .gamepad_button => {},
-                .disabled, .macro, .chord => {},
+                .disabled, .macro, .chord, .gesture => {},
             }
         }
 

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -18,6 +18,7 @@ const REL_WHEEL: u16 = c.REL_WHEEL;
 const REL_HWHEEL: u16 = c.REL_HWHEEL;
 
 const remap_mod = @import("remap.zig");
+const gesture_mod = @import("gesture.zig");
 const chord_detector_mod = @import("chord_detector.zig");
 pub const RemapTargetResolved = remap_mod.RemapTargetResolved;
 pub const resolveTarget = remap_mod.resolveTarget;
@@ -52,6 +53,45 @@ const ResolvedRemap = struct {
     suppress: u64,
 };
 
+const GESTURE_TOKEN_SLOTS = gesture_mod.GESTURE_SLOTS * 2;
+
+const GestureTokenEntry = struct {
+    token: u32,
+    src_idx: u6,
+    leg: gesture_mod.GestureLeg,
+};
+
+// Maps live timer tokens armed by the gesture engine back to (slot, leg) so
+// onMacroTimerExpired can route expiry. Bounded by concurrent gesture timers.
+const GestureTokenTable = struct {
+    entries: [GESTURE_TOKEN_SLOTS]?GestureTokenEntry = [_]?GestureTokenEntry{null} ** GESTURE_TOKEN_SLOTS,
+
+    fn put(self: *GestureTokenTable, token: u32, src_idx: u6, leg: gesture_mod.GestureLeg) void {
+        for (&self.entries) |*e| {
+            if (e.* == null) {
+                e.* = .{ .token = token, .src_idx = src_idx, .leg = leg };
+                return;
+            }
+        }
+    }
+
+    fn take(self: *GestureTokenTable, token: u32) ?GestureTokenEntry {
+        for (&self.entries) |*e| {
+            if (e.*) |v| {
+                if (v.token == token) {
+                    e.* = null;
+                    return v;
+                }
+            }
+        }
+        return null;
+    }
+
+    fn clear(self: *GestureTokenTable) void {
+        self.entries = [_]?GestureTokenEntry{null} ** GESTURE_TOKEN_SLOTS;
+    }
+};
+
 pub const Mapper = struct {
     config: *const MappingConfig,
     layer: LayerState,
@@ -67,6 +107,14 @@ pub const Mapper = struct {
     // to reach output before pending_tap_release fires; staged here, promoted
     // to injected+pending_tap_release at the next apply.
     macro_timer_tap_pending: u64,
+    gesture_engine: gesture_mod.GestureEngine,
+    gesture_tokens: GestureTokenTable,
+    // Same staging discipline as macro_timer_tap_pending: gamepad taps emitted
+    // from gesture timer expiry need one apply() to reach output.
+    gesture_timer_tap_pending: u64,
+    // Gamepad bits held by an active gesture hold leg; re-asserted each frame
+    // until the hold leg emits its release.
+    gesture_held_gamepad: u64,
     timer_fd: std.posix.fd_t,
     allocator: std.mem.Allocator,
     active_macros: std.ArrayList(MacroPlayer),
@@ -111,6 +159,10 @@ pub const Mapper = struct {
             .injected_buttons = 0,
             .pending_tap_release = null,
             .macro_timer_tap_pending = 0,
+            .gesture_engine = .{},
+            .gesture_tokens = .{},
+            .gesture_timer_tap_pending = 0,
+            .gesture_held_gamepad = 0,
             .timer_fd = timer_fd,
             .allocator = allocator,
             .active_macros = .{},
@@ -124,6 +176,8 @@ pub const Mapper = struct {
     pub fn deinit(self: *Mapper) void {
         self.layer.deinit();
         self.active_macros.deinit(self.allocator);
+        self.gesture_engine.reset();
+        self.gesture_tokens.clear();
         self.timer_queue.deinit();
         freeResolvedRemap(self.allocator, self.resolved_base);
         for (self.resolved_layers) |r| freeResolvedRemap(self.allocator, r);
@@ -184,6 +238,14 @@ pub const Mapper = struct {
             self.active_macros.clearRetainingCapacity();
             // Discard tap bits staged from a cancelled macro's timer expiry.
             self.macro_timer_tap_pending = 0;
+            // Cancel in-flight gestures; mirror the macro-cancel above.
+            for (self.gesture_tokens.entries) |maybe| {
+                if (maybe) |e| self.timer_queue.cancel(e.token, now_ns);
+            }
+            self.gesture_tokens.clear();
+            self.gesture_engine.reset();
+            self.gesture_timer_tap_pending = 0;
+            self.gesture_held_gamepad = 0;
         }
 
         self.suppressed_buttons = 0;
@@ -196,6 +258,14 @@ pub const Mapper = struct {
             const existing = self.pending_tap_release orelse 0;
             self.pending_tap_release = existing | self.macro_timer_tap_pending;
             self.macro_timer_tap_pending = 0;
+        }
+
+        // Promote gesture-timer tap bits staged at last expiry.
+        if (self.gesture_timer_tap_pending != 0) {
+            self.injected_buttons |= self.gesture_timer_tap_pending;
+            const existing = self.pending_tap_release orelse 0;
+            self.pending_tap_release = existing | self.gesture_timer_tap_pending;
+            self.gesture_timer_tap_pending = 0;
         }
 
         // Suppress layer trigger buttons so they don't leak to uinput output.
@@ -344,8 +414,18 @@ pub const Mapper = struct {
                 // Chord source button is suppressed via precomputeRemap; chord
                 // events are emitted by the chord output pipeline, not here.
                 .chord => {},
+                .gesture => |node| {
+                    if (pressed != prev_pressed) {
+                        const out = self.gesture_engine.onButtonEdge(@intCast(i), node, pressed, now_ns);
+                        self.applyGestureOutcome(@intCast(i), out, &aux, false, now_ns);
+                    }
+                },
             }
         }
+
+        // Re-assert gamepad bits held by an active gesture hold leg; the engine
+        // emits press once, so the bit must persist across frames until release.
+        self.injected_buttons |= self.gesture_held_gamepad;
 
         if (action.tap_event) |tap| {
             emitTapEvent(tap, &aux, &self.injected_buttons, &self.pending_tap_release);
@@ -444,6 +524,74 @@ pub const Mapper = struct {
         return AuxEventList{};
     }
 
+    // Translate one gesture-engine Outcome into output. `from_timer` selects
+    // the gamepad-tap staging path: timer-context taps stage into
+    // gesture_timer_tap_pending so a full press is visible one frame before the
+    // release; apply-context taps use pending_tap_release directly.
+    fn applyGestureOutcome(
+        self: *Mapper,
+        src_idx: u6,
+        out: gesture_mod.Outcome,
+        aux: *AuxEventList,
+        from_timer: bool,
+        now_ns: i128,
+    ) void {
+        if (out.cancel_hold or out.cancel_double) {
+            // Tokens are matched by value at expiry; cancel both the queue
+            // entry and the routing record so a stale expiry is inert.
+            var ti: usize = 0;
+            while (ti < self.gesture_tokens.entries.len) : (ti += 1) {
+                const e = self.gesture_tokens.entries[ti] orelse continue;
+                if (e.src_idx != src_idx) continue;
+                if ((out.cancel_hold and e.leg == .hold) or
+                    (out.cancel_double and e.leg == .double))
+                {
+                    self.timer_queue.cancel(e.token, now_ns);
+                    self.gesture_tokens.entries[ti] = null;
+                }
+            }
+        }
+        for (out.slice()) |em| {
+            switch (em.target) {
+                .gamepad_button => |dst| {
+                    const mask = @as(u64, 1) << @as(u6, @intCast(@intFromEnum(dst)));
+                    switch (em.action) {
+                        .press => {
+                            self.injected_buttons |= mask;
+                            self.gesture_held_gamepad |= mask;
+                        },
+                        .release => {
+                            self.injected_buttons &= ~mask;
+                            self.gesture_held_gamepad &= ~mask;
+                        },
+                        .tap => if (from_timer) {
+                            self.gesture_timer_tap_pending |= mask;
+                        } else {
+                            self.injected_buttons |= mask;
+                            const existing = self.pending_tap_release orelse 0;
+                            self.pending_tap_release = existing | mask;
+                        },
+                    }
+                },
+                else => {
+                    const act: remap_mod.TargetAction = switch (em.action) {
+                        .press => .press,
+                        .release => .release,
+                        .tap => .tap,
+                    };
+                    remap_mod.applyTarget(em.target, act, aux, &self.injected_buttons, null, null);
+                },
+            }
+        }
+        if (out.arm) |a| {
+            const token = self.next_token;
+            self.next_token +%= 1;
+            self.timer_queue.arm(a.deadline_ns, token, now_ns) catch return;
+            self.gesture_tokens.put(token, src_idx, a.leg);
+            self.gesture_engine.setArmToken(src_idx, a.leg, token);
+        }
+    }
+
     // Macro timerfd (slot 4) expiry only — must NOT call onLayerTimerExpired().
     pub fn onMacroTimerExpired(self: *Mapper, now_ns: i128) AuxEventList {
         var aux = AuxEventList{};
@@ -451,6 +599,13 @@ pub const Mapper = struct {
         var buf: [16]timer_queue_mod.Deadline = undefined;
         const expired = self.timer_queue.drainExpired(now_ns, &buf);
         for (expired) |d| {
+            if (self.gesture_tokens.take(d.token)) |ge| {
+                const src_bit = @as(u64, 1) << ge.src_idx;
+                const held = (self.state.buttons & src_bit) != 0;
+                const out = self.gesture_engine.onTimerExpired(ge.src_idx, ge.leg, held, now_ns);
+                self.applyGestureOutcome(ge.src_idx, out, &aux, true, now_ns);
+                continue;
+            }
             var idx: usize = 0;
             while (idx < self.active_macros.items.len) {
                 if (self.active_macros.items[idx].timer_token == d.token) {
@@ -562,6 +717,7 @@ fn freeResolvedRemap(allocator: std.mem.Allocator, r: ResolvedRemap) void {
         const t = maybe_target orelse continue;
         switch (t) {
             .chord => |codes| allocator.free(codes),
+            .gesture => |node| allocator.destroy(node),
             else => {},
         }
     }
@@ -590,6 +746,13 @@ fn precomputeRemap(allocator: std.mem.Allocator, remap_map: mapping.RemapMap) !R
                 error.OutOfMemory => return e,
                 error.ChordTooShort, error.ChordTooLong, error.DuplicateChordKey, error.UnknownKeyCode => {
                     std.log.warn("chord remap on {s} rejected: {s}", .{ entry.key_ptr.*, @errorName(e) });
+                    continue;
+                },
+            },
+            .gesture => |spec| remap_mod.resolveGestureTarget(allocator, spec) catch |e| switch (e) {
+                error.OutOfMemory => return e,
+                else => {
+                    std.log.warn("gesture remap on {s} rejected: {s}", .{ entry.key_ptr.*, @errorName(e) });
                     continue;
                 },
             },

--- a/src/core/remap.zig
+++ b/src/core/remap.zig
@@ -15,7 +15,33 @@ pub const RemapTargetResolved = union(enum) {
     // Chord output: 2..=4 evdev key codes. Codes are owned by the Mapper
     // allocator (allocated in precomputeRemap, freed in Mapper.deinit).
     chord: []const u16,
+    // Gesture node. Heap-allocated by resolveGestureTarget, freed by the
+    // Mapper allocator. The engine drives the legs; applyTarget is a no-op.
+    gesture: *ResolvedGesture,
 };
+
+pub const ResolvedGesture = struct {
+    tap: ?RemapTargetResolved,
+    hold: ?RemapTargetResolved,
+    double: ?RemapTargetResolved,
+    hold_ns: i128,
+    double_ns: i128,
+    has_double: bool,
+};
+
+pub fn resolveGestureTarget(allocator: std.mem.Allocator, spec: anytype) !RemapTargetResolved {
+    const node = try allocator.create(ResolvedGesture);
+    errdefer allocator.destroy(node);
+    node.* = .{
+        .tap = if (spec.tap) |t| try resolveTarget(t) else null,
+        .hold = if (spec.hold) |t| try resolveTarget(t) else null,
+        .double = if (spec.double) |t| try resolveTarget(t) else null,
+        .hold_ns = @as(i128, spec.hold_ms) * std.time.ns_per_ms,
+        .double_ns = @as(i128, spec.double_ms) * std.time.ns_per_ms,
+        .has_double = spec.double != null,
+    };
+    return .{ .gesture = node };
+}
 
 pub const TargetAction = enum { press, release, tap };
 
@@ -66,7 +92,7 @@ pub fn applyTarget(
                 },
             }
         },
-        .disabled, .macro, .chord => {},
+        .disabled, .macro, .chord, .gesture => {},
     }
 }
 
@@ -209,4 +235,54 @@ test "remap: resolveChordTarget: unknown key code propagates resolveKeyCode erro
     const allocator = std.testing.allocator;
     const names = [_][]const u8{ "KEY_NOT_REAL", "KEY_1" };
     try std.testing.expectError(error.UnknownKeyCode, resolveChordTarget(allocator, &names));
+}
+
+test "remap: resolveGestureTarget: all legs resolve, ms->ns conversion" {
+    const allocator = std.testing.allocator;
+    const spec = .{
+        .tap = @as(?[]const u8, "KEY_X"),
+        .hold = @as(?[]const u8, "KEY_Y"),
+        .double = @as(?[]const u8, "KEY_Z"),
+        .hold_ms = @as(u32, 400),
+        .double_ms = @as(u32, 200),
+    };
+    const target = try resolveGestureTarget(allocator, spec);
+    defer allocator.destroy(target.gesture);
+    const g = target.gesture;
+    try std.testing.expectEqual(try input_codes.resolveKeyCode("KEY_X"), g.tap.?.key);
+    try std.testing.expectEqual(try input_codes.resolveKeyCode("KEY_Y"), g.hold.?.key);
+    try std.testing.expectEqual(try input_codes.resolveKeyCode("KEY_Z"), g.double.?.key);
+    try std.testing.expectEqual(@as(i128, 400 * std.time.ns_per_ms), g.hold_ns);
+    try std.testing.expectEqual(@as(i128, 200 * std.time.ns_per_ms), g.double_ns);
+    try std.testing.expect(g.has_double);
+}
+
+test "remap: resolveGestureTarget: tap-only leaves hold/double null, has_double false" {
+    const allocator = std.testing.allocator;
+    const spec = .{
+        .tap = @as(?[]const u8, "B"),
+        .hold = @as(?[]const u8, null),
+        .double = @as(?[]const u8, null),
+        .hold_ms = @as(u32, 300),
+        .double_ms = @as(u32, 250),
+    };
+    const target = try resolveGestureTarget(allocator, spec);
+    defer allocator.destroy(target.gesture);
+    const g = target.gesture;
+    try std.testing.expectEqual(ButtonId.B, g.tap.?.gamepad_button);
+    try std.testing.expect(g.hold == null);
+    try std.testing.expect(g.double == null);
+    try std.testing.expect(!g.has_double);
+}
+
+test "remap: resolveGestureTarget: unknown leg propagates UnknownRemapTarget" {
+    const allocator = std.testing.allocator;
+    const spec = .{
+        .tap = @as(?[]const u8, "not_a_target"),
+        .hold = @as(?[]const u8, null),
+        .double = @as(?[]const u8, null),
+        .hold_ms = @as(u32, 300),
+        .double_ms = @as(u32, 250),
+    };
+    try std.testing.expectError(error.UnknownRemapTarget, resolveGestureTarget(allocator, spec));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -53,6 +53,7 @@ pub const core = struct {
     pub const interpreter = @import("core/interpreter.zig");
     pub const generic = @import("core/generic.zig");
     pub const remap = @import("core/remap.zig");
+    pub const gesture = @import("core/gesture.zig");
     pub const layer = @import("core/layer.zig");
     pub const mapper = @import("core/mapper.zig");
     pub const chord_detector = @import("core/chord_detector.zig");

--- a/src/test/gen/mapper_oracle.zig
+++ b/src/test/gen/mapper_oracle.zig
@@ -148,10 +148,8 @@ pub fn applyWithLayer(
             },
             .disabled => {},
             .macro => {},
-            // Chord dispatch lands in PR B-2; oracle treats it as a no-op for
-            // now (matches applyTarget) — generators won't produce chord
-            // remaps until B-2 lands.
             .chord => {},
+            .gesture => {},
         }
     }
 
@@ -260,11 +258,11 @@ fn collectRemap(
         const src_id = std.meta.stringToEnum(ButtonId, entry.key_ptr.*) orelse continue;
         const src_idx: u6 = @intCast(@intFromEnum(src_id));
         // Unknown targets skipped — matches production mapper.zig behaviour.
-        // Chord arrays are also skipped here: the oracle has no allocator and
-        // dispatch lands in B-2, so chord doesn't affect oracle output.
+        // Chord/gesture targets are skipped here: the oracle has no allocator and
+        // dispatch lands in B-2, so neither affects oracle output.
         const target = switch (entry.value_ptr.*) {
             .string => |s| remap_mod.resolveTarget(s) catch continue,
-            .chord_names => continue,
+            .chord_names, .gesture => continue,
         };
         suppressed.* |= @as(u64, 1) << src_idx;
         per_src[@intCast(src_idx)] = target;

--- a/src/test/gen/transition_id.zig
+++ b/src/test/gen/transition_id.zig
@@ -196,7 +196,7 @@ pub fn classify(
                         if (std.mem.startsWith(u8, s, "macro:"))
                             tracker.mark(.macro_cancelled_by_layer);
                     },
-                    .chord_names => {},
+                    .chord_names, .gesture => {},
                 }
             }
         }
@@ -246,8 +246,8 @@ fn classifyRemapTargets(tracker: *CoverageTracker, cfg: *const mapping.MappingCo
                 else
                     tracker.mark(.remap_inject_gamepad);
             },
-            // Chord arrays count as keyboard injection (every element is KEY_*).
-            .chord_names => tracker.mark(.remap_inject_key),
+            // Chord/gesture targets count as keyboard injection (elements are KEY_*).
+            .chord_names, .gesture => tracker.mark(.remap_inject_key),
         }
     }
 }

--- a/src/test/mapper_e2e_test.zig
+++ b/src/test/mapper_e2e_test.zig
@@ -688,3 +688,171 @@ test "e2e: partial modifier — only LM held, selector fires as normal input" {
     try testing.expectEqual(@as(?u8, null), ev.chord_switch_request);
     try testing.expect((ev.gamepad.buttons & btnMask(.A)) != 0);
 }
+
+// --- gesture: per-button tap/hold/double-press ---
+
+fn keyCode(name: []const u8) u16 {
+    return (mapper_mod.resolveTarget(name) catch unreachable).key;
+}
+
+fn auxHasKey(ev: anytype, code: u16, pressed: bool) bool {
+    for (ev.aux.slice()) |e| {
+        switch (e) {
+            .key => |k| if (k.code == code and k.pressed == pressed) return true,
+            else => {},
+        }
+    }
+    return false;
+}
+
+test "e2e gesture: tap-only key emits press+release on release (no double, zero latency)" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "KEY_X" }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const t0: i128 = 1_000_000_000;
+    const ev_press = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0);
+    try testing.expectEqual(@as(usize, 0), ev_press.aux.len); // nothing on press
+    // source button suppressed (gesture engine is the sole emitter)
+    try testing.expectEqual(@as(u64, 0), ev_press.gamepad.buttons & btnMask(.A));
+
+    const ev_rel = try m.apply(.{ .buttons = 0 }, 16, t0 + 30 * std.time.ns_per_ms);
+    try testing.expect(auxHasKey(ev_rel, keyCode("KEY_X"), true));
+    try testing.expect(auxHasKey(ev_rel, keyCode("KEY_X"), false));
+}
+
+test "e2e gesture: hold key fires at deadline and releases on button up" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "KEY_X", hold = "KEY_Y", hold_ms = 300 }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const t0: i128 = 1_000_000_000;
+    _ = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0);
+    // hold deadline armed on the shared macro timer queue; drive expiry while held
+    const aux_exp = m.onMacroTimerExpired(t0 + 300 * std.time.ns_per_ms);
+    var saw_hold_press = false;
+    for (aux_exp.slice()) |e| switch (e) {
+        .key => |k| if (k.code == keyCode("KEY_Y") and k.pressed) {
+            saw_hold_press = true;
+        },
+        else => {},
+    };
+    try testing.expect(saw_hold_press);
+
+    // release button -> hold key release
+    const ev_rel = try m.apply(.{ .buttons = 0 }, 16, t0 + 500 * std.time.ns_per_ms);
+    try testing.expect(auxHasKey(ev_rel, keyCode("KEY_Y"), false));
+    // tap must NOT fire when hold consumed the gesture
+    try testing.expect(!auxHasKey(ev_rel, keyCode("KEY_X"), true));
+}
+
+test "e2e gesture: double fires on second press inside window" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "KEY_X", double = "KEY_Z", double_ms = 250 }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const t0: i128 = 1_000_000_000;
+    _ = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0);
+    const ev_r1 = try m.apply(.{ .buttons = 0 }, 16, t0 + 40 * std.time.ns_per_ms);
+    // tap deferred while the double window is open
+    try testing.expect(!auxHasKey(ev_r1, keyCode("KEY_X"), true));
+
+    const ev_p2 = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0 + 100 * std.time.ns_per_ms);
+    try testing.expect(auxHasKey(ev_p2, keyCode("KEY_Z"), true));
+    try testing.expect(auxHasKey(ev_p2, keyCode("KEY_Z"), false));
+}
+
+test "e2e gesture: double-window timeout collapses to single tap" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "KEY_X", double = "KEY_Z", double_ms = 250 }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const t0: i128 = 1_000_000_000;
+    _ = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0);
+    _ = try m.apply(.{ .buttons = 0 }, 16, t0 + 40 * std.time.ns_per_ms);
+    // double window expires with no second press -> single tap
+    const aux_exp = m.onMacroTimerExpired(t0 + 300 * std.time.ns_per_ms);
+    var saw_tap_press = false;
+    for (aux_exp.slice()) |e| switch (e) {
+        .key => |k| if (k.code == keyCode("KEY_X") and k.pressed) {
+            saw_tap_press = true;
+        },
+        else => {},
+    };
+    try testing.expect(saw_tap_press);
+}
+
+test "e2e gesture: timer-context gamepad tap stages full press one frame before release" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "B", double = "Y", double_ms = 250 }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const t0: i128 = 1_000_000_000;
+    _ = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0);
+    _ = try m.apply(.{ .buttons = 0 }, 16, t0 + 40 * std.time.ns_per_ms);
+    // double window times out -> single tap of gamepad B, staged for next apply
+    _ = m.onMacroTimerExpired(t0 + 300 * std.time.ns_per_ms);
+
+    // frame N: B pressed (staged tap promoted)
+    const ev1 = try m.apply(.{ .buttons = 0 }, 16, t0 + 310 * std.time.ns_per_ms);
+    try testing.expect((ev1.gamepad.buttons & btnMask(.B)) != 0);
+    // frame N+1: B released (pending_tap_release)
+    const ev2 = try m.apply(.{ .buttons = 0 }, 16, t0 + 320 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(u64, 0), ev2.gamepad.buttons & btnMask(.B));
+}
+
+test "e2e gesture back-compat: plain string remap A=KEY_F13 unchanged (immediate edge)" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = "KEY_F13"
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const ev = try m.apply(.{ .buttons = btnMask(.A) }, 16, 0);
+    try testing.expectEqual(@as(usize, 1), ev.aux.len);
+    switch (ev.aux.get(0)) {
+        .key => |k| {
+            try testing.expectEqual(KEY_F13, k.code);
+            try testing.expect(k.pressed);
+        },
+        else => return error.WrongEventType,
+    }
+}
+
+test "e2e gesture back-compat: chord array remap A=[KEY_LEFTMETA,KEY_1] unchanged" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = ["KEY_LEFTMETA", "KEY_1"]
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    // chord source button is suppressed via precompute; chord output is driven
+    // by the chord pipeline, not the gesture engine — behaviour unchanged.
+    const ev = try m.apply(.{ .buttons = btnMask(.A) }, 16, 0);
+    try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.A));
+    try testing.expectEqual(@as(usize, 0), ev.aux.len);
+}

--- a/src/test/properties/generative_mapper_props.zig
+++ b/src/test/properties/generative_mapper_props.zig
@@ -128,12 +128,12 @@ fn configIsOracleFaithful(cfg: *const mapping.MappingConfig) bool {
         var it = rm.map.iterator();
         while (it.next()) |entry| {
             switch (entry.value_ptr.*) {
-                .chord_names => return false, // E3
+                .chord_names, .gesture => return false, // E3
                 .string => |s| {
                     const t = remap_mod.resolveTarget(s) catch continue; // unknown: skipped both sides
                     switch (t) {
                         .key, .mouse_button, .gamepad_button, .disabled => {},
-                        .macro, .chord => return false, // E2 / E3
+                        .macro, .chord, .gesture => return false, // E2 / E3
                     }
                 },
             }

--- a/tools/padctl-debug.zig
+++ b/tools/padctl-debug.zig
@@ -224,12 +224,10 @@ pub fn main() !void {
                     if (mapping_parsed) |mp| {
                         if (mp.value.remap) |remap| {
                             if (remap.map.get(entry.key_ptr.*)) |target_v| {
-                                // Chord remap is rendered as the source button
-                                // name unchanged here; the debug TUI doesn't yet
-                                // visualize chords (PR B-2 follow-up).
+                                // Chord/gesture remap not yet visualized in debug TUI.
                                 const target = switch (target_v) {
                                     .string => |s| s,
-                                    .chord_names => continue,
+                                    .chord_names, .gesture => continue,
                                 };
                                 if (std.mem.eql(u8, target, "disabled")) {
                                     continue; // skip disabled buttons
@@ -271,8 +269,8 @@ pub fn main() !void {
                     if (std.meta.stringToEnum(ButtonId, entry.key_ptr.*)) |btn| {
                         const target = switch (entry.value_ptr.*) {
                             .string => |s| s,
-                            // Chord remap not yet rendered in debug TUI.
-                            .chord_names => continue,
+                            // Chord/gesture remap not yet rendered in debug TUI.
+                            .chord_names, .gesture => continue,
                         };
                         if (std.mem.eql(u8, target, "disabled")) continue;
 


### PR DESCRIPTION
Adds an inline gesture object to `[remap]` so a single button can map to
different actions by press type.

```toml
[remap]
A  = { tap = "KEY_X", hold = "KEY_Y", double = "KEY_Z" }
B  = { tap = "B", hold = "KEY_LEFTSHIFT" }
RB = { tap = "RB", hold = "KEY_TAB", hold_ms = 400, double_ms = 200 }
X  = "KEY_SPACE"        # plain string unchanged
C  = ["K", "L"]         # chord array unchanged
```

Defaults: hold_ms 300, double_ms 250. When `double` is set the tap action
is held until the double window closes (unavoidable for double detection);
bindings without `double` keep zero added latency. Plain string and chord
remap forms are untouched.

Implementation:
- `src/config/mapping.zig`: `GestureSpec`, `RemapValue.gesture`, inline-table
  parse, `checkRemapGestures` validation at base and per-layer sites,
  aux-capability scan for gesture legs.
- `src/core/remap.zig`: `ResolvedGesture`, `resolveGestureTarget`.
- `src/core/gesture.zig` (new): pure per-button state machine, 16 slots.
- `src/core/mapper.zig`: edge-driven dispatch, deadlines on the existing
  shared macro timerfd (no new fd or poll slot), issue-72 staging for
  timer-context gamepad taps, held-gamepad re-assert, cancel on layer
  switch.
- Docs updated; back-compat for plain/chord remap preserved.

Test plan: 31 new tests (gesture state machine L0, parse/validate L0,
mapper e2e L1 incl. timer-context staging and back-compat). CI (zig 0.15.2)
is the gate; host cannot build (#147).

refs #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Gesture remapping: map a single button to separate actions for tap, hold, and double-press events, with adjustable timing thresholds for hold and double-press detection

* **Documentation**
  * Added complete gesture binding documentation describing configuration syntax, supported fields, validation rules, timing defaults, and latency behavior implications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->