### PR TITLE
docs: complete mapping manual button names, gyro, remap targets

### DIFF
--- a/docs/src/diagnostic-logging.md
+++ b/docs/src/diagnostic-logging.md
@@ -64,7 +64,7 @@ max_log_size_mb = 100 # rotation threshold (default 100 MB)
 
 <a id="schema-rewrite"></a>
 
-> ⚠️ **Rewrite behavior.** `padctl dump enable/disable` parses `config.toml`, rewrites it from the known schema, and atomically renames the result into place. Anything outside the documented schema — unknown sections, undocumented keys, hand-written comments — is **not preserved**. If you hand-edit `config.toml` with content that matters (e.g. a forward-looking `[experimental]` block, inline comments documenting a choice), keep it in a sibling file, or drive padctl via `SIGHUP` after the edit instead of using the `dump` subcommand. The current known schema is `version`, `[diagnostics]` (`dump`, `max_log_size_mb`), `[supervisor]` (`suspend_grace_sec`), and `[[device]]` entries (`name`, `default_mapping`).
+> ⚠️ **Rewrite behavior.** `padctl dump enable/disable` parses `config.toml`, rewrites it from the known schema, and atomically renames the result into place. Anything outside the documented schema — unknown sections, undocumented keys, hand-written comments — is **not preserved**. If you hand-edit `config.toml` with content that matters (e.g. a forward-looking `[experimental]` block, inline comments documenting a choice), keep it in a sibling file, or drive padctl via `SIGHUP` after the edit instead of using the `dump` subcommand. The current known schema is `version`, `[diagnostics]` (`dump`, `max_log_size_mb`), `[supervisor]` (`suspend_grace_sec`), `[chord_switch]` (`modifier`, `selectors`, `hold_ms`), and `[[device]]` entries (`name`, `default_mapping`).
 
 ## Supervisor tunables
 
@@ -96,7 +96,7 @@ name = "racing"
 chord_index = 2   # press B while holding modifier → switch to this mapping
 ```
 
-While the modifier is held, selector buttons are suppressed from the virtual gamepad output so the in-game UI does not see them. If no mapping declares a matching `chord_index`, the daemon logs a warning and does nothing. The standard `padctl switch <name>` CLI still works alongside the chord. Currently this section is not preserved by `padctl dump enable/disable`'s rewrite — edit `config.toml` directly and run `padctl reload` to pick up changes.
+While the modifier is held, selector buttons are suppressed from the virtual gamepad output so the in-game UI does not see them. If no mapping declares a matching `chord_index`, the daemon logs a warning and does nothing. The standard `padctl switch <name>` CLI still works alongside the chord. The `[chord_switch]` section is preserved across `padctl dump enable/disable` rewrites; you can use the `dump` subcommand freely without losing your chord-switch config.
 
 ## Rotation
 

--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -53,11 +53,24 @@ Use `padctl dump enable` to observe raw LT / RT axis readings and dial in the th
 
 **Jitter:** If the axis hovers around the threshold and produces rapid press/release bursts, raise the threshold by 10–20.
 
-Without `trigger_threshold`, `LT` / `RT` emit analog axis events only and do not participate in `[remap]` or layer trigger matching.
+Without `trigger_threshold`, `LT` / `RT` emit analog axis events only and do not participate in `[remap]` or layer trigger matching. This also means `[gyro] activate = "hold_LT"` / `"hold_RT"` will never fire unless `trigger_threshold` is set.
 
 ## `[remap]`
 
-Top-level button remapping (active when no layer overrides). Keys are ButtonId names, values are target button names, `KEY_*` codes, `mouse_left`/`mouse_right`/`mouse_middle`/`mouse_side`/`mouse_forward`/`mouse_back`, `disabled`, or `macro:<name>`.
+Top-level button remapping (active when no layer overrides). Keys are ButtonId names, values are target button names, `KEY_*` codes, chord arrays, `mouse_left`/`mouse_right`/`mouse_middle`/`mouse_side`/`mouse_forward`/`mouse_back`, `disabled`, or `macro:<name>`.
+
+> **`BTN_*` values route to the mouse device, not the gamepad.** Any value starting with `BTN_` (e.g. `BTN_SELECT`, `BTN_START`) produces a mouse button event. To remap to a gamepad button use the friendly ButtonId name (`"Select"`, `"Start"`, etc.).
+
+**Chord output (array of `KEY_*` strings):** a remap value can be a TOML array of 2–4 `KEY_*` strings to emit a chord: on press, key-down events are emitted in declaration order; on release, key-up events in reverse order. Example:
+
+```toml
+[remap]
+A = ["KEY_LEFTMETA", "KEY_1"]       # Super+1
+B = ["KEY_LEFTCTRL", "KEY_C"]       # Ctrl+C
+X = ["KEY_LEFTCTRL", "KEY_LEFTSHIFT", "KEY_S"]  # Ctrl+Shift+S
+```
+
+> **PREVIEW:** Chord output parses and validates, and the source button is suppressed, but key dispatch is not yet wired. Buttons remapped to chord arrays currently emit nothing on press. See `examples/mappings/chord-output.toml`.
 
 ```toml
 [remap]
