### PR TITLE
docs(mapping): document gyro blend_stick field

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -133,6 +133,7 @@ invert_y = true
 | `max_val` | float | — | Maximum output value cap |
 | `invert_x` | bool | — | Invert X axis |
 | `invert_y` | bool | — | Invert Y axis |
+| `blend_stick` | bool | `false` | When `true`, gyro joystick output is **added** to the physical stick value (`clamp(physical + gyro, -32767..32767)`) instead of replacing it. Only applies when `mode = "joystick"`. Ignored for `mode = "mouse"`. |
 
 ## `[stick.left]` / `[stick.right]`
 

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -194,6 +194,25 @@ smoothing   = 0.3
 
 This is useful for games that read the right stick for camera control but do not natively support gyro input. All other `[gyro]` fields (`sensitivity`, `deadzone`, `smoothing`, `curve`, `invert_x`, `invert_y`) apply in joystick mode the same way as in mouse mode.
 
+#### Blending gyro with the physical stick (`blend_stick`)
+
+By default, gyro joystick output **replaces** the physical stick value while gyro is active. Set `blend_stick = true` to **add** the gyro signal on top of the physical stick instead:
+
+```toml
+[gyro]
+mode        = "joystick"
+target      = "right_stick"
+activate    = "LS"
+sensitivity = 1.5
+deadzone    = 200
+smoothing   = 0.3
+blend_stick = true          # add gyro onto physical stick instead of replacing it
+```
+
+This lets the physical stick handle coarse movement while the gyro provides fine aim adjustment simultaneously — useful for aim-assist workflows. The combined value is clamped to the valid axis range (`-32767..32767`).
+
+> **Note:** when the physical stick is already at full deflection (±32767), the gyro contribution is clamped out entirely. `blend_stick` has no effect when `mode = "mouse"`.
+
 ### Sticks (`[stick.left]` / `[stick.right]`)
 
 Three modes:


### PR DESCRIPTION
## What changed

- `docs/src/mapping-config.md` — added `blend_stick` row to the `[gyro]` field reference table (type `bool`, default `false`, describes false/absent=overwrite vs true=clamped-add semantics, notes joystick-mode-only and mouse-mode ignored)
- `docs/src/mapping-guide.md` — added "Blending gyro with the physical stick (`blend_stick`)" subsection under the Joystick mode guide, with a complete TOML example and full-deflection caveat note

## Refs

- refs #278 (merged feature commit)
- Design source: `decisions/018-gyro-stick-blend.md`

## Test plan

- [ ] `git diff origin/main..docs/278-blend-stick --stat` shows only `docs/src/mapping-config.md` and `docs/src/mapping-guide.md`
- [ ] Semantics match ADR-018: `false`/absent = overwrite (zero regression), `true` = `clamp(physical + gyro, -32767..32767)`, joystick mode only, mouse mode ignores field, full-deflection clamps gyro contribution to zero