### PR TITLE
docs: refresh install and release guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,6 +347,7 @@ jobs:
           git clone ssh://aur@aur.archlinux.org/padctl-bin.git /tmp/padctl-bin
           cd /tmp/padctl-bin
 
+          cp "${GITHUB_WORKSPACE}/contrib/aur/padctl-bin/PKGBUILD" PKGBUILD
           sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
           sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
           sed -i "s/^sha256sums_x86_64=.*/sha256sums_x86_64=('${X86_HASH}')/" PKGBUILD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ No source code changes needed — no test files, no registration, no build syste
 1. **Capture**: Run `padctl-capture` against the target device to produce a TOML skeleton.
 
    ```
-   sudo ./zig-out/bin/padctl-capture /dev/hidraw0 > devices/<vendor>/<model>.toml
+   sudo ./zig-out/bin/padctl-capture --device /dev/hidraw0 --duration 30 --output devices/<vendor>/<model>.toml
    ```
 
 2. **Complete**: Fill in field names, button names, transform chains, and the `[output]` section.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ padctl is a userspace daemon that maps vendor-specific USB/HID gamepad reports t
 
 ## Supported Devices
 
-Ships with configs for **12 devices** across 8 vendors:
+Ships with production configs for **12 supported device families** across 8
+vendors. `devices/` also contains a Flydigi DInput/2.4G compatibility variant
+plus example/test fixtures, so the raw TOML file count is higher:
 
 **Sony** (3) · **Nintendo** (1) · **Microsoft** (1) · **Valve** (1) · **8BitDo** (1) · **Flydigi** (2) · **HORI** (1) · **Lenovo** (2)
 
