### PR TITLE
ci: build install-flow + distro-check binaries in the canonical image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,61 +249,57 @@ jobs:
             tsan-gdb.log
             tsan*
 
+  # Compile the musl-static padctl binary once inside the canonical build
+  # image (ADR-019) and publish it as an artifact. The distro-check matrix
+  # then `docker run`s this binary on pristine debian:12 / fedora:41 images,
+  # which stay free of any padctl toolchain so the smoke test reflects a real
+  # end-user environment.
+  distro-musl-build:
+    name: distro-musl-build
+    runs-on: ubuntu-22.04
+    needs: [image-ref, build-image]
+    container: ${{ needs.image-ref.outputs.ref }}
+    # debian:bookworm-slim links /bin/sh to dash; force bash for run: steps.
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build musl-static padctl
+        run: zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-musl -Dlibusb=false
+      - name: Upload musl binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: distro-musl-bin
+          path: zig-out/bin/padctl
+          if-no-files-found: error
+          retention-days: 1
+
   distro-check:
     name: distro-check / ${{ matrix.name }}
     runs-on: ubuntu-22.04
+    # The musl-static binary is built once in the canonical image (ADR-019);
+    # this job only `docker run`s it on pristine distros, so it cannot itself
+    # be a `container:` job and instead depends on the distro-musl-build
+    # artifact.
+    needs: [distro-musl-build]
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: debian-12
             image: debian:12
-            setup: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl xz-utils gcc g++ make pkg-config linux-libc-dev
           - name: fedora-41
             image: fedora:41
-            setup: dnf install -y ca-certificates curl xz gcc gcc-c++ make pkgconf-pkg-config kernel-headers glibc-headers glibc-devel
     steps:
       - uses: actions/checkout@v4
-      - name: Install Zig (host)
-        uses: mlugg/setup-zig@v2
+      - name: Download musl binary
+        uses: actions/download-artifact@v4
         with:
-          version: 0.15.2
-      - name: Stage host Zig for container
-        run: |
-          set -e
-          HOST_ZIG=$(which zig)
-          HOST_ZIG_DIR=$(dirname "$HOST_ZIG")
-          cp -a "$HOST_ZIG_DIR" /tmp/zig-host
-          /tmp/zig-host/zig version
-      - name: Run check-all in container
-        env:
-          DISTRO_IMAGE: ${{ matrix.image }}
-          DISTRO_SETUP: ${{ matrix.setup }}
-        run: |
-          set -euo pipefail
-          docker run --rm \
-            -v "$PWD:/work" \
-            -v /tmp/zig-host:/opt/zig:ro \
-            -w /work \
-            "$DISTRO_IMAGE" \
-            /bin/sh -lc "
-              set -eu
-              ${DISTRO_SETUP}
-              timeout 600 /opt/zig/zig build -Dlibusb=false test --summary all
-              timeout 600 /opt/zig/zig build -Dlibusb=false test-safe --summary all
-              timeout 600 /opt/zig/zig build -Dlibusb=false check-fmt
-            " 2>&1 | tee distro-check.log
-      # The container above runs as root (apt-get/dnf require it), so any
-      # .zig-cache / zig-out files it writes are root-owned on the host.
-      # The subsequent host build step and the setup-zig post-job cache-save
-      # trim both run as the unprivileged `runner` user; root-owned files make
-      # the post-job `unlink` trim fail with EACCES once the cache exceeds the
-      # 2 GiB limit. Reclaim ownership so runner-side steps can manage them.
-      - name: Reclaim container-written cache ownership
-        if: always()
-        run: sudo chown -R "$(id -u):$(id -g)" .zig-cache zig-out 2>/dev/null || true
-      - name: Build musl binary (host)
-        run: zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-musl -Dlibusb=false
+          name: distro-musl-bin
+          path: zig-out/bin
+      - name: Restore binary executable bit
+        run: chmod +x zig-out/bin/padctl
       - name: Smoke-test musl binary in container
         # Verifies the musl-static binary actually executes on minimal debian/fedora — catches packaging/loader regressions that zig build test (host-glibc) misses
         env:

