### PR TITLE
Add gyro tilt joystick response

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -125,11 +125,15 @@ invert_y = true
 |-------|------|---------|-------------|
 | `mode` | string | `"off"` | `"off"`, `"mouse"`, or `"joystick"`. In `"joystick"` mode the processed gyro signal is routed to a virtual stick axis instead of mouse `REL_X/Y` events. |
 | `target` | string | `"right_stick"` | `"right_stick"` or `"left_stick"`. Selects which stick axis receives the gyro output. Only used when `mode = "joystick"`. |
+| `response` | string | `"rate"` | `"rate"` keeps the existing gyro-rate behavior. `"tilt"` maps controller tilt to an absolute virtual stick position and is valid only with `mode = "joystick"`. |
+| `axis_x` | string | `"yaw"` / `"roll"` | Source for virtual stick X: `"yaw"`, `"pitch"`, `"roll"`, or `"none"`. Defaults to `"yaw"` in `"rate"` response and `"roll"` in `"tilt"` response. In `"tilt"` response, `roll` and `pitch` are estimated from accelerometer data; `yaw` resolves to neutral. |
+| `axis_y` | string | `"pitch"` | Source for virtual stick Y: `"yaw"`, `"pitch"`, `"roll"`, or `"none"`. |
+| `degrees_full` | float | `35.0` | In `"tilt"` response, the absolute tilt angle that maps to full stick deflection. Must be greater than `0` and no more than `180`. |
 | `activate` | string | — | Gate button: bare name (`"LS"`) or `hold_<BTN>` form (`"hold_RB"`) — both are equivalent. For analog triggers (`LT`/`RT`), also set `trigger_threshold`. Omit for always-active. |
 | `sensitivity` | float | — | Overall sensitivity multiplier |
 | `sensitivity_x` | float | — | X-axis sensitivity override |
 | `sensitivity_y` | float | — | Y-axis sensitivity override |