@@ -111,6 +113,14 @@ curl -fLO https://github.com/BANANASJIM/padctl/releases/latest/download/padctl_a
 sudo dpkg -i padctl_arm64.deb
 ```
 
+After installing via a package manager, enable the user service from your normal
+login session:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now padctl.service
+```
+
 ### From Source
 
 See [Quick Start](#quick-start) below. For other distros, see [CONTRIBUTING.md](CONTRIBUTING.md#packaging).
@@ -119,14 +129,20 @@ See [Quick Start](#quick-start) below. For other distros, see [CONTRIBUTING.md](
 
 ```sh
 zig build                                             # build from source
-sudo zig-out/bin/padctl install                       # install binary, udev rules; writes user service unit
-systemctl --user enable --now padctl.service          # start the user service
-padctl config init                                    # create a mapping in ~/.config/padctl/mappings/ interactively
+sudo zig-out/bin/padctl install                       # install binary, udev rules, service; starts user service when run via sudo
 padctl status                                         # check daemon and detected devices
+padctl config init                                    # create a mapping in ~/.config/padctl/mappings/ interactively
+padctl list-mappings                                  # show generated and installed mapping profiles
 padctl switch <name>                                  # switch mapping profile without restart
 ```
 
-padctl runs as a **systemd user service** (`~/.config/systemd/user/padctl.service`). The binary and udev rules still require root to install, but the service runs as your own user — no `User=` directive or `ProtectHome` needed.
+padctl runs as a **systemd user service**. The default root install writes the
+system-wide user unit under `/usr/lib/systemd/user/` and enables/starts it for
+the invoking user via `systemctl --user`; immutable and custom-prefix installs
+may use `/etc/systemd/user/`. The binary and udev rules still require root to
+install, but the daemon runs as your own user. Run
+`systemctl --user enable --now padctl.service` manually only if install was run
+with `--no-enable`, `--no-start`, or without a discoverable `SUDO_USER`.
 
 To auto-start at boot without an active login session (headless setups, Steam Deck game mode):
 

--- a/contrib/aur/padctl-bin/PKGBUILD
+++ b/contrib/aur/padctl-bin/PKGBUILD
@@ -1,9 +1,7 @@
 # Maintainer: padctl maintainers
-# NOTE: No release tags exist yet. Update source URLs and sha256sums when
-#       release tarballs are published at ${url}/releases/.
 # pkgver/pkgrel/sha256sums: sed-overwritten by .github/workflows/release.yml — local edits have no effect.
 pkgname=padctl-bin
-pkgver=0.1.1
+pkgver=0.1.9
 pkgrel=1
 pkgdesc="HID gamepad daemon — declarative TOML device config, uinput output (prebuilt musl binary)"
 arch=('x86_64' 'aarch64')
@@ -52,7 +50,7 @@ package() {
         "${pkgdir}/usr/lib/udev/rules.d/61-padctl-driver-block.rules"
 
     while IFS= read -r -d '' toml; do
-        install -Dm644 "${toml}" "${pkgdir}/usr/share/padctl/${toml#devices/}"
+        install -Dm644 "${toml}" "${pkgdir}/usr/share/padctl/${toml}"
     done < <(find devices -name '*.toml' -print0)
 
     install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -25,5 +25,7 @@
 - [Contributing](contributing/README.md)
   - [Device Config Guide](contributing/device-config-guide.md)
   - [HID Reverse Engineering Guide](contributing/reverse-engineering.md)
+  - [Device TOML from InputPlumber](contributing/device-toml-from-inputplumber.md)
   - [Reference Tables](contributing/reference-tables.md)
   - [Code Contributions](contributing/code-contributions.md)
+  - [Release Process](contributing/release-process.md)

--- a/docs/src/contributing/README.md
+++ b/docs/src/contributing/README.md
@@ -9,3 +9,4 @@ There are several ways to contribute to padctl:
 - **[Reference Tables](reference-tables.md)** — Type mapping, MSB0→LSB0 conversion, ButtonId enum, Linux event codes, transform DSL
 - **[Code Contributions](code-contributions.md)** — Fork workflow, code style, test commands, build flags
 - **[Device TOML from InputPlumber](device-toml-from-inputplumber.md)** — Convert InputPlumber configs to padctl format
+- **[Release Process](release-process.md)** — Version bump, tag, release workflow, artifact, and package checks

--- a/docs/src/contributing/code-contributions.md
+++ b/docs/src/contributing/code-contributions.md
@@ -21,8 +21,11 @@ zig build check-fmt
 # Run all tests (Layer 0+1, no privileges required)
 zig build test
 
-# Run all checks (test + tsan + safe + fmt)
+# Run all checks (test + safe + fmt)
 zig build check-all
+
+# Run ThreadSanitizer tests explicitly; the pre-push hook runs this by default.
+zig build test-tsan
 ```
 
 ## Build Flags

--- a/docs/src/contributing/device-config-guide.md
+++ b/docs/src/contributing/device-config-guide.md
@@ -125,7 +125,7 @@ You need separate `[[report]]` blocks for each. See `devices/sony/dualsense.toml
 
 ```bash
 # Parse check — does the config load without errors?
-padctl-debug devices/vendor/model.toml
+padctl-debug --config devices/vendor/model.toml
 
 # Live test — run padctl and verify with evtest
 padctl --config devices/vendor/model.toml &

--- a/docs/src/contributing/release-process.md
+++ b/docs/src/contributing/release-process.md
@@ -1,0 +1,41 @@
+# Release Process
+
+padctl releases are driven by annotated `v*.*.*` tags. The tag version must match
+`build.zig.zon`; the release workflow checks this before building artifacts.
+
+## Checklist
+
+1. Update `build.zig.zon` to the new version and merge that change to `main`.
+2. Create an annotated tag on the exact `main` commit to release:
+
+   ```sh
+   git fetch origin main --tags
+   git tag -a v0.1.9 origin/main -m "v0.1.9"
+   git push origin v0.1.9
+   ```
+
+3. Watch the **Release** workflow. The successful run should include:
+
+   - musl tarballs for `x86_64-linux-musl` and `aarch64-linux-musl`
+   - versioned `.deb` packages and latest aliases
+   - `SHA256SUMS.txt`
+   - `verify-release-artifact`
+   - `update-aur`
+
+   The AUR update job copies `contrib/aur/padctl-bin/PKGBUILD` into the AUR
+   checkout before setting the version and hashes, so packaging layout fixes must
+   be made in the repository template first.
+
+4. Verify the GitHub release after the workflow completes:
+
+   ```sh
+   gh release view v0.1.9 --json isDraft,isPrerelease,assets
+   ```
+
+5. If a release upload step runs inside a container, every `gh release` command
+   must pass `--repo BANANASJIM/padctl`. The container checkout may not provide
+   enough git metadata for `gh` to infer the repository.
+
+6. Do not rerun an old failed tag workflow after merging release workflow fixes.
+   Move or recreate the annotated tag so the new workflow run executes at the
+   fixed commit.

--- a/docs/src/devices/README.md
+++ b/docs/src/devices/README.md
@@ -1,5 +1,8 @@
 # Device Reference
 
-Device reference pages are generated from TOML configs via `padctl --doc-gen`.
+Device reference pages are generated from production TOML configs via
+`padctl --doc-gen`. This section lists supported device families; compatibility
+variants may share one generated page, and fixtures under `devices/example/` are
+for parser/CI coverage rather than user support claims.
 
 Run `padctl --doc-gen devices/**/*.toml` to regenerate all pages.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -24,6 +24,14 @@ curl -fLO https://github.com/BANANASJIM/padctl/releases/latest/download/padctl_a
 sudo dpkg -i padctl_arm64.deb
 ```
 
+Package installs place the binary, udev rules, and system-wide user unit on disk.
+Enable the service from your normal login session:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now padctl.service
+```
+
 ## Prerequisites
 
 - **Zig 0.15+** (build from source)
@@ -84,7 +92,7 @@ sudo ./zig-out/bin/padctl install --prefix /usr --destdir "$DESTDIR"
 
 `padctl install` also sets up the following on all systems:
 
-- **`padctl-reconnect`** — A hotplug script triggered by udev when a controller is plugged in. It starts the daemon if not running, restarts it if failed, and re-applies the active mapping. After suspend/resume the kernel re-emits udev events for re-enumerated devices, so the same hook handles post-wake reconnect — no separate resume unit is needed.
+- **`padctl-reconnect`** — A hotplug script triggered by udev when a controller is plugged in. It re-applies the active mapping through any running padctl daemon socket. It does not start or restart the daemon; `padctl install` enables/starts `padctl.service` unless you pass `--no-enable` or `--no-start`. After suspend/resume the kernel re-emits udev events for re-enumerated devices, so the same hook handles post-wake reconnect — no separate resume unit is needed.
 - **Driver conflict rules** — Auto-generated udev rules that unbind conflicting kernel drivers (e.g., `xpad`) from devices that padctl manages. Configured per-device via `block_kernel_drivers` in device TOML configs. When run as root, `padctl install` also walks `/sys/bus/usb/drivers/<driver>/unbind` for matching VID:PID pairs immediately, so already-bound devices are evicted without waiting for replug (issue #162).
 
 ### Install a Mapping
@@ -101,15 +109,19 @@ When `--mapping` is given, the installer also writes a device-to-mapping binding
 
 > **Bazzite / immutable distros:** See the [Bazzite / Immutable Distros guide](immutable-install.md) for special installation steps.
 
-> **Install problems?** See [Troubleshooting](troubleshooting.md) for the `devices/` warning, systemd 257+ `status=218/CAPABILITIES`, and the Arch glibc 2.43 build failure.
+> **Install problems?** See [Troubleshooting](troubleshooting.md) for daemon/socket checks, udev permission issues, missing device configs, and known build failures.
 
 ## Verify
 
 ```sh
+padctl status
 padctl scan
+padctl list-mappings
 ```
 
-Lists all connected HID devices and shows whether a matching device config was found for each.
+`padctl status` verifies the user service socket is reachable. `padctl scan`
+lists connected HID devices and shows whether a matching device config was found
+for each. `padctl list-mappings` verifies the mapping search paths are readable.
 
 ## Run as Service
 
@@ -224,7 +236,7 @@ See the [Diagnostic Logging guide](diagnostic-logging.md) for the full `padctl d
 
 ## udev Permissions
 
-padctl needs access to `/dev/hidraw*`, `/dev/uinput`, and `/dev/uhid`. The first two are standard for HID gamepad daemons; `/dev/uhid` is required for the SDL3-visible IMU pairing path (per ADR-015) — `padctl install` writes the necessary udev rule (`60-padctl.rules`) and a `DeviceAllow=/dev/uhid rw` entry in the systemd unit automatically.
+padctl needs access to `/dev/hidraw*`, `/dev/uinput`, and `/dev/uhid`. The first two are standard for HID gamepad daemons; `/dev/uhid` is required for the SDL3-visible IMU pairing path (per ADR-015). `padctl install` writes the necessary udev rules (`60-padctl.rules`) automatically.
 
 The `padctl install` command generates and installs udev rules automatically from device configs.
 
@@ -234,4 +246,7 @@ If you need to regenerate rules after adding custom device configs:
 sudo padctl install
 ```
 
-The udev rules use `TAG+="uaccess"` to grant the logged-in user access to supported devices without requiring root.
+The udev rules use `TAG+="uaccess"` to grant the active graphical user access
+without requiring root. For SSH, headless, or test sessions without desktop ACLs,
+the rules also grant `GROUP="input", MODE="0660"`; add your user to the `input`
+group and log in again if those sessions need direct device access.

--- a/docs/src/immutable-install.md
+++ b/docs/src/immutable-install.md
@@ -53,8 +53,8 @@ The `padctl install --immutable` flag changes where system files are placed:
 | File | Standard (`/usr`) | Immutable (`--immutable`) |
 |------|-------------------|---------------------------|
 | Binaries | `/usr/bin/` | `/usr/local/bin/` |
-| Service file | `/usr/lib/systemd/system/` | `/etc/systemd/system/` |
-| Service drop-in | *(not created)* | `/etc/systemd/system/padctl.service.d/immutable.conf` |
+| Service file | `/usr/lib/systemd/user/` | `/etc/systemd/user/` |
+| Service drop-in | *(not created)* | `/etc/systemd/user/padctl.service.d/immutable.conf` |
 | udev rules | `/usr/lib/udev/rules.d/` | `/etc/udev/rules.d/` |
 | Device configs | `/usr/share/padctl/devices/` | `/usr/local/share/padctl/devices/` |
 
@@ -64,16 +64,22 @@ Files in `/etc/` persist across system updates on immutable distros.
 
 ### The `immutable.conf` Drop-in
 
-The immutable install creates a systemd drop-in override with these changes:
+The immutable install creates a systemd user-service drop-in override with these changes:
 
 | Directive | Purpose |
 |-----------|---------|
-| `DeviceAllow=` | Resets device allowlist to permit all device access (see security note below) |
+| `DeviceAllow=` | Clears any inherited device allowlist so libusb can open USB bus nodes when permissions allow it |
 | `ProtectHome=read-only` | Allows reading user mapping configs from `~/.config/padctl/mappings/` |
+| `ReadWritePaths=/run/user/%U` | Keeps the daemon socket writable when `ProtectHome=read-only` also covers runtime paths |
 | `TimeoutStopSec=3` | Short stop timeout for processes stuck in uninterruptible I/O |
 | `KillMode=mixed` | SIGTERM to main process + SIGKILL to stuck worker threads |
 
-**Security note on `DeviceAllow=`:** The base service restricts device access to `hidraw`, `uinput`, and `input` devices. The immutable drop-in clears this allowlist because libusb needs USB bus nodes (`/dev/bus/usb/`) for vendor-specific control transfers (init commands, rumble, LED control). The specific `char-usb_device` cgroup class was tested and does not provide sufficient access. Standard (non-immutable) installs are not affected and retain the restrictive allowlist.
+**Security note on `DeviceAllow=`:** The immutable drop-in does not grant file
+permissions by itself. Device access still comes from the installed udev rules,
+desktop `uaccess` ACLs, or input-group membership for headless sessions. Clearing
+the systemd device allowlist is needed so libusb can use USB bus nodes
+(`/dev/bus/usb/`) for vendor-specific control transfers once normal file
+permissions allow access.
 
 ## Managing Mappings
 
@@ -124,4 +130,4 @@ This copies your user mapping and config to `/etc/padctl/` via sudo, so the chan
 sudo padctl uninstall --immutable --prefix /usr/local --mapping vader5
 ```
 
-This removes all installed files including the `/etc/` service files and the specified mapping. User configs in `~/.config/padctl/` are never touched.
+This removes all installed files including the `/etc/systemd/user/` service files and the specified mapping. User configs in `~/.config/padctl/` are never touched.

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -13,18 +13,18 @@ Without a mapping config, padctl passes all inputs through unchanged as a standa
 
 ### Create a mapping
 
-Copy the example and edit it:
+Use the interactive creator:
 
 ```sh
 mkdir -p ~/.config/padctl/mappings/
-cp /usr/share/padctl/config/example-mapping.toml ~/.config/padctl/mappings/my-config.toml
-$EDITOR ~/.config/padctl/mappings/my-config.toml
+padctl config init --preset xbox-360
 ```
 
-Or use the interactive creator:
+Or, from a source checkout, copy the repository example and edit it:
 
 ```sh
-padctl config init
+cp config/example-mapping.toml ~/.config/padctl/mappings/my-config.toml
+$EDITOR ~/.config/padctl/mappings/my-config.toml
 ```
 
 ### XDG Search Paths
@@ -103,7 +103,7 @@ padctl --mapping ~/.config/padctl/mappings/my-config.toml
 Mapping configs are validated at daemon startup. Errors are written to the journal:
 
 ```sh
-journalctl -u padctl.service -n 30
+journalctl --user -u padctl.service -n 30
 ```
 
 Mapping configs can also be validated with `padctl --validate`; the flag auto-detects device vs mapping schema by scanning for a `[device]` table.

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -4,6 +4,111 @@ Common runtime failures that have generated repeat issue reports, with diagnosti
 
 ---
 
+## `padctl status` says it cannot connect to the daemon
+
+**Symptoms:**
+
+- `padctl status` exits non-zero or reports that the daemon socket is unreachable.
+- `padctl switch <name>` cannot apply a mapping.
+
+**Check the user service:**
+
+```sh
+systemctl --user status padctl.service
+journalctl --user -u padctl.service -n 80
+```
+
+**Common causes:**
+
+- `padctl install` was run with `--no-enable` or `--no-start`.
+- `padctl install` was run as root without `SUDO_USER`, so it could not locate the real user's systemd user manager.
+- The user has not logged in since install, or headless boot needs linger.
+
+**Fix:**
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now padctl.service
+```
+
+For headless setups or boot-before-login:
+
+```sh
+sudo loginctl enable-linger $USER
+```
+
+---
+
+## Permission denied opening `hidraw`, `uinput`, or `uhid`
+
+**Symptoms:**
+
+- The daemon starts but logs `PermissionDenied`, `AccessDenied`, or open failures
+  for `/dev/hidraw*`, `/dev/uinput`, or `/dev/uhid`.
+- `padctl scan` sees the controller but the daemon cannot manage it.
+
+**Fix:**
+
+```sh
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+systemctl --user restart padctl.service
+```
+
+Then unplug and replug the controller. Graphical sessions normally receive access
+through `TAG+="uaccess"` ACLs. SSH/headless sessions may also need input-group
+membership:
+
+```sh
+sudo usermod -aG input $USER
+```
+
+Log out and back in after changing groups.
+
+---
+
+## Controller is visible but no matching config is found
+
+**Symptoms:**
+
+- `padctl scan` lists the HID device but says no config matched.
+- The daemon log says no devices were found in config dirs.
+
+**Check installed configs:**
+
+```sh
+find /usr/share/padctl/devices -name '*.toml' | sort
+padctl --validate /usr/share/padctl/devices/sony/dualsense.toml
+```
+
+If `/usr/share/padctl/devices` is missing or empty, reinstall the current package.
+If your device is not listed, capture it and open a device-config contribution.
+
+---
+
+## Kernel driver or another mapper still owns the controller
+
+**Symptoms:**
+
+- The physical controller continues to appear directly in games while padctl is running.
+- padctl cannot exclusively grab the device, or duplicate inputs appear.
+- Xbox-compatible devices still bind to `xpad` even though their device TOML sets
+  `block_kernel_drivers`.
+
+**Fix:**
+
+```sh
+sudo padctl install
+sudo udevadm trigger
+systemctl --user restart padctl.service
+```
+
+Then unplug and replug the controller. For devices with `block_kernel_drivers`,
+the installer writes driver-block udev rules and also tries to unbind already
+attached matching devices during install.
+
+---
+
 ## `padctl install` warns "source 'devices/' directory not found"
 
 **Symptoms:**

--- a/examples/mappings/chord-output.toml
+++ b/examples/mappings/chord-output.toml
@@ -3,10 +3,9 @@
 # On press: down events emitted in declaration order.
 # On release: up events emitted in reverse order.
 #
-# PREVIEW — As of v0.1.5 the array syntax parses and validates, and the
-# source button is suppressed, but no key events are dispatched yet.
-# Chord output dispatch lands in a follow-up release. Buttons remapped to
-# arrays in this file currently emit nothing on press; do not deploy this
+# PREVIEW — Array syntax parses and validates, and the source button is
+# suppressed, but key-event dispatch is not implemented yet. Buttons remapped
+# to arrays in this file currently emit nothing on press; do not deploy this
 # example as your daily mapping.
 
 name = "chord-output-demo"


### PR DESCRIPTION
## Summary

- refresh README/getting-started install flow for package installs vs source installs, including systemd user-service paths and verification commands
- fix stale mapping/contributor commands (`padctl config init`, `journalctl --user`, `padctl-capture --device`, `padctl-debug --config`)
- expand troubleshooting with daemon socket, udev permission, missing config, and driver-conflict checks
- add release-process docs and make the release workflow sync the canonical `padctl-bin` PKGBUILD before updating AUR version/hash fields
- fix the `padctl-bin` PKGBUILD template to preserve the `devices/` directory under `/usr/share/padctl/devices`

## Verification

- `git diff --check`
- `bash -n contrib/aur/padctl-bin/PKGBUILD`
- `mdbook build docs`
- `PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test --summary all`

Native `zig build test` is blocked on this host by the documented Zig/glibc `.sframe` linker issue. The pre-push hook also picks the system Zig and fails before reaching project code, so this branch was pushed with `SKIP_TSAN=1`; PR CI should run the canonical checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified installation instructions, including explicit systemd service enablement for package-manager setups.
  * Added comprehensive troubleshooting sections covering daemon connectivity, permissions, missing device configs, and kernel driver conflicts.
  * Expanded getting-started guide with additional verification commands and udev permission clarity.
  * Updated immutable-install guide with corrected systemd user unit paths.
  * Added release process documentation.

* **Chores**
  * Updated package version to 0.1.9.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->