### PR TITLE
Fix hot-swap held remap aux edges

### DIFF
--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -53,6 +53,11 @@ const ResolvedRemap = struct {
     suppress: u64,
 };
 
+const AuxDownTarget = union(enum) {
+    key: u16,
+    mouse_button: u16,
+};
+
 const GESTURE_TOKEN_SLOTS = gesture_mod.GESTURE_SLOTS * 2;
 
 const GestureTokenEntry = struct {
@@ -102,6 +107,10 @@ pub const Mapper = struct {
     stick_right: stick.StickProcessor,
     suppressed_buttons: u64,
     injected_buttons: u64,
+    // Buttons already held when this mapper was seeded; ignore their edges until release.
+    seeded_buttons: u64,
+    aux_down_targets: [BUTTON_COUNT]?AuxDownTarget,
+    gesture_aux_down_targets: [BUTTON_COUNT]?AuxDownTarget,
     pending_tap_release: ?u64,
     // Gamepad-button taps emitted by macro timer expiry need one apply() cycle
     // to reach output before pending_tap_release fires; staged here, promoted
@@ -157,6 +166,9 @@ pub const Mapper = struct {
             .stick_right = .{},
             .suppressed_buttons = 0,
             .injected_buttons = 0,
+            .seeded_buttons = 0,
+            .aux_down_targets = [_]?AuxDownTarget{null} ** BUTTON_COUNT,
+            .gesture_aux_down_targets = [_]?AuxDownTarget{null} ** BUTTON_COUNT,
             .pending_tap_release = null,
             .macro_timer_tap_pending = 0,
             .gesture_engine = .{},
@@ -188,6 +200,70 @@ pub const Mapper = struct {
         self.chord_detector = ChordDetector.init(cfg);
     }
 
+    pub fn seedInputState(self: *Mapper, current: GamepadState) void {
+        var seeded = current;
+        self.applyTriggerThreshold(&seeded);
+        self.state = seeded;
+        self.prev = seeded;
+        self.seeded_buttons = seeded.buttons;
+    }
+
+    fn applyTriggerThreshold(self: *const Mapper, gs: *GamepadState) void {
+        if (self.config.trigger_threshold) |threshold| {
+            const lt_bit = @as(u64, 1) << @intCast(@intFromEnum(ButtonId.LT));
+            const rt_bit = @as(u64, 1) << @intCast(@intFromEnum(ButtonId.RT));
+            if (gs.lt > threshold) {
+                gs.buttons |= lt_bit;
+            } else {
+                gs.buttons &= ~lt_bit;
+            }
+            if (gs.rt > threshold) {
+                gs.buttons |= rt_bit;
+            } else {
+                gs.buttons &= ~rt_bit;
+            }
+        }
+    }
+
+    pub fn releaseHeldAux(self: *Mapper) AuxEventList {
+        var aux = AuxEventList{};
+        for (&self.aux_down_targets) |*target| {
+            if (target.*) |down| {
+                emitAuxDownRelease(down, &aux);
+                target.* = null;
+            }
+        }
+
+        var injected: u64 = 0;
+        for (self.active_macros.items) |*player| {
+            player.emitPendingReleases(&aux, &injected);
+        }
+        self.active_macros.clearRetainingCapacity();
+
+        for (&self.gesture_aux_down_targets) |*target| {
+            if (target.*) |down| {
+                emitAuxDownRelease(down, &aux);
+                target.* = null;
+            }
+        }
+        return aux;
+    }
+
+    fn suppressSeededEdges(self: *Mapper) void {
+        if (self.seeded_buttons == 0) return;
+
+        const still_held = self.seeded_buttons & self.state.buttons;
+        const released = self.seeded_buttons & ~self.state.buttons;
+        var suppress_release = released;
+        for (self.aux_down_targets, 0..) |target, i| {
+            if (target != null) {
+                suppress_release &= ~(@as(u64, 1) << @as(u6, @intCast(i)));
+            }
+        }
+        self.prev.buttons = (self.prev.buttons | still_held) & ~suppress_release;
+        self.seeded_buttons = still_held;
+    }
+
     // `now_ns` is the ppoll-wakeup CLOCK_MONOTONIC snapshot from the caller;
     // must match the value passed to onMacroTimerExpired() in the same wakeup so
     // tap/hold boundary decisions see a single timeline.
@@ -201,22 +277,8 @@ pub const Mapper = struct {
         }
 
         self.state.applyDelta(delta);
-
-        // Synthesize LT/RT as digital buttons when trigger_threshold is configured.
-        if (self.config.trigger_threshold) |threshold| {
-            const lt_bit = @as(u64, 1) << @intCast(@intFromEnum(ButtonId.LT));
-            const rt_bit = @as(u64, 1) << @intCast(@intFromEnum(ButtonId.RT));
-            if (self.state.lt > threshold) {
-                self.state.buttons |= lt_bit;
-            } else {
-                self.state.buttons &= ~lt_bit;
-            }
-            if (self.state.rt > threshold) {
-                self.state.buttons |= rt_bit;
-            } else {
-                self.state.buttons &= ~rt_bit;
-            }
-        }
+        self.applyTriggerThreshold(&self.state);
+        self.suppressSeededEdges();
 
         const configs = self.config.layer orelse &.{};
         const action = self.layer.processLayerTriggers(configs, self.state.buttons, self.prev.buttons, now_ns);
@@ -379,10 +441,17 @@ pub const Mapper = struct {
         }
 
         for (0..BUTTON_COUNT) |i| {
-            const target = per_src_inject[i] orelse continue;
             const src_mask: u64 = @as(u64, 1) << @as(u6, @intCast(i));
             const pressed = (self.state.buttons & src_mask) != 0;
             const prev_pressed = (self.prev.buttons & src_mask) != 0;
+            if (!pressed and prev_pressed) {
+                if (self.aux_down_targets[i]) |down| {
+                    emitAuxDownRelease(down, &aux);
+                    self.aux_down_targets[i] = null;
+                }
+            }
+
+            const target = per_src_inject[i] orelse continue;
             switch (target) {
                 .macro => |name| {
                     if (pressed and !prev_pressed) {
@@ -407,10 +476,10 @@ pub const Mapper = struct {
                     if (pressed) remap_mod.applyTarget(target, .press, &aux, &self.injected_buttons, null, null);
                 },
                 .key, .mouse_button => {
-                    if (pressed and !prev_pressed)
+                    if (pressed and !prev_pressed) {
                         remap_mod.applyTarget(target, .press, &aux, &self.injected_buttons, null, null);
-                    if (!pressed and prev_pressed)
-                        remap_mod.applyTarget(target, .release, &aux, &self.injected_buttons, null, null);
+                        self.aux_down_targets[i] = auxDownTarget(target);
+                    }
                 },
                 .disabled => {},
                 // Chord source button is suppressed via precomputeRemap; chord
@@ -593,6 +662,13 @@ pub const Mapper = struct {
                         .release => .release,
                         .tap => .tap,
                     };
+                    if (auxDownTarget(em.target)) |down| {
+                        switch (em.action) {
+                            .press => self.gesture_aux_down_targets[src_idx] = down,
+                            .release => self.gesture_aux_down_targets[src_idx] = null,
+                            .tap => {},
+                        }
+                    }
                     remap_mod.applyTarget(em.target, act, aux, &self.injected_buttons, null, null);
                 },
             }
@@ -738,6 +814,21 @@ fn freeResolvedRemap(allocator: std.mem.Allocator, r: ResolvedRemap) void {
     }
 }
 
+fn auxDownTarget(target: RemapTargetResolved) ?AuxDownTarget {
+    return switch (target) {
+        .key => |code| .{ .key = code },
+        .mouse_button => |code| .{ .mouse_button = code },
+        else => null,
+    };
+}
+
+fn emitAuxDownRelease(target: AuxDownTarget, aux: *AuxEventList) void {
+    switch (target) {
+        .key => |code| aux.append(.{ .key = .{ .code = code, .pressed = false } }) catch {},
+        .mouse_button => |code| aux.append(.{ .mouse_button = .{ .code = code, .pressed = false } }) catch {},
+    }
+}
+
 fn precomputeRemap(allocator: std.mem.Allocator, remap_map: mapping.RemapMap) !ResolvedRemap {
     var result = ResolvedRemap{
         .inject = [_]?RemapTargetResolved{null} ** BUTTON_COUNT,
@@ -871,6 +962,28 @@ test "mapper: base remap key: source -> KEY_F13 aux event" {
         },
         else => return error.WrongEventType,
     }
+}
+
+test "mapper: releaseHeldAux releases old trigger-threshold aux down" {
+    const allocator = testing.allocator;
+    const old_parsed = try makeMapping(
+        \\trigger_threshold = 128
+        \\
+        \\[remap]
+        \\LT = "KEY_F13"
+    , allocator);
+    defer old_parsed.deinit();
+
+    var old = try makeMapper(&old_parsed.value, allocator);
+    defer old.deinit();
+    const down = try old.apply(.{ .lt = 200 }, 16, 0);
+    try testing.expectEqual(@as(usize, 1), down.aux.len);
+    try testing.expect(down.aux.get(0).key.pressed);
+
+    const release = old.releaseHeldAux();
+    try testing.expectEqual(@as(usize, 1), release.len);
+    try testing.expectEqual(@as(u16, 183), release.get(0).key.code);
+    try testing.expect(!release.get(0).key.pressed);
 }
 
 test "mapper: base remap gamepad_button: A -> B" {

--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -498,9 +498,14 @@ pub const DeviceInstance = struct {
             // Apply pending mapping before processing any fds
             if (@atomicLoad(?*MappingConfig, &self.pending_mapping, .acquire)) |new| {
                 const old_mcfg: ?*const MappingConfig = if (self.mapper) |*m| m.config else self.mapping_cfg;
-                if (Mapper.init(new, self.loop.macro_timer_fd, self.allocator)) |nm| {
-                    if (self.mapper) |*m| m.deinit();
-                    self.mapper = nm;
+                if (Mapper.init(new, self.loop.macro_timer_fd, self.allocator)) |created| {
+                    var new_mapper = created;
+                    if (self.mapper) |*old| {
+                        self.releaseMapperAux(old);
+                        old.deinit();
+                    }
+                    new_mapper.seedInputState(self.loop.gamepad_state);
+                    self.mapper = new_mapper;
                     self.mapping_cfg = new;
                 } else |err| {
                     std.log.err("mapping hot-swap failed: {}", .{err});
@@ -626,6 +631,16 @@ pub const DeviceInstance = struct {
     pub fn updateMapping(self: *DeviceInstance, new: *MappingConfig) void {
         @atomicStore(?*MappingConfig, &self.pending_mapping, new, .release);
         self.loop.stop();
+    }
+
+    pub fn releaseMapperAux(self: *DeviceInstance, mapper: *Mapper) void {
+        const releases = mapper.releaseHeldAux();
+        if (releases.len == 0) return;
+        if (self.aux_dev) |*aux| {
+            aux.emitAux(releases.slice()) catch |err| {
+                std.log.warn("aux release during mapping swap failed: {}", .{err});
+            };
+        }
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -95,6 +95,7 @@ pub const testing_support = struct {
     pub const mock_device_io = @import("test/mock_device_io.zig");
     pub const mock_output = @import("test/mock_output.zig");
     pub const helpers = @import("test/helpers.zig");
+    pub const aux_drt = @import("test/aux_drt.zig");
     pub const interpreter_e2e_test = @import("test/interpreter_e2e_test.zig");
     pub const mapper_e2e_test = @import("test/mapper_e2e_test.zig");
     pub const gyro_stick_e2e_test = @import("test/gyro_stick_e2e_test.zig");

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -699,6 +699,7 @@ pub const Supervisor = struct {
             m.instance.stop();
             m.thread.join();
             if (m.instance.mapper) |*cur| {
+                m.instance.releaseMapperAux(cur);
                 cur.deinit();
                 m.instance.mapper = null;
             }
@@ -807,6 +808,12 @@ pub const Supervisor = struct {
             return error.SwitchFailed;
         }
 
+        if (tx.new_mapper) |*new_mapper| {
+            if (tx.old_mapper) |*old_mapper| {
+                m.instance.releaseMapperAux(old_mapper);
+            }
+            new_mapper.seedInputState(m.instance.loop.gamepad_state);
+        }
         m.instance.mapper = tx.new_mapper.?;
         tx.new_mapper = null;
         m.instance.mapping_cfg = &tx.parsed_ptr.?.value;
@@ -965,10 +972,13 @@ pub const Supervisor = struct {
                 // Stop-Swap-Restart: stop thread before touching arena
                 m.instance.stop();
                 m.thread.join();
-                self.clearSwitchMapping(m);
 
                 var old_mapper = m.instance.mapper;
                 const old_mapping_cfg = m.instance.mapping_cfg;
+                if (old_mapper) |*mapper| {
+                    m.instance.releaseMapperAux(mapper);
+                }
+                self.clearSwitchMapping(m);
                 _ = m.mapping_arena.reset(.retain_capacity);
                 const arena_alloc = m.mapping_arena.allocator();
                 const map_copy = try arena_alloc.create(MappingConfig);
@@ -977,6 +987,7 @@ pub const Supervisor = struct {
                 // Rebuild the mapper so layer state/timers do not keep slices into
                 // the old mapping arena after the reset above.
                 var new_mapper = try Mapper.init(map_copy, m.instance.loop.macro_timer_fd, self.allocator);
+                new_mapper.seedInputState(m.instance.loop.gamepad_state);
                 m.instance.mapper = new_mapper;
                 m.instance.mapping_cfg = map_copy;
                 self.installChordDetector(m);
@@ -998,12 +1009,13 @@ pub const Supervisor = struct {
                 if (m.suspended) continue;
                 m.instance.stop();
                 m.thread.join();
-                self.clearSwitchMapping(m);
-                _ = m.mapping_arena.reset(.retain_capacity);
                 if (m.instance.mapper) |*mapper| {
+                    m.instance.releaseMapperAux(mapper);
                     mapper.deinit();
                     m.instance.mapper = null;
                 }
+                self.clearSwitchMapping(m);
+                _ = m.mapping_arena.reset(.retain_capacity);
                 m.instance.mapping_cfg = null;
                 try restartManagedThread(m);
             }

--- a/src/test/aux_drt.zig
+++ b/src/test/aux_drt.zig
@@ -1,0 +1,101 @@
+const std = @import("std");
+const aux_event_mod = @import("../core/aux_event.zig");
+
+pub const AuxEvent = aux_event_mod.AuxEvent;
+
+pub const CompareError = error{
+    MissingAuxEvent,
+    UnexpectedAuxEvent,
+    AuxEventMismatch,
+};
+
+fn isDeterministic(ev: AuxEvent) bool {
+    return switch (ev) {
+        .key, .mouse_button => true,
+        .rel => false,
+    };
+}
+
+fn nextDeterministic(events: []const AuxEvent, cursor: *usize) ?AuxEvent {
+    while (cursor.* < events.len) : (cursor.* += 1) {
+        const ev = events[cursor.*];
+        if (isDeterministic(ev)) {
+            cursor.* += 1;
+            return ev;
+        }
+    }
+    return null;
+}
+
+fn sameDeterministic(a: AuxEvent, b: AuxEvent) bool {
+    return switch (a) {
+        .key => |ak| switch (b) {
+            .key => |bk| ak.code == bk.code and ak.pressed == bk.pressed,
+            else => false,
+        },
+        .mouse_button => |am| switch (b) {
+            .mouse_button => |bm| am.code == bm.code and am.pressed == bm.pressed,
+            else => false,
+        },
+        .rel => false,
+    };
+}
+
+/// Strict DRT comparator for deterministic aux output.
+///
+/// `rel` events are intentionally ignored because gyro/stick mouse output is
+/// float-derived and covered by property constraints elsewhere. KEY_* and
+/// mouse-button events are exact: same count, same order, same code/pressed.
+pub fn compareDeterministicAux(expected: []const AuxEvent, captured: []const AuxEvent) CompareError!void {
+    var ei: usize = 0;
+    var ci: usize = 0;
+
+    while (true) {
+        const e = nextDeterministic(expected, &ei);
+        const c = nextDeterministic(captured, &ci);
+
+        if (e == null and c == null) return;
+        if (e != null and c == null) return error.MissingAuxEvent;
+        if (e == null and c != null) return error.UnexpectedAuxEvent;
+        if (!sameDeterministic(e.?, c.?)) return error.AuxEventMismatch;
+    }
+}
+
+const testing = std.testing;
+
+test "aux_drt: positive exact key/mouse sequence passes" {
+    const expected = [_]AuxEvent{
+        .{ .key = .{ .code = 30, .pressed = true } },
+        .{ .key = .{ .code = 30, .pressed = false } },
+        .{ .mouse_button = .{ .code = 0x110, .pressed = true } },
+    };
+    const captured = [_]AuxEvent{
+        .{ .rel = .{ .code = 0, .value = 4 } },
+        .{ .key = .{ .code = 30, .pressed = true } },
+        .{ .key = .{ .code = 30, .pressed = false } },
+        .{ .mouse_button = .{ .code = 0x110, .pressed = true } },
+    };
+
+    try compareDeterministicAux(&expected, &captured);
+}
+
+test "aux_drt: negative missing expected key fails" {
+    const expected = [_]AuxEvent{.{ .key = .{ .code = 30, .pressed = true } }};
+    const captured = [_]AuxEvent{};
+
+    try testing.expectError(error.MissingAuxEvent, compareDeterministicAux(&expected, &captured));
+}
+
+test "aux_drt: negative ghost key while oracle is idle fails" {
+    const expected = [_]AuxEvent{};
+    const captured = [_]AuxEvent{.{ .key = .{ .code = 23, .pressed = true } }};
+
+    try testing.expectError(error.UnexpectedAuxEvent, compareDeterministicAux(&expected, &captured));
+}
+
+test "aux_drt: negative wrong key code fails" {
+    const expected = [_]AuxEvent{.{ .key = .{ .code = 30, .pressed = true } }};
+    const captured = [_]AuxEvent{.{ .key = .{ .code = 31, .pressed = true } }};
+
+    try testing.expectError(error.AuxEventMismatch, compareDeterministicAux(&expected, &captured));
+}

--- a/src/test/full_e2e_generative_test.zig
+++ b/src/test/full_e2e_generative_test.zig
@@ -36,6 +36,7 @@ const DeviceIO = src.io.device_io.DeviceIO;
 const EventLoop = src.event_loop.EventLoop;
 const ioctl_consts = src.io.ioctl_constants;
 const helpers = src.testing_support.helpers;
+const aux_drt = src.testing_support.aux_drt;
 const config_gen = src.testing_support.gen.config_gen;
 const sequence_gen = src.testing_support.gen.sequence_gen;
 const oracle_mod = src.testing_support.gen.mapper_oracle;
@@ -663,6 +664,57 @@ fn hasKeyEvent(events: []const InputEvent, code: u16, pressed: bool) bool {
     return false;
 }
 
+fn auxOracleIsExact(cfg: *const mapping_mod.MappingConfig) bool {
+    if (cfg.layer) |layers| {
+        if (layers.len != 0) return false;
+    }
+    if (cfg.macro) |macros| {
+        if (macros.len != 0) return false;
+    }
+    if (cfg.remap) |rm| {
+        var it = rm.map.iterator();
+        while (it.next()) |entry| {
+            switch (entry.value_ptr.*) {
+                .chord_names, .gesture => return false,
+                .string => |s| {
+                    const target = mapper_mod.resolveTarget(s) catch continue;
+                    switch (target) {
+                        .key, .mouse_button, .gamepad_button, .disabled => {},
+                        .macro, .chord, .gesture => return false,
+                    }
+                },
+            }
+        }
+    }
+    return true;
+}
+
+fn hasDeterministicAuxEvent(events: []const AuxEvent, expected: AuxEvent) bool {
+    for (events) |got| {
+        switch (expected) {
+            .key => |k| switch (got) {
+                .key => |gk| if (gk.code == k.code and gk.pressed == k.pressed) return true,
+                else => {},
+            },
+            .mouse_button => |mb| switch (got) {
+                .mouse_button => |gm| if (gm.code == mb.code and gm.pressed == mb.pressed) return true,
+                else => {},
+            },
+            .rel => return true,
+        }
+    }
+    return false;
+}
+
+fn compareExpectedDeterministicAux(expected: []const AuxEvent, captured: []const AuxEvent) aux_drt.CompareError!void {
+    for (expected) |ev| {
+        switch (ev) {
+            .key, .mouse_button => if (!hasDeterministicAuxEvent(captured, ev)) return error.MissingAuxEvent,
+            .rel => {},
+        }
+    }
+}
+
 fn getAbsValue(events: []const InputEvent, code: u16) ?i32 {
     for (eventSlice(events)) |ev| {
         if (ev.type == EV_ABS and ev.code == code) return ev.value;
@@ -734,6 +786,7 @@ test "l3_e2e: generative full pipeline for all device configs with mapping" {
             return err;
         };
         defer mapping_parsed.deinit();
+        const exact_aux_oracle = auxOracleIsExact(&mapping_parsed.value);
 
         // Use unique VID/PID per device to avoid collisions
         const test_vid: u16 = 0xFA00 | @as(u16, @truncate(std.hash.Adler32.hash(config_path) & 0xFF));
@@ -891,7 +944,7 @@ test "l3_e2e: generative full pipeline for all device configs with mapping" {
         var prev_oracle_gs = oracle_state.gs;
         var frames_verified: usize = 0;
         var events_received: usize = 0;
-        var press_misses: usize = 0;
+        var deterministic_mismatches: usize = 0;
 
         var frame_err: ?anyerror = null;
         for (frames[0..N_FRAMES]) |frame| {
@@ -957,7 +1010,7 @@ test "l3_e2e: generative full pipeline for all device configs with mapping" {
                     // M2: if oracle says pressed (transition from 0→1), verify press event present
                     if (oracle_pressed and !was_pressed and ev_slice.len > 0) {
                         if (!hasKeyEvent(ev_slice, code, true)) {
-                            press_misses += 1;
+                            deterministic_mismatches += 1;
                         }
                     }
                 }
@@ -1018,42 +1071,19 @@ test "l3_e2e: generative full pipeline for all device configs with mapping" {
                 }
             }
 
-            // DRT 3: aux key/mouse_button events — oracle-predicted events must be captured
+            // DRT 3: exact aux compare only when the oracle models the mapping shape.
             {
                 var aux_buf: [64]AuxEvent = undefined;
                 const n = aux_capture.drain(&aux_buf);
                 const captured = aux_buf[0..n];
-                for (oracle_out.aux.slice()) |expected| {
-                    switch (expected) {
-                        .key => |k| {
-                            var found = false;
-                            for (captured) |got| {
-                                switch (got) {
-                                    .key => |gk| if (gk.code == k.code and gk.pressed == k.pressed) {
-                                        found = true;
-                                        break;
-                                    },
-                                    else => {},
-                                }
-                            }
-                            if (!found) press_misses += 1;
-                        },
-                        .mouse_button => |mb| {
-                            var found = false;
-                            for (captured) |got| {
-                                switch (got) {
-                                    .mouse_button => |gm| if (gm.code == mb.code and gm.pressed == mb.pressed) {
-                                        found = true;
-                                        break;
-                                    },
-                                    else => {},
-                                }
-                            }
-                            if (!found) press_misses += 1;
-                        },
-                        .rel => {}, // not compared (floating-point subsystems)
-                    }
-                }
+                const cmp = if (exact_aux_oracle)
+                    aux_drt.compareDeterministicAux(oracle_out.aux.slice(), captured)
+                else
+                    compareExpectedDeterministicAux(oracle_out.aux.slice(), captured);
+                cmp catch |err| {
+                    std.debug.print("AUX DRT FAIL [{s}] frame={d}: {}\n", .{ config_path, frames_verified, err });
+                    deterministic_mismatches += 1;
+                };
             }
 
             prev_oracle_gs = oracle_out.gamepad;
@@ -1079,9 +1109,10 @@ test "l3_e2e: generative full pipeline for all device configs with mapping" {
             continue;
         }
 
-        // M2: button press completeness — all expected presses must arrive
-        if (press_misses > 0) {
-            std.debug.print("FAIL [{s}] button press misses: {d}\n", .{ config_path, press_misses });
+        // M2: deterministic exactness — expected events must arrive, and no
+        // unpredicted KEY_*/mouse-button aux events may appear.
+        if (deterministic_mismatches > 0) {
+            std.debug.print("FAIL [{s}] deterministic DRT mismatches: {d}\n", .{ config_path, deterministic_mismatches });
             return error.TestUnexpectedResult;
         }
 
@@ -1172,6 +1203,7 @@ test "l3_e2e: fully generated random device config + random mapping — DRT" {
             continue;
         };
         defer map_parsed.deinit();
+        const exact_aux_oracle = auxOracleIsExact(&map_parsed.value);
 
         // Use first compiled report
         const cr = &interp.compiled[0];
@@ -1323,7 +1355,7 @@ test "l3_e2e: fully generated random device config + random mapping — DRT" {
         var prev_oracle_gs = oracle_state.gs;
         var frames_verified: usize = 0;
         var events_received: usize = 0;
-        var press_misses: usize = 0;
+        var deterministic_mismatches: usize = 0;
 
         // 8. Inject frames and verify
         // Use a local interpreter to re-derive the actual delta from each packet,
@@ -1387,7 +1419,7 @@ test "l3_e2e: fully generated random device config + random mapping — DRT" {
                     }
                     if (oracle_pressed and !was_pressed and ev_slice.len > 0) {
                         if (!hasKeyEvent(ev_slice, code, true)) {
-                            press_misses += 1;
+                            deterministic_mismatches += 1;
                         }
                     }
                 }
@@ -1448,42 +1480,19 @@ test "l3_e2e: fully generated random device config + random mapping — DRT" {
                 }
             }
 
-            // DRT 3: aux key/mouse_button events — oracle-predicted events must be captured
+            // DRT 3: exact aux compare only when the oracle models the mapping shape.
             {
                 var aux_buf: [64]AuxEvent = undefined;
                 const n = aux_capture2.drain(&aux_buf);
                 const captured = aux_buf[0..n];
-                for (oracle_out.aux.slice()) |expected| {
-                    switch (expected) {
-                        .key => |k| {
-                            var found = false;
-                            for (captured) |got| {
-                                switch (got) {
-                                    .key => |gk| if (gk.code == k.code and gk.pressed == k.pressed) {
-                                        found = true;
-                                        break;
-                                    },
-                                    else => {},
-                                }
-                            }
-                            if (!found) press_misses += 1;
-                        },
-                        .mouse_button => |mb| {
-                            var found = false;
-                            for (captured) |got| {
-                                switch (got) {
-                                    .mouse_button => |gm| if (gm.code == mb.code and gm.pressed == mb.pressed) {
-                                        found = true;
-                                        break;
-                                    },
-                                    else => {},
-                                }
-                            }
-                            if (!found) press_misses += 1;
-                        },
-                        .rel => {},
-                    }
-                }
+                const cmp = if (exact_aux_oracle)
+                    aux_drt.compareDeterministicAux(oracle_out.aux.slice(), captured)
+                else
+                    compareExpectedDeterministicAux(oracle_out.aux.slice(), captured);
+                cmp catch |err| {
+                    std.debug.print("AUX DRT FAIL [gen-ci={d}] frame={d}: {}\n", .{ ci, frames_verified, err });
+                    deterministic_mismatches += 1;
+                };
             }
 
             prev_oracle_gs = oracle_out.gamepad;
@@ -1508,9 +1517,9 @@ test "l3_e2e: fully generated random device config + random mapping — DRT" {
             return error.TestUnexpectedResult;
         }
 
-        // M2: button press completeness — soft for random configs (timing, transforms)
-        if (press_misses > 0) {
-            std.debug.print("WARN [gen-ci={d}] button press misses: {d}\n", .{ ci, press_misses });
+        // M2: deterministic exactness — soft for random configs (timing, transforms)
+        if (deterministic_mismatches > 0) {
+            std.debug.print("WARN [gen-ci={d}] deterministic DRT mismatches: {d}\n", .{ ci, deterministic_mismatches });
         }
 
         total_frames += frames_verified;

--- a/src/test/macro_e2e_test.zig
+++ b/src/test/macro_e2e_test.zig
@@ -12,6 +12,7 @@ const state_mod = @import("../core/state.zig");
 const macro_mod = @import("../core/macro.zig");
 const macro_player_mod = @import("../core/macro_player.zig");
 const timer_queue_mod = @import("../core/timer_queue.zig");
+const aux_drt = @import("aux_drt.zig");
 const device_mod = @import("../config/device.zig");
 const EventLoop = @import("../event_loop.zig").EventLoop;
 const DeviceInstance = @import("../device_instance.zig").DeviceInstance;
@@ -27,6 +28,7 @@ const MacroPlayer = macro_player_mod.MacroPlayer;
 const TimerQueue = timer_queue_mod.TimerQueue;
 
 const KEY_B = h.KEY_B;
+const KEY_F13 = h.KEY_F13;
 const KEY_LEFT = h.KEY_LEFT;
 const KEY_LEFTSHIFT = h.KEY_LEFTSHIFT;
 
@@ -431,6 +433,131 @@ test "macro: hot-reload — updateMapping swaps config; next apply uses new mapp
         }
     }
     try testing.expect(found_key_a);
+}
+
+test "macro: hot-reload — held remap source does not synthesize a new aux edge" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+
+    const parsed_initial = try mapping.parseString(allocator, "");
+    defer parsed_initial.deinit();
+
+    const new_toml =
+        \\[remap]
+        \\M1 = "KEY_F13"
+    ;
+    var parsed_new = try mapping.parseString(allocator, new_toml);
+    defer parsed_new.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+
+    const devices = try allocator.alloc(@import("../io/device_io.zig").DeviceIO, 1);
+    devices[0] = mock.deviceIO();
+
+    var loop = try EventLoop.initManaged();
+    try loop.addDevice(devices[0]);
+
+    var inst = DeviceInstance{
+        .allocator = allocator,
+        .devices = devices,
+        .loop = loop,
+        .interp = @import("../core/interpreter.zig").Interpreter.init(&parsed_dev.value),
+        .mapper = try Mapper.init(&parsed_initial.value, loop.macro_timer_fd, allocator),
+        .owner = .none,
+        .primary_output = null,
+        .imu_output = null,
+        .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
+        .device_cfg = &parsed_dev.value,
+        .pending_mapping = null,
+        .stopped = false,
+        .poll_timeout_ms = 100,
+    };
+    defer {
+        inst.mapper.?.deinit();
+        inst.loop.deinit();
+        allocator.free(inst.devices);
+    }
+
+    const m1_mask = btnMask(.M1);
+    _ = try inst.mapper.?.apply(.{ .buttons = m1_mask }, 16, 0);
+    inst.loop.gamepad_state.buttons = m1_mask;
+
+    const RunFn = struct {
+        fn run(i: *DeviceInstance) !void {
+            try i.run();
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, RunFn.run, .{&inst});
+
+    try h.waitRunning(&inst.loop);
+    inst.updateMapping(&parsed_new.value);
+    var w: usize = 0;
+    while (w < 1000) : (w += 1) {
+        if (@atomicLoad(?*mapping.MappingConfig, &inst.pending_mapping, .acquire) == null) break;
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+
+    inst.stop();
+    thread.join();
+
+    var m = &inst.mapper.?;
+    const held_after_swap = try m.apply(.{ .buttons = m1_mask }, 16, 1);
+    try aux_drt.compareDeterministicAux(&.{}, held_after_swap.aux.slice());
+
+    const release_after_swap = try m.apply(.{ .buttons = 0 }, 16, 2);
+    try aux_drt.compareDeterministicAux(&.{}, release_after_swap.aux.slice());
+
+    const real_press = try m.apply(.{ .buttons = m1_mask }, 16, 3);
+    const expected_press = [_]aux_drt.AuxEvent{.{ .key = .{ .code = KEY_F13, .pressed = true } }};
+    try aux_drt.compareDeterministicAux(&expected_press, real_press.aux.slice());
+}
+
+test "macro: releaseHeldAux releases held remap target before reset" {
+    const allocator = testing.allocator;
+
+    var ctx = try makeMapper(
+        \\[remap]
+        \\M1 = "KEY_F13"
+    , allocator);
+    defer ctx.deinit();
+
+    const m1_mask = btnMask(.M1);
+    const expected_press = [_]aux_drt.AuxEvent{.{ .key = .{ .code = KEY_F13, .pressed = true } }};
+    const old_press = try ctx.mapper.apply(.{ .buttons = m1_mask }, 16, 0);
+    try aux_drt.compareDeterministicAux(&expected_press, old_press.aux.slice());
+
+    const release = ctx.mapper.releaseHeldAux();
+    const expected_release = [_]aux_drt.AuxEvent{.{ .key = .{ .code = KEY_F13, .pressed = false } }};
+    try aux_drt.compareDeterministicAux(&expected_release, release.slice());
+}
+
+test "macro: releaseHeldAux releases macro-held aux before reset" {
+    const allocator = testing.allocator;
+
+    var old_ctx = try makeMapper(
+        \\[[macro]]
+        \\name = "hold_shift"
+        \\steps = [{ down = "KEY_LEFTSHIFT" }, { delay = 1000 }]
+        \\
+        \\[remap]
+        \\M1 = "macro:hold_shift"
+    , allocator);
+    defer old_ctx.deinit();
+
+    const m1_mask = btnMask(.M1);
+    const old_press = try old_ctx.mapper.apply(.{ .buttons = m1_mask }, 16, 0);
+    const expected_press = [_]aux_drt.AuxEvent{.{ .key = .{ .code = KEY_LEFTSHIFT, .pressed = true } }};
+    try aux_drt.compareDeterministicAux(&expected_press, old_press.aux.slice());
+
+    const release = old_ctx.mapper.releaseHeldAux();
+    const expected_release = [_]aux_drt.AuxEvent{.{ .key = .{ .code = KEY_LEFTSHIFT, .pressed = false } }};
+    try aux_drt.compareDeterministicAux(&expected_release, release.slice());
 }
 
 // --- L0: macro trigger via Mapper.apply (regression guard) ---

--- a/src/test/mapper_e2e_test.zig
+++ b/src/test/mapper_e2e_test.zig
@@ -754,6 +754,24 @@ test "e2e gesture: hold key fires at deadline and releases on button up" {
     try testing.expect(!auxHasKey(ev_rel, keyCode("KEY_X"), true));
 }
 
+test "e2e gesture: releaseHeldAux releases held key before reset" {
+    const allocator = testing.allocator;
+    var old_ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "KEY_X", hold = "KEY_Y", hold_ms = 300 }
+    , allocator);
+    defer old_ctx.deinit();
+    var old = &old_ctx.mapper;
+
+    const t0: i128 = 1_000_000_000;
+    _ = try old.apply(.{ .buttons = btnMask(.A) }, 16, t0);
+    _ = old.onMacroTimerExpired(t0 + 300 * std.time.ns_per_ms);
+
+    const release = old.releaseHeldAux();
+    const wrapper = mapper_mod.OutputEvents{ .gamepad = .{}, .prev = .{}, .aux = release };
+    try testing.expect(auxHasKey(wrapper, keyCode("KEY_Y"), false));
+}
+
 test "e2e gesture: double fires on second press inside window" {
     const allocator = testing.allocator;
     var ctx = try makeMapper(


### PR DESCRIPTION
## Summary

- Seed replacement mappers from current input state so a button held across reload/switch does not synthesize a new aux press.
- Release old mapper aux outputs before mapper teardown or aux-device rebuild, covering direct remaps, macros, and gesture holds.
- Add deterministic aux DRT coverage with positive and negative checks, and tighten full e2e aux comparison only where the oracle is exact.

Fixes #299

## Tests

- Docker Zig 0.15.2: `zig build test -Dtest-filter='held remap source'`
- Docker Zig 0.15.2: `zig build test -Dtest-filter=aux_drt`
- Docker Zig 0.15.2: `zig build test -Dtest-filter=hot-reload`
- Docker Zig 0.15.2: `zig build test -Dtest-filter=releaseHeldAux`
- Docker Zig 0.15.2: `zig build test -Dtest-filter='switch none'`
- Docker Zig 0.15.2: `zig build test`
- Docker Zig 0.15.2: `zig build test-tsan`

## Review

- Independent reviewer subagent found no blocking issues after follow-up fixes.
- Local pre-push TSAN was skipped only because host Zig 0.15.2 cannot link against this machine's current system libraries (`.sframe` relocation); the same `test-tsan` target passes in the pinned Docker Zig 0.15.2 image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed improper release of remapped auxiliary inputs (keyboard/mouse buttons) during gamepad source transitions and mapping configuration changes
  * Improved auxiliary input state consistency during hot-swap and mapping reload operations

* **Tests**
  * Added comprehensive test coverage for auxiliary input release behavior across remapping and gesture scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->