@@ -70,12 +83,13 @@ M4 = "macro:dodge_roll"
 
 ## `[gyro]`
 
-Global gyro-to-mouse configuration.
+Global gyro configuration. Supports mouse and joystick output modes.
 
 ```toml
 [gyro]
 mode = "mouse"
-activate = "LS"
+activate = "hold_RB"   # hold RB to enable; omit or "always" for always-on
+target = "right_stick" # joystick mode: "right_stick" (default) or "left_stick"
 sensitivity = 2.0
 deadzone = 300
 smoothing = 0.4
@@ -85,8 +99,9 @@ invert_y = true
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `mode` | string | `"off"` | `"off"` or `"mouse"` |
-| `activate` | string | — | Button name to hold for activation (e.g. `"LS"`, `"hold_RB"`) |
+| `mode` | string | `"off"` | `"off"`, `"mouse"`, or `"joystick"` |
+| `activate` | string | — | Use `"hold_<ButtonId>"` (e.g. `"hold_RB"`, `"hold_LS"`) for hold-to-enable. Use `"always"` or omit to make gyro always active. Any value without the `hold_` prefix is treated as always-on. |
+| `target` | string | `"right_stick"` | Which stick the gyro overrides in `"joystick"` mode (and suppresses in `"mouse"` mode). Accepted values: `"right_stick"`, `"left_stick"`. |
 | `sensitivity` | float | — | Overall sensitivity multiplier |
 | `sensitivity_x` | float | — | X-axis sensitivity override |
 | `sensitivity_y` | float | — | Y-axis sensitivity override |
@@ -96,6 +111,8 @@ invert_y = true
 | `max_val` | float | — | Maximum output value cap |
 | `invert_x` | bool | — | Invert X axis |
 | `invert_y` | bool | — | Invert Y axis |
+
+> **Note:** `activate = "hold_LT"` / `"hold_RT"` only works when `trigger_threshold` is set at the top level of the mapping file. LT and RT are analog axes; without `trigger_threshold` the LT/RT button bit is never synthesized, so hold_LT/hold_RT activation will silently never fire.
 
 ## `[stick.left]` / `[stick.right]`
 
@@ -154,7 +171,7 @@ hold_timeout = 200
 | `trigger` | string | yes | Button name that activates this layer |
 | `activation` | string | no | `"hold"` (default) or `"toggle"` |
 | `tap` | string | no | Button/key emitted on short press (when using hold activation). May be a `ButtonId`, `KEY_*`, `mouse_*`, or `disabled`. **Cannot be `macro:<name>`** — the layer tap dispatch path does not run macros, so `tap = "macro:foo"` is rejected at validate time (`error.LayerTapCannotBeMacro`). Use `macro:<name>` from `[remap]` / `[layer.remap]` instead. |
-| `hold_timeout` | integer | no | Hold detection threshold in ms (1–5000) |
+| `hold_timeout` | integer | no | Hold detection threshold in ms (1–5000). Default: 200 ms. |
 
 ### `[layer.remap]`
 

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -138,7 +138,6 @@ Available target types:
 | `"macro:<name>"` | Run a named macro sequence |
 
 > **`BTN_*` values route to the mouse device, not the gamepad.** `BTN_SELECT`, `BTN_START`, and other `BTN_*` names always produce mouse button events. To remap a button to another gamepad button use the friendly ButtonId name (`"Select"`, `"Start"`, etc.), not the `BTN_*` Linux code.
-
 > **Chord output (`["KEY_A", "KEY_B", ...]`) is a preview feature.** The array syntax parses and validates, and the source button is suppressed, but key dispatch is not yet wired. Buttons remapped to chord arrays currently emit nothing on press. See `examples/mappings/chord-output.toml`.
 
 Available button names: `A`, `B`, `X`, `Y`, `LB`, `RB`, `LT`, `RT`, `Start`, `Select`, `Home`, `Capture`, `LS`, `RS`, `DPadUp`, `DPadDown`, `DPadLeft`, `DPadRight`, `M1`, `M2`, `M3`, `M4`, `Paddle1`, `Paddle2`, `Paddle3`, `Paddle4`, `TouchPad`, `Mic`, `C`, `Z`, `LM`, `RM`, `O`

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -106,7 +106,7 @@ Mapping configs are validated at daemon startup. Errors are written to the journ
 journalctl -u padctl.service -n 30
 ```
 
