### PR TITLE
Fix oracle vector freshness checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,11 @@ jobs:
         run: lake build oracle
       - name: Verify oracle binary exists
         run: test -x formal/lean/.lake/build/bin/oracle
+      - name: Verify generated Lean vectors are current
+        working-directory: formal/lean
+        run: |
+          .lake/build/bin/oracle > /tmp/padctl-lean-test-vectors.csv
+          diff -u test_vectors.csv /tmp/padctl-lean-test-vectors.csv
       - name: Upload oracle artifact
         uses: actions/upload-artifact@v4
         with:

--- a/formal/lean/test_vectors.csv
+++ b/formal/lean/test_vectors.csv
@@ -31,11 +31,14 @@ scale,0,255,-100,100,-100
 scale,255,255,-100,100,100
 scale,127,255,-100,100,-1
 scale,128,255,-100,100,0
+scale,-7,127,0,100,-5
+scale,-128,127,0,100,-100
 # CHAIN
 # input,tMax,op1,op2,...,expected
 50,255,negate,clamp:-100:100,-50
 5,255,scale:-100:100,deadzone:10,-97
 -80,255,abs,clamp:0:50,50
+7,127,negate,scale:0:100,-5
 42,255,,42
 # READFIELD
 # field_type,offset,hex_bytes,expected
@@ -63,6 +66,22 @@ FieldType.i16be,0,0
 FieldType.i16be,2,32767
 FieldType.i16be,4,-32768
 FieldType.i16be,6,-1
+FieldType.u32le,0,0
+FieldType.u32le,4,2147483647
+FieldType.u32le,8,2147483648
+FieldType.u32le,12,4294967295
+FieldType.i32le,0,0
+FieldType.i32le,4,2147483647
+FieldType.i32le,8,-2147483648
+FieldType.i32le,12,-1
+FieldType.u32be,0,0
+FieldType.u32be,4,2147483647
+FieldType.u32be,8,2147483648
+FieldType.u32be,12,4294967295
+FieldType.i32be,0,0
+FieldType.i32be,4,2147483647
+FieldType.i32be,8,-2147483648
+FieldType.i32be,12,-1
 # EXTRACTBITS
 # byteOff,startBit,bitCount,hex_bytes,expected
 0,0,0,0
@@ -110,6 +129,20 @@ sum8,0,3,3,1
 sum8,0,3,3,0
 xor,0,2,2,1
 xor,0,2,2,0
+crc32,0,9,computed=3421780262,expected=3421780262,1
+crc32_verify,0,9,9,1
+# HAT_DECODE
+# hatValue,expected_dx,expected_dy
+0,0,-1
+1,1,-1
+2,1,0
+3,1,1
+4,0,1
+5,-1,1
+6,-1,0
+7,-1,-1
+8,0,0
+15,0,0
 # BUTTON_DECODE
 # srcOff,srcSize,entries,hex_bytes,expected
 0,1,0:0|2:4,17
@@ -117,10 +150,10 @@ xor,0,2,2,0
 0,1,0:0,0
 # LAYER_FSM
 # action,description,tapHold_before,tapHold_after
-press,idle_to_pending,none,some { layerIdx := 0, phase := TapHoldPhase.pending, layerActivated := false }
-timer,pending_to_active,some { layerIdx := 0, phase := TapHoldPhase.pending, layerActivated := false },some { layerIdx := 0, phase := TapHoldPhase.active, layerActivated := true }
-release,active_to_idle,some { layerIdx := 0, phase := TapHoldPhase.active, layerActivated := true },none
-press,pending_noop,some { layerIdx := 0, phase := TapHoldPhase.pending, layerActivated := false },some { layerIdx := 0, phase := TapHoldPhase.pending, layerActivated := false }
+press,idle_to_pending,none,some { layerIdx := 0, phase := TapHoldPhase.pending, layerActivated := false, elapsedMs := 0 }
+timer,pending_to_active,some { layerIdx := 0, phase := TapHoldPhase.pending, layerActivated := false, elapsedMs := 0 },some { layerIdx := 0, phase := TapHoldPhase.active, layerActivated := true, elapsedMs := 0 }
+release,active_to_idle,some { layerIdx := 0, phase := TapHoldPhase.active, layerActivated := true, elapsedMs := 0 },none
+press,pending_noop,some { layerIdx := 0, phase := TapHoldPhase.pending, layerActivated := false, elapsedMs := 0 },some { layerIdx := 0, phase := TapHoldPhase.pending, layerActivated := false, elapsedMs := 0 }
 # REMAP
 # buttons,prevButtons,entries,suppress,inject,aux_count
 1,0,0>g4,1,16,0

