### PR TITLE
docs: complete button name lists and fix stale config-doc claims

### DIFF
--- a/docs/src/diagnostic-logging.md
+++ b/docs/src/diagnostic-logging.md
@@ -64,7 +64,7 @@ max_log_size_mb = 100 # rotation threshold (default 100 MB)
 
 <a id="schema-rewrite"></a>
 
-> ⚠️ **Rewrite behavior.** `padctl dump enable/disable` parses `config.toml`, rewrites it from the known schema, and atomically renames the result into place. Anything outside the documented schema — unknown sections, undocumented keys, hand-written comments — is **not preserved**. If you hand-edit `config.toml` with content that matters (e.g. a forward-looking `[experimental]` block, inline comments documenting a choice), keep it in a sibling file, or drive padctl via `SIGHUP` after the edit instead of using the `dump` subcommand. The current known schema is `version`, `[diagnostics]` (`dump`, `max_log_size_mb`), `[supervisor]` (`suspend_grace_sec`), and `[[device]]` entries (`name`, `default_mapping`).
+> ⚠️ **Rewrite behavior.** `padctl dump enable/disable` parses `config.toml`, rewrites it from the known schema, and atomically renames the result into place. Anything outside the documented schema — unknown sections, undocumented keys, hand-written comments — is **not preserved**. If you hand-edit `config.toml` with content that matters (e.g. a forward-looking `[experimental]` block, inline comments documenting a choice), keep it in a sibling file, or drive padctl via `SIGHUP` after the edit instead of using the `dump` subcommand. The current known schema is `version`, `[diagnostics]` (`dump`, `max_log_size_mb`), `[supervisor]` (`suspend_grace_sec`), `[chord_switch]` (`modifier`, `selectors`, `hold_ms`), and `[[device]]` entries (`name`, `default_mapping`).
 
 ## Supervisor tunables
 
@@ -96,7 +96,7 @@ name = "racing"
 chord_index = 2   # press B while holding modifier → switch to this mapping
 ```
 
-While the modifier is held, selector buttons are suppressed from the virtual gamepad output so the in-game UI does not see them. If no mapping declares a matching `chord_index`, the daemon logs a warning and does nothing. The standard `padctl switch <name>` CLI still works alongside the chord. Currently this section is not preserved by `padctl dump enable/disable`'s rewrite — edit `config.toml` directly and run `padctl reload` to pick up changes.
+While the modifier is held, selector buttons are suppressed from the virtual gamepad output so the in-game UI does not see them. If no mapping declares a matching `chord_index`, the daemon logs a warning and does nothing. The standard `padctl switch <name>` CLI still works alongside the chord. `[chord_switch]` is preserved across `padctl dump enable/disable`'s rewrite. Comments inside the section follow the same rewrite caveat as the rest of `config.toml`.
 
 ## Rotation
 

--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -59,6 +59,8 @@ Without `trigger_threshold`, `LT` / `RT` emit analog axis events only and do not
 
 Top-level button remapping (active when no layer overrides). Keys are ButtonId names, values are target button names, `KEY_*` codes, `mouse_left`/`mouse_right`/`mouse_middle`/`mouse_side`/`mouse_extra`/`mouse_forward`/`mouse_back`, `disabled`, or `macro:<name>`.
 
+> **Note:** `BTN_*` values (e.g. `"BTN_SOUTH"`) are routed to the virtual **mouse** device, not the gamepad. To target a gamepad button use a friendly `ButtonId` name (`"A"`, `"Select"`, etc.) instead.
+
 ```toml
 [remap]
 M1 = "KEY_F13"
@@ -192,7 +194,7 @@ hold_timeout = 200
 | `trigger` | string | yes | Button name that activates this layer |
 | `activation` | string | no | `"hold"` (default) or `"toggle"` |
 | `tap` | string | no | Button/key emitted on short press (when using hold activation). May be a `ButtonId`, `KEY_*`, `mouse_*`, or `disabled`. **Cannot be `macro:<name>`** — the layer tap dispatch path does not run macros, so `tap = "macro:foo"` is rejected at validate time (`error.LayerTapCannotBeMacro`). Use `macro:<name>` from `[remap]` / `[layer.remap]` instead. |
