### PR TITLE
Add hold-to-toggle layer activation

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -196,8 +196,8 @@ hold_timeout = 200
 |-------|------|----------|-------------|
 | `name` | string | yes | Unique layer identifier |
 | `trigger` | string | yes | Button name that activates this layer |
-| `activation` | string | no | `"hold"` (default) or `"toggle"` |
-| `tap` | string | no | Button/key emitted on short press (when using hold activation). May be a `ButtonId`, `KEY_*`, `mouse_*`, or `disabled`. **Cannot be `macro:<name>`** — the layer tap dispatch path does not run macros, so `tap = "macro:foo"` is rejected at validate time (`error.LayerTapCannotBeMacro`). Use `macro:<name>` from `[remap]` / `[layer.remap]` instead. |
+| `activation` | string | no | `"hold"` (default), `"toggle"`, or `"hold_toggle"`. `hold_toggle` starts like `hold`, but holding past `hold_timeout` toggles the layer sticky on/off instead of making it momentary. |
+| `tap` | string | no | Button/key emitted on short press (when using `hold` or `hold_toggle` activation). May be a `ButtonId`, `KEY_*`, `mouse_*`, or `disabled`. **Cannot be `macro:<name>`** — the layer tap dispatch path does not run macros, so `tap = "macro:foo"` is rejected at validate time (`error.LayerTapCannotBeMacro`). Use `macro:<name>` from `[remap]` / `[layer.remap]` instead. |
 | `hold_timeout` | integer | no | Hold detection threshold in ms (1–5000); default 200 |
 
 ### `[layer.remap]`

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -272,10 +272,11 @@ Default is `"gamepad"`. Set to `"arrows"` to make the d-pad behave as arrow keys
 
 Layers are the most powerful feature. A layer is a context-sensitive override: while active, its remap/gyro/stick/dpad settings replace the base config.
 
-Two activation modes:
+Three activation modes:
 
 - `"hold"` — active while the trigger button is held
 - `"toggle"` — press once to enter, press again to exit
+- `"hold_toggle"` — short press fires `tap`; holding past `hold_timeout` toggles the layer on or off
 
 The `tap` + `hold_timeout` combination lets a button do double duty: if released before `hold_timeout` ms, it fires `tap` instead of activating the layer.
 
@@ -330,6 +331,26 @@ A = "KEY_F1"
 B = "KEY_F2"
 X = "KEY_F3"
 Y = "KEY_F4"
