### PR TITLE
chore: gitignore build artifacts and OpenPlan governance files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,15 @@ zig-cache/
 zig-pkg/
 *.o
 *.a
+*.deb
 kcov-output/
 .worktrees/
 
 # OpenPlan framework (development governance, not public)
 bin/
 openplan.jsonc
+CLAUDE.md
+deviations/
 .claude/
 openspec/
 _skills/


### PR DESCRIPTION
## Changes

- Add `*.deb` to build-artifact ignores (alongside `*.o`, `*.a`)
- Add `CLAUDE.md` to OpenPlan governance ignores (alongside `openplan.jsonc`, `.claude/`, etc.)
- Add `deviations/` to OpenPlan governance ignores (alongside `openspec/`, `_agent/`, etc.)

## Test plan

- `.gitignore`-only change; no source files modified, no build impact