-| `hold_timeout` | integer | no | Hold detection threshold in ms (1–5000) |
+| `hold_timeout` | integer | no | Hold detection threshold in ms (1–5000); default 200 |
 
 ### `[layer.remap]`
 

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -106,7 +106,7 @@ Mapping configs are validated at daemon startup. Errors are written to the journ
 journalctl -u padctl.service -n 30
 ```
 
-Note: `padctl --validate` is for device configs only.
+Mapping configs can also be validated with `padctl --validate`; the flag auto-detects device vs mapping schema by scanning for a `[device]` table.
 
 ## Configuration Sections
 
@@ -136,7 +136,9 @@ Available target types:
 | `"disabled"` | Suppress the button entirely |
 | `"macro:<name>"` | Run a named macro sequence |
 
-Available button names: `A`, `B`, `X`, `Y`, `LB`, `RB`, `LT`, `RT`, `Start`, `Select`, `LS`, `RS`, `M1`, `M2`, `M3`, `M4`, `LM`, `RM`, `C`, `Z`
+> **Note:** `BTN_*` values (e.g. `"BTN_SOUTH"`) are routed to the virtual **mouse** device, not the gamepad. To remap to a gamepad button use a friendly `ButtonId` name (`"A"`, `"Select"`, etc.) instead.
+
+Available button names: `A`, `B`, `X`, `Y`, `LB`, `RB`, `LT`, `RT`, `Start`, `Select`, `Home`, `Capture`, `LS`, `RS`, `DPadUp`, `DPadDown`, `DPadLeft`, `DPadRight`, `M1`, `M2`, `M3`, `M4`, `Paddle1`, `Paddle2`, `Paddle3`, `Paddle4`, `TouchPad`, `Mic`, `C`, `Z`, `LM`, `RM`, `O`
 
 #### Tap / hold / double-press on one button
 

--- a/examples/mappings/chord-output.toml
+++ b/examples/mappings/chord-output.toml
@@ -9,7 +9,6 @@
 # arrays in this file currently emit nothing on press; do not deploy this
 # example as your daily mapping.
 
-[meta]
 name = "chord-output-demo"
 
 # Chord output: array of KEY_* strings (length 2..=4, no duplicates).

--- a/examples/mappings/comprehensive.toml
+++ b/examples/mappings/comprehensive.toml
@@ -4,7 +4,9 @@
 # Every major feature is shown here with a one-line explanation.
 # Remove or comment out any section your device does not need.
 #
-# Button names: A B X Y  LB RB LT RT  Start Select  LS RS  M1 M2 M3 M4  LM RM  C Z
+# Button names: A B X Y  LB RB LT RT  Start Select  Home Capture  LS RS
+#               DPadUp DPadDown DPadLeft DPadRight
+#               M1 M2 M3 M4  Paddle1 Paddle2 Paddle3 Paddle4  TouchPad  Mic  LM RM  C Z  O
 
 name = "comprehensive-example"
 


### PR DESCRIPTION
Fills genuine gaps in the user-facing docs found while answering a Vader 5 Pro user report. Docs and example files only; no source changes. Each change re-verified against current main (bff7902).

Refs #284. Supersedes #285 (that branch was based on a stale checkout and is closed).

Changes:
- mapping-guide.md / comprehensive.toml: "Available button names" list completed (was missing DPadUp/Down/Left/Right, Home, Capture, Paddle1-4, TouchPad, Mic, O) — full set from the ButtonId enum
- mapping-guide.md / mapping-config.md: noted that `BTN_*` remap values route to the virtual mouse device, not the gamepad (use friendly ButtonId names like `Select`/`Start`)
- mapping-guide.md: `--validate` auto-detects device vs mapping schema, not device configs only (confirmed src/tools/validate.zig)
- diagnostic-logging.md: `[chord_switch]` is preserved across `dump enable/disable` rewrites (stale "not preserved" caveat removed); added it to the known-schema list
- chord-output.toml: removed the unrecognized `[meta]` table, moved `name` to top level
- mapping-config.md: stated the `hold_timeout` default (200 ms)

Note: gyro joystick mode, the `target` field, the `hold_LT`/`trigger_threshold` interaction, and chord-array preview are already documented on main (#271, #275) and were intentionally left untouched.

Test plan:
- Docs-only; no code paths touched
- Each change verified against code at bff7902 (ButtonId enum, remap.zig BTN_ branch, validate.zig detectFileKind, user_config.zig chord_switch round-trip, layer.zig hold_timeout default)