--- a/scripts/padctl-docker
+++ b/scripts/padctl-docker
@@ -146,7 +146,7 @@ cmd_canary() {
     bash -c '
       set -euo pipefail
       mount -t devtmpfs devtmpfs /dev
-      PADCTL_TEST_REQUIRE_UHID=1 zig build test-uhid-uniq -Dlibusb=false
+      PADCTL_TEST_REQUIRE_UHID=1 zig build test-uhid -Dlibusb=false
     '
 }
 

--- a/src/core/interpreter.zig
+++ b/src/core/interpreter.zig
@@ -142,20 +142,28 @@ fn applyFieldTag(delta: *GamepadStateDelta, tag: FieldTag, val: i64) void {
         .touch1_active => delta.touch1_active = val != 0,
         .battery_level => delta.battery_level = @intCast(val & 0xff),
         .dpad => {
-            // HID hat switch: 0=N, 1=NE, 2=E, 3=SE, 4=S, 5=SW, 6=W, 7=NW, 8+=neutral
-            const HAT_X = [8]i8{ 0, 1, 1, 1, 0, -1, -1, -1 };
-            const HAT_Y = [8]i8{ -1, -1, 0, 1, 1, 1, 0, -1 };
-            if (val >= 0 and val < 8) {
-                const idx: usize = @intCast(val);
-                delta.dpad_x = HAT_X[idx];
-                delta.dpad_y = HAT_Y[idx];
-            } else {
-                delta.dpad_x = 0;
-                delta.dpad_y = 0;
-            }
+            const decoded = decodeDpadHat(val);
+            delta.dpad_x = decoded.x;
+            delta.dpad_y = decoded.y;
         },
         .unknown => {},
     }
+}
+
+pub const DpadHat = struct {
+    x: i8,
+    y: i8,
+};
+
+pub fn decodeDpadHat(val: i64) DpadHat {
+    // HID hat switch: 0=N, 1=NE, 2=E, 3=SE, 4=S, 5=SW, 6=W, 7=NW, 8+=neutral.
+    const HAT_X = [8]i8{ 0, 1, 1, 1, 0, -1, -1, -1 };
+    const HAT_Y = [8]i8{ -1, -1, 0, 1, 1, 1, 0, -1 };
+    if (val >= 0 and val < 8) {
+        const idx: usize = @intCast(val);
+        return .{ .x = HAT_X[idx], .y = HAT_Y[idx] };
+    }
+    return .{ .x = 0, .y = 0 };
 }
 
 // --- pre-compiled transform chain ---

--- a/src/test/properties/lean_drt_props.zig
+++ b/src/test/properties/lean_drt_props.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 const testing = std.testing;
 const interp = @import("../../core/interpreter.zig");
 const state = @import("../../core/state.zig");
+const device = @import("../../config/device.zig");
 
 const csv_data = @embedFile("../../../formal/lean/test_vectors.csv");
 
@@ -29,31 +30,42 @@ const Lines = struct {
     }
 };
 