-| `deadzone` | integer | — | Raw gyro deadzone threshold |
+| `deadzone` | integer | — | Raw gyro deadzone threshold in `"rate"` response. In `"tilt"` response this is an output stick deadzone after angle conversion. |
 | `smoothing` | float | — | Smoothing factor (0–1) |
 | `curve` | float | — | Acceleration curve exponent |
 | `max_val` | float | — | Maximum output value cap |

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -194,7 +194,32 @@ sensitivity = 1.5
 smoothing   = 0.3
 ```
 
-This is useful for games that read the right stick for camera control but do not natively support gyro input. All other `[gyro]` fields (`sensitivity`, `deadzone`, `smoothing`, `curve`, `invert_x`, `invert_y`) apply in joystick mode the same way as in mouse mode.
+This is useful for games that read the right stick for camera control but do not natively support gyro input. In the default `response = "rate"` mode, the usual gyro fields (`sensitivity`, `deadzone`, `smoothing`, `curve`, `invert_x`, `invert_y`) apply in joystick mode the same way as in mouse mode.
+
+For racing games, `response = "tilt"` maps controller tilt to an absolute stick
+position instead of treating gyro motion like stick velocity. `degrees_full`
+controls how far the controller must be tilted for full stick deflection, and
+`axis_x` / `axis_y` choose which motion axis drives each virtual stick axis:
+
+```toml
+[gyro]
+mode = "joystick"
+response = "tilt"
+target = "left_stick"
+axis_x = "roll"          # steer by rolling the controller left/right
+axis_y = "none"          # leave the Y stick axis unchanged
+degrees_full = 35.0      # +/-35 degrees maps to full stick deflection
+smoothing = 0.2
+```
+
+`response = "tilt"` uses the accelerometer to estimate `roll` and `pitch`, so
+it gives a stable absolute stick position without gyro integration drift. `yaw`
+does not have an absolute tilt estimate and resolves to neutral in tilt mode.
+When `response = "tilt"`, the default X source is `roll`; in the default
+`response = "rate"` mode, X still uses `yaw`. If a device has not reported a
+non-zero accelerometer vector yet, tilt mode leaves the physical stick axes
+unchanged for that frame. In tilt mode, `deadzone` is applied after converting
+tilt to virtual stick output rather than to raw gyro units.
 
 #### Blending gyro with the physical stick (`blend_stick`)
 

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -246,6 +246,10 @@ pub fn buildAuxKeyCodes(caps: DerivedAuxCaps, buf: []u16) []u16 {
 pub const GyroConfig = struct {
     mode: []const u8 = "off",
     target: ?[]const u8 = null, // "right_stick" (default) or "left_stick"
+    response: ?[]const u8 = null, // "rate" (default) or "tilt"
+    axis_x: ?[]const u8 = null, // "yaw" in rate, "roll" in tilt, "pitch", or "none"
+    axis_y: ?[]const u8 = null, // "pitch" (default), "yaw", "roll", or "none"
+    degrees_full: ?f64 = null, // tilt degrees that map to full stick deflection
     activate: ?[]const u8 = null,
     sensitivity: ?f64 = null,
     sensitivity_x: ?f64 = null,
@@ -450,6 +454,8 @@ fn remapHasTriggerKey(map: *const RemapMap) bool {
 
 const valid_gyro_modes = [_][]const u8{ "off", "mouse", "joystick" };
 const valid_gyro_targets = [_][]const u8{ "right_stick", "left_stick" };
+const valid_gyro_responses = [_][]const u8{ "rate", "tilt" };
+const valid_gyro_axes = [_][]const u8{ "none", "pitch", "yaw", "roll" };
 
 fn validateGyroConfig(g: *const GyroConfig, trigger_threshold: ?u8) !void {
     var mode_ok = false;
@@ -472,6 +478,29 @@ fn validateGyroConfig(g: *const GyroConfig, trigger_threshold: ?u8) !void {
         if (!target_ok) return error.InvalidConfig;
     }
 
+    if (g.response) |r| {
+        var response_ok = false;
+        for (valid_gyro_responses) |v| {
+            if (std.mem.eql(u8, r, v)) {
+                response_ok = true;
+                break;
+            }
+        }
+        if (!response_ok) return error.InvalidConfig;
+        if (std.mem.eql(u8, r, "tilt") and !std.mem.eql(u8, g.mode, "joystick")) return error.InvalidConfig;
+    }
+
+    if (g.axis_x) |axis| {
+        if (!gyroAxisValid(axis)) return error.InvalidConfig;
+    }
+    if (g.axis_y) |axis| {
+        if (!gyroAxisValid(axis)) return error.InvalidConfig;
+    }
+
+    if (g.degrees_full) |v| {
+        if (v <= 0.0 or v > 180.0) return error.InvalidConfig;
+    }
+
     if (g.activate) |spec| {
         const btn_name = if (std.mem.startsWith(u8, spec, "hold_"))
             spec["hold_".len..]
@@ -485,6 +514,13 @@ fn validateGyroConfig(g: *const GyroConfig, trigger_threshold: ?u8) !void {
             }
         }
     }
+}
+
+fn gyroAxisValid(axis: []const u8) bool {
+    for (valid_gyro_axes) |v| {
+        if (std.mem.eql(u8, axis, v)) return true;
+    }
+    return false;
 }
 
 // Returns true when LT/RT appear in any remap but trigger_threshold is not set.
@@ -1785,6 +1821,75 @@ test "validate: gyro mode=joystick target=left_stick is valid" {
     );
     defer result.deinit();
     try validate(&result.value);
+}
+
+test "validate: gyro joystick tilt response and axes are valid" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[gyro]
+        \\mode = "joystick"
+        \\response = "tilt"
+        \\axis_x = "roll"
+        \\axis_y = "none"
+        \\degrees_full = 35.0
+    );
+    defer result.deinit();
+    try validate(&result.value);
+    try std.testing.expectEqualStrings("tilt", result.value.gyro.?.response.?);
+    try std.testing.expectEqualStrings("roll", result.value.gyro.?.axis_x.?);
+    try std.testing.expectEqual(@as(?f64, 35.0), result.value.gyro.?.degrees_full);
+}
+
+test "validate: layer gyro joystick tilt response is valid" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[[layer]]
+        \\name = "race"
+        \\trigger = "LB"
+        \\
+        \\[layer.gyro]
+        \\mode = "joystick"
+        \\response = "tilt"
+        \\axis_x = "roll"
+        \\axis_y = "none"
+        \\degrees_full = 30.0
+    );
+    defer result.deinit();
+    try validate(&result.value);
+}
+
+test "validate: gyro tilt response requires joystick mode" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[gyro]
+        \\mode = "mouse"
+        \\response = "tilt"
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "validate: gyro axis invalid returns error" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[gyro]
+        \\mode = "joystick"
+        \\axis_x = "diagonal"
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "validate: gyro degrees_full must be positive" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[gyro]
+        \\mode = "joystick"
+        \\response = "tilt"
+        \\degrees_full = 0.0
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
 }
 
 test "validate: layer gyro mode bogus returns error" {

--- a/src/core/gyro.zig
+++ b/src/core/gyro.zig
@@ -1,10 +1,16 @@
 const std = @import("std");
 
 pub const GyroTarget = enum { right_stick, left_stick };
+pub const GyroResponse = enum { rate, tilt };
+pub const GyroAxis = enum { none, pitch, yaw, roll };
 
 pub const GyroConfig = struct {
     mode: []const u8 = "off", // "off" | "mouse" | "joystick"
     target: GyroTarget = .right_stick,
+    response: GyroResponse = .rate,
+    axis_x: GyroAxis = .yaw,
+    axis_y: GyroAxis = .pitch,
+    degrees_full: f32 = 35.0,
     sensitivity_x: f32 = 1.5,
     sensitivity_y: f32 = 1.5,
     deadzone: i16 = 0,
@@ -30,19 +36,43 @@ pub const GyroProcessor = struct {
     accum_y: f32 = 0,
 
     pub fn process(self: *GyroProcessor, cfg: *const GyroConfig, gx: i16, gy: i16, gz: i16) GyroOutput {
-        _ = gz;
+        return self.processMotion(cfg, gx, gy, gz, 0, 0, 0);
+    }
+
+    pub fn processMotion(
+        self: *GyroProcessor,
+        cfg: *const GyroConfig,
+        gx: i16,
+        gy: i16,
+        gz: i16,
+        accel_x: i16,
+        accel_y: i16,
+        accel_z: i16,
+    ) GyroOutput {
         if (!std.mem.eql(u8, cfg.mode, "mouse") and !std.mem.eql(u8, cfg.mode, "joystick")) {
             return .{ .rel_x = 0, .rel_y = 0, .joy_x = null, .joy_y = null };
         }
 
-        // gyro_x = pitch (up/down tilt) → REL_Y; gyro_y = yaw (left/right rotation) → REL_X
-        // [1] deadzone
-        const fyaw: f32 = if (@abs(@as(i32, gy)) < cfg.deadzone) 0.0 else @floatFromInt(gy);
-        const fpitch: f32 = if (@abs(@as(i32, gx)) < cfg.deadzone) 0.0 else @floatFromInt(gx);
+        if (std.mem.eql(u8, cfg.mode, "joystick") and cfg.response == .tilt) {
+            return self.processTilt(cfg, accel_x, accel_y, accel_z);
+        }
 
-        // [2] EMA smoothing (ema_x tracks yaw→REL_X, ema_y tracks pitch→REL_Y)
-        self.ema_x = self.ema_x * cfg.smoothing + fyaw * (1.0 - cfg.smoothing);
-        self.ema_y = self.ema_y * cfg.smoothing + fpitch * (1.0 - cfg.smoothing);
+        const raw_x = selectRateAxis(cfg.axis_x, gx, gy, gz);
+        const raw_y = selectRateAxis(cfg.axis_y, gx, gy, gz);
+
+        // [1] deadzone
+        const fsrc_x: f32 = if (raw_x) |v|
+            if (@abs(@as(i32, v)) < cfg.deadzone) 0.0 else @floatFromInt(v)
+        else
+            0.0;
+        const fsrc_y: f32 = if (raw_y) |v|
+            if (@abs(@as(i32, v)) < cfg.deadzone) 0.0 else @floatFromInt(v)
+        else
+            0.0;
+
+        // [2] EMA smoothing (ema_x tracks source->X, ema_y tracks source->Y)
+        self.ema_x = self.ema_x * cfg.smoothing + fsrc_x * (1.0 - cfg.smoothing);
+        self.ema_y = self.ema_y * cfg.smoothing + fsrc_y * (1.0 - cfg.smoothing);
 
         // [3] normalized curve (vader5): normalize [deadzone,max_val]→[0,1], apply pow, sensitivity scale
         const scaled_x = applyCurve(self.ema_x, cfg) * cfg.sensitivity_x;
@@ -53,8 +83,8 @@ pub const GyroProcessor = struct {
         const final_y = if (cfg.invert_y) -scaled_y else scaled_y;
 
         if (std.mem.eql(u8, cfg.mode, "joystick")) {
-            const jx: i16 = @intFromFloat(std.math.clamp(final_x * 20000.0, -32767.0, 32767.0));
-            const jy: i16 = @intFromFloat(std.math.clamp(final_y * 20000.0, -32767.0, 32767.0));
+            const jx: ?i16 = if (raw_x != null) @intFromFloat(std.math.clamp(final_x * 20000.0, -32767.0, 32767.0)) else null;
+            const jy: ?i16 = if (raw_y != null) @intFromFloat(std.math.clamp(final_y * 20000.0, -32767.0, 32767.0)) else null;
             return .{ .rel_x = 0, .rel_y = 0, .joy_x = jx, .joy_y = jy };
         }
 
@@ -69,6 +99,24 @@ pub const GyroProcessor = struct {
         return .{ .rel_x = dx, .rel_y = dy, .joy_x = null, .joy_y = null };
     }
 
+    fn processTilt(self: *GyroProcessor, cfg: *const GyroConfig, accel_x: i16, accel_y: i16, accel_z: i16) GyroOutput {
+        const angle_x = selectTiltAxis(cfg.axis_x, accel_x, accel_y, accel_z);
+        const angle_y = selectTiltAxis(cfg.axis_y, accel_x, accel_y, accel_z);
+
+        if (angle_x) |a| self.ema_x = self.ema_x * cfg.smoothing + a * (1.0 - cfg.smoothing);
+        if (angle_y) |a| self.ema_y = self.ema_y * cfg.smoothing + a * (1.0 - cfg.smoothing);
+
+        const jx: ?i16 = if (angle_x != null)
+            angleToStick(self.ema_x, cfg.degrees_full, cfg.curve, cfg.sensitivity_x, cfg.deadzone, cfg.invert_x)
+        else
+            null;
+        const jy: ?i16 = if (angle_y != null)
+            angleToStick(self.ema_y, cfg.degrees_full, cfg.curve, cfg.sensitivity_y, cfg.deadzone, cfg.invert_y)
+        else
+            null;
+        return .{ .rel_x = 0, .rel_y = 0, .joy_x = jx, .joy_y = jy };
+    }
+
     pub fn reset(self: *GyroProcessor) void {
         self.ema_x = 0;
         self.ema_y = 0;
@@ -76,6 +124,42 @@ pub const GyroProcessor = struct {
         self.accum_y = 0;
     }
 };
+
+fn selectRateAxis(axis: GyroAxis, gx: i16, gy: i16, gz: i16) ?i16 {
+    return switch (axis) {
+        .none => null,
+        .pitch => gx,
+        .yaw => gy,
+        .roll => gz,
+    };
+}
+
+fn selectTiltAxis(axis: GyroAxis, ax: i16, ay: i16, az: i16) ?f32 {
+    if (axis == .none) return null;
+    const fx: f32 = @floatFromInt(ax);
+    const fy: f32 = @floatFromInt(ay);
+    const fz: f32 = @floatFromInt(az);
+    if (fx == 0.0 and fy == 0.0 and fz == 0.0) return null;
+
+    const radians_to_degrees: f32 = 180.0 / std.math.pi;
+    return switch (axis) {
+        .none => null,
+        .pitch => std.math.atan2(-fx, @sqrt(fy * fy + fz * fz)) * radians_to_degrees,
+        .roll => std.math.atan2(fy, fz) * radians_to_degrees,
+        .yaw => 0.0,
+    };
+}
+
+fn angleToStick(angle_degrees: f32, degrees_full: f32, curve: f32, sensitivity: f32, deadzone: i16, invert: bool) i16 {
+    const full = @max(degrees_full, 0.001);
+    var normalized = std.math.clamp(angle_degrees / full, -1.0, 1.0);
+    normalized = std.math.copysign(std.math.pow(f32, @abs(normalized), curve), normalized);
+
+    var value = std.math.clamp(normalized * sensitivity * 32767.0, -32767.0, 32767.0);
+    if (@abs(value) < @as(f32, @floatFromInt(deadzone))) value = 0.0;
+    if (invert) value = -value;
+    return @intFromFloat(value);
+}
 
 fn applyCurve(ema: f32, cfg: *const GyroConfig) f32 {
     const dz: f32 = @floatFromInt(cfg.deadzone);
@@ -99,6 +183,77 @@ test "gyro: mode=off: zero output" {
     try testing.expectEqual(@as(i32, 0), out.rel_x);
     try testing.expectEqual(@as(i32, 0), out.rel_y);
     try testing.expect(out.joy_x == null);
+    try testing.expect(out.joy_y == null);
+}
+
+test "gyro: joystick tilt response maps roll degrees to stick position" {
+    var g = GyroProcessor{};
+    const cfg = GyroConfig{
+        .mode = "joystick",
+        .response = .tilt,
+        .axis_x = .roll,
+        .axis_y = .none,
+        .degrees_full = 35.0,
+        .smoothing = 0.0,
+        .sensitivity_x = 1.0,
+    };
+
+    // atan2(5735, 8192) is approximately 35 degrees, so it should be full X deflection.
+    const out = g.processMotion(&cfg, 0, 0, 0, 0, 5735, 8192);
+    try testing.expect(out.joy_x != null);
+    try testing.expect(out.joy_y == null);
+    try testing.expect(out.joy_x.? > 32000);
+}
+
+test "gyro: joystick tilt response supports invert and negative roll" {
+    var g = GyroProcessor{};
+    const cfg = GyroConfig{
+        .mode = "joystick",
+        .response = .tilt,
+        .axis_x = .roll,
+        .axis_y = .none,
+        .degrees_full = 35.0,
+        .smoothing = 0.0,
+        .sensitivity_x = 1.0,
+        .invert_x = true,
+    };
+
+    const out = g.processMotion(&cfg, 0, 0, 0, 0, -5735, 8192);
+    try testing.expect(out.joy_x != null);
+    try testing.expect(out.joy_x.? > 32000);
+}
+
+test "gyro: joystick tilt response ignores missing accelerometer vector" {
+    var g = GyroProcessor{ .ema_x = 12.0, .ema_y = -8.0 };
+    const cfg = GyroConfig{
+        .mode = "joystick",
+        .response = .tilt,
+        .axis_x = .roll,
+        .axis_y = .pitch,
+        .smoothing = 0.0,
+    };
+
+    const out = g.processMotion(&cfg, 0, 0, 0, 0, 0, 0);
+    try testing.expect(out.joy_x == null);
+    try testing.expect(out.joy_y == null);
+    try testing.expectEqual(@as(f32, 12.0), g.ema_x);
+    try testing.expectEqual(@as(f32, -8.0), g.ema_y);
+}
+
+test "gyro: joystick rate response can route roll gyro to X axis" {
+    var g = GyroProcessor{};
+    const cfg = GyroConfig{
+        .mode = "joystick",
+        .response = .rate,
+        .axis_x = .roll,
+        .axis_y = .none,
+        .smoothing = 0.0,
+        .sensitivity_x = 1.0,
+    };
+
+    const out = g.process(&cfg, 0, 0, 10000);
+    try testing.expect(out.joy_x != null);
+    try testing.expect(out.joy_x.? > 0);
     try testing.expect(out.joy_y == null);
 }
 

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -367,7 +367,15 @@ pub const Mapper = struct {
                 break :blk if (self.config.gyro) |g| g.activate else null;
             };
             if (checkGyroActivate(activate_spec, self.state.buttons)) {
-                const gout = self.gyro_proc.process(&gcfg, self.state.gyro_x, self.state.gyro_y, self.state.gyro_z);
+                const gout = self.gyro_proc.processMotion(
+                    &gcfg,
+                    self.state.gyro_x,
+                    self.state.gyro_y,
+                    self.state.gyro_z,
+                    self.state.accel_x,
+                    self.state.accel_y,
+                    self.state.accel_z,
+                );
                 if (std.mem.eql(u8, gcfg.mode, "mouse")) {
                     if (gout.rel_x != 0) aux.append(.{ .rel = .{ .code = REL_X, .value = gout.rel_x } }) catch {};
                     if (gout.rel_y != 0) aux.append(.{ .rel = .{ .code = REL_Y, .value = gout.rel_y } }) catch {};
@@ -779,8 +787,13 @@ fn resolveGyroConfig(config: *const MappingConfig) gyro.GyroConfig {
 }
 
 fn resolveGyroConfig2(mc: *const mapping.GyroConfig) gyro.GyroConfig {
+    const response = resolveGyroResponse(mc.response);
     return .{
         .mode = mc.mode,
+        .response = response,
+        .axis_x = resolveGyroAxis(mc.axis_x, if (response == .tilt) .roll else .yaw),
+        .axis_y = resolveGyroAxis(mc.axis_y, .pitch),
+        .degrees_full = if (mc.degrees_full) |v| @floatCast(v) else 35.0,
         .sensitivity_x = if (mc.sensitivity_x) |v| @floatCast(v) else if (mc.sensitivity) |v| @floatCast(v) else 1.5,
         .sensitivity_y = if (mc.sensitivity_y) |v| @floatCast(v) else if (mc.sensitivity) |v| @floatCast(v) else 1.5,
         .deadzone = if (mc.deadzone) |v| @intCast(v) else 0,
@@ -792,6 +805,21 @@ fn resolveGyroConfig2(mc: *const mapping.GyroConfig) gyro.GyroConfig {
         .target = if (mc.target) |t| (if (std.mem.eql(u8, t, "left_stick")) .left_stick else .right_stick) else .right_stick,
         .blend_stick = mc.blend_stick orelse false,
     };
+}
+
+fn resolveGyroResponse(response: ?[]const u8) gyro.GyroResponse {
+    const r = response orelse return .rate;
+    if (std.mem.eql(u8, r, "tilt")) return .tilt;
+    return .rate;
+}
+
+fn resolveGyroAxis(axis: ?[]const u8, default: gyro.GyroAxis) gyro.GyroAxis {
+    const a = axis orelse return default;
+    if (std.mem.eql(u8, a, "none")) return .none;
+    if (std.mem.eql(u8, a, "pitch")) return .pitch;
+    if (std.mem.eql(u8, a, "roll")) return .roll;
+    if (std.mem.eql(u8, a, "yaw")) return .yaw;
+    return default;
 }
 
 fn resolveStickConfig(mc: *const mapping.StickConfig) stick.StickConfig {

--- a/src/test/gyro_stick_e2e_test.zig
+++ b/src/test/gyro_stick_e2e_test.zig
@@ -255,6 +255,84 @@ test "e2e: gyro joystick target=right_stick (explicit) — same as default" {
     try testing.expectEqual(@as(i16, 4321), ev.gamepad.ay);
 }
 
+test "e2e: gyro joystick tilt — roll can drive left stick X by degrees" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[gyro]
+        \\mode = "joystick"
+        \\response = "tilt"
+        \\target = "left_stick"
+        \\axis_x = "roll"
+        \\axis_y = "none"
+        \\degrees_full = 35.0
+        \\sensitivity_x = 1.0
+        \\smoothing = 0.0
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const ev = try m.apply(.{ .accel_y = 5735, .accel_z = 8192, .ax = 111, .ay = -222 }, 16, 0);
+
+    try testing.expect(ev.gamepad.ax > 32000);
+    try testing.expectEqual(@as(i16, -222), ev.gamepad.ay);
+    try testing.expectEqual(@as(i16, 0), ev.gamepad.rx);
+    try testing.expectEqual(@as(i16, 0), ev.gamepad.ry);
+}
+
+test "e2e: gyro joystick tilt — default X axis is roll" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[gyro]
+        \\mode = "joystick"
+        \\response = "tilt"
+        \\target = "left_stick"
+        \\axis_y = "none"
+        \\degrees_full = 35.0
+        \\sensitivity_x = 1.0
+        \\smoothing = 0.0
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const ev = try m.apply(.{ .accel_y = 5735, .accel_z = 8192 }, 16, 0);
+    try testing.expect(ev.gamepad.ax > 32000);
+}
+
+test "e2e: gyro joystick tilt — missing accel does not suppress physical stick" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[gyro]
+        \\mode = "joystick"
+        \\response = "tilt"
+        \\target = "left_stick"
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const ev = try m.apply(.{ .ax = 1234, .ay = -4321, .accel_x = 0, .accel_y = 0, .accel_z = 0 }, 16, 0);
+    try testing.expectEqual(@as(i16, 1234), ev.gamepad.ax);
+    try testing.expectEqual(@as(i16, -4321), ev.gamepad.ay);
+}
+
+test "e2e: gyro joystick rate — roll axis can drive right stick X" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[gyro]
+        \\mode = "joystick"
+        \\axis_x = "roll"
+        \\axis_y = "none"
+        \\sensitivity_x = 1.0
+        \\smoothing = 0.0
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const ev = try m.apply(.{ .gyro_z = 10000, .rx = 1234, .ry = -4321 }, 16, 0);
+
+    try testing.expect(ev.gamepad.rx > 0);
+    try testing.expectEqual(@as(i16, -4321), ev.gamepad.ry);
+}
+
 // --- Layer switch reset (L0) ---
 
 test "e2e: layer switch resets gyro EMA — no jump after activation" {


### PR DESCRIPTION
## Summary

- add `response = "tilt"` for gyro joystick mappings, using accelerometer roll/pitch as absolute virtual stick position
- add `axis_x`, `axis_y`, and `degrees_full` mapping fields with validation and docs
- preserve existing rate gyro behavior by default, and keep physical stick axes when tilt has no valid accelerometer vector

Refs #298

## Testing

- `/home/jim_z/.local/bin/zig test src/core/gyro.zig --cache-dir /tmp/padctl-issue-298-zig-cache --global-cache-dir /tmp/padctl-issue-298-zig-global-cache`
- `docker run --rm --network host -v /tmp/padctl-issue-298:/src -w /src padctl-build:0.15.2 zig build test --summary all`
  - result: `1418/1427 tests passed; 9 skipped`

## Review

- subagent code review completed with no blocking findings
