### PR TITLE
build: canonical Docker build image + padctl-docker helper (ADR-019)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,67 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Build and publish the canonical padctl build image (ADR-019) to GHCR.
+  # The image is tagged with the Zig version read from .zigversion. On a
+  # push event the job builds and pushes only when that version tag is not
+  # already in the registry (manifest-inspect cache check); on a fork
+  # pull_request it cannot push, so it builds locally for verification.
+  # This job is currently additive — no other job consumes the image yet.
+  build-image:
+    name: build-image
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve image reference
+        id: img
+        run: |
+          set -euo pipefail
+          ver="$(head -n1 .zigversion | tr -d '[:space:]')"
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "ref=ghcr.io/${owner}/padctl-build:${ver}" >> "$GITHUB_OUTPUT"
+          echo "version=${ver}" >> "$GITHUB_OUTPUT"
+      - name: Look up Zig SHA256
+        id: sha
+        run: |
+          set -euo pipefail
+          amd64="$(scripts/padctl-docker --print-sha amd64)"
+          test -n "$amd64"
+          echo "amd64=${amd64}" >> "$GITHUB_OUTPUT"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check whether image tag already exists
+        id: exists
+        run: |
+          set -euo pipefail
+          if docker manifest inspect "${{ steps.img.outputs.ref }}" >/dev/null 2>&1; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Build and push canonical image
+        if: steps.exists.outputs.found == 'false'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.img.outputs.ref }}
+          build-args: |
+            ZIG_VERSION=${{ steps.img.outputs.version }}
+            ZIG_SHA256=${{ steps.sha.outputs.amd64 }}
+            TARGETARCH=amd64
+
   # Build the Lean formal-spec oracle once and publish it as an artifact.
   # The interactive-Lean-oracle DRT suite in src/test/properties/drt_props.zig
   # only runs when formal/lean/.lake/build/bin/oracle exists; without this job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
           build-args: |
             ZIG_VERSION=${{ steps.img.outputs.version }}
             ZIG_SHA256=${{ steps.sha.outputs.amd64 }}
-            TARGETARCH=amd64
 
   # Build the Lean formal-spec oracle once and publish it as an artifact.
   # The interactive-Lean-oracle DRT suite in src/test/properties/drt_props.zig

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1
+#
+# Canonical padctl build image (ADR-019).
+#
+# debian:bookworm-slim ships glibc 2.36, which avoids the Zig issue #147
+# `R_X86_64_PC64 in .sframe` linker error seen on glibc 2.43+ hosts.
+#
+# ZIG_VERSION and ZIG_SHA256 are mandatory build-args with NO defaults: a bare
+# `docker build .` fails by design. Builds must go through scripts/padctl-docker
+# so the Zig version and its verified checksum stay in sync with .zigversion.
+ARG TARGETARCH
+FROM debian:bookworm-slim
+
+ARG ZIG_VERSION
+ARG ZIG_SHA256
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libusb-1.0-0-dev \
+      linux-libc-dev \
+      curl \
+      ca-certificates \
+      xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# TARGETARCH (set by buildx) maps to the Zig release arch name.
+RUN set -eu; \
+    case "${TARGETARCH}" in \
+      amd64) _arch=x86_64 ;; \
+      arm64) _arch=aarch64 ;; \
+      *) echo "unsupported arch: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    _tarball="zig-${_arch}-linux-${ZIG_VERSION}.tar.xz"; \
+    curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/${_tarball}" -o /tmp/zig.tar.xz; \
+    echo "${ZIG_SHA256}  /tmp/zig.tar.xz" | sha256sum -c -; \
+    tar -xJf /tmp/zig.tar.xz -C /usr/local; \
+    ln -s "/usr/local/zig-${_arch}-linux-${ZIG_VERSION}/zig" /usr/local/bin/zig; \
+    rm /tmp/zig.tar.xz
+
+WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,13 @@
 # ZIG_VERSION and ZIG_SHA256 are mandatory build-args with NO defaults: a bare
 # `docker build .` fails by design. Builds must go through scripts/padctl-docker
 # so the Zig version and its verified checksum stay in sync with .zigversion.