-fn parseInt(s: []const u8) i64 {
-    if (s.len == 0) return 0;
-    if (s[0] == '-') return -@as(i64, @intCast(std.fmt.parseInt(u64, s[1..], 10) catch 0));
-    return @intCast(std.fmt.parseInt(u64, s, 10) catch 0);
+fn parseInt(s: []const u8) !i64 {
+    if (s.len == 0) return error.EmptyField;
+    return std.fmt.parseInt(i64, s, 10);
 }
 
-fn parseUint(s: []const u8) u64 {
-    return std.fmt.parseInt(u64, s, 10) catch 0;
+fn parseUint(s: []const u8) !u64 {
+    if (s.len == 0) return error.EmptyField;
+    return std.fmt.parseInt(u64, s, 10);
 }
 
-fn splitFields(line: []const u8) [8][]const u8 {
+fn splitFields(line: []const u8) ![8][]const u8 {
     var result: [8][]const u8 = .{""} ** 8;
     var n: usize = 0;
     var start: usize = 0;
     for (line, 0..) |ch, i| {
         if (ch == ',') {
-            if (n < 8) {
-                result[n] = line[start..i];
-                n += 1;
-            }
+            if (n >= result.len) return error.TooManyFields;
+            result[n] = line[start..i];
+            n += 1;
             start = i + 1;
         }
     }
-    if (n < 8) result[n] = line[start..];
+    if (n >= result.len) return error.TooManyFields;
+    result[n] = line[start..];
     return result;
+}
+
+fn parseBool01(s: []const u8) !bool {
+    if (std.mem.eql(u8, s, "1")) return true;
+    if (std.mem.eql(u8, s, "0")) return false;
+    return error.InvalidBool;
+}
+
+fn parseNamedUint(s: []const u8, comptime prefix: []const u8) !u64 {
+    if (!std.mem.startsWith(u8, s, prefix)) return error.MalformedVector;
+    return parseUint(s[prefix.len..]);
 }
 
 fn isDataLine(line: []const u8) bool {
@@ -77,13 +89,13 @@ test "lean_drt: transform negate vectors" {
     var count: usize = 0;
     while (lines.next()) |line| {
         if (!isDataLine(line)) break;
-        const f = splitFields(line);
+        const f = try splitFields(line);
         if (!std.mem.eql(u8, f[0], "negate") and !std.mem.eql(u8, f[0], "abs")) continue;
-        const input = parseInt(f[1]);
-        const t_max_raw = parseUint(f[2]);
-        const expected = parseInt(f[3]);
+        const input = try parseInt(f[1]);
+        const t_max_raw = try parseUint(f[2]);
+        const expected = try parseInt(f[3]);
         const op: interp.TransformOp = if (std.mem.eql(u8, f[0], "negate")) .negate else .abs;
-        var chain = interp.CompiledTransformChain{ .type_tag = tMaxToFieldType(t_max_raw) };
+        var chain = interp.CompiledTransformChain{ .type_tag = try tMaxToFieldType(t_max_raw) };
         chain.items[0] = .{ .op = op };
         chain.len = 1;
         const actual = interp.runTransformChain(input, &chain);
@@ -99,12 +111,12 @@ test "lean_drt: transform clamp vectors" {
     var count: usize = 0;
     while (lines.next()) |line| {
         if (!isDataLine(line)) break;
-        const f = splitFields(line);
+        const f = try splitFields(line);
         if (!std.mem.eql(u8, f[0], "clamp")) continue;
-        const input = parseInt(f[1]);
-        const lo = parseInt(f[2]);
-        const hi = parseInt(f[3]);
-        const expected = parseInt(f[4]);
+        const input = try parseInt(f[1]);
+        const lo = try parseInt(f[2]);
+        const hi = try parseInt(f[3]);
+        const expected = try parseInt(f[4]);
         var chain = interp.CompiledTransformChain{ .type_tag = .u8 };
         chain.items[0] = .{ .op = .clamp, .a = lo, .b = hi };
         chain.len = 1;
@@ -121,11 +133,11 @@ test "lean_drt: transform deadzone vectors" {
     var count: usize = 0;
     while (lines.next()) |line| {
         if (!isDataLine(line)) break;
-        const f = splitFields(line);
+        const f = try splitFields(line);
         if (!std.mem.eql(u8, f[0], "deadzone")) continue;
-        const input = parseInt(f[1]);
-        const threshold = parseInt(f[2]);
-        const expected = parseInt(f[3]);
+        const input = try parseInt(f[1]);
+        const threshold = try parseInt(f[2]);
+        const expected = try parseInt(f[3]);
         var chain = interp.CompiledTransformChain{ .type_tag = .u8 };
         chain.items[0] = .{ .op = .deadzone, .a = threshold };
         chain.len = 1;
@@ -142,15 +154,15 @@ test "lean_drt: transform scale vectors" {
     var count: usize = 0;
     while (lines.next()) |line| {
         if (!isDataLine(line)) break;
-        const f = splitFields(line);
+        const f = try splitFields(line);
         if (!std.mem.eql(u8, f[0], "scale")) continue;
         // scale,input,tMax,a,b,expected
-        const input = parseInt(f[1]);
-        const t_max_raw = parseUint(f[2]);
-        const a = parseInt(f[3]);
-        const b = parseInt(f[4]);
-        const expected = parseInt(f[5]);
-        var chain = interp.CompiledTransformChain{ .type_tag = tMaxToFieldType(t_max_raw) };
+        const input = try parseInt(f[1]);
+        const t_max_raw = try parseUint(f[2]);
+        const a = try parseInt(f[3]);
+        const b = try parseInt(f[4]);
+        const expected = try parseInt(f[5]);
+        var chain = interp.CompiledTransformChain{ .type_tag = try tMaxToFieldType(t_max_raw) };
         chain.items[0] = .{ .op = .scale, .a = a, .b = b };
         chain.len = 1;
         const actual = interp.runTransformChain(input, &chain);
@@ -168,18 +180,18 @@ test "lean_drt: transform chain vectors" {
         if (!isDataLine(line)) break;
         // input,tMax,op1,op2,...,expected
         // Last non-empty field is expected; ops live in f[2]..f[expected_idx-1].
-        const f = splitFields(line);
-        const input = parseInt(f[0]);
-        const t_max_raw = parseUint(f[1]);
+        const f = try splitFields(line);
+        const input = try parseInt(f[0]);
+        const t_max_raw = try parseUint(f[1]);
         var expected_idx: usize = 7;
         while (expected_idx > 2 and f[expected_idx].len == 0) : (expected_idx -= 1) {}
-        const expected = parseInt(f[expected_idx]);
+        const expected = try parseInt(f[expected_idx]);
 
-        var chain = interp.CompiledTransformChain{ .type_tag = tMaxToFieldType(t_max_raw) };
+        var chain = interp.CompiledTransformChain{ .type_tag = try tMaxToFieldType(t_max_raw) };
         chain.len = 0;
         for (2..expected_idx) |i| {
             if (f[i].len == 0) continue; // empty chain slot
-            chain.items[chain.len] = parseChainOp(f[i]);
+            chain.items[chain.len] = try parseChainOp(f[i]);
             chain.len += 1;
         }
         const actual = interp.runTransformChain(input, &chain);
@@ -198,21 +210,34 @@ test "lean_drt: readField vectors" {
     const raw_16le = [_]u8{ 0x00, 0x00, 0xFF, 0x7F, 0x00, 0x80, 0xFF, 0xFF };
     // u16be/i16be raw: [0x00, 0x00, 0x7F, 0xFF, 0x80, 0x00, 0xFF, 0xFF]
     const raw_16be = [_]u8{ 0x00, 0x00, 0x7F, 0xFF, 0x80, 0x00, 0xFF, 0xFF };
+    const raw_32le = [_]u8{
+        0x00, 0x00, 0x00, 0x00,
+        0xFF, 0xFF, 0xFF, 0x7F,
+        0x00, 0x00, 0x00, 0x80,
+        0xFF, 0xFF, 0xFF, 0xFF,
+    };
+    const raw_32be = [_]u8{
+        0x00, 0x00, 0x00, 0x00,
+        0x7F, 0xFF, 0xFF, 0xFF,
+        0x80, 0x00, 0x00, 0x00,
+        0xFF, 0xFF, 0xFF, 0xFF,
+    };
 
     var lines = seekSection("# READFIELD");
     _ = lines.next();
     var count: usize = 0;
     while (lines.next()) |line| {
         if (!isDataLine(line)) break;
-        const f = splitFields(line);
-        const ft = parseLeanFieldType(f[0]);
-        const off: usize = @intCast(parseUint(f[1]));
-        const expected = parseInt(f[2]);
+        const f = try splitFields(line);
+        const ft = try parseLeanFieldType(f[0]);
+        const off: usize = @intCast(try parseUint(f[1]));
+        const expected = try parseInt(f[2]);
         const raw: []const u8 = switch (ft) {
             .u8, .i8 => &raw_u8,
             .u16le, .i16le => &raw_16le,
             .u16be, .i16be => &raw_16be,
-            else => continue,
+            .u32le, .i32le => &raw_32le,
+            .u32be, .i32be => &raw_32be,
         };
         const actual = interp.readFieldByTag(raw, off, ft);
         try testing.expectEqual(expected, actual);
@@ -228,11 +253,11 @@ test "lean_drt: extractBits vectors" {
     var count: usize = 0;
     while (lines.next()) |line| {
         if (!isDataLine(line)) break;
-        const f = splitFields(line);
-        const byte_off: u16 = @intCast(parseUint(f[0]));
-        const start_bit: u3 = @intCast(parseUint(f[1]));
-        const bit_count: u6 = @intCast(parseUint(f[2]));
-        const expected: u32 = @intCast(parseUint(f[3]));
+        const f = try splitFields(line);
+        const byte_off: u16 = @intCast(try parseUint(f[0]));
+        const start_bit: u3 = @intCast(try parseUint(f[1]));
+        const bit_count: u6 = @intCast(try parseUint(f[2]));
+        const expected: u32 = @intCast(try parseUint(f[3]));
         const actual = interp.extractBits(&raw, byte_off, start_bit, bit_count);
         try testing.expectEqual(expected, actual);
         count += 1;
@@ -246,10 +271,10 @@ test "lean_drt: signExtend vectors" {
     var count: usize = 0;
     while (lines.next()) |line| {
         if (!isDataLine(line)) break;
-        const f = splitFields(line);
-        const val: u32 = @intCast(parseUint(f[0]));
-        const bits: u6 = @intCast(parseUint(f[1]));
-        const expected: i32 = @intCast(parseInt(f[2]));
+        const f = try splitFields(line);
+        const val: u32 = @intCast(try parseUint(f[0]));
+        const bits: u6 = @intCast(try parseUint(f[1]));
+        const expected: i32 = @intCast(try parseInt(f[2]));
         const actual = interp.signExtend(val, bits);
         try testing.expectEqual(expected, actual);
         count += 1;
@@ -264,11 +289,11 @@ test "lean_drt: button assembly vectors" {
     while (lines.next()) |line| {
         if (!isDataLine(line)) break;
         // raw,suppress,inject,expected
-        const f = splitFields(line);
-        const raw = parseUint(f[0]);
-        const suppress = parseUint(f[1]);
-        const inject = parseUint(f[2]);
-        const expected = parseUint(f[3]);
+        const f = try splitFields(line);
+        const raw = try parseUint(f[0]);
+        const suppress = try parseUint(f[1]);
+        const inject = try parseUint(f[2]);
+        const expected = try parseUint(f[3]);
         const actual = (raw & ~suppress) | inject;
         try testing.expectEqual(expected, actual);
         count += 1;
@@ -282,10 +307,10 @@ test "lean_drt: dpad synthesis vectors" {
     var count: usize = 0;
     while (lines.next()) |line| {
         if (!isDataLine(line)) break;
-        const f = splitFields(line);
-        const buttons = parseUint(f[0]);
-        const expected_dx: i8 = @intCast(parseInt(f[1]));
-        const expected_dy: i8 = @intCast(parseInt(f[2]));
+        const f = try splitFields(line);
+        const buttons = try parseUint(f[0]);
+        const expected_dx: i8 = @intCast(try parseInt(f[1]));
+        const expected_dy: i8 = @intCast(try parseInt(f[2]));
         var gs = state.GamepadState{};
         gs.buttons = buttons;
         gs.synthesizeDpadAxes();
@@ -310,58 +335,175 @@ test "lean_drt: checksum vectors" {
     var raw_idx: usize = 0;
     while (lines.next()) |line| {
         if (!isDataLine(line)) break;
-        if (raw_idx >= raws.len) break;
-        const f = splitFields(line);
+        const f = try splitFields(line);
         const algo_str = f[0];
-        const start: usize = @intCast(parseUint(f[1]));
-        const stop: usize = @intCast(parseUint(f[2]));
-        const offset: usize = @intCast(parseUint(f[3]));
-        const expected_bool = std.mem.eql(u8, f[4], "1");
-
-        const algo: interp.ChecksumAlgo = if (std.mem.eql(u8, algo_str, "sum8")) .sum8 else .xor;
-
-        // Build a minimal CompiledReport with just checksum info
-        // We call the checksum verification directly
-        const raw = raws[raw_idx];
-        const actual_bool = verifyChecksumDirect(raw, algo, start, stop, offset);
+        const start: usize = @intCast(try parseUint(f[1]));
+        const stop: usize = @intCast(try parseUint(f[2]));
+        const actual_bool = blk: {
+            if (std.mem.eql(u8, algo_str, "sum8") or std.mem.eql(u8, algo_str, "xor")) {
+                const offset: usize = @intCast(try parseUint(f[3]));
+                if (raw_idx >= raws.len) return error.MalformedVector;
+                const algo: interp.ChecksumAlgo = if (std.mem.eql(u8, algo_str, "sum8")) .sum8 else .xor;
+                const raw = raws[raw_idx];
+                raw_idx += 1;
+                break :blk verifyChecksumViaCompiled(raw, algo, start, stop, offset);
+            }
+            if (std.mem.eql(u8, algo_str, "crc32")) {
+                const computed = try parseNamedUint(f[3], "computed=");
+                const expected_crc = try parseNamedUint(f[4], "expected=");
+                var crc = std.hash.crc.Crc32IsoHdlc.init();
+                crc.update("123456789");
+                const actual_crc = crc.final();
+                try testing.expectEqual(expected_crc, actual_crc);
+                break :blk actual_crc == computed;
+            }
+            if (std.mem.eql(u8, algo_str, "crc32_verify")) {
+                const offset: usize = @intCast(try parseUint(f[3]));
+                const raw = [_]u8{
+                    0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39,
+                    0x26, 0x39, 0xF4, 0xCB,
+                };
+                break :blk verifyChecksumViaCompiled(&raw, .crc32, start, stop, offset);
+            }
+            return error.UnknownChecksumAlgo;
+        };
+        const expected_bool = try parseBool01(if (std.mem.eql(u8, algo_str, "crc32")) f[5] else f[4]);
         try testing.expectEqual(expected_bool, actual_bool);
         count += 1;
-        raw_idx += 1;
+    }
+    try testing.expectEqual(raws.len, raw_idx);
+    try testing.expect(count > 0);
+}
+
+test "lean_drt: hat decode vectors" {
+    var lines = seekSection("# HAT_DECODE");
+    _ = lines.next();
+    var count: usize = 0;
+    while (lines.next()) |line| {
+        if (!isDataLine(line)) break;
+        const f = try splitFields(line);
+        const decoded = interp.decodeDpadHat(try parseInt(f[0]));
+        const expected_dx: i8 = @intCast(try parseInt(f[1]));
+        const expected_dy: i8 = @intCast(try parseInt(f[2]));
+        try testing.expectEqual(expected_dx, decoded.x);
+        try testing.expectEqual(expected_dy, decoded.y);
+        count += 1;
     }
     try testing.expect(count > 0);
 }
 
-// Direct checksum verification (avoids needing a full CompiledReport)
-fn verifyChecksumDirect(raw: []const u8, algo: interp.ChecksumAlgo, start: usize, stop: usize, offset: usize) bool {
-    const data = raw[start..stop];
-    switch (algo) {
-        .sum8 => {
-            var sum: u8 = 0;
-            for (data) |b| sum +%= b;
-            return sum == raw[offset];
-        },
-        .xor => {
-            var xv: u8 = 0;
-            for (data) |b| xv ^= b;
-            return xv == raw[offset];
-        },
-        .crc32 => return false, // not tested by oracle yet
+test "lean_drt: button decode vectors" {
+    var lines = seekSection("# BUTTON_DECODE");
+    _ = lines.next();
+    var count: usize = 0;
+    const raws = [_][]const u8{
+        &[_]u8{0x05},
+        &[_]u8{0xFF},
+        &[_]u8{0x00},
+    };
+    while (lines.next()) |line| {
+        if (!isDataLine(line)) break;
+        if (count >= raws.len) return error.MalformedVector;
+        const f = try splitFields(line);
+        const src_off: usize = @intCast(try parseUint(f[0]));
+        const src_size: usize = @intCast(try parseUint(f[1]));
+        const expected = try parseUint(f[3]);
+        const actual = try decodeButtonEntries(testing.allocator, raws[count], src_off, src_size, f[2]);
+        try testing.expectEqual(expected, actual);
+        count += 1;
     }
+    try testing.expectEqual(raws.len, count);
+}
+
+fn verifyChecksumViaCompiled(raw: []const u8, algo: interp.ChecksumAlgo, start: usize, stop: usize, offset: usize) bool {
+    var report = interp.ReportConfig{
+        .name = "lean-checksum",
+        .interface = 0,
+        .size = @intCast(raw.len),
+    };
+    var cr = interp.CompiledReport{
+        .src = &report,
+        .checksum = .{
+            .algo = algo,
+            .range_start = start,
+            .range_end = stop,
+            .expect_off = offset,
+            .seed = null,
+        },
+        .fields = undefined,
+        .field_count = 0,
+        .button_group = null,
+    };
+    interp.verifyChecksumCompiled(&cr, raw) catch |err| switch (err) {
+        error.ChecksumMismatch => return false,
+        else => return false,
+    };
+    return true;
+}
+
+fn decodeButtonEntries(allocator: std.mem.Allocator, raw: []const u8, src_off: usize, src_size: usize, entries: []const u8) !u64 {
+    var map_buf = std.ArrayList(u8){};
+    defer map_buf.deinit(allocator);
+    const map_w = map_buf.writer(allocator);
+    var it = std.mem.splitScalar(u8, entries, '|');
+    var first = true;
+    while (it.next()) |entry| {
+        const sep = std.mem.indexOfScalar(u8, entry, ':') orelse return error.MalformedVector;
+        const src_bit = try parseUint(entry[0..sep]);
+        const button_name = try buttonNameFromIndex(try parseUint(entry[sep + 1 ..]));
+        if (!first) try map_w.writeAll(", ");
+        try map_w.print("{s} = {d}", .{ button_name, src_bit });
+        first = false;
+    }
+
+    const toml_str = try std.fmt.allocPrint(allocator,
+        \\[device]
+        \\name = "Lean Button Decode"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = {d}
+        \\[report.match]
+        \\offset = 0
+        \\expect = [{d}]
+        \\[report.button_group]
+        \\source = {{ offset = {d}, size = {d} }}
+        \\map = {{ {s} }}
+    , .{ raw.len, raw[0], src_off, src_size, map_buf.items });
+    defer allocator.free(toml_str);
+
+    const parsed = try device.parseString(allocator, toml_str);
+    defer parsed.deinit();
+    const runner = interp.Interpreter.init(&parsed.value);
+    const delta = (try runner.processReport(0, raw)) orelse return error.NoMatch;
+    return delta.buttons orelse 0;
+}
+
+fn buttonNameFromIndex(idx: u64) ![]const u8 {
+    const field_count = @typeInfo(state.ButtonId).@"enum".fields.len;
+    if (idx >= field_count) return error.MalformedVector;
+    const button: state.ButtonId = @enumFromInt(idx);
+    return @tagName(button);
 }
 
 // --- Helpers ---
 
-fn tMaxToFieldType(t_max: u64) interp.FieldType {
+fn tMaxToFieldType(t_max: u64) !interp.FieldType {
     return switch (t_max) {
         255 => .u8,
         127 => .i8,
         65535 => .u16le,
         32767 => .i16le,
-        else => .u8,
+        else => error.UnknownFieldType,
     };
 }
 
-fn parseLeanFieldType(s: []const u8) interp.FieldType {
+fn parseLeanFieldType(s: []const u8) !interp.FieldType {
     if (std.mem.eql(u8, s, "FieldType.u8")) return .u8;
     if (std.mem.eql(u8, s, "FieldType.i8")) return .i8;
     if (std.mem.eql(u8, s, "FieldType.u16le")) return .u16le;
@@ -372,25 +514,25 @@ fn parseLeanFieldType(s: []const u8) interp.FieldType {
     if (std.mem.eql(u8, s, "FieldType.i32le")) return .i32le;
     if (std.mem.eql(u8, s, "FieldType.u32be")) return .u32be;
     if (std.mem.eql(u8, s, "FieldType.i32be")) return .i32be;
-    return .u8;
+    return error.UnknownFieldType;
 }
 
-fn parseChainOp(s: []const u8) interp.CompiledTransform {
+fn parseChainOp(s: []const u8) !interp.CompiledTransform {
     if (std.mem.eql(u8, s, "negate")) return .{ .op = .negate };
     if (std.mem.eql(u8, s, "abs")) return .{ .op = .abs };
     if (std.mem.startsWith(u8, s, "clamp:")) {
         // clamp:lo:hi
         const rest = s[6..];
-        const sep = std.mem.indexOfScalar(u8, rest, ':') orelse return .{ .op = .clamp };
-        return .{ .op = .clamp, .a = parseInt(rest[0..sep]), .b = parseInt(rest[sep + 1 ..]) };
+        const sep = std.mem.indexOfScalar(u8, rest, ':') orelse return error.MalformedVector;
+        return .{ .op = .clamp, .a = try parseInt(rest[0..sep]), .b = try parseInt(rest[sep + 1 ..]) };
     }
     if (std.mem.startsWith(u8, s, "scale:")) {
         const rest = s[6..];
-        const sep = std.mem.indexOfScalar(u8, rest, ':') orelse return .{ .op = .scale };
-        return .{ .op = .scale, .a = parseInt(rest[0..sep]), .b = parseInt(rest[sep + 1 ..]) };
+        const sep = std.mem.indexOfScalar(u8, rest, ':') orelse return error.MalformedVector;
+        return .{ .op = .scale, .a = try parseInt(rest[0..sep]), .b = try parseInt(rest[sep + 1 ..]) };
     }
     if (std.mem.startsWith(u8, s, "deadzone:")) {
-        return .{ .op = .deadzone, .a = parseInt(s[9..]) };
+        return .{ .op = .deadzone, .a = try parseInt(s[9..]) };
     }
-    return .{ .op = .deadzone };
+    return error.UnknownTransformOp;
 }


### PR DESCRIPTION
## Summary
- point Docker canary at the existing `test-uhid` build step
- regenerate Lean oracle CSV vectors and add a CI diff so drift fails early
- harden Lean DRT CSV parsing and cover new u32, CRC32, hat, and button decode vectors through production paths where available

## Verification
- `lake build oracle`
- `.lake/build/bin/oracle > /tmp/padctl-lean-test-vectors.csv && diff -u test_vectors.csv /tmp/padctl-lean-test-vectors.csv`
- `zig build test -Dlibusb=false -Dwasm=false -Dtarget=x86_64-linux-musl -Dtest-filter=lean_drt`
- `zig build test -Dlibusb=false -Dwasm=false -Dtarget=x86_64-linux-musl -Dtest-filter="FieldTag.dpad"`
- `zig build check-fmt`
- `git diff --check`

Full `zig build test -Dlibusb=false -Dwasm=false -Dtarget=x86_64-linux-musl` still fails locally because `/dev/uinput` is unavailable for `uinput: initBoxed heap-allocates and returns owning pointer`; unrelated filtered tests passed.

## Review
- Independent subagent code review completed; no findings remain.