-Note: `padctl --validate` is for device configs only.
+Note: `padctl --validate` validates both device and mapping configs. The schema is auto-detected by scanning for a `[device]` section — files with `[device]` are validated as device configs; all others are validated as mapping configs.
 
 ## Configuration Sections
 
@@ -129,30 +129,40 @@ Available target types:
 
 | Value | Effect |
 |-------|--------|
-| `"A"`, `"B"`, `"LB"`, … | Remap to another gamepad button |
+| `"A"`, `"B"`, `"LB"`, … | Remap to another gamepad button (use ButtonId names — see list below) |
 | `"KEY_*"` | Emit a Linux keyboard key (e.g. `"KEY_F13"`, `"KEY_LEFTSHIFT"`) |
+| `["KEY_A", "KEY_B"]` | Emit a key chord (2–4 `KEY_*` strings; see note below) |
 | `"mouse_left"` / `"mouse_right"` / `"mouse_middle"` / `"mouse_side"` / `"mouse_extra"` | Emit a mouse button |
 | `"mouse_forward"` / `"mouse_back"` | Emit mouse forward/back (button 4/5) |
 | `"disabled"` | Suppress the button entirely |
 | `"macro:<name>"` | Run a named macro sequence |
 
-Available button names: `A`, `B`, `X`, `Y`, `LB`, `RB`, `LT`, `RT`, `Start`, `Select`, `LS`, `RS`, `M1`, `M2`, `M3`, `M4`, `LM`, `RM`, `C`, `Z`
+> **`BTN_*` values route to the mouse device, not the gamepad.** `BTN_SELECT`, `BTN_START`, and other `BTN_*` names always produce mouse button events. To remap a button to another gamepad button use the friendly ButtonId name (`"Select"`, `"Start"`, etc.), not the `BTN_*` Linux code.
+
+> **Chord output (`["KEY_A", "KEY_B", ...]`) is a preview feature.** The array syntax parses and validates, and the source button is suppressed, but key dispatch is not yet wired. Buttons remapped to chord arrays currently emit nothing on press. See `examples/mappings/chord-output.toml`.
+
+Available button names: `A`, `B`, `X`, `Y`, `LB`, `RB`, `LT`, `RT`, `Start`, `Select`, `Home`, `Capture`, `LS`, `RS`, `DPadUp`, `DPadDown`, `DPadLeft`, `DPadRight`, `M1`, `M2`, `M3`, `M4`, `Paddle1`, `Paddle2`, `Paddle3`, `Paddle4`, `TouchPad`, `Mic`, `C`, `Z`, `LM`, `RM`, `O`
 
 ### Gyroscope (`[gyro]`)
 
-Translates gyroscope motion to mouse movement. Off by default.
+Translates gyroscope motion to mouse or joystick output. Off by default.
 
 ```toml
 [gyro]
 mode        = "mouse"
-activate    = "LS"      # hold left stick click to enable gyro
+activate    = "hold_LS"  # hold left stick click to enable gyro
+target      = "right_stick"  # joystick mode: which stick gyro overrides
 sensitivity = 2.0
-deadzone    = 300       # raw gyro units; filters small wobble
-smoothing   = 0.4       # 0–1; higher = smoother but more latency
+deadzone    = 300         # raw gyro units; filters small wobble
+smoothing   = 0.4         # 0–1; higher = smoother but more latency
 invert_y    = true
 ```
 
