### PR TITLE
fix(install): conditional SupplementaryGroups=input — omit when input group absent (#279)

### DIFF
--- a/src/cli/install/phase.zig
+++ b/src/cli/install/phase.zig
@@ -12,6 +12,7 @@ const detectImmutableOs = plan_mod.detectImmutableOs;
 const shouldAbortForImmutable = plan_mod.shouldAbortForImmutable;
 const ensureDirAll = plan_mod.ensureDirAll;
 const userInGroup = plan_mod.userInGroup;
+const hostHasInputGroup = plan_mod.hostHasInputGroup;
 const runCmd = plan_mod.runCmd;
 
 pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
@@ -179,8 +180,14 @@ fn printCompletionHint(plan: *const InstallPlan) void {
     _ = std.posix.write(std.posix.STDOUT_FILENO, "\nInstall complete.\n") catch {};
 }
 
+/// Returns true when the hint should be printed: the host has an input group
+/// but the current user is not yet a member. Exposed for testing.
+pub fn inputGroupHintNeeded(has_group: bool, in_group: bool) bool {
+    return has_group and !in_group;
+}
+
 fn printInputGroupHint() void {
-    if (userInGroup("input")) return;
+    if (!inputGroupHintNeeded(hostHasInputGroup(), userInGroup("input"))) return;
     _ = std.posix.write(std.posix.STDOUT_FILENO,
         \\
         \\[padctl] Note: /dev/uhid and /dev/uinput now grant rw to 'input' group members.

--- a/src/cli/install/plan.zig
+++ b/src/cli/install/plan.zig
@@ -236,6 +236,11 @@ pub fn groupGid(name: []const u8) ?std.os.linux.gid_t {
     return null;
 }
 
+/// Returns true if the host has the named group defined in /etc/group.
+pub fn hostHasInputGroup() bool {
+    return groupGid("input") != null;
+}
+
 /// Returns true if the current process is a member of the named group.
 pub fn userInGroup(name: []const u8) bool {
     const target_gid = groupGid(name) orelse return false;

--- a/src/cli/install/services.zig
+++ b/src/cli/install/services.zig
@@ -401,7 +401,7 @@ pub fn installServiceFiles(allocator: std.mem.Allocator, plan: *const InstallPla
     // Probe once: distros using uaccess/ACL (e.g. Bazzite/Fedora) have no
     // 'input' unix group. Emitting SupplementaryGroups=input on those systems
     // causes systemd EXIT_GROUP (216) and a restart loop (#279).
-    const has_input_group = plan_mod.groupGid("input") != null;
+    const has_input_group = plan_mod.hostHasInputGroup();
     // Always use the user-service template. Even on immutable-root installs,
     // the service file is placed under /etc/systemd/user/ so systemd discovers
     // it as a user unit and each user's systemd instance runs its own copy.

--- a/src/cli/install/services.zig
+++ b/src/cli/install/services.zig
@@ -16,52 +16,29 @@ pub fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8, 
         try std.fmt.allocPrint(allocator, "{s}/bin/padctl --config-dir {s}/share/padctl/devices", .{ prefix, prefix });
     defer allocator.free(exec_start);
 
-    if (has_input_group) {
-        return std.fmt.allocPrint(allocator,
-            \\[Unit]
-            \\Description=padctl gamepad compatibility daemon
-            \\After=graphical-session.target
-            \\
-            \\[Service]
-            \\Type=simple
-            \\ExecStart={s}
-            \\SupplementaryGroups=input
-            \\Restart=on-failure
-            \\RestartSec=3
-            \\# Canonical state/log dir: $XDG_STATE_HOME/padctl on user services,
-            \\# /var/lib/padctl on system services. systemd pre-creates it with
-            \\# the right perms, exports $STATE_DIRECTORY, and auto-whitelists
-            \\# the path through read-only home/system protections applied via
-            \\# drop-ins so the daemon can always write its dump log there.
-            \\StateDirectory=padctl
-            \\
-            \\[Install]
-            \\WantedBy=default.target
-            \\
-        , .{exec_start});
-    } else {
-        return std.fmt.allocPrint(allocator,
-            \\[Unit]
-            \\Description=padctl gamepad compatibility daemon
-            \\After=graphical-session.target
-            \\
-            \\[Service]
-            \\Type=simple
-            \\ExecStart={s}
-            \\Restart=on-failure
-            \\RestartSec=3
-            \\# Canonical state/log dir: $XDG_STATE_HOME/padctl on user services,
-            \\# /var/lib/padctl on system services. systemd pre-creates it with
-            \\# the right perms, exports $STATE_DIRECTORY, and auto-whitelists
-            \\# the path through read-only home/system protections applied via
-            \\# drop-ins so the daemon can always write its dump log there.
-            \\StateDirectory=padctl
-            \\
-            \\[Install]
-            \\WantedBy=default.target
-            \\
-        , .{exec_start});
-    }
+    const group_line: []const u8 = if (has_input_group) "SupplementaryGroups=input\n" else "";
+
+    return std.fmt.allocPrint(allocator,
+        \\[Unit]
+        \\Description=padctl gamepad compatibility daemon
+        \\After=graphical-session.target
+        \\
+        \\[Service]
+        \\Type=simple
+        \\ExecStart={s}
+        \\{s}Restart=on-failure
+        \\RestartSec=3
+        \\# Canonical state/log dir: $XDG_STATE_HOME/padctl on user services,
+        \\# /var/lib/padctl on system services. systemd pre-creates it with
+        \\# the right perms, exports $STATE_DIRECTORY, and auto-whitelists
+        \\# the path through read-only home/system protections applied via
+        \\# drop-ins so the daemon can always write its dump log there.
+        \\StateDirectory=padctl
+        \\
+        \\[Install]
+        \\WantedBy=default.target
+        \\
+    , .{ exec_start, group_line });
 }
 
 pub const immutable_dropin_content =
@@ -124,58 +101,32 @@ pub fn generateSystemServiceContent(allocator: std.mem.Allocator, prefix: []cons
         try std.fmt.allocPrint(allocator, "{s}/bin/padctl --config-dir {s}/share/padctl/devices", .{ prefix, prefix });
     defer allocator.free(exec_start);
 
-    if (has_input_group) {
-        return std.fmt.allocPrint(allocator,
-            \\[Unit]
-            \\Description=padctl gamepad compatibility daemon
-            \\After=local-fs.target
-            \\
-            \\[Service]
-            \\Type=simple
-            \\ExecStart={s}
-            \\Restart=on-failure
-            \\RestartSec=3
-            \\ProtectSystem=strict
-            \\ProtectHome=true
-            \\PrivateTmp=true
-            \\RuntimeDirectory=padctl
-            \\StateDirectory=padctl
-            \\SupplementaryGroups=input
-            \\DeviceAllow=/dev/hidraw* rw
-            \\DeviceAllow=/dev/uinput rw
-            \\DeviceAllow=/dev/uhid rw
-            \\DeviceAllow=char-input rw
-            \\
-            \\[Install]
-            \\WantedBy=multi-user.target
-            \\
-        , .{exec_start});
-    } else {
-        return std.fmt.allocPrint(allocator,
-            \\[Unit]
-            \\Description=padctl gamepad compatibility daemon
-            \\After=local-fs.target
-            \\
-            \\[Service]
-            \\Type=simple
-            \\ExecStart={s}
-            \\Restart=on-failure
-            \\RestartSec=3
-            \\ProtectSystem=strict
-            \\ProtectHome=true
-            \\PrivateTmp=true
-            \\RuntimeDirectory=padctl
-            \\StateDirectory=padctl
-            \\DeviceAllow=/dev/hidraw* rw
-            \\DeviceAllow=/dev/uinput rw
-            \\DeviceAllow=/dev/uhid rw
-            \\DeviceAllow=char-input rw
-            \\
-            \\[Install]
-            \\WantedBy=multi-user.target
-            \\
-        , .{exec_start});
-    }
+    const group_line: []const u8 = if (has_input_group) "SupplementaryGroups=input\n" else "";
+
+    return std.fmt.allocPrint(allocator,
+        \\[Unit]
+        \\Description=padctl gamepad compatibility daemon
+        \\After=local-fs.target
+        \\
+        \\[Service]
+        \\Type=simple
+        \\ExecStart={s}
+        \\Restart=on-failure
+        \\RestartSec=3
+        \\ProtectSystem=strict
+        \\ProtectHome=true
+        \\PrivateTmp=true
+        \\RuntimeDirectory=padctl
+        \\StateDirectory=padctl
+        \\{s}DeviceAllow=/dev/hidraw* rw
+        \\DeviceAllow=/dev/uinput rw
+        \\DeviceAllow=/dev/uhid rw
+        \\DeviceAllow=char-input rw
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+        \\
+    , .{ exec_start, group_line });
 }
 
 /// Update any legacy system service files left behind by pre-user-service

--- a/src/cli/install/services.zig
+++ b/src/cli/install/services.zig
@@ -9,35 +9,59 @@ const runCmdWarn = plan_mod.runCmdWarn;
 const planSystemctlUser = plan_mod.planSystemctlUser;
 const atomicInstallBinary = plan_mod.atomicInstallBinary;
 
-pub fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8) ![]const u8 {
+pub fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8, has_input_group: bool) ![]const u8 {
     const exec_start = if (std.mem.eql(u8, prefix, "/usr"))
         try std.fmt.allocPrint(allocator, "{s}/bin/padctl", .{prefix})
     else
         try std.fmt.allocPrint(allocator, "{s}/bin/padctl --config-dir {s}/share/padctl/devices", .{ prefix, prefix });
     defer allocator.free(exec_start);
 
-    return std.fmt.allocPrint(allocator,
-        \\[Unit]
-        \\Description=padctl gamepad compatibility daemon
-        \\After=graphical-session.target
-        \\
-        \\[Service]
-        \\Type=simple
-        \\ExecStart={s}
-        \\SupplementaryGroups=input
-        \\Restart=on-failure
-        \\RestartSec=3
-        \\# Canonical state/log dir: $XDG_STATE_HOME/padctl on user services,
-        \\# /var/lib/padctl on system services. systemd pre-creates it with
-        \\# the right perms, exports $STATE_DIRECTORY, and auto-whitelists
-        \\# the path through read-only home/system protections applied via
-        \\# drop-ins so the daemon can always write its dump log there.
-        \\StateDirectory=padctl
-        \\
-        \\[Install]
-        \\WantedBy=default.target
-        \\
-    , .{exec_start});
+    if (has_input_group) {
+        return std.fmt.allocPrint(allocator,
+            \\[Unit]
+            \\Description=padctl gamepad compatibility daemon
+            \\After=graphical-session.target
+            \\
+            \\[Service]
+            \\Type=simple
+            \\ExecStart={s}
+            \\SupplementaryGroups=input
+            \\Restart=on-failure
+            \\RestartSec=3
+            \\# Canonical state/log dir: $XDG_STATE_HOME/padctl on user services,
+            \\# /var/lib/padctl on system services. systemd pre-creates it with
+            \\# the right perms, exports $STATE_DIRECTORY, and auto-whitelists
+            \\# the path through read-only home/system protections applied via
+            \\# drop-ins so the daemon can always write its dump log there.
+            \\StateDirectory=padctl
+            \\
+            \\[Install]
+            \\WantedBy=default.target
+            \\
+        , .{exec_start});
+    } else {
+        return std.fmt.allocPrint(allocator,
+            \\[Unit]
+            \\Description=padctl gamepad compatibility daemon
+            \\After=graphical-session.target
+            \\
+            \\[Service]
+            \\Type=simple
+            \\ExecStart={s}
+            \\Restart=on-failure
+            \\RestartSec=3
+            \\# Canonical state/log dir: $XDG_STATE_HOME/padctl on user services,
+            \\# /var/lib/padctl on system services. systemd pre-creates it with
+            \\# the right perms, exports $STATE_DIRECTORY, and auto-whitelists
+            \\# the path through read-only home/system protections applied via
+            \\# drop-ins so the daemon can always write its dump log there.
+            \\StateDirectory=padctl
+            \\
+            \\[Install]
+            \\WantedBy=default.target
+            \\
+        , .{exec_start});
+    }
 }
 
 pub const immutable_dropin_content =
@@ -93,63 +117,91 @@ pub fn generateReconnectScript(allocator: std.mem.Allocator, prefix: []const u8)
 
 /// Generate the system service content matching the legacy format but with
 /// correct ExecStart for the given prefix.
-pub fn generateSystemServiceContent(allocator: std.mem.Allocator, prefix: []const u8) ![]const u8 {
+pub fn generateSystemServiceContent(allocator: std.mem.Allocator, prefix: []const u8, has_input_group: bool) ![]const u8 {
     const exec_start = if (std.mem.eql(u8, prefix, "/usr"))
         try std.fmt.allocPrint(allocator, "{s}/bin/padctl", .{prefix})
     else
         try std.fmt.allocPrint(allocator, "{s}/bin/padctl --config-dir {s}/share/padctl/devices", .{ prefix, prefix });
     defer allocator.free(exec_start);
 
-    return std.fmt.allocPrint(allocator,
-        \\[Unit]
-        \\Description=padctl gamepad compatibility daemon
-        \\After=local-fs.target
-        \\
-        \\[Service]
-        \\Type=simple
-        \\ExecStart={s}
-        \\Restart=on-failure
-        \\RestartSec=3
-        \\ProtectSystem=strict
-        \\ProtectHome=true
-        \\PrivateTmp=true
-        \\RuntimeDirectory=padctl
-        \\StateDirectory=padctl
-        \\SupplementaryGroups=input
-        \\DeviceAllow=/dev/hidraw* rw
-        \\DeviceAllow=/dev/uinput rw
-        \\DeviceAllow=/dev/uhid rw
-        \\DeviceAllow=char-input rw
-        \\
-        \\[Install]
-        \\WantedBy=multi-user.target
-        \\
-    , .{exec_start});
+    if (has_input_group) {
+        return std.fmt.allocPrint(allocator,
+            \\[Unit]
+            \\Description=padctl gamepad compatibility daemon
+            \\After=local-fs.target
+            \\
+            \\[Service]
+            \\Type=simple
+            \\ExecStart={s}
+            \\Restart=on-failure
+            \\RestartSec=3
+            \\ProtectSystem=strict
+            \\ProtectHome=true
+            \\PrivateTmp=true
+            \\RuntimeDirectory=padctl
+            \\StateDirectory=padctl
+            \\SupplementaryGroups=input
+            \\DeviceAllow=/dev/hidraw* rw
+            \\DeviceAllow=/dev/uinput rw
+            \\DeviceAllow=/dev/uhid rw
+            \\DeviceAllow=char-input rw
+            \\
+            \\[Install]
+            \\WantedBy=multi-user.target
+            \\
+        , .{exec_start});
+    } else {
+        return std.fmt.allocPrint(allocator,
+            \\[Unit]
+            \\Description=padctl gamepad compatibility daemon
+            \\After=local-fs.target
+            \\
+            \\[Service]
+            \\Type=simple
+            \\ExecStart={s}
+            \\Restart=on-failure
+            \\RestartSec=3
+            \\ProtectSystem=strict
+            \\ProtectHome=true
+            \\PrivateTmp=true
+            \\RuntimeDirectory=padctl
+            \\StateDirectory=padctl
+            \\DeviceAllow=/dev/hidraw* rw
+            \\DeviceAllow=/dev/uinput rw
+            \\DeviceAllow=/dev/uhid rw
+            \\DeviceAllow=char-input rw
+            \\
+            \\[Install]
+            \\WantedBy=multi-user.target
+            \\
+        , .{exec_start});
+    }
 }
 
 /// Update any legacy system service files left behind by pre-user-service
 /// installs. Without this, upgrades leave stale ExecStart (missing
 /// --config-dir) and stale drop-ins on disk; if a user later re-enables
 /// the legacy unit manually, they would get the old stale content.
-pub fn updateLegacySystemService(allocator: std.mem.Allocator, destdir: []const u8, prefix: []const u8) void {
+pub fn updateLegacySystemService(allocator: std.mem.Allocator, destdir: []const u8, prefix: []const u8, has_input_group: bool) void {
     const etc_dir = std.fmt.allocPrint(allocator, "{s}/etc/systemd/system", .{destdir}) catch return;
     defer allocator.free(etc_dir);
-    updateLegacyAt(allocator, prefix, etc_dir);
+    updateLegacyAt(allocator, prefix, etc_dir, has_input_group);
 
     const lib_dir = std.fmt.allocPrint(allocator, "{s}{s}/lib/systemd/system", .{ destdir, prefix }) catch return;
     defer allocator.free(lib_dir);
-    updateLegacyAt(allocator, prefix, lib_dir);
+    updateLegacyAt(allocator, prefix, lib_dir, has_input_group);
 }
 
 pub fn updateLegacyAt(
     allocator: std.mem.Allocator,
     prefix: []const u8,
     base_dir: []const u8,
+    has_input_group: bool,
 ) void {
     const svc_path = std.fmt.allocPrint(allocator, "{s}/padctl.service", .{base_dir}) catch return;
     defer allocator.free(svc_path);
     if (std.fs.accessAbsolute(svc_path, .{})) {
-        const content = generateSystemServiceContent(allocator, prefix) catch return;
+        const content = generateSystemServiceContent(allocator, prefix, has_input_group) catch return;
         defer allocator.free(content);
         if (std.fs.createFileAbsolute(svc_path, .{ .truncate = true })) |f| {
             defer f.close();
@@ -346,10 +398,14 @@ pub fn installBinaries(
 pub fn installServiceFiles(allocator: std.mem.Allocator, plan: *const InstallPlan) !void {
     const service_path = try std.fmt.allocPrint(allocator, "{s}/padctl.service", .{plan.service_dir});
     defer allocator.free(service_path);
+    // Probe once: distros using uaccess/ACL (e.g. Bazzite/Fedora) have no
+    // 'input' unix group. Emitting SupplementaryGroups=input on those systems
+    // causes systemd EXIT_GROUP (216) and a restart loop (#279).
+    const has_input_group = plan_mod.groupGid("input") != null;
     // Always use the user-service template. Even on immutable-root installs,
     // the service file is placed under /etc/systemd/user/ so systemd discovers
     // it as a user unit and each user's systemd instance runs its own copy.
-    const service_content = try generateServiceContent(allocator, plan.prefix);
+    const service_content = try generateServiceContent(allocator, plan.prefix, has_input_group);
     defer allocator.free(service_content);
     {
         var f = try std.fs.createFileAbsolute(service_path, .{ .truncate = true });
@@ -380,7 +436,7 @@ pub fn installServiceFiles(allocator: std.mem.Allocator, plan: *const InstallPla
     // of effective_immutable. Pre-user-service installs on any distro
     // placed the unit under /etc/systemd/system/ or <prefix>/lib/systemd/
     // system/. The helper is a no-op when no legacy file is present.
-    updateLegacySystemService(allocator, plan.opts.destdir, plan.prefix);
+    updateLegacySystemService(allocator, plan.opts.destdir, plan.prefix, has_input_group);
 }
 
 pub fn installReconnectScript(allocator: std.mem.Allocator, plan: *const InstallPlan) !void {

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -243,7 +243,7 @@ test "install: extractVidPid ignores [output] section vid/pid" {
 test "install: generateServiceContent uses prefix" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr/local");
+    const content = try generateServiceContent(allocator, "/usr/local", true);
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "/usr/local/bin/padctl") != null);
     try testing.expect(std.mem.indexOf(u8, content, "--config-dir /usr/local/share/padctl/devices") != null);
@@ -255,7 +255,7 @@ test "install: generateServiceContent uses prefix" {
 test "install: generateServiceContent default prefix omits --config-dir" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr");
+    const content = try generateServiceContent(allocator, "/usr", true);
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "/usr/bin/padctl") != null);
     try testing.expect(std.mem.indexOf(u8, content, "--config-dir") == null);
@@ -265,7 +265,7 @@ test "install: generateServiceContent default prefix omits --config-dir" {
 test "install: generateServiceContent is user unit" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr");
+    const content = try generateServiceContent(allocator, "/usr", true);
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "WantedBy=default.target") != null);
     try testing.expect(std.mem.indexOf(u8, content, "ProtectHome") == null);
@@ -273,18 +273,27 @@ test "install: generateServiceContent is user unit" {
     try testing.expect(std.mem.indexOf(u8, content, "User=") == null);
 }
 
-test "install: generateServiceContent user unit has SupplementaryGroups=input" {
+test "install: generateServiceContent emits SupplementaryGroups=input when input group exists" {
+    // Falsifiability: remove the has_input_group branch in generateServiceContent → this fails.
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr");
+    const content = try generateServiceContent(allocator, "/usr", true);
     defer allocator.free(content);
-    // The headless/linger user daemon needs the 'input' GID to reach
-    // group-owned hidraw nodes. Strict newline boundaries pin it as its own
-    // directive line.
-    // Falsifiability: revert SupplementaryGroups=input in generateServiceContent → this fails.
     try testing.expect(std.mem.indexOf(u8, content, "\nSupplementaryGroups=input\n") != null);
-    // Coexists with the user-unit invariant: still no User= directive.
     try testing.expect(std.mem.indexOf(u8, content, "User=") == null);
+}
+
+test "install: generateServiceContent omits SupplementaryGroups=input when input group absent" {
+    // Regression test for issue #279: distros using uaccess/ACL (e.g. Bazzite)
+    // have no 'input' unix group; emitting SupplementaryGroups=input causes
+    // systemd EXIT_GROUP (216) and a restart loop.
+    // Falsifiability: make generateServiceContent always emit the line → this fails.
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const content = try generateServiceContent(allocator, "/usr", false);
+    defer allocator.free(content);
+    try testing.expect(std.mem.indexOf(u8, content, "SupplementaryGroups=input") == null);
+    try testing.expect(std.mem.indexOf(u8, content, "WantedBy=default.target") != null);
 }
 
 test "install: generateUdevRules produces valid output" {
@@ -563,7 +572,7 @@ test "install: generateServiceContent uses StateDirectory (not LogsDirectory)" {
     // the path between daemon and CLI.
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr/local");
+    const content = try generateServiceContent(allocator, "/usr/local", true);
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "StateDirectory=padctl") != null);
     try testing.expect(std.mem.indexOf(u8, content, "LogsDirectory") == null);
@@ -576,7 +585,7 @@ test "install: generateSystemServiceContent uses StateDirectory (not LogsDirecto
     // legacy unit, its state dir matches what stateDir() resolves to.
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateSystemServiceContent(allocator, "/usr/local");
+    const content = try generateSystemServiceContent(allocator, "/usr/local", true);
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "StateDirectory=padctl") != null);
     try testing.expect(std.mem.indexOf(u8, content, "LogsDirectory") == null);
@@ -587,10 +596,30 @@ test "install: generateSystemServiceContent grants /dev/uhid DeviceAllow" {
     // fails with EACCES on a default install.
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateSystemServiceContent(allocator, "/usr/local");
+    const content = try generateSystemServiceContent(allocator, "/usr/local", true);
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "DeviceAllow=/dev/uhid rw") != null);
     try testing.expect(std.mem.indexOf(u8, content, "DeviceAllow=/dev/uinput rw") != null);
+}
+
+test "install: generateSystemServiceContent emits SupplementaryGroups=input when input group exists" {
+    // Falsifiability: remove the has_input_group branch in generateSystemServiceContent → this fails.
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const content = try generateSystemServiceContent(allocator, "/usr", true);
+    defer allocator.free(content);
+    try testing.expect(std.mem.indexOf(u8, content, "\nSupplementaryGroups=input\n") != null);
+}
+
+test "install: generateSystemServiceContent omits SupplementaryGroups=input when input group absent" {
+    // Regression test for issue #279: same guard applies to the legacy system unit.
+    // Falsifiability: make generateSystemServiceContent always emit the line → this fails.
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const content = try generateSystemServiceContent(allocator, "/usr", false);
+    defer allocator.free(content);
+    try testing.expect(std.mem.indexOf(u8, content, "SupplementaryGroups=input") == null);
+    try testing.expect(std.mem.indexOf(u8, content, "DeviceAllow=/dev/uhid rw") != null);
 }
 
 test "install: parseYesNoDefaultYes empty input is yes (default-yes)" {
@@ -1989,7 +2018,7 @@ test "install: udev rules must not contain SYSTEMD_WANTS" {
 test "install: user unit has no systemd 257+ incompatible hardening" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr");
+    const content = try generateServiceContent(allocator, "/usr", true);
     defer allocator.free(content);
     // NoNewPrivileges, LockPersonality, ProtectClock cause EXIT_CAPABILITIES (218)
     // in user scope on systemd 257+ — must be absent from the user unit.
@@ -1997,8 +2026,7 @@ test "install: user unit has no systemd 257+ incompatible hardening" {
     try testing.expect(std.mem.indexOf(u8, content, "LockPersonality=") == null);
     try testing.expect(std.mem.indexOf(u8, content, "ProtectClock=") == null);
     // SupplementaryGroups=input is NOT a systemd 257+ incompatible directive
-    // and intentionally stays in the user unit; only the hardening triad above
-    // is forbidden.
+    // when the input group exists; only the hardening triad above is forbidden.
     try testing.expect(std.mem.indexOf(u8, content, "StateDirectory=padctl") != null);
 }
 
@@ -2027,7 +2055,7 @@ test "install: old system unit triggers migration hint" {
 test "install: generateServiceContent /usr prefix omits --config-dir" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr");
+    const content = try generateServiceContent(allocator, "/usr", true);
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "--config-dir") == null);
     try testing.expect(std.mem.indexOf(u8, content, "ExecStart=/usr/bin/padctl\n") != null);
@@ -2036,7 +2064,7 @@ test "install: generateServiceContent /usr prefix omits --config-dir" {
 test "install: generateServiceContent non-usr prefix includes --config-dir for its own share" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr/local");
+    const content = try generateServiceContent(allocator, "/usr/local", true);
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "--config-dir /usr/local/share/padctl/devices") != null);
     try testing.expect(std.mem.indexOf(u8, content, "--config-dir /usr/share") == null);

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -298,6 +298,51 @@ test "install: generateServiceContent omits SupplementaryGroups=input when input
     try testing.expect(std.mem.indexOf(u8, content, "WantedBy=default.target") != null);
 }
 
+test "install: generateServiceContent group-present output == group-absent + single inserted line" {
+    // Pins the exact byte layout: the only difference between the two cases
+    // must be one inserted "SupplementaryGroups=input\n" line, immediately
+    // after "ExecStart=...\n". A single shared template guarantees this; this
+    // test catches any future divergence between the two cases.
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const with_group = try generateServiceContent(allocator, "/usr", true);
+    defer allocator.free(with_group);
+    const without_group = try generateServiceContent(allocator, "/usr", false);
+    defer allocator.free(without_group);
+
+    const marker = "ExecStart=/usr/bin/padctl\n";
+    const idx = std.mem.indexOf(u8, without_group, marker).?;
+    const insert_at = idx + marker.len;
+    const reconstructed = try std.fmt.allocPrint(allocator, "{s}SupplementaryGroups=input\n{s}", .{
+        without_group[0..insert_at],
+        without_group[insert_at..],
+    });
+    defer allocator.free(reconstructed);
+    try testing.expectEqualStrings(reconstructed, with_group);
+}
+
+test "install: generateSystemServiceContent group-present output == group-absent + single inserted line" {
+    // Pins the exact byte layout for the legacy system unit: the only
+    // difference must be one "SupplementaryGroups=input\n" line, immediately
+    // after "StateDirectory=padctl\n".
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const with_group = try generateSystemServiceContent(allocator, "/usr", true);
+    defer allocator.free(with_group);
+    const without_group = try generateSystemServiceContent(allocator, "/usr", false);
+    defer allocator.free(without_group);
+
+    const marker = "StateDirectory=padctl\n";
+    const idx = std.mem.indexOf(u8, without_group, marker).?;
+    const insert_at = idx + marker.len;
+    const reconstructed = try std.fmt.allocPrint(allocator, "{s}SupplementaryGroups=input\n{s}", .{
+        without_group[0..insert_at],
+        without_group[insert_at..],
+    });
+    defer allocator.free(reconstructed);
+    try testing.expectEqualStrings(reconstructed, with_group);
+}
+
 test "install: generateUdevRules produces valid output" {
     const testing = std.testing;
     const allocator = testing.allocator;

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -76,6 +76,8 @@ const PromptResult = mappings_mod.PromptResult;
 // phase.zig
 const run = phase_mod.run;
 const uninstall = phase_mod.uninstall;
+const inputGroupHintNeeded = phase_mod.inputGroupHintNeeded;
+const hostHasInputGroup = plan_mod.hostHasInputGroup;
 
 // stdout silencer used by tests that exercise live install/uninstall paths.
 const SilencedStdout = struct {
@@ -620,6 +622,28 @@ test "install: generateSystemServiceContent omits SupplementaryGroups=input when
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "SupplementaryGroups=input") == null);
     try testing.expect(std.mem.indexOf(u8, content, "DeviceAllow=/dev/uhid rw") != null);
+}
+
+test "install: inputGroupHintNeeded suppressed when host has no input group" {
+    // Falsifiability: remove the has_group guard in inputGroupHintNeeded → this fails.
+    // Distros without an input group (e.g. Bazzite/Fedora) must not show usermod advice.
+    try std.testing.expect(!inputGroupHintNeeded(false, false));
+    try std.testing.expect(!inputGroupHintNeeded(false, true));
+}
+
+test "install: inputGroupHintNeeded shown only when group exists and user not yet a member" {
+    // Falsifiability: remove the !in_group guard → second case fails.
+    try std.testing.expect(inputGroupHintNeeded(true, false));
+    try std.testing.expect(!inputGroupHintNeeded(true, true));
+}
+
+test "install: hostHasInputGroup returns bool (smoke — value is host-dependent)" {
+    // Falsifiability: if hostHasInputGroup always panics, this fails.
+    // We cannot assert the value — it's host-dependent — but we confirm the
+    // function is callable and consistent with groupGid("input").
+    const has = hostHasInputGroup();
+    const gid = plan_mod.groupGid("input");
+    try std.testing.expectEqual(gid != null, has);
 }
 
 test "install: parseYesNoDefaultYes empty input is yes (default-yes)" {

--- a/src/tools/docgen.zig
+++ b/src/tools/docgen.zig
@@ -26,7 +26,8 @@ pub fn generateDevicePage(
                     const s = try std.fmt.bufPrint(&buf, "{d}", .{ep});
                     break :blk s;
                 } else "—",
-                if (iface.ep_out) |ep| blk: {
+                if (iface.ep_out) |ep|
+                blk: {
                     var buf: [8]u8 = undefined;
                     const s = try std.fmt.bufPrint(&buf, "{d}", .{ep});
                     break :blk s;

--- a/src/tools/docgen.zig
+++ b/src/tools/docgen.zig
@@ -26,8 +26,7 @@ pub fn generateDevicePage(
                     const s = try std.fmt.bufPrint(&buf, "{d}", .{ep});
                     break :blk s;
                 } else "—",
-                if (iface.ep_out) |ep|
-                blk: {
+                if (iface.ep_out) |ep| blk: {
                     var buf: [8]u8 = undefined;
                     const s = try std.fmt.bufPrint(&buf, "{d}", .{ep});
                     break :blk s;


### PR DESCRIPTION
## What changed

**Commit 1 — narrow fix** (`c463858`):
- `generateServiceContent` and `generateSystemServiceContent` gain `has_input_group: bool`; `SupplementaryGroups=input` emitted only when true
- `installServiceFiles` probes once and passes result to generators + legacy-update path
- Four falsifiable regression tests for both service generators (group present / absent)

**Commit 2 — structural refactor** (`1535f90`):
- `plan.hostHasInputGroup() bool` added as single chokepoint (wraps `groupGid("input") != null`)
- `services.installServiceFiles` uses `plan_mod.hostHasInputGroup()` instead of inline `groupGid` call
- `phase.printInputGroupHint` gated via `inputGroupHintNeeded(hostHasInputGroup(), ...)` — distros without an `input` group (e.g. Bazzite/Fedora) no longer see the misleading `sudo usermod -aG input $USER` advice
- `phase.inputGroupHintNeeded(has_group, in_group) bool` extracted as testable pure function
- Three additional tests: `inputGroupHintNeeded` suppressed when no group, `inputGroupHintNeeded` shows only when group exists + user not yet member, `hostHasInputGroup` smoke (consistency with `groupGid`)

**Commit 3 — template dedupe** (`36b6934`):
- `generateServiceContent` and `generateSystemServiceContent` previously duplicated the entire multi-line unit template across the `has_input_group` if/else branches, differing by exactly one line (~60 duplicated lines, silent-drift hazard)
- Each generator now has ONE template string with a conditional `group_line` slot (`"SupplementaryGroups=input\n"` or `""`); single `allocPrint` call per generator
- Generated output is byte-identical to the pre-refactor branch output for both cases (group present → line at the same position with the same surrounding newlines; group absent → no stray blank line)
- Two byte-layout pin tests added (one per generator): assert group-present output equals group-absent output with exactly one `SupplementaryGroups=input\n` inserted at the documented position — catches any future divergence

**udev.zig** — `GROUP="input"` rules left unchanged. udev silently no-ops an unknown group and `TAG+="uaccess"` remains effective for graphical sessions. Structural gating adds complexity without correctness benefit.

**docs/src/contributing/reverse-engineering.md** — out of scope here; follow-up docs pass.

## Why

On Bazzite (Fedora/rpm-ostree) there is no `input` unix group; device access is via uaccess/ACL. The unconditional `SupplementaryGroups=input` caused `systemd status=216/GROUP` → restart loop. Same root cause also produced a spurious `sudo usermod -aG input` hint on those distros. refs #279

## Test plan

- [ ] `zig build test` — all 7 new tests pass (4 service generator + 3 hint/probe)
- [ ] CI green across all jobs
- [ ] Manual on Bazzite: `padctl install` → `systemctl --user status padctl.service` active (running), no GROUP exit, no usermod hint
- [ ] Manual on Debian/Arch/Ubuntu: `SupplementaryGroups=input` still present in generated service file

## Known limitation / follow-up

- udev rule emission is intentionally NOT gated on the input group. udev silently no-ops an unknown `GROUP=`, and `TAG+="uaccess"` already covers device access for an active graphical seat. This is not a boot-loop path, so it is out of scope for #279 (which is specifically the systemd 216/GROUP boot-loop).
- Residual gap: on a group-absent host running the daemon headless / non-seat (systemd linger or SSH, no active uaccess seat), device-node access falls back to the default node owner/mode. The previously-shown `sudo usermod -aG input` hint (now correctly suppressed on group-absent hosts) used to paper over this. Tracked as an out-of-scope follow-up.
- `docs/src/contributing/reverse-engineering.md:27` (`usermod -aG input`) is a separate docs-pass follow-up, not addressed here.
