### PR TITLE
Delay aux tap releases

### DIFF
--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -63,7 +63,52 @@ const AuxDownTarget = union(enum) {
     mouse_button: u16,
 };
 
+const AUX_TAP_RELEASE_DELAY_NS: i128 = 30 * std.time.ns_per_ms;
+const AUX_TAP_RELEASE_TOKEN_SLOTS = BUTTON_COUNT;
 const GESTURE_TOKEN_SLOTS = gesture_mod.GESTURE_SLOTS * 2;
+
+const AuxTapReleaseTokenEntry = struct {
+    token: u32,
+    target: AuxDownTarget,
+};
+
+const AuxTapReleaseTokenTable = struct {
+    entries: [AUX_TAP_RELEASE_TOKEN_SLOTS]?AuxTapReleaseTokenEntry = [_]?AuxTapReleaseTokenEntry{null} ** AUX_TAP_RELEASE_TOKEN_SLOTS,
+
+    fn put(self: *AuxTapReleaseTokenTable, token: u32, target: AuxDownTarget) bool {
+        for (&self.entries) |*e| {
+            if (e.* == null) {
+                e.* = .{ .token = token, .target = target };
+                return true;
+            }
+        }
+        return false;
+    }
+
+    fn take(self: *AuxTapReleaseTokenTable, token: u32) ?AuxDownTarget {
+        for (&self.entries) |*e| {
+            if (e.*) |v| {
+                if (v.token == token) {
+                    e.* = null;
+                    return v.target;
+                }
+            }
+        }
+        return null;
+    }
+
+    fn takeTarget(self: *AuxTapReleaseTokenTable, target: AuxDownTarget) ?AuxTapReleaseTokenEntry {
+        for (&self.entries) |*e| {
+            if (e.*) |v| {
+                if (auxDownTargetEql(v.target, target)) {
+                    e.* = null;
+                    return v;
+                }
+            }
+        }
+        return null;
+    }
+};
 
 const GestureTokenEntry = struct {
     token: u32,
@@ -117,6 +162,7 @@ pub const Mapper = struct {
     aux_down_targets: [BUTTON_COUNT]?AuxDownTarget,
     gesture_aux_down_targets: [BUTTON_COUNT]?AuxDownTarget,
     pending_tap_release: ?u64,
+    aux_tap_release_tokens: AuxTapReleaseTokenTable,
     // Gamepad-button taps emitted by macro timer expiry need one apply() cycle
     // to reach output before pending_tap_release fires; staged here, promoted
     // to injected+pending_tap_release at the next apply.
@@ -175,6 +221,7 @@ pub const Mapper = struct {
             .aux_down_targets = [_]?AuxDownTarget{null} ** BUTTON_COUNT,
             .gesture_aux_down_targets = [_]?AuxDownTarget{null} ** BUTTON_COUNT,
             .pending_tap_release = null,
+            .aux_tap_release_tokens = .{},
             .macro_timer_tap_pending = 0,
             .gesture_engine = .{},
             .gesture_tokens = .{},
@@ -251,6 +298,7 @@ pub const Mapper = struct {
                 target.* = null;
             }
         }
+        releasePendingAuxTapReleases(self, &aux, null);
         return aux;
     }
 
@@ -494,7 +542,7 @@ pub const Mapper = struct {
         self.injected_buttons |= self.gesture_held_gamepad;
 
         if (action.tap_event) |tap| {
-            emitTapEvent(tap, &aux, &self.injected_buttons, &self.pending_tap_release);
+            emitTapEvent(self, tap, &aux, now_ns);
         }
 
         var macro_tap_release: u64 = 0;
@@ -620,6 +668,7 @@ pub const Mapper = struct {
         // Cancel in-flight macros; emit releases for any held keys/buttons.
         for (self.active_macros.items) |*p| p.emitPendingReleases(aux, &self.injected_buttons);
         self.active_macros.clearRetainingCapacity();
+        releasePendingAuxTapReleases(self, aux, now_ns);
         // Discard tap bits staged from a cancelled macro's timer expiry.
         self.macro_timer_tap_pending = 0;
         // Cancel in-flight gestures; mirror the macro-cancel above.
@@ -776,6 +825,7 @@ pub const Mapper = struct {
                             .tap => {},
                         }
                     }
+                    if (em.action == .tap and emitDelayedAuxTap(self, em.target, aux, now_ns)) continue;
                     remap_mod.applyTarget(em.target, act, aux, &self.injected_buttons, null, null);
                 },
             }
