### PR TITLE
Fix suspended re-init failure lifecycle

### DIFF
--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -32,6 +32,38 @@ const init_seq = @import("init.zig");
 const GamepadState = @import("core/state.zig").GamepadState;
 const FfEvent = uinput.FfEvent;
 
+var closed_device_sentinel: u8 = 0;
+
+const closed_device_vtable = DeviceIO.VTable{
+    .read = closedRead,
+    .write = closedWrite,
+    .feature_report = closedFeatureReport,
+    .pollfd = closedPollfd,
+    .close = closedClose,
+};
+
+fn closedDeviceIO() DeviceIO {
+    return .{ .ptr = &closed_device_sentinel, .vtable = &closed_device_vtable };
+}
+
+fn closedRead(_: *anyopaque, _: []u8) DeviceIO.ReadError!usize {
+    return DeviceIO.ReadError.Disconnected;
+}
+
+fn closedWrite(_: *anyopaque, _: []const u8) DeviceIO.WriteError!void {
+    return DeviceIO.WriteError.Disconnected;
+}
+
+fn closedFeatureReport(_: *anyopaque, _: []const u8) DeviceIO.WriteError!void {
+    return DeviceIO.WriteError.Disconnected;
+}
+
+fn closedPollfd(_: *anyopaque) posix.pollfd {
+    return .{ .fd = -1, .events = 0, .revents = 0 };
+}
+
+fn closedClose(_: *anyopaque) void {}
+
 fn createDeviceIO(
     allocator: std.mem.Allocator,
     iface: InterfaceConfig,
@@ -596,7 +628,10 @@ pub const DeviceInstance = struct {
     /// Close physical device fds only, keeping uinput/aux/touchpad alive.
     /// Used when suspending an instance across device sleep/wake.
     pub fn closeDeviceIO(self: *DeviceInstance) void {
-        for (self.devices) |dev| dev.close();
+        for (self.devices) |*dev| {
+            dev.close();
+            dev.* = closedDeviceIO();
+        }
     }
 
     /// Replace physical device fds with new ones and re-register them in the
@@ -609,7 +644,7 @@ pub const DeviceInstance = struct {
 
     /// Re-run the device init sequence (e.g. handshake packets) using the
     /// current devices[] fds and device_cfg.
-    pub fn rerunInitSequence(self: *DeviceInstance) void {
+    pub fn rerunInitSequence(self: *DeviceInstance) !void {
         if (self.device_cfg.device.init) |init_cfg| {
             for (self.device_cfg.device.interface, self.devices) |iface, dev| {
                 const match = if (init_cfg.interface) |init_iface|
@@ -619,6 +654,7 @@ pub const DeviceInstance = struct {
                 if (!match) continue;
                 init_seq.runInitSequence(self.allocator, dev, init_cfg) catch |err| {
                     std.log.debug("re-init on interface {d}: {}", .{ iface.id, err });
+                    return err;
                 };
             }
         }
@@ -754,6 +790,26 @@ const init_toml =
     \\expect = [0x01]
 ;
 
+const feature_init_toml =
+    \\[device]
+    \\name = "FeatureInitDevice"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[device.init]
+    \\interface = 0
+    \\feature_report = [0x81, 0, 0]
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 1
+    \\[report.match]
+    \\offset = 0
+    \\expect = [0x01]
+;
+
 const FailWriteDeviceIO = struct {
     pub fn deviceIO(self: *FailWriteDeviceIO) DeviceIO {
         return .{ .ptr = self, .vtable = &vtable };
@@ -803,6 +859,99 @@ test "DeviceInstance.init propagates init write errors" {
     });
 
     try testing.expectError(DeviceIO.WriteError.Io, result);
+}
+
+test "DeviceInstance.init propagates feature_report init errors" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, feature_init_toml);
+    defer parsed.deinit();
+
+    var failing = FailWriteDeviceIO{};
+    const devices = try allocator.alloc(DeviceIO, 1);
+    defer allocator.free(devices);
+    devices[0] = failing.deviceIO();
+
+    var uniq_counter: u16 = 1;
+    const result = DeviceInstance.init(allocator, &parsed.value, null, null, &uniq_counter, .{
+        .test_devices_override = devices,
+    });
+
+    try testing.expectError(DeviceIO.WriteError.Io, result);
+}
+
+test "DeviceInstance: rerunInitSequence propagates init write errors" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, init_toml);
+    defer parsed.deinit();
+
+    var failing = FailWriteDeviceIO{};
+    const devices = try allocator.alloc(DeviceIO, 1);
+    defer allocator.free(devices);
+    devices[0] = failing.deviceIO();
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+    try loop.addDevice(devices[0]);
+
+    var inst = DeviceInstance{
+        .allocator = allocator,
+        .devices = devices,
+        .loop = loop,
+        .interp = Interpreter.init(&parsed.value),
+        .mapper = null,
+        .owner = .none,
+        .primary_output = null,
+        .imu_output = null,
+        .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
+        .device_cfg = &parsed.value,
+        .pending_mapping = null,
+        .stopped = false,
+        .poll_timeout_ms = 100,
+    };
+
+    try testing.expectError(DeviceIO.WriteError.Io, inst.rerunInitSequence());
+}
+
+test "DeviceInstance: rerunInitSequence propagates feature_report errors" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, feature_init_toml);
+    defer parsed.deinit();
+
+    var failing = FailWriteDeviceIO{};
+    const devices = try allocator.alloc(DeviceIO, 1);
+    defer allocator.free(devices);
+    devices[0] = failing.deviceIO();
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+    try loop.addDevice(devices[0]);
+
+    var inst = DeviceInstance{
+        .allocator = allocator,
+        .devices = devices,
+        .loop = loop,
+        .interp = Interpreter.init(&parsed.value),
+        .mapper = null,
+        .owner = .none,
+        .primary_output = null,
+        .imu_output = null,
+        .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
+        .device_cfg = &parsed.value,
+        .pending_mapping = null,
+        .stopped = false,
+        .poll_timeout_ms = 100,
+    };
+
+    try testing.expectError(DeviceIO.WriteError.Io, inst.rerunInitSequence());
 }
 
 test "DeviceInstance: stop() causes run() to exit" {
@@ -1010,6 +1159,8 @@ test "DeviceInstance: closeDeviceIO closes device fds without touching uinput" {
     // closeDeviceIO must not crash; owner stays .none (not touched)
     inst.closeDeviceIO();
     try testing.expect(inst.owner == .none);
+    try testing.expectEqual(@as(posix.fd_t, -1), inst.devices[0].pollfd().fd);
+    try testing.expectError(DeviceIO.WriteError.Disconnected, inst.devices[0].write(&[_]u8{0x01}));
 }
 
 test "DeviceInstance: rebindDeviceIO replaces device fds" {

--- a/src/init.zig
+++ b/src/init.zig
@@ -102,7 +102,8 @@ pub fn runInitSequence(
         const n = @min(fr.len, buf.len);
         for (fr[0..n], 0..) |b, i| buf[i] = @intCast(b);
         device.featureReport(buf[0..n]) catch |err| {
-            std.log.warn("feature_report ioctl failed: {}, continuing", .{err});
+            std.log.warn("feature_report ioctl failed: {}", .{err});
+            return err;
         };
         total += 1;
     }
@@ -144,6 +145,36 @@ test "init: parseHexBytes odd length returns error" {
 }
 
 const MockDeviceIO = @import("test/mock_device_io.zig").MockDeviceIO;
+
+const FailFeatureReportDeviceIO = struct {
+    pub fn deviceIO(self: *FailFeatureReportDeviceIO) DeviceIO {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = DeviceIO.VTable{
+        .read = read,
+        .write = write,
+        .feature_report = featureReport,
+        .pollfd = pollfd,
+        .close = close,
+    };
+
+    fn read(_: *anyopaque, _: []u8) DeviceIO.ReadError!usize {
+        return DeviceIO.ReadError.Again;
+    }
+
+    fn write(_: *anyopaque, _: []const u8) DeviceIO.WriteError!void {}
+
+    fn featureReport(_: *anyopaque, _: []const u8) DeviceIO.WriteError!void {
+        return DeviceIO.WriteError.Io;
+    }
+
+    fn pollfd(_: *anyopaque) std.posix.pollfd {
+        return .{ .fd = -1, .events = 0, .revents = 0 };
+    }
+
+    fn close(_: *anyopaque) void {}
+};
 
 test "init: runInitSequence: sends command and matches response_prefix" {
     const allocator = std.testing.allocator;
@@ -269,4 +300,15 @@ test "init: runInitSequence: feature_report after commands" {
     try std.testing.expectEqualSlices(u8, &[_]u8{0xaa}, mock.write_log.items);
     try std.testing.expectEqual(@as(usize, 3), mock.feature_report_log.items.len);
     try std.testing.expectEqual(@as(u8, 0x81), mock.feature_report_log.items[0]);
+}
+
+test "init: runInitSequence: feature_report write errors propagate" {
+    const allocator = std.testing.allocator;
+
+    var failing = FailFeatureReportDeviceIO{};
+    const init_cfg = device_mod.InitConfig{
+        .feature_report = &[_]i64{ 0x81, 0, 0 },
+    };
+
+    try std.testing.expectError(DeviceIO.WriteError.Io, runInitSequence(allocator, failing.deviceIO(), init_cfg));
 }

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -654,6 +654,13 @@ pub const Supervisor = struct {
         m.thread = try std.Thread.spawn(.{}, threadEntry, .{m.instance});
     }
 
+    fn rerunInitAfterRebind(m: *ManagedInstance) !void {
+        m.instance.rerunInitSequence() catch |err| {
+            m.instance.closeDeviceIO();
+            return err;
+        };
+    }
+
     /// Commit bookkeeping for a suspended instance whose device fds have
     /// just been rebound by `attachWithRoot()`. Allocates the devname /
     /// phys slices, updates `devname_map`, restarts the worker thread,
@@ -2026,7 +2033,11 @@ pub const Supervisor = struct {
 
             m.instance.rebindDeviceIO(new_devices);
             self.allocator.free(new_devices);
-            m.instance.rerunInitSequence();
+            rerunInitAfterRebind(m) catch |err| {
+                std.log.warn("hotplug: suspended instance resume aborted: re-init failed: {}", .{err});
+                if (isTransientOpenError(err)) return error.HotplugTransient;
+                return;
+            };
 
             // Commit bookkeeping only after every fallible step succeeds. On
             // failure `m.suspended`/`m.grace_deadline_ns` stay as-is so the
@@ -2124,6 +2135,78 @@ const minimal_device_toml =
     \\[report.fields]
     \\left_x = { offset = 1, type = "i16le" }
 ;
+
+const init_device_toml =
+    \\[device]
+    \\name = "InitDevice"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[device.init]
+    \\interface = 0
+    \\commands = ["0101"]
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 1
+    \\[report.match]
+    \\offset = 0
+    \\expect = [0x01]
+;
+
+const feature_init_device_toml =
+    \\[device]
+    \\name = "FeatureInitDevice"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[device.init]
+    \\interface = 0
+    \\feature_report = [0x81, 0, 0]
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 1
+    \\[report.match]
+    \\offset = 0
+    \\expect = [0x01]
+;
+
+const FailWriteDeviceIO = struct {
+    pub fn deviceIO(self: *FailWriteDeviceIO) DeviceIO {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = DeviceIO.VTable{
+        .read = read,
+        .write = write,
+        .feature_report = featureReport,
+        .pollfd = pollfd,
+        .close = close,
+    };
+
+    fn read(_: *anyopaque, _: []u8) DeviceIO.ReadError!usize {
+        return DeviceIO.ReadError.Again;
+    }
+
+    fn write(_: *anyopaque, _: []const u8) DeviceIO.WriteError!void {
+        return DeviceIO.WriteError.Io;
+    }
+
+    fn featureReport(_: *anyopaque, _: []const u8) DeviceIO.WriteError!void {
+        return DeviceIO.WriteError.Io;
+    }
+
+    fn pollfd(_: *anyopaque) posix.pollfd {
+        return .{ .fd = -1, .events = 0, .revents = 0 };
+    }
+
+    fn close(_: *anyopaque) void {}
+};
 
 fn makeTestInstance(
     inst_alloc: std.mem.Allocator,
@@ -2938,6 +3021,78 @@ test "supervisor: Supervisor: suspend preserves instance, resume rebinds device 
         sup.stopAll();
         sup.deinit();
     }
+}
+
+test "supervisor: failed re-init after suspended rebind preserves grace state" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, init_device_toml);
+    defer parsed_dev.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+    sup.suspend_grace_sec = 5;
+    sup.test_now_override_ns = 10 * std.time.ns_per_s;
+
+    const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", inst_a, null);
+
+    sup.detach("hidraw3");
+    try testing.expect(sup.managed.items[0].suspended);
+    const original_deadline = sup.managed.items[0].grace_deadline_ns.?;
+
+    var failing = FailWriteDeviceIO{};
+    var new_devs = [_]DeviceIO{failing.deviceIO()};
+    const m = &sup.managed.items[0];
+    m.instance.rebindDeviceIO(&new_devs);
+    try testing.expectError(DeviceIO.WriteError.Io, Supervisor.rerunInitAfterRebind(m));
+
+    try testing.expect(m.suspended);
+    try testing.expectEqual(original_deadline, m.grace_deadline_ns.?);
+    try testing.expectEqual(@as(?[]const u8, null), m.devname);
+    try testing.expect(!sup.devname_map.contains("hidraw3"));
+    try testing.expectEqual(@as(posix.fd_t, -1), m.instance.devices[0].pollfd().fd);
+}
+
+test "supervisor: failed feature-report re-init after suspended rebind preserves grace state" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, feature_init_device_toml);
+    defer parsed_dev.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+    sup.suspend_grace_sec = 5;
+    sup.test_now_override_ns = 10 * std.time.ns_per_s;
+
+    const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", inst_a, null);
+
+    sup.detach("hidraw3");
+    try testing.expect(sup.managed.items[0].suspended);
+    const original_deadline = sup.managed.items[0].grace_deadline_ns.?;
+
+    var failing = FailWriteDeviceIO{};
+    var new_devs = [_]DeviceIO{failing.deviceIO()};
+    const m = &sup.managed.items[0];
+    m.instance.rebindDeviceIO(&new_devs);
+    try testing.expectError(DeviceIO.WriteError.Io, Supervisor.rerunInitAfterRebind(m));
+
+    try testing.expect(m.suspended);
+    try testing.expectEqual(original_deadline, m.grace_deadline_ns.?);
+    try testing.expectEqual(@as(?[]const u8, null), m.devname);
+    try testing.expect(!sup.devname_map.contains("hidraw3"));
+    try testing.expectEqual(@as(posix.fd_t, -1), m.instance.devices[0].pollfd().fd);
 }
 
 test "supervisor: Supervisor: stopAll handles suspended instances" {


### PR DESCRIPTION
## Summary
- make feature-report init failures propagate instead of declaring a device ready after a failed init
- make suspended rebind rerun init before finalize/restart, preserving suspended/grace state and retrying transient failures when re-init fails
- replace closed physical DeviceIO slots with a disconnected no-op sentinel to avoid stale backend pointers after suspend/rebind failure

## Why
Issue #236 reports Steam still seeing the virtual controller, including rumble/ping, while no input reports reach Steam after game/boot lifecycle transitions. PR #304 increased the number of boot-present/retry attach paths; the suspended rebind path still swallowed re-init failures and could mark a device resumed even when the physical input side was not initialized.

## Tests
- PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test --summary all
  - 1457/1463 passed, 6 skipped
- PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test-tsan --summary all
  - 1446/1452 passed, 6 skipped
- pre-push Docker test-tsan passed

Host native zig build still hits the known Arch/GCC .sframe linker issue; Docker is the canonical verification path here.

Fixes #236
Refs #304


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during device initialization—failures in feature report configuration now properly halt initialization instead of continuing silently.
  * Enhanced hotplug device reconnection—transient failures during rebind are now correctly identified and state is preserved, preventing devices from entering invalid states.

* **Tests**
  * Expanded test coverage for initialization error propagation and device disconnection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->