### PR TITLE
fix(install): drop SupplementaryGroups from systemd user unit (216/GROUP)

### DIFF
--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -426,6 +426,85 @@ jobs:
           fi
           echo "PASS: no incompatible hardening directives"
 
+      - name: Verify no SupplementaryGroups in user unit (issues #287/#288)
+        run: |
+          set -euo pipefail
+          # A systemd --user manager runs unprivileged (no CAP_SETGID) and cannot
+          # apply SupplementaryGroups=; the directive aborts startup with
+          # status=216/GROUP. It must never appear in the user unit.
+          if grep -E "^SupplementaryGroups=" /tmp/padctl.service; then
+            echo "FAIL: SupplementaryGroups in user unit causes status=216/GROUP (issues #287/#288)"
+            exit 1
+          fi
+          echo "PASS: no SupplementaryGroups in user unit"
+
+      - name: Start generated user unit under a real --user manager (issues #287/#288)
+        run: |
+          set -euo pipefail
+          # Boot systemd in a container, install the GENERATED user unit into a
+          # test user's manager, start it, and assert it does NOT fail with
+          # status=216/GROUP. Runtime counterpart to the static grep check
+          # above and the Zig generation test. The container is started
+          # detached with systemd as PID 1 — a backgrounded systemd inside a
+          # bash -c does not reliably reach a running state.
+          docker build -t padctl-sd-runtime - <<'DOCKERFILE'
+          FROM debian:12
+          RUN apt-get update -qq \
+           && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+                systemd systemd-sysv dbus libpam-systemd procps \
+           && rm -rf /var/lib/apt/lists/*
+          DOCKERFILE
+
+          docker run -d --name sd-runtime --privileged --cgroupns=host \
+            --tmpfs /run --tmpfs /run/lock \
+            -v /sys/fs/cgroup:/sys/fs/cgroup \
+            -v /tmp/padctl.service:/tmp/in.service:ro \
+            -e container=docker \
+            padctl-sd-runtime /lib/systemd/systemd
+
+          for i in $(seq 1 30); do
+            S=$(docker exec sd-runtime systemctl is-system-running 2>/dev/null || true)
+            echo "${S}" | grep -qE "running|degraded" && break
+            sleep 1
+          done
+
+          docker exec sd-runtime /bin/bash -euo pipefail -c '
+            # Arch-shape host: the input group EXISTS — exactly the #288
+            # scenario where the PR #280 conditional still wrote the line.
+            groupadd input
+            useradd -m -s /bin/bash tu
+            UID_TU=$(id -u tu)
+            cp /bin/sh /usr/bin/padctl
+            mkdir -p /home/tu/.config/systemd/user
+            # The generated unit uses ExecStart=/usr/bin/padctl; swap to a
+            # long-running stub so the only failure mode under test is GROUP.
+            sed "s#^ExecStart=.*#ExecStart=/bin/sleep 600#" /tmp/in.service \
+              > /home/tu/.config/systemd/user/padctl.service
+            chown -R tu:tu /home/tu
+            loginctl enable-linger tu
+            sleep 3
+            su - tu -c "XDG_RUNTIME_DIR=/run/user/${UID_TU} systemctl --user daemon-reload"
+            su - tu -c "XDG_RUNTIME_DIR=/run/user/${UID_TU} systemctl --user start padctl.service" || true
+            sleep 2
+            STATUS=$(su - tu -c "XDG_RUNTIME_DIR=/run/user/${UID_TU} systemctl --user show -p ExecMainStatus --value padctl.service")
+            ACTIVE=$(su - tu -c "XDG_RUNTIME_DIR=/run/user/${UID_TU} systemctl --user is-active padctl.service" || true)
+            echo "ExecMainStatus=${STATUS} ActiveState=${ACTIVE}"
+            su - tu -c "XDG_RUNTIME_DIR=/run/user/${UID_TU} systemctl --user --no-pager status padctl.service" || true
+            if [ "${STATUS}" = "216" ]; then
+              echo "FAIL: user unit exited status=216/GROUP (issues #287/#288)"
+              exit 1
+            fi
+            if [ "${ACTIVE}" != "active" ]; then
+              echo "FAIL: user unit did not reach active state"
+              exit 1
+            fi
+            echo "PASS: generated user unit reaches active state, no 216/GROUP"
+          '
+
+      - name: Tear down systemd runtime container
+        if: always()
+        run: docker rm -f sd-runtime 2>/dev/null || true
+
       - name: systemd-analyze verify in Ubuntu 26.04 (systemd 259)
         run: |
           set -euo pipefail

--- a/src/cli/install/services.zig
+++ b/src/cli/install/services.zig
@@ -9,14 +9,18 @@ const runCmdWarn = plan_mod.runCmdWarn;
 const planSystemctlUser = plan_mod.planSystemctlUser;
 const atomicInstallBinary = plan_mod.atomicInstallBinary;
 
-pub fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8, has_input_group: bool) ![]const u8 {
+/// Generate the systemd --user unit. SupplementaryGroups= is intentionally
+/// NOT emitted: a user-scope service manager runs unprivileged (no CAP_SETGID)
+/// and cannot apply it, so the directive aborts startup with status=216/GROUP
+/// regardless of whether the host has an 'input' group (issues #287, #288).
+/// Device-node access for the daemon comes from udev GROUP="input" MODE="0660"
+/// rules plus desktop uaccess ACLs, not from the unit.
+pub fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8) ![]const u8 {
     const exec_start = if (std.mem.eql(u8, prefix, "/usr"))
         try std.fmt.allocPrint(allocator, "{s}/bin/padctl", .{prefix})
     else
         try std.fmt.allocPrint(allocator, "{s}/bin/padctl --config-dir {s}/share/padctl/devices", .{ prefix, prefix });
     defer allocator.free(exec_start);
-
-    const group_line: []const u8 = if (has_input_group) "SupplementaryGroups=input\n" else "";
 
     return std.fmt.allocPrint(allocator,
         \\[Unit]
@@ -26,7 +30,7 @@ pub fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8, 
         \\[Service]
         \\Type=simple
         \\ExecStart={s}
-        \\{s}Restart=on-failure
+        \\Restart=on-failure
         \\RestartSec=3
         \\# Canonical state/log dir: $XDG_STATE_HOME/padctl on user services,
         \\# /var/lib/padctl on system services. systemd pre-creates it with
@@ -38,7 +42,7 @@ pub fn generateServiceContent(allocator: std.mem.Allocator, prefix: []const u8, 
         \\[Install]
         \\WantedBy=default.target
         \\
-    , .{ exec_start, group_line });
+    , .{exec_start});
 }
 
 pub const immutable_dropin_content =
@@ -349,14 +353,10 @@ pub fn installBinaries(
 pub fn installServiceFiles(allocator: std.mem.Allocator, plan: *const InstallPlan) !void {
     const service_path = try std.fmt.allocPrint(allocator, "{s}/padctl.service", .{plan.service_dir});
     defer allocator.free(service_path);
-    // Probe once: distros using uaccess/ACL (e.g. Bazzite/Fedora) have no
-    // 'input' unix group. Emitting SupplementaryGroups=input on those systems
-    // causes systemd EXIT_GROUP (216) and a restart loop (#279).
-    const has_input_group = plan_mod.hostHasInputGroup();
     // Always use the user-service template. Even on immutable-root installs,
     // the service file is placed under /etc/systemd/user/ so systemd discovers
     // it as a user unit and each user's systemd instance runs its own copy.
-    const service_content = try generateServiceContent(allocator, plan.prefix, has_input_group);
+    const service_content = try generateServiceContent(allocator, plan.prefix);
     defer allocator.free(service_content);
     {
         var f = try std.fs.createFileAbsolute(service_path, .{ .truncate = true });
@@ -387,7 +387,9 @@ pub fn installServiceFiles(allocator: std.mem.Allocator, plan: *const InstallPla
     // of effective_immutable. Pre-user-service installs on any distro
     // placed the unit under /etc/systemd/system/ or <prefix>/lib/systemd/
     // system/. The helper is a no-op when no legacy file is present.
-    updateLegacySystemService(allocator, plan.opts.destdir, plan.prefix, has_input_group);
+    // SupplementaryGroups= remains valid on a system-scope unit (PID 1 has
+    // CAP_SETGID), so the legacy path keeps the conditional probe.
+    updateLegacySystemService(allocator, plan.opts.destdir, plan.prefix, plan_mod.hostHasInputGroup());
 }
 
 pub fn installReconnectScript(allocator: std.mem.Allocator, plan: *const InstallPlan) !void {

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -245,7 +245,7 @@ test "install: extractVidPid ignores [output] section vid/pid" {
 test "install: generateServiceContent uses prefix" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr/local", true);
+    const content = try generateServiceContent(allocator, "/usr/local");
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "/usr/local/bin/padctl") != null);
     try testing.expect(std.mem.indexOf(u8, content, "--config-dir /usr/local/share/padctl/devices") != null);
@@ -257,7 +257,7 @@ test "install: generateServiceContent uses prefix" {
 test "install: generateServiceContent default prefix omits --config-dir" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr", true);
+    const content = try generateServiceContent(allocator, "/usr");
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "/usr/bin/padctl") != null);
     try testing.expect(std.mem.indexOf(u8, content, "--config-dir") == null);
@@ -267,7 +267,7 @@ test "install: generateServiceContent default prefix omits --config-dir" {
 test "install: generateServiceContent is user unit" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr", true);
+    const content = try generateServiceContent(allocator, "/usr");
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "WantedBy=default.target") != null);
     try testing.expect(std.mem.indexOf(u8, content, "ProtectHome") == null);
@@ -275,50 +275,21 @@ test "install: generateServiceContent is user unit" {
     try testing.expect(std.mem.indexOf(u8, content, "User=") == null);
 }
 
-test "install: generateServiceContent emits SupplementaryGroups=input when input group exists" {
-    // Falsifiability: remove the has_input_group branch in generateServiceContent → this fails.
+test "install: generateServiceContent never emits SupplementaryGroups (issues #287/#288)" {
+    // A systemd --user service manager runs unprivileged (no CAP_SETGID) and
+    // cannot apply SupplementaryGroups=; the directive aborts startup with
+    // status=216/GROUP. It must never appear in the user unit, on any host
+    // shape — whether or not the host has an 'input' group.
+    // Falsifiability: re-add the SupplementaryGroups line to
+    // generateServiceContent and this test fails.
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr", true);
-    defer allocator.free(content);
-    try testing.expect(std.mem.indexOf(u8, content, "\nSupplementaryGroups=input\n") != null);
-    try testing.expect(std.mem.indexOf(u8, content, "User=") == null);
-}
-
-test "install: generateServiceContent omits SupplementaryGroups=input when input group absent" {
-    // Regression test for issue #279: distros using uaccess/ACL (e.g. Bazzite)
-    // have no 'input' unix group; emitting SupplementaryGroups=input causes
-    // systemd EXIT_GROUP (216) and a restart loop.
-    // Falsifiability: make generateServiceContent always emit the line → this fails.
-    const testing = std.testing;
-    const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr", false);
-    defer allocator.free(content);
-    try testing.expect(std.mem.indexOf(u8, content, "SupplementaryGroups=input") == null);
-    try testing.expect(std.mem.indexOf(u8, content, "WantedBy=default.target") != null);
-}
-
-test "install: generateServiceContent group-present output == group-absent + single inserted line" {
-    // Pins the exact byte layout: the only difference between the two cases
-    // must be one inserted "SupplementaryGroups=input\n" line, immediately
-    // after "ExecStart=...\n". A single shared template guarantees this; this
-    // test catches any future divergence between the two cases.
-    const testing = std.testing;
-    const allocator = testing.allocator;
-    const with_group = try generateServiceContent(allocator, "/usr", true);
-    defer allocator.free(with_group);
-    const without_group = try generateServiceContent(allocator, "/usr", false);
-    defer allocator.free(without_group);
-
-    const marker = "ExecStart=/usr/bin/padctl\n";
-    const idx = std.mem.indexOf(u8, without_group, marker).?;
-    const insert_at = idx + marker.len;
-    const reconstructed = try std.fmt.allocPrint(allocator, "{s}SupplementaryGroups=input\n{s}", .{
-        without_group[0..insert_at],
-        without_group[insert_at..],
-    });
-    defer allocator.free(reconstructed);
-    try testing.expectEqualStrings(reconstructed, with_group);
+    for ([_][]const u8{ "/usr", "/usr/local" }) |prefix| {
+        const content = try generateServiceContent(allocator, prefix);
+        defer allocator.free(content);
+        try testing.expect(std.mem.indexOf(u8, content, "SupplementaryGroups") == null);
+        try testing.expect(std.mem.indexOf(u8, content, "WantedBy=default.target") != null);
+    }
 }
 
 test "install: generateSystemServiceContent group-present output == group-absent + single inserted line" {
@@ -619,7 +590,7 @@ test "install: generateServiceContent uses StateDirectory (not LogsDirectory)" {
     // the path between daemon and CLI.
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr/local", true);
+    const content = try generateServiceContent(allocator, "/usr/local");
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "StateDirectory=padctl") != null);
     try testing.expect(std.mem.indexOf(u8, content, "LogsDirectory") == null);
@@ -2087,15 +2058,16 @@ test "install: udev rules must not contain SYSTEMD_WANTS" {
 test "install: user unit has no systemd 257+ incompatible hardening" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr", true);
+    const content = try generateServiceContent(allocator, "/usr");
     defer allocator.free(content);
     // NoNewPrivileges, LockPersonality, ProtectClock cause EXIT_CAPABILITIES (218)
     // in user scope on systemd 257+ — must be absent from the user unit.
     try testing.expect(std.mem.indexOf(u8, content, "NoNewPrivileges=") == null);
     try testing.expect(std.mem.indexOf(u8, content, "LockPersonality=") == null);
     try testing.expect(std.mem.indexOf(u8, content, "ProtectClock=") == null);
-    // SupplementaryGroups=input is NOT a systemd 257+ incompatible directive
-    // when the input group exists; only the hardening triad above is forbidden.
+    // SupplementaryGroups= is unappliable in user scope (no CAP_SETGID) and
+    // aborts startup with status=216/GROUP — must be absent (issues #287/#288).
+    try testing.expect(std.mem.indexOf(u8, content, "SupplementaryGroups") == null);
     try testing.expect(std.mem.indexOf(u8, content, "StateDirectory=padctl") != null);
 }
 
@@ -2124,7 +2096,7 @@ test "install: old system unit triggers migration hint" {
 test "install: generateServiceContent /usr prefix omits --config-dir" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr", true);
+    const content = try generateServiceContent(allocator, "/usr");
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "--config-dir") == null);
     try testing.expect(std.mem.indexOf(u8, content, "ExecStart=/usr/bin/padctl\n") != null);
@@ -2133,7 +2105,7 @@ test "install: generateServiceContent /usr prefix omits --config-dir" {
 test "install: generateServiceContent non-usr prefix includes --config-dir for its own share" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const content = try generateServiceContent(allocator, "/usr/local", true);
+    const content = try generateServiceContent(allocator, "/usr/local");
     defer allocator.free(content);
     try testing.expect(std.mem.indexOf(u8, content, "--config-dir /usr/local/share/padctl/devices") != null);
     try testing.expect(std.mem.indexOf(u8, content, "--config-dir /usr/share") == null);


### PR DESCRIPTION
## Problem

The `padctl.service` systemd **user** service fails to start with `status=216/GROUP`:

- `#288` (Arch, v0.1.8): `Changing group credentials failed: Operation not permitted` / `Failed at step GROUP spawning /usr/bin/padctl: Operation not permitted`
- `#287` (Bazzite): `Main PID ... (code=exited, status=216/GROUP)`, daemon stuck in `activating (auto-restart)`

## Root cause

PR #268 added `SupplementaryGroups=input` to the systemd **user** unit. PR #280 made the line conditional on the host having an `input` group. That does not fix it:

- A systemd `--user` service manager runs unprivileged and lacks `CAP_SETGID`, so it physically cannot apply `SupplementaryGroups=`.
- The directive aborts startup with `status=216/GROUP` regardless of whether the `input` group exists.
- Arch (#288) has an `input` group, so the PR #280 conditional still writes the line and it still fails.

`SupplementaryGroups=` is fundamentally invalid in user scope on every host.

## Empirical verification

Booting a real `--user` manager (systemd 252) with the input group present (GID 1000):

- Unit **with** `SupplementaryGroups=input` -> `ExecMainStatus=216`, `Changing group credentials failed: Operation not permitted`, `Failed at step GROUP` -- reproduces #288/#287 exactly.
- Unit **without** the directive -> `active (running)`.

## Changes

- `generateServiceContent` (the `--user` unit): never emit `SupplementaryGroups`; drop the now-unused `has_input_group` parameter.
- `generateSystemServiceContent` (legacy **system**-scope unit): keeps the conditional `SupplementaryGroups=input` line -- PID 1 has `CAP_SETGID`, so it is valid there.
- Device-node access is unaffected: udev rules set `GROUP="input" MODE="0660"`, desktop sessions get uaccess ACLs, and the installer prints a `usermod -aG input` hint for headless users. None of this depends on `SupplementaryGroups`.

## Test plan

- Zig unit-generation test (`src/cli/install/tests.zig`): asserts the generated user unit contains no `SupplementaryGroups` for both host shapes (input group present / absent). Verified it FAILS on `origin/main` (origin/main emits the line) and PASSES on this branch.
- CI (`install-flow.yml` `systemd-hardening` job): static `grep` assertion plus a runtime check that boots a real `--user` manager on an Arch-shape host (input group present) and asserts the generated unit reaches `active` without `status=216/GROUP`. Verified the runtime check FAILS for an origin/main-shape unit (`ExecMainStatus=216`) and PASSES for the fixed unit.
- `zig build test` passes (Docker, zig 0.15.2).

refs #287 #288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User-scope systemd units no longer include SupplementaryGroups directive
  * Fixed malformed Restart directive in systemd unit templates

* **Tests**
  * Added CI validation to enforce SupplementaryGroups absence in user-scope units

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->