@@ -796,6 +846,10 @@ pub const Mapper = struct {
         var buf: [16]timer_queue_mod.Deadline = undefined;
         const expired = self.timer_queue.drainExpired(now_ns, &buf);
         for (expired) |d| {
+            if (self.aux_tap_release_tokens.take(d.token)) |target| {
+                emitAuxDownRelease(target, &aux);
+                continue;
+            }
             if (self.gesture_tokens.take(d.token)) |ge| {
                 const src_bit = @as(u64, 1) << ge.src_idx;
                 const held = (self.state.buttons & src_bit) != 0;
@@ -949,11 +1003,75 @@ fn auxDownTarget(target: RemapTargetResolved) ?AuxDownTarget {
     };
 }
 
+fn auxDownTargetEql(a: AuxDownTarget, b: AuxDownTarget) bool {
+    return switch (a) {
+        .key => |a_code| switch (b) {
+            .key => |b_code| a_code == b_code,
+            else => false,
+        },
+        .mouse_button => |a_code| switch (b) {
+            .mouse_button => |b_code| a_code == b_code,
+            else => false,
+        },
+    };
+}
+
+fn emitAuxDownPress(target: AuxDownTarget, aux: *AuxEventList) bool {
+    switch (target) {
+        .key => |code| aux.append(.{ .key = .{ .code = code, .pressed = true } }) catch return false,
+        .mouse_button => |code| aux.append(.{ .mouse_button = .{ .code = code, .pressed = true } }) catch return false,
+    }
+    return true;
+}
+
 fn emitAuxDownRelease(target: AuxDownTarget, aux: *AuxEventList) void {
     switch (target) {
         .key => |code| aux.append(.{ .key = .{ .code = code, .pressed = false } }) catch {},
         .mouse_button => |code| aux.append(.{ .mouse_button = .{ .code = code, .pressed = false } }) catch {},
     }
+}
+
+fn releasePendingAuxTapReleases(self: *Mapper, aux: *AuxEventList, now_ns: ?i128) void {
+    for (&self.aux_tap_release_tokens.entries) |*entry| {
+        if (entry.*) |e| {
+            if (now_ns) |now| self.timer_queue.cancel(e.token, now);
+            emitAuxDownRelease(e.target, aux);
+            entry.* = null;
+        }
+    }
+}
+
+fn emitDelayedAuxTap(self: *Mapper, target: RemapTargetResolved, aux: *AuxEventList, now_ns: i128) bool {
+    const down = auxDownTarget(target) orelse return false;
+    if (self.aux_tap_release_tokens.takeTarget(down)) |prior| {
+        self.timer_queue.cancel(prior.token, now_ns);
+        emitAuxDownRelease(prior.target, aux);
+    }
+
+    const token = self.next_token;
+    self.next_token +%= 1;
+    if (!self.aux_tap_release_tokens.put(token, down)) {
+        remap_mod.applyTarget(target, .tap, aux, &self.injected_buttons, null, null);
+        return true;
+    }
+    if (!emitAuxDownPress(down, aux)) {
+        _ = self.aux_tap_release_tokens.take(token);
+        return true;
+    }
+    self.timer_queue.arm(now_ns + AUX_TAP_RELEASE_DELAY_NS, token, now_ns) catch |err| {
+        _ = self.aux_tap_release_tokens.take(token);
+        std.log.warn("aux tap release timer arm failed: {}", .{err});
+        emitAuxDownRelease(down, aux);
+    };
+    return true;
+}
+
+fn emitTapEvent(self: *Mapper, target: RemapTargetResolved, aux: *AuxEventList, now_ns: i128) void {
+    if (emitDelayedAuxTap(self, target, aux, now_ns)) return;
+
+    var local_pending: u64 = self.pending_tap_release orelse 0;
+    remap_mod.applyTarget(target, .tap, aux, &self.injected_buttons, &local_pending, null);
+    if (local_pending != 0) self.pending_tap_release = local_pending;
 }
 
 fn precomputeRemap(allocator: std.mem.Allocator, remap_map: mapping.RemapMap) !ResolvedRemap {
@@ -994,17 +1112,6 @@ fn precomputeRemap(allocator: std.mem.Allocator, remap_map: mapping.RemapMap) !R
         result.inject[@intCast(src_idx)] = target;
     }
     return result;
-}
-
-fn emitTapEvent(
-    target: RemapTargetResolved,
-    aux: *AuxEventList,
-    injected_buttons: *u64,
-    pending_tap_release: *?u64,
-) void {
-    var local_pending: u64 = pending_tap_release.* orelse 0;
-    remap_mod.applyTarget(target, .tap, aux, injected_buttons, &local_pending, null);
-    if (local_pending != 0) pending_tap_release.* = local_pending;
 }
 
 fn buttonBit(name: []const u8) u64 {

--- a/src/test/mapper_e2e_test.zig
+++ b/src/test/mapper_e2e_test.zig
@@ -14,6 +14,7 @@ const state_mod = @import("../core/state.zig");
 
 const Mapper = mapper_mod.Mapper;
 const AuxEvent = mapper_mod.AuxEvent;
+const AuxEventList = mapper_mod.AuxEventList;
 const ButtonId = state_mod.ButtonId;
 const GamepadStateDelta = state_mod.GamepadStateDelta;
 
@@ -110,6 +111,49 @@ test "e2e: layer tap — quick release emits tap event" {
         .mouse_button => |code| try testing.expectEqual(BTN_LEFT, code),
         else => return error.WrongTapEventType,
     }
+}
+
+fn auxListMouseCount(list: *const AuxEventList, code: u16, pressed: bool) usize {
+    var count: usize = 0;
+    for (list.slice()) |e| {
+        switch (e) {
+            .mouse_button => |b| {
+                if (b.code == code and b.pressed == pressed) count += 1;
+            },
+            else => {},
+        }
+    }
+    return count;
+}
+
+fn auxMouseCount(ev: anytype, code: u16, pressed: bool) usize {
+    return auxListMouseCount(&ev.aux, code, pressed);
+}
+
+test "e2e: layer tap mouse delays aux release" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[[layer]]
+        \\name = "aim"
+        \\trigger = "LT"
+        \\activation = "hold"
+        \\tap = "mouse_left"
+        \\hold_timeout = 200
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const t0: i128 = 1_000_000_000;
+    const ev_press = try m.apply(.{ .buttons = btnMask(.LT) }, 16, t0);
+    try testing.expectEqual(@as(usize, 0), ev_press.aux.len);
+
+    const ev_release = try m.apply(.{ .buttons = 0 }, 16, t0 + 50 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 1), auxMouseCount(ev_release, BTN_LEFT, true));
+    try testing.expectEqual(@as(usize, 0), auxMouseCount(ev_release, BTN_LEFT, false));
+
+    const aux_release = m.onMacroTimerExpired(t0 + 90 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 1), auxListMouseCount(&aux_release, BTN_LEFT, false));
+    try testing.expectEqual(@as(usize, 0), auxListMouseCount(&aux_release, BTN_LEFT, true));
 }
 
 test "e2e: layer tap — no tap after timeout (ACTIVE release)" {
@@ -696,16 +740,39 @@ fn keyCode(name: []const u8) u16 {
 }
 
 fn auxHasKey(ev: anytype, code: u16, pressed: bool) bool {
-    for (ev.aux.slice()) |e| {
+    return auxListHasKey(&ev.aux, code, pressed);
+}
+
+fn auxListKeyCount(list: *const AuxEventList, code: u16, pressed: bool) usize {
+    var count: usize = 0;
+    for (list.slice()) |e| {
         switch (e) {
-            .key => |k| if (k.code == code and k.pressed == pressed) return true,
+            .key => |k| {
+                if (k.code == code and k.pressed == pressed) count += 1;
+            },
             else => {},
         }
     }
-    return false;
+    return count;
 }
 
-test "e2e gesture: tap-only key emits press+release on release (no double, zero latency)" {
+fn auxKeyCount(ev: anytype, code: u16, pressed: bool) usize {
+    return auxListKeyCount(&ev.aux, code, pressed);
+}
+
+fn auxListHasKey(list: *const AuxEventList, code: u16, pressed: bool) bool {
+    return auxListKeyCount(list, code, pressed) != 0;
+}
+
+fn auxHasAnyKey(ev: anytype, code: u16) bool {
+    return auxHasKey(ev, code, true) or auxHasKey(ev, code, false);
+}
+
+fn auxListHasAnyKey(list: *const AuxEventList, code: u16) bool {
+    return auxListHasKey(list, code, true) or auxListHasKey(list, code, false);
+}
+
+test "e2e gesture: tap-only key delays aux release" {
     const allocator = testing.allocator;
     var ctx = try makeMapper(
         \\[remap]
@@ -722,7 +789,41 @@ test "e2e gesture: tap-only key emits press+release on release (no double, zero 
 
     const ev_rel = try m.apply(.{ .buttons = 0 }, 16, t0 + 30 * std.time.ns_per_ms);
     try testing.expect(auxHasKey(ev_rel, keyCode("KEY_X"), true));
-    try testing.expect(auxHasKey(ev_rel, keyCode("KEY_X"), false));
+    try testing.expect(!auxHasKey(ev_rel, keyCode("KEY_X"), false));
+
+    const aux_release = m.onMacroTimerExpired(t0 + 70 * std.time.ns_per_ms);
+    try testing.expect(auxListHasKey(&aux_release, keyCode("KEY_X"), false));
+    try testing.expect(!auxListHasKey(&aux_release, keyCode("KEY_X"), true));
+}
+
+test "e2e gesture: repeated same key tap refreshes delayed aux release" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "KEY_J" }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const key_j = keyCode("KEY_J");
+    const t0: i128 = 1_000_000_000;
+
+    _ = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0);
+    const first_release = try m.apply(.{ .buttons = 0 }, 16, t0 + 10 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 1), auxKeyCount(first_release, key_j, true));
+    try testing.expectEqual(@as(usize, 0), auxKeyCount(first_release, key_j, false));
+
+    _ = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0 + 20 * std.time.ns_per_ms);
+    const second_release = try m.apply(.{ .buttons = 0 }, 16, t0 + 25 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 1), auxKeyCount(second_release, key_j, false));
+    try testing.expectEqual(@as(usize, 1), auxKeyCount(second_release, key_j, true));
+
+    const old_release_deadline = m.onMacroTimerExpired(t0 + 45 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 0), old_release_deadline.len);
+
+    const final_release = m.onMacroTimerExpired(t0 + 60 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 1), auxListKeyCount(&final_release, key_j, false));
+    try testing.expectEqual(@as(usize, 0), auxListKeyCount(&final_release, key_j, true));
 }
 
 test "e2e gesture: hold key fires at deadline and releases on button up" {
@@ -752,6 +853,37 @@ test "e2e gesture: hold key fires at deadline and releases on button up" {
     try testing.expect(auxHasKey(ev_rel, keyCode("KEY_Y"), false));
     // tap must NOT fire when hold consumed the gesture
     try testing.expect(!auxHasKey(ev_rel, keyCode("KEY_X"), true));
+}
+
+test "e2e gesture regression: tap+hold KEY_J release is delayed to timer tick" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "KEY_J", hold = "KEY_K", hold_ms = 300 }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const key_j = keyCode("KEY_J");
+    const key_k = keyCode("KEY_K");
+    const t0: i128 = 1_000_000_000;
+
+    const ev_press = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0);
+    try testing.expectEqual(@as(usize, 0), ev_press.aux.len);
+    try testing.expectEqual(@as(u64, 0), ev_press.gamepad.buttons & btnMask(.A));
+
+    const ev_release = try m.apply(.{ .buttons = 0 }, 16, t0 + 40 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 1), auxKeyCount(ev_release, key_j, true));
+    try testing.expectEqual(@as(usize, 0), auxKeyCount(ev_release, key_j, false));
+    try testing.expect(!auxHasAnyKey(ev_release, key_k));
+
+    const early_timer = m.onMacroTimerExpired(t0 + 60 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 0), early_timer.len);
+
+    const aux_release = m.onMacroTimerExpired(t0 + 80 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 1), auxListKeyCount(&aux_release, key_j, false));
+    try testing.expectEqual(@as(usize, 0), auxListKeyCount(&aux_release, key_j, true));
+    try testing.expect(!auxListHasAnyKey(&aux_release, key_k));
 }
 
 test "e2e gesture: releaseHeldAux releases held key before reset" {
@@ -789,7 +921,11 @@ test "e2e gesture: double fires on second press inside window" {
 
     const ev_p2 = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0 + 100 * std.time.ns_per_ms);
     try testing.expect(auxHasKey(ev_p2, keyCode("KEY_Z"), true));
-    try testing.expect(auxHasKey(ev_p2, keyCode("KEY_Z"), false));
+    try testing.expect(!auxHasKey(ev_p2, keyCode("KEY_Z"), false));
+
+    const aux_release = m.onMacroTimerExpired(t0 + 140 * std.time.ns_per_ms);
+    try testing.expect(auxListHasKey(&aux_release, keyCode("KEY_Z"), false));
+    try testing.expect(!auxListHasKey(&aux_release, keyCode("KEY_Z"), true));
 }
 
 test "e2e gesture: double-window timeout collapses to single tap" {
@@ -814,6 +950,41 @@ test "e2e gesture: double-window timeout collapses to single tap" {
         else => {},
     };
     try testing.expect(saw_tap_press);
+    try testing.expect(!auxListHasKey(&aux_exp, keyCode("KEY_X"), false));
+
+    const aux_release = m.onMacroTimerExpired(t0 + 340 * std.time.ns_per_ms);
+    try testing.expect(auxListHasKey(&aux_release, keyCode("KEY_X"), false));
+    try testing.expect(!auxListHasKey(&aux_release, keyCode("KEY_X"), true));
+}
+
+test "e2e gesture regression: tap+double KEY_J timeout release is delayed to timer tick" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "KEY_J", double = "KEY_K", double_ms = 250 }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const key_j = keyCode("KEY_J");
+    const key_k = keyCode("KEY_K");
+    const t0: i128 = 1_000_000_000;
+
+    _ = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0);
+    const ev_release = try m.apply(.{ .buttons = 0 }, 16, t0 + 40 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 0), auxKeyCount(ev_release, key_j, true));
+    try testing.expectEqual(@as(usize, 0), auxKeyCount(ev_release, key_j, false));
+    try testing.expect(!auxHasAnyKey(ev_release, key_k));
+
+    const aux_timeout = m.onMacroTimerExpired(t0 + 300 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 1), auxListKeyCount(&aux_timeout, key_j, true));
+    try testing.expectEqual(@as(usize, 0), auxListKeyCount(&aux_timeout, key_j, false));
+    try testing.expect(!auxListHasAnyKey(&aux_timeout, key_k));
+
+    const aux_release = m.onMacroTimerExpired(t0 + 340 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 1), auxListKeyCount(&aux_release, key_j, false));
+    try testing.expectEqual(@as(usize, 0), auxListKeyCount(&aux_release, key_j, true));
+    try testing.expect(!auxListHasAnyKey(&aux_release, key_k));
 }
 
 test "e2e gesture: timer-context gamepad tap stages full press one frame before release" {


### PR DESCRIPTION
## Summary
- Delay aux key/mouse tap releases through the mapper timer queue so tap outputs have a real down interval.
- Refresh same-target pending aux taps by canceling the old release before starting the new tap.
- Add regression coverage for tap+hold, tap+double timeout, repeated same-key taps, and layer tap mouse output.

Fixes #314

## Verification
- `git diff --check`
- `/home/jim_z/.local/bin/zig build --cache-dir /tmp/padctl-314-zig-cache --global-cache-dir /tmp/padctl-314-zig-global-cache test -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false --summary all`
- `PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test --summary all`
- `PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test-tsan --summary all`
- pre-push Docker `test-tsan`

## Review
- Subagent reviewer re-reviewed the updated diff and reported no blockers.