-Omit `activate` to have gyro always active when mode is `"mouse"`.
+Omit `activate` (or set `activate = "always"`) to have gyro always active when mode is `"mouse"` or `"joystick"`.
+
+The `activate` field requires the `hold_<ButtonId>` prefix for hold-to-enable behavior (e.g. `"hold_LS"`, `"hold_RB"`). Any value without this prefix (including bare button names like `"LS"`) is treated as always-on.
+
+> **Note:** `activate = "hold_LT"` / `"hold_RT"` only works when `trigger_threshold` is set at the top level of the mapping file. LT and RT are analog axes; without `trigger_threshold` the LT/RT button bit is never synthesized, so gyro activation via hold_LT/hold_RT will silently never fire.
 
 ### Sticks (`[stick.left]` / `[stick.right]`)
 

--- a/examples/mappings/chord-output.toml
+++ b/examples/mappings/chord-output.toml
@@ -9,7 +9,6 @@
 # arrays in this file currently emit nothing on press; do not deploy this
 # example as your daily mapping.
 
-[meta]
 name = "chord-output-demo"
 
 # Chord output: array of KEY_* strings (length 2..=4, no duplicates).

--- a/examples/mappings/comprehensive.toml
+++ b/examples/mappings/comprehensive.toml
@@ -4,7 +4,9 @@
 # Every major feature is shown here with a one-line explanation.
 # Remove or comment out any section your device does not need.
 #
-# Button names: A B X Y  LB RB LT RT  Start Select  LS RS  M1 M2 M3 M4  LM RM  C Z
+# Button names: A B X Y  LB RB LT RT  Start Select Home Capture  LS RS
+#               DPadUp DPadDown DPadLeft DPadRight  M1 M2 M3 M4
+#               Paddle1 Paddle2 Paddle3 Paddle4  TouchPad Mic  C Z  LM RM  O
 
 name = "comprehensive-example"
 


### PR DESCRIPTION
Fills in gaps in the user-facing mapping manual found while answering a Vader 5 Pro user report. Docs and example files only; no source changes.

Refs #284.

Changes:
- mapping-guide.md / comprehensive.toml: "Available button names" list completed (was missing DPadUp/Down/Left/Right, Home, Capture, Paddle1-4, TouchPad, Mic, O)
- gyro `activate`: fixed the wrong `activate = "LS"` example (a value without the `hold_` prefix makes gyro always-on); documented the `hold_<ButtonId>` requirement and `"always"`
- gyro: documented the `joystick` mode and the `target` field; noted `hold_LT`/`hold_RT` need a top-level `trigger_threshold`
- remap: noted that `BTN_*` values route to the mouse device, not the gamepad (use `Select`/`Start`, not `BTN_SELECT`/`BTN_START`)
- remap: documented the chord-array syntax, flagged as preview (dispatch not yet wired)
- chord-output.toml: removed the unrecognized `[meta]` table, moved `name` to top level
- diagnostic-logging.md: `[chord_switch]` is preserved across `dump` rewrites (stale caveat removed); added it to the known-schema list
- mapping-guide.md: `--validate` works on mapping configs too (schema auto-detected), not device configs only
- mapping-config.md: stated the `hold_timeout` default (200 ms)

Test plan:
- Docs-only; no code paths touched
- Each change verified against code at baf2292 (ButtonId enum, checkGyroActivate, remap.zig BTN_ branch, GyroConfig fields, user_config.zig chord_switch round-trip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified trigger_threshold requirements for gyro, LT/RT, and layer trigger behavior
  * Noted that LT/RT without trigger_threshold emit analog only and won’t match remap/layer triggers
  * Stated BTN_* remaps route to the mouse device and chord output is a preview (chord dispatch not yet wired)
  * Documented config rewrite behavior and preservation of chord-switch section
  * Expanded supported button names in mapping examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->