### PR TITLE
fix gyro tilt pitch roll axes

### DIFF
--- a/src/core/gyro.zig
+++ b/src/core/gyro.zig
@@ -144,8 +144,8 @@ fn selectTiltAxis(axis: GyroAxis, ax: i16, ay: i16, az: i16) ?f32 {
     const radians_to_degrees: f32 = 180.0 / std.math.pi;
     return switch (axis) {
         .none => null,
-        .pitch => std.math.atan2(-fx, @sqrt(fy * fy + fz * fz)) * radians_to_degrees,
-        .roll => std.math.atan2(fy, fz) * radians_to_degrees,
+        .pitch => std.math.atan2(fy, @sqrt(fx * fx + fz * fz)) * radians_to_degrees,
+        .roll => std.math.atan2(-fx, @sqrt(fy * fy + fz * fz)) * radians_to_degrees,
         .yaw => 0.0,
     };
 }
@@ -198,8 +198,12 @@ test "gyro: joystick tilt response maps roll degrees to stick position" {
         .sensitivity_x = 1.0,
     };
 
-    // atan2(5735, 8192) is approximately 35 degrees, so it should be full X deflection.
-    const out = g.processMotion(&cfg, 0, 0, 0, 0, 5735, 8192);
+    // Forward/back pitch must not drive roll.
+    const pitch_only = g.processMotion(&cfg, 0, 0, 0, 0, 5735, 8192);
+    try testing.expectEqual(@as(i16, 0), pitch_only.joy_x.?);
+
+    // Roll is left/right tilt, reported through accel_x. atan2(5735, 8192) is approximately 35 degrees.
+    const out = g.processMotion(&cfg, 0, 0, 0, -5735, 0, 8192);
     try testing.expect(out.joy_x != null);
     try testing.expect(out.joy_y == null);
     try testing.expect(out.joy_x.? > 32000);
@@ -218,9 +222,31 @@ test "gyro: joystick tilt response supports invert and negative roll" {
         .invert_x = true,
     };
 
-    const out = g.processMotion(&cfg, 0, 0, 0, 0, -5735, 8192);
+    const out = g.processMotion(&cfg, 0, 0, 0, 5735, 0, 8192);
     try testing.expect(out.joy_x != null);
     try testing.expect(out.joy_x.? > 32000);
+}
+
+test "gyro: joystick tilt response maps pitch degrees independently of roll" {
+    var g = GyroProcessor{};
+    const cfg = GyroConfig{
+        .mode = "joystick",
+        .response = .tilt,
+        .axis_x = .pitch,
+        .axis_y = .none,
+        .degrees_full = 35.0,
+        .smoothing = 0.0,
+        .sensitivity_x = 1.0,
+    };
+
+    // Pitch is forward/back tilt, reported through accel_y; accel_x-only roll must not drive it.
+    const roll_only = g.processMotion(&cfg, 0, 0, 0, -5735, 0, 8192);
+    try testing.expectEqual(@as(i16, 0), roll_only.joy_x.?);
+
+    const pitch = g.processMotion(&cfg, 0, 0, 0, 0, 5735, 8192);
+    try testing.expect(pitch.joy_x != null);
+    try testing.expect(pitch.joy_y == null);
+    try testing.expect(pitch.joy_x.? > 32000);
 }
 
 test "gyro: joystick tilt response ignores missing accelerometer vector" {

--- a/src/test/gyro_stick_e2e_test.zig
+++ b/src/test/gyro_stick_e2e_test.zig
@@ -271,7 +271,11 @@ test "e2e: gyro joystick tilt — roll can drive left stick X by degrees" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .accel_y = 5735, .accel_z = 8192, .ax = 111, .ay = -222 }, 16, 0);
+    const pitch_only = try m.apply(.{ .accel_y = 5735, .accel_z = 8192, .ax = 111, .ay = -222 }, 16, 0);
+    try testing.expectEqual(@as(i16, 0), pitch_only.gamepad.ax);
+    try testing.expectEqual(@as(i16, -222), pitch_only.gamepad.ay);
+
+    const ev = try m.apply(.{ .accel_x = -5735, .accel_y = 0, .accel_z = 8192, .ax = 111, .ay = -222 }, 16, 16_000_000);
 
     try testing.expect(ev.gamepad.ax > 32000);
     try testing.expectEqual(@as(i16, -222), ev.gamepad.ay);
@@ -294,8 +298,32 @@ test "e2e: gyro joystick tilt — default X axis is roll" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .accel_y = 5735, .accel_z = 8192 }, 16, 0);
+    const ev = try m.apply(.{ .accel_x = -5735, .accel_z = 8192 }, 16, 0);
     try testing.expect(ev.gamepad.ax > 32000);
+}
+
+test "e2e: gyro joystick tilt — pitch can drive X from forward/back tilt" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[gyro]
+        \\mode = "joystick"
+        \\response = "tilt"
+        \\target = "left_stick"
+        \\axis_x = "pitch"
+        \\axis_y = "none"
+        \\degrees_full = 35.0
+        \\sensitivity_x = 1.0
+        \\smoothing = 0.0
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const roll_only = try m.apply(.{ .accel_x = -5735, .accel_y = 0, .accel_z = 8192 }, 16, 0);
+    try testing.expectEqual(@as(i16, 0), roll_only.gamepad.ax);
+
+    const pitch = try m.apply(.{ .accel_x = 0, .accel_y = 5735, .accel_z = 8192 }, 16, 16_000_000);
+    try testing.expect(pitch.gamepad.ax > 32000);
+    try testing.expectEqual(@as(i16, 0), pitch.gamepad.ay);
 }
 
 test "e2e: gyro joystick tilt — missing accel does not suppress physical stick" {


### PR DESCRIPTION
## Summary

- swap tilt-response pitch/roll accelerometer formulas so roll tracks left/right tilt and pitch tracks forward/back tilt
- update gyro unit tests and mapper e2e coverage for the issue #298 axis regression
- leave rate-response gyro axis mapping unchanged

Fixes #298

## Verification

- `PATH=$HOME/.local/bin:$PATH ZIG_GLOBAL_CACHE_DIR=$PWD/.zig-global-cache zig test src/core/gyro.zig --cache-dir .zig-cache-gyro`
- `PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test --summary all`
- pre-push hook: Docker `test-tsan` passed after native Zig detected the known host `.sframe` linker issue
- subagent review: no findings

## Notes

- Native `zig build test` on this host still hits the known Arch/GCC `.sframe` linker issue, so full project validation used the canonical Docker image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved gyro tilt control by refining how accelerometer data maps to stick axes
  * Fixed pitch and roll axis independence to ensure proper stick behavior with gyro tilt input

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->