-ARG TARGETARCH
 FROM debian:bookworm-slim
 
 ARG ZIG_VERSION
 ARG ZIG_SHA256
+# TARGETARCH is a predefined build arg populated by BuildKit from --platform;
+# it must be re-declared inside the stage to be visible to RUN.
+ARG TARGETARCH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       libusb-1.0-0-dev \

--- a/README.md
+++ b/README.md
@@ -186,6 +186,18 @@ This is an upstream Zig limitation, not a padctl bug. Workarounds:
 2. **Install Zig 0.15.2 from the official tarball** (`https://ziglang.org/download/`) on a system with **glibc ≤ 2.41** (Debian 12 = glibc 2.36, Ubuntu 22.04 = glibc 2.35, Ubuntu 24.04 = glibc 2.39 all work; Arch with glibc 2.43+ does NOT).
 3. Track upstream fix progress at [ziglang/zig#31272](https://codeberg.org/ziglang/zig/issues/31272).
 
+## Build with Docker
+
+If you cannot install Zig locally — or hit the glibc 2.43+ linker error above — build padctl inside the canonical Docker image instead. It pins the exact Zig version from `.zigversion` against Debian bookworm (glibc 2.36), so it matches the CI build environment.
+
+```sh
+./scripts/padctl-docker build      # zig build inside the image
+./scripts/padctl-docker test       # zig build test inside the image
+./scripts/padctl-docker shell      # interactive shell for debugging
+```
+
+The first invocation builds the image (`padctl-build:<zig-version>`); later runs reuse it. The repository is bind-mounted at `/src`, so build output lands in your working tree as usual. Requires only Docker — no local Zig toolchain.
+
 ## Bazzite / Immutable Distros
 
 On immutable distributions (Bazzite, Fedora Atomic, etc.) where `/usr` is read-only, use the bootstrap script for a complete one-command setup:

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -53,6 +53,18 @@ Optional build flags:
 > Ubuntu 22.04/24.04 all work; Arch with glibc 2.43+ does NOT).
 > Upstream fix: [ziglang/zig#31272](https://codeberg.org/ziglang/zig/issues/31272).
 
+## Build with Docker
+
+If you do not have Zig installed — or hit the glibc 2.43+ linker error above — build inside the canonical Docker image. It pins the Zig version from `.zigversion` against Debian bookworm (glibc 2.36) and matches the CI build environment, so it needs only Docker:
+
+```sh
+./scripts/padctl-docker build      # zig build inside the image
+./scripts/padctl-docker test       # zig build test inside the image
+./scripts/padctl-docker shell      # interactive shell for debugging
+```
+
+The first run builds the image (`padctl-build:<zig-version>`) and later runs reuse it. The repository is bind-mounted at `/src`, so `zig-out/` appears in your working tree as with a native build.
+
 ## Install
 
 ```sh

--- a/scripts/padctl-docker
+++ b/scripts/padctl-docker
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# padctl-docker — single entry point for the canonical Docker build image (ADR-019).
+#
+# Subcommands:
+#   image    build (or reuse) the canonical build image for the pinned Zig version
+#   build    run `zig build` inside the image
+#   test     run `zig build test` inside the image
+#   canary   run the UHID L2 privileged tests against the host /dev/uhid
+#   shell    open an interactive shell inside the image
+#
+# The Zig version is read from .zigversion; its SHA256 is looked up in the
+# table below. A version/arch combination missing from the table is a hard
+# error — there is no fallback to an unverified download.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# SHA256 of the official ziglang.org tarballs, keyed by "<version>-<arch>".
+# Source: https://ziglang.org/download/index.json
+# On a Zig upgrade, add both the amd64 and arm64 entries for the new version.
+declare -A SHA256_TABLE=(
+  ["0.15.2-amd64"]="02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239"
+  ["0.15.2-arm64"]="958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f"
+)
+
+die() {
+  echo "padctl-docker: $*" >&2
+  exit 1
+}
+
+zig_version() {
+  local f="${REPO_ROOT}/.zigversion"
+  [ -f "$f" ] || die ".zigversion not found at ${f}"
+  local v
+  v="$(head -n1 "$f" | tr -d '[:space:]')"
+  [ -n "$v" ] || die ".zigversion is empty"
+  printf '%s' "$v"
+}
+
+# Map `uname -m` to the Docker TARGETARCH value used by the Dockerfile.
+host_arch() {
+  case "$(uname -m)" in
+    x86_64) printf 'amd64' ;;
+    aarch64 | arm64) printf 'arm64' ;;
+    *) die "unsupported host arch: $(uname -m)" ;;
+  esac
+}
+
+sha256_for() {
+  local version="$1" arch="$2" key sha
+  key="${version}-${arch}"
+  sha="${SHA256_TABLE[$key]:-}"
+  [ -n "$sha" ] || die "no SHA256 for ${key} — add it to SHA256_TABLE in $0"
+  printf '%s' "$sha"
+}
+
+# Build the canonical image locally if the version tag is not already present.
+cmd_image() {
+  local version arch sha tag
+  version="$(zig_version)"
+  arch="$(host_arch)"
+  sha="$(sha256_for "$version" "$arch")"
+  tag="padctl-build:${version}"
+
+  if docker image inspect "$tag" >/dev/null 2>&1; then
+    echo "padctl-docker: reusing existing image ${tag}"
+    return 0
+  fi
+
+  echo "padctl-docker: building ${tag} (zig ${version}, ${arch})"
+  docker buildx build \
+    --build-arg "ZIG_VERSION=${version}" \
+    --build-arg "ZIG_SHA256=${sha}" \
+    --build-arg "TARGETARCH=${arch}" \
+    --load \
+    -t "$tag" \
+    -f "${REPO_ROOT}/Dockerfile" \
+    "${REPO_ROOT}"
+}
+
+image_tag() {
+  printf 'padctl-build:%s' "$(zig_version)"
+}
+
+# Run a command inside the canonical image with the repo bind-mounted at /src.
+run_in_image() {
+  cmd_image
+  docker run --rm \
+    -v "${REPO_ROOT}:/src" \
+    -w /src \
+    "$(image_tag)" \
+    "$@"
+}
+
+cmd_build() {
+  run_in_image zig build "$@"
+}
+
+cmd_test() {
+  run_in_image zig build test "$@"
+}
+
+cmd_canary() {
+  cmd_image
+  [ -e /dev/uhid ] || die "/dev/uhid missing on host — run: sudo modprobe uhid"
+  # --privileged + devtmpfs remount makes UHID-born evdev nodes visible inside
+  # the container; see scripts/wave5-canary-docker.sh for the rationale.
+  docker run --rm \
+    --privileged \
+    --device /dev/uhid \
+    -v "${REPO_ROOT}:/src" \
+    -w /src \
+    "$(image_tag)" \
+    bash -c '
+      set -euo pipefail
+      mount -t devtmpfs devtmpfs /dev
+      PADCTL_TEST_REQUIRE_UHID=1 zig build test-uhid-uniq -Dlibusb=false
+    '
+}
+
+cmd_shell() {
+  cmd_image
+  docker run --rm -it \
+    -v "${REPO_ROOT}:/src" \
+    -w /src \
+    "$(image_tag)" \
+    bash
+}
+
+usage() {
+  cat >&2 <<'EOF'
+usage: padctl-docker <image|build|test|canary|shell> [args...]
+
+  image           build or reuse the canonical build image
+  build [args]    run `zig build [args]` inside the image
+  test  [args]    run `zig build test [args]` inside the image
+  canary          run the UHID L2 privileged tests (needs /dev/uhid)
+  shell           open an interactive shell inside the image
+EOF
+  exit 2
+}
+
+# Print the SHA256 for the pinned Zig version and the given arch (amd64|arm64).
+# Used by the CI build-image job so the checksum has a single source of truth.
+cmd_print_sha() {
+  [ $# -eq 1 ] || die "--print-sha needs one arg: amd64 or arm64"
+  sha256_for "$(zig_version)" "$1"
+  echo
+}
+
+main() {
+  [ $# -ge 1 ] || usage
+  local sub="$1"
+  shift
+  case "$sub" in
+    image) cmd_image "$@" ;;
+    build) cmd_build "$@" ;;
+    test) cmd_test "$@" ;;
+    canary) cmd_canary "$@" ;;
+    shell) cmd_shell "$@" ;;
+    --print-sha) cmd_print_sha "$@" ;;
+    -h | --help | help) usage ;;
+    *) die "unknown subcommand: ${sub}" ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
Additive foundation for the Docker workflow standardization (ADR-019, migration-plan steps 1, 2, 10). This PR is purely additive — `Dockerfile.wave5` and every existing CI job are untouched, nothing existing breaks.

## What this adds

- **`Dockerfile`** (repo root) — canonical build image: `debian:bookworm-slim` base (glibc 2.36, avoids issue #147), mandatory `ZIG_VERSION` / `ZIG_SHA256` build-args with no defaults, SHA256-verified Zig tarball download, multi-arch via `TARGETARCH` (amd64→x86_64, arm64→aarch64), `libusb-1.0-0-dev` + `linux-libc-dev`, `WORKDIR /src`.
- **`scripts/padctl-docker`** — single-entry helper with `image | build | test | canary | shell` subcommands. Reads `.zigversion`, holds the Zig tarball SHA256 table (amd64 + arm64, keyed by version). A missing version/arch combination is a hard error — no unverified-download fallback. Adds a `--print-sha` helper used by CI.
- **`build-image` job in `ci.yml`** — builds and pushes `ghcr.io/<owner>/padctl-build:<zig-version>` to GHCR, gated on a `docker manifest inspect` cache check (skips build when the tag already exists). Uses `docker/login-action` + `GITHUB_TOKEN` with `permissions: packages: write`. On `pull_request` it builds locally for verification without pushing (fork-safe). No other job consumes the image yet — `container:` migration is a follow-up PR.
- **"Build with Docker" docs** in `README.md` and `docs/src/getting-started.md` — the exact `./scripts/padctl-docker build|test|shell` commands for end users.

## Notes / deviations

- The engineering-spec Dockerfile snippet used the URL form `zig-linux-<arch>-<ver>.tar.xz`, but the actual ziglang.org filename is arch-first: `zig-<arch>-linux-<ver>.tar.xz` (confirmed against `ziglang.org/download/index.json`, and consistent with the existing `Dockerfile.wave5`). The implemented `Dockerfile` uses the correct, verified form.
- arm64 Zig 0.15.2 SHA256 (`958ed7d1...f667f`) fetched from `ziglang.org/download/index.json` and added to the SHA256 table — no TODO placeholder needed.

## Test plan

- `bash -n scripts/padctl-docker` — clean.
- `.zigversion` parsing, SHA256 table lookup, `--print-sha amd64/arm64`, and bad-arch error path verified locally.
- `ci.yml` validated as well-formed YAML.
- The Dockerfile itself is verified by the new `build-image` CI job — this host's `docker build` cannot run (broken bridge networking), so CI is the authoritative check for the image build.

refs #289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Docker-based build, test, and interactive shell commands via `./scripts/padctl-docker` script.
  * Canonical Docker image with pinned Zig toolchain environment for consistent builds across platforms.
  * CI workflow now builds and publishes Docker images to container registry.

* **Documentation**
  * Added Docker build guidance to README and getting started documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->