### PR TITLE
ci: run validate, docs and e2e workflows in the canonical Docker image

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,17 +15,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  # Resolve the canonical build image reference from .zigversion (ADR-019).
+  # GitHub Actions cannot read a file inside a `container:` expression, so the
+  # tag is computed once here and consumed via needs.image-ref.outputs.ref.
+  # Mirrors the image-ref job in ci.yml — .zigversion stays the single source
+  # of truth for the Zig version.
+  image-ref:
+    name: image-ref
+    runs-on: ubuntu-22.04
+    outputs:
+      ref: ${{ steps.img.outputs.ref }}
     steps:
       - uses: actions/checkout@v4
+      - name: Resolve image reference
+        id: img
+        run: |
+          set -euo pipefail
+          ver="$(head -n1 .zigversion | tr -d '[:space:]')"
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "ref=ghcr.io/${owner}/padctl-build:${ver}" >> "$GITHUB_OUTPUT"
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev
-
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
+  build:
+    runs-on: ubuntu-22.04
+    needs: [image-ref]
+    # Run inside the canonical build image (ADR-019): Zig + libusb + kernel
+    # headers are baked in, so no setup-zig step or apt install is needed.
+    container: ${{ needs.image-ref.outputs.ref }}
+    # debian:bookworm-slim links /bin/sh to dash; force bash for run: steps.
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Install mdbook
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,20 +6,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e:
+  # Resolve the canonical build image reference from .zigversion (ADR-019).
+  # GitHub Actions cannot read a file inside a `container:` expression, so the
+  # tag is computed once here and consumed via needs.image-ref.outputs.ref.
+  # Mirrors the image-ref job in ci.yml — .zigversion stays the single source
+  # of truth for the Zig version.
+  image-ref:
+    name: image-ref
     runs-on: ubuntu-22.04
+    outputs:
+      ref: ${{ steps.img.outputs.ref }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install Zig
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libusb-1.0-0-dev
+      - name: Resolve image reference
+        id: img
+        run: |
+          set -euo pipefail
+          ver="$(head -n1 .zigversion | tr -d '[:space:]')"
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "ref=ghcr.io/${owner}/padctl-build:${ver}" >> "$GITHUB_OUTPUT"
+
+  e2e:
+    runs-on: ubuntu-22.04
+    needs: [image-ref]
+    # Run inside the canonical build image (ADR-019): Zig + libusb are baked
+    # in. --privileged is required so the UHID L2/L3 tests can load the uhid
+    # kernel module and access /dev/uhid from inside the container.
+    container:
+      image: ${{ needs.image-ref.outputs.ref }}
+      options: --privileged -v /dev:/dev
+    # debian:bookworm-slim links /bin/sh to dash; force bash for run: steps.
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
       - name: Enable UHID/uinput (best-effort)
         run: |
-          sudo modprobe uhid uinput 2>/dev/null || true
-          sudo chmod 666 /dev/uhid /dev/uinput 2>/dev/null || true
+          modprobe uhid uinput 2>/dev/null || true
+          chmod 666 /dev/uhid /dev/uinput 2>/dev/null || true
       - name: Probe /dev/uhid accessibility
         id: uhid_probe
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,15 +12,38 @@ on:
       - 'src/config/device.zig'
 
 jobs:
-  validate:
-    runs-on: ubuntu-latest
+  # Resolve the canonical build image reference from .zigversion (ADR-019).
+  # GitHub Actions cannot read a file inside a `container:` expression, so the
+  # tag is computed once here and consumed via needs.image-ref.outputs.ref.
+  # Mirrors the image-ref job in ci.yml — .zigversion stays the single source
+  # of truth for the Zig version.
+  image-ref:
+    name: image-ref
+    runs-on: ubuntu-22.04
+    outputs:
+      ref: ${{ steps.img.outputs.ref }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install libusb
-        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
+      - name: Resolve image reference
+        id: img
+        run: |
+          set -euo pipefail
+          ver="$(head -n1 .zigversion | tr -d '[:space:]')"
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "ref=ghcr.io/${owner}/padctl-build:${ver}" >> "$GITHUB_OUTPUT"
+
+  validate:
+    runs-on: ubuntu-22.04
+    needs: [image-ref]
+    # Run inside the canonical build image (ADR-019): Zig + libusb + kernel
+    # headers are baked in, so no setup-zig step or apt install is needed.
+    container: ${{ needs.image-ref.outputs.ref }}
+    # debian:bookworm-slim links /bin/sh to dash; force bash for run: steps.
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
       - name: Build
         run: zig build
       - name: Validate all device configs


### PR DESCRIPTION
Step 4 of the ADR-019 Docker workflow migration. Migrates `validate.yml`,
`docs.yml` and `e2e.yml` off `mlugg/setup-zig` + apt-installed libusb and onto
the canonical build image published by `ci.yml`'s `build-image` job
(`ghcr.io/<owner>/padctl-build:<zigversion>`).

## What changed

- **`validate.yml`** — added an `image-ref` job (resolves the GHCR tag from
  `.zigversion`, owner lowercased); the `validate` job now runs in
  `container: ${{ needs.image-ref.outputs.ref }}`. Dropped the `setup-zig`
  step and the `libusb` apt-install. Added `defaults.run.shell: bash`.
- **`docs.yml`** — same `image-ref` job; the `build` job runs in `container:`,
  dropped `setup-zig` and the libusb apt-install, added
  `defaults.run.shell: bash`. The `deploy` job stays on a plain runner (it
  only runs `actions/deploy-pages`, no Zig needed).
- **`e2e.yml`** — same `image-ref` job; the `e2e` job runs in `container:`
  with `options: --privileged -v /dev:/dev` so the UHID L2/L3 tests can load
  the `uhid` kernel module and reach `/dev/uhid`. The existing best-effort
  UHID probe and `PADCTL_TEST_REQUIRE_UHID` gating logic are preserved
  verbatim; `sudo` is dropped from the `modprobe`/`chmod` step since the
  container already runs as root. Added `defaults.run.shell: bash`.

Each workflow carries its own `image-ref` job because `needs:` cannot
reference a job in another workflow file — the pattern is copied from
`ci.yml` (PR #293), keeping `.zigversion` the single source of the Zig
version.

`ci.yml`, `release.yml` and `install-flow.yml` are untouched (later
migration steps).

## Test plan

- Cannot be tested locally (host Docker networking broken). The PR's own CI
  run is the verification: the `validate`, `docs` and `e2e` jobs running
  green inside the canonical container is the proof.
- `validate`/`docs` triggers vary by changed paths; `e2e` runs on every
  push. Watch `gh pr checks`.

refs ADR-019