+```
+
+Hold-to-toggle example — hold LM to keep a racing layer enabled, hold it again
+to disable it. A short press still emits `tap`:
+
+```toml
+[[layer]]
+name         = "race"
+trigger      = "LM"
+activation   = "hold_toggle"
+hold_timeout = 300
+tap          = "LM"
+
+[layer.gyro]
+mode = "joystick"
+response = "tilt"
+target = "left_stick"
+axis_x = "roll"
+axis_y = "none"
+degrees_full = 35.0
 ```
 
 Layers are evaluated in declaration order. Only one layer is active at a time.
@@ -443,7 +464,7 @@ See [Mapping Config Reference — chord_switch](mapping-config.md#chord_switch--
 
 ## Full Example
 
-A copy-paste-ready example covering every major feature is included in the repository at [`examples/mappings/comprehensive.toml`](https://github.com/BANANASJIM/padctl/blob/main/examples/mappings/comprehensive.toml). It covers base remaps, two layers (hold + toggle), macros, stick modes, and gyro.
+A copy-paste-ready example covering every major feature is included in the repository at [`examples/mappings/comprehensive.toml`](https://github.com/BANANASJIM/padctl/blob/main/examples/mappings/comprehensive.toml). It covers base remaps, hold/toggle/hold-toggle layers, macros, stick modes, and gyro.
 
 ## Reference
 

--- a/examples/mappings/comprehensive.toml
+++ b/examples/mappings/comprehensive.toml
@@ -122,3 +122,23 @@ A = "KEY_F1"
 B = "KEY_F2"
 X = "KEY_F3"
 Y = "KEY_F4"
+
+# --- Layer 3: hold RM to sticky-toggle a racing tilt layer (hold_toggle activation) ---
+#
+# Short press RM passes through as RM. Holding past hold_timeout toggles the
+# layer on; holding RM again toggles it off.
+
+[[layer]]
+name         = "race"
+trigger      = "RM"
+activation   = "hold_toggle"
+hold_timeout = 300
+tap          = "RM"
+
+[layer.gyro]
+mode = "joystick"
+response = "tilt"
+target = "left_stick"
+axis_x = "roll"
+axis_y = "none"
+degrees_full = 35.0

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -795,7 +795,8 @@ pub fn validate(cfg: *const MappingConfig) !void {
 
     for (layers) |*layer| {
         if (!std.mem.eql(u8, layer.activation, "hold") and
-            !std.mem.eql(u8, layer.activation, "toggle"))
+            !std.mem.eql(u8, layer.activation, "toggle") and
+            !std.mem.eql(u8, layer.activation, "hold_toggle"))
             return error.InvalidConfig;
 
         if (layer.hold_timeout) |t| {
@@ -1045,6 +1046,22 @@ test "mapping: validate: invalid activation value returns error" {
     const result = try parseString(allocator, toml_str);
     defer result.deinit();
     try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "mapping: validate: hold_toggle activation value is valid" {
+    const allocator = std.testing.allocator;
+    const toml_str =
+        \\[[layer]]
+        \\name = "race"
+        \\trigger = "LM"
+        \\activation = "hold_toggle"
+        \\tap = "LM"
+        \\hold_timeout = 300
+    ;
+    const result = try parseString(allocator, toml_str);
+    defer result.deinit();
+    try validate(&result.value);
+    try std.testing.expectEqualStrings("hold_toggle", result.value.layer.?[0].activation);
 }
 
 test "mapping: validate: duplicate layer name returns error" {

--- a/src/core/layer.zig
+++ b/src/core/layer.zig
@@ -13,11 +13,13 @@ pub const LayerAction = struct {
 };
 
 pub const TapHoldPhase = enum { pending, active };
+pub const TapHoldMode = enum { hold, hold_toggle };
 
 pub const TapHoldState = struct {
     layer_name: []const u8,
     layer_activated: bool = false,
     phase: TapHoldPhase = .pending,
+    mode: TapHoldMode = .hold,
     press_ns: i128 = 0,
     hold_timeout_ns: i128 = 0,
 };
@@ -28,6 +30,7 @@ pub const TapHoldResult = struct {
     tap_event: ?RemapTarget = null,
     layer_activated: bool = false,
     layer_deactivated: bool = false,
+    sticky_toggled: bool = false,
 };
 
 pub const LayerState = struct {
@@ -90,14 +93,21 @@ pub const LayerState = struct {
             const pressed = (buttons & mask) != 0;
             const was_pressed = (prev_buttons & mask) != 0;
 
-            if (std.mem.eql(u8, cfg.activation, "hold")) {
+            if (std.mem.eql(u8, cfg.activation, "hold") or std.mem.eql(u8, cfg.activation, "hold_toggle")) {
+                const mode: TapHoldMode = if (std.mem.eql(u8, cfg.activation, "hold_toggle")) .hold_toggle else .hold;
                 if (pressed and !was_pressed) {
                     // Mutual exclusion: if another layer is already PENDING or ACTIVE, ignore.
                     if (self.tap_hold) |th| {
                         if (!std.mem.eql(u8, th.layer_name, cfg.name)) continue;
                     }
+                    if (mode == .hold_toggle) {
+                        const toggled_self = self.toggled.contains(cfg.name);
+                        if (self.getActive(configs)) |active| {
+                            if (!toggled_self or !std.mem.eql(u8, active.name, cfg.name)) continue;
+                        }
+                    }
                     const timeout: u64 = @intCast(cfg.hold_timeout orelse 200);
-                    const res = self.onTriggerPress(cfg.name, timeout, now_ns);
+                    const res = self.onTriggerPressWithMode(cfg.name, timeout, now_ns, mode);
                     if (res.arm_timer_ms) |ms| {
                         action.arm_timer_ms = ms;
                     }
@@ -114,7 +124,7 @@ pub const LayerState = struct {
                     if (res.tap_event) |ev| action.tap_event = ev;
                     if (res.layer_activated or res.layer_deactivated) action.active_changed = true;
                 }
-            } else { // toggle
+            } else if (std.mem.eql(u8, cfg.activation, "toggle")) {
                 if (!pressed and was_pressed) {
                     if (self.toggled.contains(cfg.name)) {
                         _ = self.toggled.remove(cfg.name);
@@ -136,12 +146,17 @@ pub const LayerState = struct {
     }
 
     pub fn onTriggerPress(self: *LayerState, layer_name: []const u8, hold_timeout_ms: u64, now_ns: i128) TapHoldResult {
+        return self.onTriggerPressWithMode(layer_name, hold_timeout_ms, now_ns, .hold);
+    }
+
+    pub fn onTriggerPressWithMode(self: *LayerState, layer_name: []const u8, hold_timeout_ms: u64, now_ns: i128, mode: TapHoldMode) TapHoldResult {
         if (self.tap_hold) |th| {
             if (std.mem.eql(u8, th.layer_name, layer_name)) return .{};
         }
         self.tap_hold = .{
             .layer_name = layer_name,
             .phase = .pending,
+            .mode = mode,
             .press_ns = now_ns,
             .hold_timeout_ns = @as(i128, hold_timeout_ms) * 1_000_000,
         };
@@ -166,8 +181,18 @@ pub const LayerState = struct {
     }
 
     pub fn onTimerExpired(self: *LayerState) TapHoldResult {
-        const th = &(self.tap_hold orelse return .{}); // IDLE: stale, no-op
+        const th_snapshot = self.tap_hold orelse return .{}; // IDLE: stale, no-op
+        const th = &self.tap_hold.?;
         if (th.phase != .pending) return .{};
+        if (th.mode == .hold_toggle) {
+            self.tap_hold = null;
+            if (self.toggled.contains(th_snapshot.layer_name)) {
+                _ = self.toggled.remove(th_snapshot.layer_name);
+                return .{ .layer_deactivated = true, .sticky_toggled = true };
+            }
+            self.toggled.put(th_snapshot.layer_name, {}) catch return .{};
+            return .{ .layer_activated = true, .sticky_toggled = true };
+        }
         th.phase = .active;
         th.layer_activated = true;
         return .{ .layer_activated = true };
@@ -420,6 +445,7 @@ test "layer: tap-hold: ACTIVE re-press same trigger → ignored" {
 
 const hold_aim = LayerConfig{ .name = "aim", .trigger = "LT", .activation = "hold" };
 const hold_fn = LayerConfig{ .name = "fn", .trigger = "RB", .activation = "hold" };
+const hold_toggle_aim = LayerConfig{ .name = "aim", .trigger = "LT", .activation = "hold_toggle" };
 const toggle_sel = LayerConfig{ .name = "sel", .trigger = "Select", .activation = "toggle" };
 
 fn ltMask() u64 {
@@ -538,6 +564,108 @@ test "layer: processLayerTriggers: Hold PENDING release → tap event + disarm" 
     try testing.expect(action.disarm_timer);
     try testing.expect(action.tap_event != null);
     try testing.expect(ls.tap_hold == null);
+}
+
+test "layer: processLayerTriggers: HoldToggle PENDING release → tap event + no toggle" {
+    var ls = LayerState.init(testing.allocator);
+    defer ls.deinit();
+    const tap_cfg = LayerConfig{ .name = "aim", .trigger = "LT", .activation = "hold_toggle", .tap = "KEY_F13" };
+    const configs = [_]LayerConfig{tap_cfg};
+    const lt = ltMask();
+
+    _ = ls.processLayerTriggers(&configs, lt, 0, 0);
+    const action = ls.processLayerTriggers(&configs, 0, lt, 0);
+
+    try testing.expect(action.disarm_timer);
+    try testing.expect(action.tap_event != null);
+    try testing.expect(!action.active_changed);
+    try testing.expect(!ls.toggled.contains("aim"));
+    try testing.expect(ls.tap_hold == null);
+}
+
+test "layer: processLayerTriggers: HoldToggle timer toggles sticky layer on" {
+    var ls = LayerState.init(testing.allocator);
+    defer ls.deinit();
+    const configs = [_]LayerConfig{hold_toggle_aim};
+    const lt = ltMask();
+
+    const action = ls.processLayerTriggers(&configs, lt, 0, 0);
+    try testing.expectEqual(@as(?u64, 200), action.arm_timer_ms);
+
+    const res = ls.onTimerExpired();
+    try testing.expect(res.layer_activated);
+    try testing.expect(!res.layer_deactivated);
+    try testing.expect(res.sticky_toggled);
+    try testing.expect(ls.tap_hold == null);
+    try testing.expect(ls.toggled.contains("aim"));
+    try testing.expectEqualStrings("aim", ls.getActive(&configs).?.name);
+}
+
+test "layer: processLayerTriggers: HoldToggle timer toggles sticky layer off" {
+    var ls = LayerState.init(testing.allocator);
+    defer ls.deinit();
+    const configs = [_]LayerConfig{hold_toggle_aim};
+    const lt = ltMask();
+    try ls.toggled.put("aim", {});
+
+    _ = ls.processLayerTriggers(&configs, lt, 0, 0);
+    const res = ls.onTimerExpired();
+
+    try testing.expect(!res.layer_activated);
+    try testing.expect(res.layer_deactivated);
+    try testing.expect(res.sticky_toggled);
+    try testing.expect(ls.tap_hold == null);
+    try testing.expect(!ls.toggled.contains("aim"));
+    try testing.expect(ls.getActive(&configs) == null);
+}
+
+test "layer: processLayerTriggers: HoldToggle release after timer is ignored" {
+    var ls = LayerState.init(testing.allocator);
+    defer ls.deinit();
+    const configs = [_]LayerConfig{hold_toggle_aim};
+    const lt = ltMask();
+
+    _ = ls.processLayerTriggers(&configs, lt, 0, 0);
+    _ = ls.onTimerExpired();
+    const action = ls.processLayerTriggers(&configs, 0, lt, 0);
+
+    try testing.expect(!action.active_changed);
+    try testing.expect(action.tap_event == null);
+    try testing.expect(ls.toggled.contains("aim"));
+}
+
+test "layer: processLayerTriggers: HoldToggle short tap while sticky on keeps layer on" {
+    var ls = LayerState.init(testing.allocator);
+    defer ls.deinit();
+    const tap_cfg = LayerConfig{ .name = "aim", .trigger = "LT", .activation = "hold_toggle", .tap = "KEY_F13" };
+    const configs = [_]LayerConfig{tap_cfg};
+    const lt = ltMask();
+    try ls.toggled.put("aim", {});
+
+    _ = ls.processLayerTriggers(&configs, lt, 0, 0);
+    const action = ls.processLayerTriggers(&configs, 0, lt, 0);
+
+    try testing.expect(action.tap_event != null);
+    try testing.expect(!action.active_changed);
+    try testing.expect(ls.toggled.contains("aim"));
+    try testing.expectEqualStrings("aim", ls.getActive(&configs).?.name);
+}
+
+test "layer: processLayerTriggers: HoldToggle on blocked while another layer active" {
+    var ls = LayerState.init(testing.allocator);
+    defer ls.deinit();
+    const fn_hold_toggle = LayerConfig{ .name = "fn", .trigger = "RB", .activation = "hold_toggle" };
+    const configs = [_]LayerConfig{ hold_aim, fn_hold_toggle };
+    const lt = ltMask();
+    const rb = rbMask();
+
+    _ = ls.processLayerTriggers(&configs, lt, 0, 0);
+    _ = ls.onTimerExpired();
+
+    const action = ls.processLayerTriggers(&configs, lt | rb, lt, 0);
+    try testing.expect(action.arm_timer_ms == null);
+    try testing.expect(ls.tap_hold != null);
+    try testing.expectEqualStrings("aim", ls.getActive(&configs).?.name);
 }
 
 test "layer: processLayerTriggers: mutual exclusion — second Hold press ignored while PENDING" {

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -46,6 +46,11 @@ pub const OutputEvents = struct {
     chord_switch_request: ?u8 = null,
 };
 
+pub const LayerTimerEvents = struct {
+    gamepad: ?GamepadState = null,
+    aux: AuxEventList = .{},
+};
+
 const BUTTON_COUNT = @typeInfo(ButtonId).@"enum".fields.len;
 
 const ResolvedRemap = struct {
@@ -289,25 +294,7 @@ pub const Mapper = struct {
             timer_request = .{ .disarm = {} };
         }
         if (action.active_changed) {
-            self.gyro_proc.reset();
-            self.stick_left.reset();
-            self.stick_right.reset();
-            // Reset dpad prev so edge detection fires on the next frame.
-            self.prev.dpad_x = 0;
-            self.prev.dpad_y = 0;
-            // Cancel in-flight macros; emit releases for any held keys/buttons.
-            for (self.active_macros.items) |*p| p.emitPendingReleases(&aux, &self.injected_buttons);
-            self.active_macros.clearRetainingCapacity();
-            // Discard tap bits staged from a cancelled macro's timer expiry.
-            self.macro_timer_tap_pending = 0;
-            // Cancel in-flight gestures; mirror the macro-cancel above.
-            for (self.gesture_tokens.entries) |maybe| {
-                if (maybe) |e| self.timer_queue.cancel(e.token, now_ns);
-            }
-            self.gesture_tokens.clear();
-            self.gesture_engine.reset();
-            self.gesture_timer_tap_pending = 0;
-            self.gesture_held_gamepad = 0;
+            self.handleLayerActiveChanged(&aux, now_ns);
         }
 
         self.suppressed_buttons = 0;
@@ -607,12 +594,124 @@ pub const Mapper = struct {
 
     // Layer-hold timerfd (slot 2) expiry only — macro timerfd (slot 4) is a separate fd.
     pub fn onLayerTimerExpired(self: *Mapper) AuxEventList {
+        return self.onLayerTimerExpiredAt(0).aux;
+    }
+
+    pub fn onLayerTimerExpiredAt(self: *Mapper, now_ns: i128) LayerTimerEvents {
+        var events = LayerTimerEvents{};
         const th_res = self.layer.onTimerExpired();
-        if (th_res.layer_activated) {
+        if (th_res.sticky_toggled) {
+            self.handleLayerActiveChanged(&events.aux, now_ns);
+            events.gamepad = self.currentMappedGamepadFrame();
+        } else if (th_res.layer_activated) {
             self.prev.dpad_x = 0;
             self.prev.dpad_y = 0;
         }
-        return AuxEventList{};
+        return events;
+    }
+
+    fn handleLayerActiveChanged(self: *Mapper, aux: *AuxEventList, now_ns: i128) void {
+        self.gyro_proc.reset();
+        self.stick_left.reset();
+        self.stick_right.reset();
+        // Reset dpad prev so edge detection fires on the next frame.
+        self.prev.dpad_x = 0;
+        self.prev.dpad_y = 0;
+        // Cancel in-flight macros; emit releases for any held keys/buttons.
+        for (self.active_macros.items) |*p| p.emitPendingReleases(aux, &self.injected_buttons);
+        self.active_macros.clearRetainingCapacity();
+        // Discard tap bits staged from a cancelled macro's timer expiry.
+        self.macro_timer_tap_pending = 0;
+        // Cancel in-flight gestures; mirror the macro-cancel above.
+        for (self.gesture_tokens.entries) |maybe| {
+            if (maybe) |e| self.timer_queue.cancel(e.token, now_ns);
+        }
+        self.gesture_tokens.clear();
+        self.gesture_engine.reset();
+        self.gesture_timer_tap_pending = 0;
+        self.gesture_held_gamepad = 0;
+    }
+
+    fn currentMappedGamepadFrame(self: *Mapper) GamepadState {
+        const configs = self.config.layer orelse &.{};
+        var suppressed: u64 = 0;
+        var injected: u64 = self.gesture_held_gamepad;
+        var per_src_inject: [BUTTON_COUNT]?RemapTargetResolved = [_]?RemapTargetResolved{null} ** BUTTON_COUNT;
+
+        for (self.active_macros.items) |player| {
+            injected |= player.held_gamepad_buttons;
+        }
+
+        for (configs) |*cfg| {
+            const trigger_id = std.meta.stringToEnum(ButtonId, cfg.trigger) orelse continue;
+            suppressed |= @as(u64, 1) << @as(u6, @intCast(@intFromEnum(trigger_id)));
+        }
+        suppressed |= self.currentChordSwitchSuppressMask();
+
+        suppressed |= self.resolved_base.suppress;
+        for (self.resolved_base.inject, 0..) |t, i| {
+            if (t) |target| per_src_inject[i] = target;
+        }
+        if (self.layer.getActiveIndex(configs)) |idx| {
+            const lr = &self.resolved_layers[idx];
+            suppressed |= lr.suppress;
+            for (lr.inject, 0..) |t, i| {
+                if (t) |target| per_src_inject[i] = target;
+            }
+        }
+
+        for (0..BUTTON_COUNT) |i| {
+            const src_mask: u64 = @as(u64, 1) << @as(u6, @intCast(i));
+            if ((self.state.buttons & src_mask) == 0) continue;
+            const target = per_src_inject[i] orelse continue;
+            switch (target) {
+                .gamepad_button => |dst| injected |= @as(u64, 1) << @as(u6, @intCast(@intFromEnum(dst))),
+                else => {},
+            }
+        }
+
+        const dpad_cfg = self.effectiveDpadConfig();
+        var suppress_dpad_hat = false;
+        if (std.mem.eql(u8, dpad_cfg.mode, "arrows") and (dpad_cfg.suppress_gamepad orelse false)) {
+            suppressed |= (@as(u64, 1) << @as(u6, @intCast(@intFromEnum(ButtonId.DPadUp)))) |
+                (@as(u64, 1) << @as(u6, @intCast(@intFromEnum(ButtonId.DPadDown)))) |
+                (@as(u64, 1) << @as(u6, @intCast(@intFromEnum(ButtonId.DPadLeft)))) |
+                (@as(u64, 1) << @as(u6, @intCast(@intFromEnum(ButtonId.DPadRight))));
+            suppress_dpad_hat = true;
+        }
+
+        var emit_state = self.state;
+        emit_state.buttons = (self.state.buttons & ~suppressed) | injected;
+        emit_state.synthesizeDpadAxes();
+        if (suppress_dpad_hat) {
+            emit_state.dpad_x = 0;
+            emit_state.dpad_y = 0;
+        }
+
+        const left_cfg = self.effectiveStickConfig(.left);
+        const right_cfg = self.effectiveStickConfig(.right);
+        if (left_cfg.suppress_gamepad or !std.mem.eql(u8, left_cfg.mode, "gamepad")) {
+            emit_state.ax = 0;
+            emit_state.ay = 0;
+        }
+        if (right_cfg.suppress_gamepad or !std.mem.eql(u8, right_cfg.mode, "gamepad")) {
+            emit_state.rx = 0;
+            emit_state.ry = 0;
+        }
+        return emit_state;
+    }
+
+    fn currentChordSwitchSuppressMask(self: *const Mapper) u64 {
+        const cd = self.chord_detector orelse return 0;
+        if (cd.cfg.selector_count == 0 or cd.cfg.modifier_mask == 0) return 0;
+        if ((self.state.buttons & cd.cfg.modifier_mask) != cd.cfg.modifier_mask) return 0;
+
+        var suppress: u64 = 0;
+        var i: u8 = 0;
+        while (i < cd.cfg.selector_count) : (i += 1) {
+            suppress |= cd.cfg.selectors[i];
+        }
+        return suppress;
     }
 
     // Translate one gesture-engine Outcome into output. `from_timer` selects
@@ -1195,6 +1294,294 @@ test "mapper: onLayerTimerExpired: PENDING -> ACTIVE activates layer" {
     const b_idx: u6 = @intCast(@intFromEnum(ButtonId.B));
     const events = try m.apply(.{ .buttons = @as(u64, 1) << a_idx }, 16, 0);
     try testing.expect((events.gamepad.buttons & (@as(u64, 1) << b_idx)) != 0);
+}
+
+test "mapper: hold_toggle layer short tap emits tap without toggling" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[[layer]]
+        \\name = "race"
+        \\trigger = "LT"
+        \\activation = "hold_toggle"
+        \\tap = "B"
+        \\hold_timeout = 200
+        \\
+        \\[layer.remap]
+        \\A = "X"
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const lt_idx: u6 = @intCast(@intFromEnum(ButtonId.LT));
+    const lt_mask: u64 = @as(u64, 1) << lt_idx;
+    const b_idx: u6 = @intCast(@intFromEnum(ButtonId.B));
+    const b_mask: u64 = @as(u64, 1) << b_idx;
+
+    _ = try m.apply(.{ .buttons = lt_mask }, 16, 0);
+    const ev_tap = try m.apply(.{ .buttons = 0 }, 16, 100_000_000);
+
+    try testing.expect((ev_tap.gamepad.buttons & b_mask) != 0);
+    try testing.expect(!m.layer.toggled.contains("race"));
+    try testing.expect(m.layer.getActive(parsed.value.layer.?) == null);
+}
+
+test "mapper: hold_toggle layer hold toggles sticky on and off" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[[layer]]
+        \\name = "race"
+        \\trigger = "LT"
+        \\activation = "hold_toggle"
+        \\hold_timeout = 200
+        \\
+        \\[layer.remap]
+        \\A = "X"
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const lt_idx: u6 = @intCast(@intFromEnum(ButtonId.LT));
+    const lt_mask: u64 = @as(u64, 1) << lt_idx;
+    const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
+    const a_mask: u64 = @as(u64, 1) << a_idx;
+    const x_idx: u6 = @intCast(@intFromEnum(ButtonId.X));
+    const x_mask: u64 = @as(u64, 1) << x_idx;
+
+    _ = try m.apply(.{ .buttons = lt_mask }, 16, 0);
+    _ = m.onLayerTimerExpired();
+    try testing.expect(m.layer.toggled.contains("race"));
+    try testing.expect(m.layer.tap_hold == null);
+
+    _ = try m.apply(.{ .buttons = 0 }, 16, 250_000_000);
+    try testing.expect(m.layer.toggled.contains("race"));
+
+    const ev_layer = try m.apply(.{ .buttons = a_mask }, 16, 260_000_000);
+    try testing.expectEqual(@as(u64, 0), ev_layer.gamepad.buttons & a_mask);
+    try testing.expect((ev_layer.gamepad.buttons & x_mask) != 0);
+
+    _ = try m.apply(.{ .buttons = lt_mask }, 16, 300_000_000);
+    _ = m.onLayerTimerExpired();
+    try testing.expect(!m.layer.toggled.contains("race"));
+
+    _ = try m.apply(.{ .buttons = 0 }, 16, 550_000_000);
+    const ev_base = try m.apply(.{ .buttons = a_mask }, 16, 560_000_000);
+    try testing.expect((ev_base.gamepad.buttons & a_mask) != 0);
+    try testing.expectEqual(@as(u64, 0), ev_base.gamepad.buttons & x_mask);
+}
+
+test "mapper: hold_toggle timer transition resets processors" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[[layer]]
+        \\name = "race"
+        \\trigger = "LT"
+        \\activation = "hold_toggle"
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const lt_idx: u6 = @intCast(@intFromEnum(ButtonId.LT));
+    const lt_mask: u64 = @as(u64, 1) << lt_idx;
+
+    m.gyro_proc.ema_x = 99.0;
+    m.stick_left.mouse_accum_x = 1.25;
+    m.stick_right.scroll_accum = -0.5;
+
+    _ = try m.apply(.{ .buttons = lt_mask }, 16, 0);
+    _ = m.onLayerTimerExpired();
+
+    try testing.expectEqual(@as(f32, 0), m.gyro_proc.ema_x);
+    try testing.expectEqual(@as(f32, 0), m.stick_left.mouse_accum_x);
+    try testing.expectEqual(@as(f32, 0), m.stick_right.scroll_accum);
+}
+
+test "mapper: hold_toggle pending preserves macros but sticky transition cancels them" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[[layer]]
+        \\name = "race"
+        \\trigger = "LT"
+        \\activation = "hold_toggle"
+        \\hold_timeout = 200
+        \\
+        \\[remap]
+        \\M1 = "macro:hold_x"
+        \\
+        \\[[macro]]
+        \\name = "hold_x"
+        \\steps = [
+        \\  { down = "X" },
+        \\  { delay = 100000 },
+        \\  { up = "X" },
+        \\]
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const lt_idx: u6 = @intCast(@intFromEnum(ButtonId.LT));
+    const lt_mask: u64 = @as(u64, 1) << lt_idx;
+    const m1_idx: u6 = @intCast(@intFromEnum(ButtonId.M1));
+    const m1_mask: u64 = @as(u64, 1) << m1_idx;
+    const x_idx: u6 = @intCast(@intFromEnum(ButtonId.X));
+    const x_mask: u64 = @as(u64, 1) << x_idx;
+
+    const ev_macro = try m.apply(.{ .buttons = m1_mask }, 16, 0);
+    try testing.expect((ev_macro.gamepad.buttons & x_mask) != 0);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
+
+    const ev_pending = try m.apply(.{ .buttons = m1_mask | lt_mask }, 16, 0);
+    try testing.expect((ev_pending.gamepad.buttons & x_mask) != 0);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
+
+    _ = m.onLayerTimerExpired();
+    try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
+    try testing.expect(m.layer.toggled.contains("race"));
+}
+
+test "mapper: hold_toggle sticky transition emits gamepad frame after macro cancel" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[[layer]]
+        \\name = "race"
+        \\trigger = "LT"
+        \\activation = "hold_toggle"
+        \\hold_timeout = 200
+        \\
+        \\[remap]
+        \\M1 = "macro:hold_x"
+        \\
+        \\[[macro]]
+        \\name = "hold_x"
+        \\steps = [
+        \\  { down = "X" },
+        \\  { delay = 100000 },
+        \\  { up = "X" },
+        \\]
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const lt_idx: u6 = @intCast(@intFromEnum(ButtonId.LT));
+    const lt_mask: u64 = @as(u64, 1) << lt_idx;
+    const m1_idx: u6 = @intCast(@intFromEnum(ButtonId.M1));
+    const m1_mask: u64 = @as(u64, 1) << m1_idx;
+    const x_idx: u6 = @intCast(@intFromEnum(ButtonId.X));
+    const x_mask: u64 = @as(u64, 1) << x_idx;
+
+    _ = try m.apply(.{ .buttons = m1_mask }, 16, 0);
+    const ev_pending = try m.apply(.{ .buttons = m1_mask | lt_mask }, 16, 0);
+    try testing.expect((ev_pending.gamepad.buttons & x_mask) != 0);
+
+    const timer_events = m.onLayerTimerExpiredAt(200_000_000);
+    try testing.expect(timer_events.gamepad != null);
+    try testing.expectEqual(@as(u64, 0), timer_events.gamepad.?.buttons & x_mask);
+    try testing.expectEqual(@as(u64, 0), timer_events.gamepad.?.buttons & m1_mask);
+    try testing.expectEqual(@as(u64, 0), timer_events.gamepad.?.buttons & lt_mask);
+}
+
+test "mapper: hold_toggle timer frame recomputes held source remaps" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[remap]
+        \\A = "X"
+        \\
+        \\[[layer]]
+        \\name = "race"
+        \\trigger = "LT"
+        \\activation = "hold_toggle"
+        \\hold_timeout = 200
+        \\
+        \\[layer.remap]
+        \\A = "Y"
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
+    const a_mask: u64 = @as(u64, 1) << a_idx;
+    const lt_idx: u6 = @intCast(@intFromEnum(ButtonId.LT));
+    const lt_mask: u64 = @as(u64, 1) << lt_idx;
+    const x_idx: u6 = @intCast(@intFromEnum(ButtonId.X));
+    const x_mask: u64 = @as(u64, 1) << x_idx;
+    const y_idx: u6 = @intCast(@intFromEnum(ButtonId.Y));
+    const y_mask: u64 = @as(u64, 1) << y_idx;
+
+    const ev_base = try m.apply(.{ .buttons = a_mask }, 16, 0);
+    try testing.expectEqual(@as(u64, 0), ev_base.gamepad.buttons & a_mask);
+    try testing.expect((ev_base.gamepad.buttons & x_mask) != 0);
+    try testing.expectEqual(@as(u64, 0), ev_base.gamepad.buttons & y_mask);
+
+    _ = try m.apply(.{ .buttons = a_mask | lt_mask }, 16, 10_000_000);
+    const timer_on = m.onLayerTimerExpiredAt(210_000_000);
+    try testing.expect(timer_on.gamepad != null);
+    try testing.expectEqual(@as(u64, 0), timer_on.gamepad.?.buttons & a_mask);
+    try testing.expectEqual(@as(u64, 0), timer_on.gamepad.?.buttons & lt_mask);
+    try testing.expectEqual(@as(u64, 0), timer_on.gamepad.?.buttons & x_mask);
+    try testing.expect((timer_on.gamepad.?.buttons & y_mask) != 0);
+
+    _ = try m.apply(.{ .buttons = a_mask }, 16, 220_000_000);
+    _ = try m.apply(.{ .buttons = a_mask | lt_mask }, 16, 300_000_000);
+    const timer_off = m.onLayerTimerExpiredAt(500_000_000);
+    try testing.expect(timer_off.gamepad != null);
+    try testing.expectEqual(@as(u64, 0), timer_off.gamepad.?.buttons & a_mask);
+    try testing.expectEqual(@as(u64, 0), timer_off.gamepad.?.buttons & lt_mask);
+    try testing.expect((timer_off.gamepad.?.buttons & x_mask) != 0);
+    try testing.expectEqual(@as(u64, 0), timer_off.gamepad.?.buttons & y_mask);
+}
+
+test "mapper: hold_toggle timer frame preserves chord selector suppression" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[[layer]]
+        \\name = "race"
+        \\trigger = "LT"
+        \\activation = "hold_toggle"
+        \\hold_timeout = 200
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const a_idx: u6 = @intCast(@intFromEnum(ButtonId.A));
+    const a_mask: u64 = @as(u64, 1) << a_idx;
+    const lm_idx: u6 = @intCast(@intFromEnum(ButtonId.LM));
+    const lm_mask: u64 = @as(u64, 1) << lm_idx;
+    const rm_idx: u6 = @intCast(@intFromEnum(ButtonId.RM));
+    const rm_mask: u64 = @as(u64, 1) << rm_idx;
+    const lt_idx: u6 = @intCast(@intFromEnum(ButtonId.LT));
+    const lt_mask: u64 = @as(u64, 1) << lt_idx;
+
+    var selectors: [chord_detector_mod.MAX_SELECTORS]u64 = [_]u64{0} ** chord_detector_mod.MAX_SELECTORS;
+    selectors[0] = a_mask;
+    m.setChordDetector(.{
+        .modifier_mask = lm_mask | rm_mask,
+        .selectors = selectors,
+        .selector_count = 1,
+        .hold_ns = 80 * std.time.ns_per_ms,
+    });
+
+    _ = try m.apply(.{ .buttons = lm_mask | rm_mask | a_mask }, 16, 0);
+    _ = try m.apply(.{ .buttons = lm_mask | rm_mask | a_mask | lt_mask }, 16, 10_000_000);
+    const timer_events = m.onLayerTimerExpiredAt(210_000_000);
+
+    try testing.expect(timer_events.gamepad != null);
+    try testing.expectEqual(@as(u64, 0), timer_events.gamepad.?.buttons & a_mask);
+    try testing.expectEqual(@as(u64, 0), timer_events.gamepad.?.buttons & lt_mask);
+    try testing.expect((timer_events.gamepad.?.buttons & lm_mask) != 0);
+    try testing.expect((timer_events.gamepad.?.buttons & rm_mask) != 0);
 }
 
 test "mapper: layer gyro override: active layer gyro config used" {

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -779,9 +779,14 @@ pub const EventLoop = struct {
                 var expiry: [8]u8 = undefined;
                 _ = posix.read(self.timer_fd, &expiry) catch {};
                 if (ctx.mapper) |m| {
-                    const aux = m.onLayerTimerExpired();
-                    if (aux.len > 0) {
-                        if (ctx.aux_output) |ao| ao.emitAux(aux.slice()) catch {};
+                    const events = m.onLayerTimerExpiredAt(now);
+                    if (events.gamepad) |gamepad| {
+                        ctx.output.emit(gamepad) catch |err| {
+                            std.log.err("output.emit failed: {}", .{err});
+                        };
+                    }
+                    if (events.aux.len > 0) {
+                        if (ctx.aux_output) |ao| ao.emitAux(events.aux.slice()) catch {};
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Add `activation = "hold_toggle"` for layers: short press still emits `tap`; holding past `hold_timeout` toggles the layer sticky on/off.
- Emit an immediate gamepad frame on sticky timer transitions so cancelled macro/gesture/remap outputs release without waiting for the next input event.
- Update the mapping docs and comprehensive example to document the new activation mode.

Refs #283

## Validation

- `docker run --rm --network host -v /tmp/padctl-issue-283:/src -w /src padctl-build:0.15.2 zig build test -Dtest-filter=hold_toggle --summary all`
- `docker run --rm --network host -v /tmp/padctl-issue-283:/src -w /src padctl-build:0.15.2 zig build test -Dtest-filter=layer --summary all`
- `docker run --rm --network host -v /tmp/padctl-issue-283:/src -w /src padctl-build:0.15.2 zig build test --summary all` (`1432/1441 tests passed; 9 skipped`)
- `git diff --check`
- `mdbook build docs/`

## Review

- Independent subagent review completed.
- Initial high finding around stale timer-frame gamepad injection was fixed and covered by regression tests.
- Follow-up chord-switch suppression finding was fixed and covered by a regression test.
- Final reviewer pass reported no blocking findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hold_toggle` layer activation mode: initially behaves like hold, but toggles the layer sticky state after hold_timeout expires.

* **Documentation**
  * Updated layer configuration and mapping guide with `hold_toggle` mode description and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->