### PR TITLE
Fix local TSAN Docker fallback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,11 @@ To enable repository git hooks locally:
 git config core.hooksPath hooks
 ```
 
-With hooks enabled, `pre-push` runs `zig build test-tsan` before push.
+With hooks enabled, `pre-push` runs `zig build test-tsan` before push. On
+systems whose libc startup objects trigger Zig's known `.sframe` linker issue,
+the hook runs `test-tsan` in the canonical Docker build image instead, using
+`PADCTL_DOCKER_NETWORK=host`. Docker build/test commands run as your UID/GID so
+generated cache files remain writable.
 
 ### Code Style
 

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -5,17 +5,76 @@
 # that touches UHID paths: PADCTL_TEST_REQUIRE_UHID=1 zig build test-uhid
 set -e
 
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+run_docker_tsan() {
+    PADCTL_DOCKER_NETWORK="${PADCTL_DOCKER_NETWORK:-host}" ./scripts/padctl-docker build test-tsan --summary all
+}
+
+host_has_zig_sframe_linker_issue() {
+    command -v zig >/dev/null 2>&1 || return 1
+    command -v gcc >/dev/null 2>&1 || return 1
+    command -v readelf >/dev/null 2>&1 || return 1
+
+    case "$(zig version 2>/dev/null)" in
+        0.15.*) ;;
+        *) return 1 ;;
+    esac
+
+    for obj in "$(gcc -print-file-name=Scrt1.o)" "$(gcc -print-file-name=crt1.o)"; do
+        [ -r "$obj" ] || continue
+        if readelf -r "$obj" 2>/dev/null | grep -q '[.]rela[.]sframe' &&
+            readelf -r "$obj" 2>/dev/null | grep -q 'R_X86_64_PC64'; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 if [ "$SKIP_TSAN" = "1" ]; then
     echo "pre-push: SKIP_TSAN=1 set, skipping zig build test-tsan"
     exit 0
 fi
 
-echo "pre-push: running zig build test-tsan..."
-if ! zig build test-tsan; then
-    echo "ERROR: zig build test-tsan failed. Push aborted."
-    echo "Hint: run 'zig build test-tsan' locally to inspect failures."
-    echo "If you must bypass temporarily: SKIP_TSAN=1 git push"
-    exit 1
+if ! command -v zig >/dev/null 2>&1; then
+    echo "pre-push: zig not found, running test-tsan in the canonical Docker build image..."
+    run_docker_tsan
+    echo "pre-push: Docker test-tsan passed."
+    exit 0
 fi
 
-echo "pre-push: test-tsan passed."
+if host_has_zig_sframe_linker_issue; then
+    echo "pre-push: Zig 0.15.x cannot link this host's .sframe startup objects."
+    echo "pre-push: running test-tsan in the canonical Docker build image..."
+    run_docker_tsan
+    echo "pre-push: Docker test-tsan passed."
+    exit 0
+fi
+
+echo "pre-push: running zig build test-tsan..."
+tsan_log="${TMPDIR:-/tmp}/padctl-pre-push-tsan.$$"
+trap 'rm -f "$tsan_log"' EXIT HUP INT TERM
+if zig build test-tsan >"$tsan_log" 2>&1; then
+    cat "$tsan_log"
+    echo "pre-push: test-tsan passed."
+    exit 0
+fi
+
+cat "$tsan_log"
+
+if grep -Eq 'fatal linker error|relocation .*unsupported|unhandled relocation' "$tsan_log" &&
+    grep -q 'R_X86_64_PC64' "$tsan_log" &&
+    grep -q '[.]sframe' "$tsan_log"; then
+    echo "pre-push: native Zig hit known glibc .sframe linker incompatibility."
+    echo "pre-push: retrying test-tsan in the canonical Docker build image..."
+    run_docker_tsan
+    echo "pre-push: Docker test-tsan passed."
+    exit 0
+fi
+
+echo "ERROR: zig build test-tsan failed. Push aborted."
+echo "Hint: run 'zig build test-tsan' locally to inspect failures."
+echo "If you must bypass temporarily: SKIP_TSAN=1 git push"
+exit 1

--- a/scripts/padctl-docker
+++ b/scripts/padctl-docker
@@ -55,6 +55,18 @@ sha256_for() {
   printf '%s' "$sha"
 }
 
+docker_network_args() {
+  if [ -n "${PADCTL_DOCKER_NETWORK:-}" ]; then
+    printf '%s\n' --network "$PADCTL_DOCKER_NETWORK"
+  fi
+}
+
+docker_user_args() {
+  if [ "$(id -u)" -ne 0 ]; then
+    printf '%s\n' --user "$(id -u):$(id -g)"
+  fi
+}
+
 # Build the canonical image locally if the version tag is not already present.
 cmd_image() {
   local version arch sha tag
@@ -69,14 +81,27 @@ cmd_image() {
   fi
 
   echo "padctl-docker: building ${tag} (zig ${version}, ${arch})"
-  docker buildx build \
-    --build-arg "ZIG_VERSION=${version}" \
-    --build-arg "ZIG_SHA256=${sha}" \
-    --build-arg "TARGETARCH=${arch}" \
-    --load \
-    -t "$tag" \
-    -f "${REPO_ROOT}/Dockerfile" \
-    "${REPO_ROOT}"
+  if docker buildx version >/dev/null 2>&1; then
+    docker buildx build \
+      $(docker_network_args) \
+      --build-arg "ZIG_VERSION=${version}" \
+      --build-arg "ZIG_SHA256=${sha}" \
+      --build-arg "TARGETARCH=${arch}" \
+      --load \
+      -t "$tag" \
+      -f "${REPO_ROOT}/Dockerfile" \
+      "${REPO_ROOT}"
+  else
+    echo "padctl-docker: docker buildx not found, falling back to docker build"
+    docker build \
+      $(docker_network_args) \
+      --build-arg "ZIG_VERSION=${version}" \
+      --build-arg "ZIG_SHA256=${sha}" \
+      --build-arg "TARGETARCH=${arch}" \
+      -t "$tag" \
+      -f "${REPO_ROOT}/Dockerfile" \
+      "${REPO_ROOT}"
+  fi
 }
 
 image_tag() {
@@ -87,6 +112,10 @@ image_tag() {
 run_in_image() {
   cmd_image
   docker run --rm \
+    $(docker_network_args) \
+    $(docker_user_args) \
+    -e HOME=/tmp \
+    -e ZIG_GLOBAL_CACHE_DIR=/tmp/zig-global-cache \
     -v "${REPO_ROOT}:/src" \
     -w /src \
     "$(image_tag)" \
@@ -109,6 +138,7 @@ cmd_canary() {
   # reflect input nodes the kernel creates from UHID_CREATE2.
   docker run --rm \
     --privileged \
+    $(docker_network_args) \
     --device /dev/uhid \
     -v "${REPO_ROOT}:/src" \
     -w /src \
@@ -123,6 +153,10 @@ cmd_canary() {
 cmd_shell() {
   cmd_image
   docker run --rm -it \
+    $(docker_network_args) \
+    $(docker_user_args) \
+    -e HOME=/tmp \
+    -e ZIG_GLOBAL_CACHE_DIR=/tmp/zig-global-cache \
     -v "${REPO_ROOT}:/src" \
     -w /src \
     "$(image_tag)" \
@@ -138,6 +172,10 @@ usage: padctl-docker <image|build|test|canary|shell> [args...]
   test  [args]    run `zig build test [args]` inside the image
   canary          run the UHID L2 privileged tests (needs /dev/uhid)
   shell           open an interactive shell inside the image
+
+Set PADCTL_DOCKER_NETWORK=host to pass --network host to docker build/run.
+Build, test, and shell run as the current UID/GID with HOME=/tmp so cache files
+remain writable.
 EOF
   exit 2
 }


### PR DESCRIPTION
## Summary

- Make `pre-push` detect the Zig 0.15.x + host `.sframe` linker incompatibility before running native TSAN, then run `test-tsan` in the canonical Docker image instead.
- Keep native TSAN for compatible hosts, and keep ordinary TSAN/test failures blocking push.
- Let `scripts/padctl-docker` fall back to plain `docker build` when the buildx plugin is unavailable, and run build/test/shell as the current UID/GID to avoid root-owned cache files.

Refs #288

## Tests

- `sh -n hooks/pre-push`
- `bash -n scripts/padctl-docker`
- `git diff --check`
- Stubbed ordinary `zig build test-tsan` failure: verified it does not trigger Docker fallback.
- Stubbed missing `docker buildx`: verified `scripts/padctl-docker image` falls back to `docker build` and preserves `--network host`.
- `PATH=$HOME/.local/bin:$PATH hooks/pre-push` on this host: direct Docker `test-tsan`, 1394 passed / 6 skipped.
- `PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test --summary all`: 1405/1414 passed / 9 skipped.

## Notes

- This does not treat linker setup failures as TSAN findings. Actual TSAN runtime reports still fail the hook.
- PR association intentionally uses `Refs`, not a closing keyword.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for local git hook setup, including Docker-based testing for systems with known Zig linker compatibility issues.

* **Bug Fixes**
  * Improved pre-push hook robustness with automatic Docker fallback when native testing encounters known linker issues.
  * Enhanced Docker container execution to preserve file permissions and support custom network configuration via `PADCTL_DOCKER_NETWORK=host`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->