--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -7,19 +7,68 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Resolve the canonical build image reference from .zigversion (ADR-019).
+  # GitHub Actions cannot read a file inside a `container:` expression, so the
+  # tag is computed once here and consumed via needs.image-ref.outputs.ref.
+  # Mirrors the image-ref job in ci.yml — .zigversion stays the single source
+  # of truth for the Zig version.
+  image-ref:
+    name: image-ref
+    runs-on: ubuntu-22.04
+    outputs:
+      ref: ${{ steps.img.outputs.ref }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve image reference
+        id: img
+        run: |
+          set -euo pipefail
+          ver="$(head -n1 .zigversion | tr -d '[:space:]')"
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "ref=ghcr.io/${owner}/padctl-build:${ver}" >> "$GITHUB_OUTPUT"
+
+  # Compile the padctl binary once inside the canonical build image (ADR-019)
+  # and publish it as an artifact. The downstream install/pkg/systemd jobs run
+  # on the bare runner so they can `docker run` pristine distro images, which
+  # is not possible from inside a `container:` job. A musl-static binary is
+  # built so the same artifact runs unchanged on the runner host (older glibc)
+  # and inside debian:12 / ubuntu:26.04 test targets.
+  build-binary:
+    name: build-binary
+    runs-on: ubuntu-22.04
+    needs: [image-ref]
+    container: ${{ needs.image-ref.outputs.ref }}
+    # debian:bookworm-slim links /bin/sh to dash; force bash for run: steps.
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build padctl (musl-static, no libusb)
+        run: zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-musl -Dlibusb=false
+      - name: Upload padctl binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: padctl-bin
+          path: zig-out/bin/
+          if-no-files-found: error
+          retention-days: 1
+
   install-sandbox:
     name: install / rootless-docker sandbox
     runs-on: ubuntu-22.04
+    needs: [build-binary]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Zig
-        uses: mlugg/setup-zig@v2
+      - name: Download padctl binary
+        uses: actions/download-artifact@v4
         with:
-          version: 0.15.2
+          name: padctl-bin
+          path: zig-out/bin
 
-      - name: Build padctl (no libusb — install flow only needs the static binary)
-        run: zig build -Dlibusb=false
+      - name: Restore binary executable bit
+        run: chmod +x zig-out/bin/padctl
 
       - name: Run install-flow sandbox
         run: |
@@ -227,15 +276,18 @@ jobs:
   pkg-deb-smoke:
     name: pkg / deb structure invariants
     runs-on: ubuntu-22.04
+    needs: [build-binary]
     steps:
       - uses: actions/checkout@v4
 
-      - uses: mlugg/setup-zig@v2
+      - name: Download padctl binary
+        uses: actions/download-artifact@v4
         with:
-          version: 0.15.2
+          name: padctl-bin
+          path: zig-out/bin
 
-      - name: Build static padctl (musl)
-        run: zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-musl -Dlibusb=false
+      - name: Restore binary executable bit
+        run: chmod +x zig-out/bin/padctl* 2>/dev/null || true
 
       - name: Stage release tarball (mirror release.yml build job)
         run: |
@@ -396,15 +448,18 @@ jobs:
   systemd-hardening:
     name: systemd / unit hardening compat (Ubuntu 26.04 + systemd 259)
     runs-on: ubuntu-22.04
+    needs: [build-binary]
     steps:
       - uses: actions/checkout@v4
 
-      - uses: mlugg/setup-zig@v2
+      - name: Download padctl binary
+        uses: actions/download-artifact@v4
         with:
-          version: 0.15.2
+          name: padctl-bin
+          path: zig-out/bin
 
-      - name: Build padctl
-        run: zig build -Dlibusb=false
+      - name: Restore binary executable bit
+        run: chmod +x zig-out/bin/padctl
 
       - name: Generate user unit from installed binary
         run: |


### PR DESCRIPTION
ADR-019 Docker workflow migration, step 6. Migrates how the padctl
binary is **built** for `install-flow.yml` and the `ci.yml`
`distro-check` job — using the canonical GHCR build image instead of
`mlugg/setup-zig` / host-zig bind-mounts — while keeping the
pristine-distro **test targets** exactly as they are.

## What changed

### `install-flow.yml`
- New `image-ref` job resolves the canonical image tag from `.zigversion`
  (mirrors the established pattern in `ci.yml` / `e2e.yml` / `release.yml`).
- New `build-binary` job compiles a musl-static `padctl` inside
  `container: <canonical image>` and uploads it as an artifact.
- `install-sandbox`, `pkg-deb-smoke`, and `systemd-hardening` drop
  `mlugg/setup-zig` and their on-runner `zig build` step; they download
  the prebuilt artifact instead.
- musl-static is used so the single artifact runs unchanged both on the
  runner host and inside the `debian:12` / `ubuntu:26.04` test targets.

### `ci.yml` `distro-check`
- New `distro-musl-build` job compiles the musl-static binary in
  `container: <canonical image>` and uploads it as an artifact.
- `distro-check` drops `mlugg/setup-zig` and the `/tmp/zig-host`
  bind-mount; `debian:12` / `fedora:41` are now pure execution targets
  that `docker run` the prebuilt binary for the `--version` /
  `--validate` smoke tests.

## What was deliberately kept pristine
- Every `docker run` target invocation against `debian:12`,
  `ubuntu:26.04`, and `fedora:41` is unchanged — these images stay free
  of any padctl toolchain so the tests reflect a real end-user environment.
- All install / uninstall / `.deb` / systemd assertions are preserved
  byte-for-byte.
- The `systemd-hardening` job's `216/GROUP` regression test (PR #290,
  issues #287/#288) is untouched — only its binary-build mechanism moved.

## Test plan
`install-flow.yml` and `ci.yml` run on `pull_request`, so this PR's own
CI exercises the changes directly. Verification is the `install-sandbox`,
`pkg-deb-smoke`, `systemd-hardening`, and `distro-check` jobs going green
while building inside / consuming the canonical image.

refs ADR-019

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build pipeline to compile the binary once and reuse it across validation jobs for improved efficiency.
  * Updated build container configuration to derive from a canonical source for consistent builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->