### PR TITLE
ci: run check-matrix and tsan inside canonical build image (ADR-019)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,26 @@ jobs:
             ZIG_VERSION=${{ steps.img.outputs.version }}
             ZIG_SHA256=${{ steps.sha.outputs.amd64 }}
 
+  # Resolve the canonical build image reference from .zigversion (ADR-019).
+  # GitHub Actions cannot read a file inside a `container:` expression, so the
+  # tag is computed once here and consumed via needs.image-ref.outputs.ref.
+  # Mirrors the build-image job's "Resolve image reference" step — .zigversion
+  # stays the single source of truth for the Zig version.
+  image-ref:
+    name: image-ref
+    runs-on: ubuntu-22.04
+    outputs:
+      ref: ${{ steps.img.outputs.ref }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve image reference
+        id: img
+        run: |
+          set -euo pipefail
+          ver="$(head -n1 .zigversion | tr -d '[:space:]')"
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "ref=ghcr.io/${owner}/padctl-build:${ver}" >> "$GITHUB_OUTPUT"
+
   # Build the Lean formal-spec oracle once and publish it as an artifact.
   # The interactive-Lean-oracle DRT suite in src/test/properties/drt_props.zig
   # only runs when formal/lean/.lake/build/bin/oracle exists; without this job
@@ -104,7 +124,15 @@ jobs:
   check-matrix:
     name: check / ${{ matrix.os }} / ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    needs: [lean-oracle]
+    needs: [lean-oracle, image-ref, build-image]
+    # Run inside the canonical build image (ADR-019): Zig + libusb + kernel
+    # headers are baked in, so no setup-zig step or apt install is needed.
+    container: ${{ needs.image-ref.outputs.ref }}
+    # debian:bookworm-slim links /bin/sh to dash; force bash so run: steps
+    # keep their `set -o pipefail` and `| tee` pipelines.
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -124,13 +152,6 @@ jobs:
       PADCTL_TEST_REQUIRE_LEAN: "1"
     steps:
       - uses: actions/checkout@v4
-      - name: Install Zig
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
-      - name: Install system dependencies
-        if: matrix.name != 'libusb-false'
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libusb-1.0-0-dev
       - name: Download Lean oracle artifact
         uses: actions/download-artifact@v4
         with:
@@ -175,14 +196,18 @@ jobs:
   tsan:
     name: tsan / ubuntu-22.04
     runs-on: ubuntu-22.04
+    needs: [image-ref, build-image]
+    # Run inside the canonical build image (ADR-019): Zig + libusb are baked
+    # in. gdb is only needed by the failure-only diagnostics step below and is
+    # installed there to keep the happy path free of an apt install.
+    container: ${{ needs.image-ref.outputs.ref }}
+    # debian:bookworm-slim links /bin/sh to dash; force bash so run: steps
+    # keep their `set -o pipefail`, `| tee` and `bash -lc` usage.
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
-      - name: Install Zig
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libusb-1.0-0-dev gdb
       - name: Run TSAN tests
         run: |
           set -o pipefail
@@ -193,6 +218,7 @@ jobs:
         if: failure()
         run: |
           set -euo pipefail
+          apt-get update && apt-get install -y --no-install-recommends gdb
           echo "==== TSAN summary from build log ===="
           grep -nE "ThreadSanitizer|data race|thread leak|SUMMARY|signal [0-9]+|terminated with signal|error: while executing test" tsan-build.log || true
           FAILED_CMD="$(grep -E '^\.?/?\.zig-cache/o/.+/test --cache-dir=' tsan-build.log | tail -n 1 || true)"


### PR DESCRIPTION
## What changed

Migrate the `ci.yml` `check-matrix` legs (`default`, `libusb-false`, `wasm-false`) and the `tsan` job to run inside `container: ghcr.io/<owner>/padctl-build:<zigversion>` instead of a bare runner with `mlugg/setup-zig` plus an apt install of libusb. This is step 3 of the ADR-019 Docker workflow migration; the canonical image (PR #292) already ships Zig, libusb and kernel headers.

- Add an `image-ref` job that resolves the image tag from `.zigversion` and exposes it as a job output. GitHub Actions cannot read a file inside a `container:` expression, so the tag is computed once and consumed via `needs.image-ref.outputs.ref`. This keeps `.zigversion` the single source of truth.
- `check-matrix` and `tsan` gain `needs: [image-ref, build-image]` so the image is resolved and pushed before consumers pull it.
- Remove the `setup-zig` step and the libusb apt step from both jobs. The `zig build` invocations are byte-for-byte unchanged.
- `gdb` (used only by the failure-only `tsan` diagnostics step) is installed inside that step, keeping the happy path free of an apt install.

The `padctl-build` GHCR package is public, so no login step or `container.credentials` is required; same-repo and fork `pull_request` runs can pull it anonymously.

Out of scope (later steps): `distro-check` and `build-image` in this file are untouched, as are `e2e.yml`, `validate.yml`, `docs.yml`, `release.yml`, `install-flow.yml`.

## Test plan

- This PR's own CI run is the verification. The migrated `check / ubuntu-22.04 / {default,libusb-false,wasm-false}` and `tsan / ubuntu-22.04` jobs running green inside the container proves the canonical image provides a working Zig + libusb + kernel-headers toolchain.
- The image cannot be pulled or built locally on the author's host (no network for docker); CI is the authoritative check.

refs ADR-019