### PR TITLE
chore(release): bump 0.2.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.8",
+    .version = "0.2.0",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
## Summary
- bump build.zig.zon version from 0.1.8 to 0.2.0

## Why 0.2.0
Since v0.1.8, main includes user-visible feature additions, not only fixes: per-button tap/hold/double-press gesture bindings, gyro joystick blend/tilt improvements, hold-toggle layer activation, and the canonical Docker build path.

## Release notes candidates
- Add per-button tap / hold / double-press gesture bindings for remaps and layer remaps.
- Add gyro joystick improvements: blend_stick, tilt response, axis selection, degrees_full, and stricter gyro config validation.
- Add hold_toggle layer activation.
- Fix install behavior around SupplementaryGroups=input, including systems without an input group and dropping the user-unit setting.
- Fix mapper hot-swap held aux edge handling.
- Fix boot-present hotplug retry path.
- Add broader mapping/config docs and canonical Docker build/release path.
- Fix Lean oracle vector freshness checks and strengthen Lean DRT coverage.

## Verification
- git diff --check
- /home/jim_z/.local/bin/zig build --cache-dir /tmp/padctl-release-zig-cache --global-cache-dir /tmp/padctl-release-zig-global-cache test -Dlibusb=false -Dwasm=false -Dtarget=x86_64-linux-musl -Dtest-filter="smoke: padctl --version"

## Local caveat
- git commit without hooks: local hook failed on unrelated src/tools/docgen.zig fmt check.
- initial push pre-push TSAN used system /usr/bin/zig and failed on Zig API mismatch; branch was pushed with documented SKIP_TSAN=1 escape. PR CI should validate with the canonical build image.