### PR TITLE
Harden output lifecycle handling

### DIFF
--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -260,6 +260,34 @@ pub const Mapper = struct {
         self.seeded_buttons = seeded.buttons;
     }
 
+    pub fn resetRuntimeState(self: *Mapper) void {
+        self.layer.tap_hold = null;
+        self.layer.toggled.clearRetainingCapacity();
+        self.state = .{};
+        self.prev = .{};
+        self.gyro_proc.reset();
+        self.stick_left.reset();
+        self.stick_right.reset();
+        self.suppressed_buttons = 0;
+        self.injected_buttons = 0;
+        self.seeded_buttons = 0;
+        self.aux_down_targets = [_]?AuxDownTarget{null} ** BUTTON_COUNT;
+        self.gesture_aux_down_targets = [_]?AuxDownTarget{null} ** BUTTON_COUNT;
+        self.pending_tap_release = null;
+        self.aux_tap_release_tokens = .{};
+        self.macro_timer_tap_pending = 0;
+        self.gesture_engine.reset();
+        self.gesture_tokens.clear();
+        self.gesture_timer_tap_pending = 0;
+        self.gesture_held_gamepad = 0;
+        self.active_macros.clearRetainingCapacity();
+        self.timer_queue.clear();
+        self.next_token = 1;
+        if (self.chord_detector) |cd| {
+            self.chord_detector = ChordDetector.init(cd.cfg);
+        }
+    }
+
     fn applyTriggerThreshold(self: *const Mapper, gs: *GamepadState) void {
         if (self.config.trigger_threshold) |threshold| {
             const lt_bit = @as(u64, 1) << @intCast(@intFromEnum(ButtonId.LT));
@@ -1140,6 +1168,46 @@ fn makeMapping(toml_str: []const u8, allocator: std.mem.Allocator) !mapping.Pars
 fn makeMapper(cfg: *const MappingConfig, allocator: std.mem.Allocator) !Mapper {
     // Use -1 as a dummy fd for tests (timer operations are no-ops on invalid fd)
     return Mapper.init(cfg, std.posix.STDIN_FILENO, allocator);
+}
+
+test "mapper: resetRuntimeState clears transient layer timer and input state" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[[layer]]
+        \\name = "aim"
+        \\trigger = "LT"
+        \\activation = "hold_toggle"
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    try m.layer.toggled.put("aim", {});
+    _ = m.layer.onTriggerPressWithMode("aim", 200, 1_000, .hold_toggle);
+    m.state.buttons = buttonBit("A");
+    m.prev.buttons = buttonBit("A");
+    m.seeded_buttons = buttonBit("A");
+    m.pending_tap_release = buttonBit("B");
+    m.macro_timer_tap_pending = buttonBit("X");
+    m.gesture_timer_tap_pending = buttonBit("Y");
+    m.gesture_held_gamepad = buttonBit("RB");
+    m.aux_down_targets[@intFromEnum(ButtonId.A)] = .{ .key = 30 };
+    try m.timer_queue.arm(2_000, 99, 1_000);
+
+    m.resetRuntimeState();
+
+    try testing.expect(m.layer.tap_hold == null);
+    try testing.expectEqual(@as(usize, 0), m.layer.toggled.count());
+    try testing.expect(std.meta.eql(GamepadState{}, m.state));
+    try testing.expect(std.meta.eql(GamepadState{}, m.prev));
+    try testing.expectEqual(@as(u64, 0), m.seeded_buttons);
+    try testing.expectEqual(@as(?u64, null), m.pending_tap_release);
+    try testing.expectEqual(@as(u64, 0), m.macro_timer_tap_pending);
+    try testing.expectEqual(@as(u64, 0), m.gesture_timer_tap_pending);
+    try testing.expectEqual(@as(u64, 0), m.gesture_held_gamepad);
+    try testing.expect(m.aux_down_targets[@intFromEnum(ButtonId.A)] == null);
+    try testing.expectEqual(@as(usize, 0), m.timer_queue.heap.count());
 }
 
 test "mapper: no layer no remap: apply passes through unchanged" {

--- a/src/core/timer_queue.zig
+++ b/src/core/timer_queue.zig
@@ -26,6 +26,11 @@ pub const TimerQueue = struct {
         self.heap.deinit();
     }
 
+    pub fn clear(self: *TimerQueue) void {
+        self.heap.clearRetainingCapacity();
+        self.rearmFd(0);
+    }
+
     pub fn arm(self: *TimerQueue, deadline_ns: i128, token: u32, now_ns: i128) !void {
         try self.heap.add(.{ .absolute_ns = deadline_ns, .token = token });
         self.rearmFd(now_ns);
@@ -147,6 +152,18 @@ test "TimerQueue: cancel nonexistent token is a no-op" {
     try q.arm(1000, 5, 0);
     q.cancel(99, 0);
     try testing.expectEqual(@as(usize, 1), q.heap.count());
+}
+
+test "TimerQueue: clear removes all deadlines and disarms" {
+    const allocator = testing.allocator;
+    var q = TimerQueue.init(allocator, -1);
+    defer q.deinit();
+
+    try q.arm(1000, 5, 0);
+    try q.arm(2000, 6, 0);
+
+    q.clear();
+    try testing.expectEqual(@as(usize, 0), q.heap.count());
 }
 
 test "TimerQueue: arm + drain with real timerfd fires within deadline" {

--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -30,6 +30,7 @@ const mapping_mod = @import("config/mapping.zig");
 const MappingConfig = mapping_mod.MappingConfig;
 const init_seq = @import("init.zig");
 const GamepadState = @import("core/state.zig").GamepadState;
+const ButtonId = @import("core/state.zig").ButtonId;
 const FfEvent = uinput.FfEvent;
 
 var closed_device_sentinel: u8 = 0;
@@ -207,6 +208,11 @@ pub const DeviceInstance = struct {
     // Test-only: counts rebuildAuxIfChanged invocations so tests can verify
     // the switch path rebuilds aux caps without relying on /dev/uinput.
     rebuild_aux_calls: if (builtin.is_test) usize else void = if (builtin.is_test) 0 else {},
+
+    pub const QuiesceOptions = struct {
+        reset_input_state: bool = false,
+        reset_mapper_state: bool = false,
+    };
 
     /// Open all interfaces, run init handshake, create EventLoop/Interpreter/Output.
     ///
@@ -535,8 +541,8 @@ pub const DeviceInstance = struct {
                 const old_mcfg: ?*const MappingConfig = if (self.mapper) |*m| m.config else self.mapping_cfg;
                 if (Mapper.init(new, self.loop.macro_timer_fd, self.allocator)) |created| {
                     var new_mapper = created;
+                    self.quiesceOutputs(.{});
                     if (self.mapper) |*old| {
-                        self.releaseMapperAux(old);
                         old.deinit();
                     }
                     new_mapper.seedInputState(self.loop.gamepad_state);
@@ -625,6 +631,45 @@ pub const DeviceInstance = struct {
         self.aux_dev = try AuxDevice.create(key_codes, caps.needs_rel);
     }
 
+    pub fn quiesceOutputs(self: *DeviceInstance, options: QuiesceOptions) void {
+        self.loop.quiesceTimersAndRumble(self.devices, self.allocator, self.device_cfg, self.device_cfg.device.name);
+
+        if (self.mapper) |*m| {
+            self.releaseMapperAux(m);
+            if (options.reset_mapper_state) {
+                m.resetRuntimeState();
+            }
+        }
+
+        const neutral = GamepadState{};
+        if (self.primary_output) |output| {
+            output.emit(neutral) catch |err| {
+                std.log.warn("primary output quiesce failed: {}", .{err});
+            };
+        }
+        if (self.imu_output) |imu_output| {
+            imu_output.emit(neutral) catch |err| {
+                std.log.warn("imu output quiesce failed: {}", .{err});
+            };
+        }
+        if (self.touchpad_dev) |*tp| {
+            tp.touchpadOutputDevice().emitTouch(neutral) catch |err| {
+                std.log.warn("touchpad output quiesce failed: {}", .{err});
+            };
+        }
+        if (self.generic_state) |*gs| {
+            if (self.generic_uinput) |*gu| {
+                @memset(gs.values[0..gs.count], 0);
+                gu.genericOutputDevice().emitGeneric(gs) catch |err| {
+                    std.log.warn("generic output quiesce failed: {}", .{err});
+                };
+            }
+        }
+        if (options.reset_input_state) {
+            self.loop.gamepad_state = .{};
+        }
+    }
+
     /// Close physical device fds only, keeping uinput/aux/touchpad alive.
     /// Used when suspending an instance across device sleep/wake.
     pub fn closeDeviceIO(self: *DeviceInstance) void {
@@ -705,6 +750,7 @@ fn nullOutput() OutputDevice {
 
 const testing = std.testing;
 const MockDeviceIO = @import("test/mock_device_io.zig").MockDeviceIO;
+const MockOutput = @import("test/mock_output.zig").MockOutput;
 const mapping = @import("config/mapping.zig");
 const device_mod = @import("config/device.zig");
 
@@ -1161,6 +1207,67 @@ test "DeviceInstance: closeDeviceIO closes device fds without touching uinput" {
     try testing.expect(inst.owner == .none);
     try testing.expectEqual(@as(posix.fd_t, -1), inst.devices[0].pollfd().fd);
     try testing.expectError(DeviceIO.WriteError.Disconnected, inst.devices[0].write(&[_]u8{0x01}));
+}
+
+test "DeviceInstance: quiesceOutputs emits neutral primary frame and resets input state when requested" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, minimal_toml);
+    defer parsed.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    var out = MockOutput.init(allocator);
+    defer out.deinit();
+
+    var inst = try testInstance(allocator, &mock, &parsed.value);
+    defer {
+        inst.loop.deinit();
+        allocator.free(inst.devices);
+    }
+    inst.primary_output = out.outputDevice();
+    inst.loop.gamepad_state = .{
+        .ax = 123,
+        .buttons = @as(u64, 1) << @intFromEnum(ButtonId.A),
+    };
+    out.prev = inst.loop.gamepad_state;
+
+    inst.quiesceOutputs(.{ .reset_input_state = true });
+
+    try testing.expectEqual(@as(usize, 1), out.emitted.items.len);
+    try testing.expect(std.meta.eql(GamepadState{}, out.emitted.items[0]));
+    try testing.expect(std.meta.eql(GamepadState{}, inst.loop.gamepad_state));
+}
+
+test "DeviceInstance: quiesceOutputs can preserve input state for mapper reseed" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, minimal_toml);
+    defer parsed.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    var out = MockOutput.init(allocator);
+    defer out.deinit();
+
+    var inst = try testInstance(allocator, &mock, &parsed.value);
+    defer {
+        inst.loop.deinit();
+        allocator.free(inst.devices);
+    }
+    const held = GamepadState{
+        .rx = -50,
+        .buttons = @as(u64, 1) << @intFromEnum(ButtonId.RB),
+    };
+    inst.primary_output = out.outputDevice();
+    inst.loop.gamepad_state = held;
+    out.prev = held;
+
+    inst.quiesceOutputs(.{});
+
+    try testing.expectEqual(@as(usize, 1), out.emitted.items.len);
+    try testing.expect(std.meta.eql(GamepadState{}, out.emitted.items[0]));
+    try testing.expect(std.meta.eql(held, inst.loop.gamepad_state));
 }
 
 test "DeviceInstance: rebindDeviceIO replaces device fds" {

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -227,6 +227,27 @@ pub fn disarmTimer(fd: posix.fd_t) void {
     }
 }
 
+/// Best-effort lifecycle drain used after the worker thread has stopped.
+/// It clears pending timerfds and emits a zero rumble frame while physical
+/// device fds are still open, so later teardown/restart cannot inherit stale
+/// layer, macro, or force-feedback state.
+fn quiesceTimersAndRumbleImpl(
+    self: *EventLoop,
+    devices: []DeviceIO,
+    alloc: std.mem.Allocator,
+    dcfg: ?*const DeviceConfig,
+    tag: []const u8,
+) void {
+    disarmTimer(self.timer_fd);
+    disarmTimer(self.macro_timer_fd);
+    disarmTimer(self.rumble_stop_fd);
+    self.rumble_scheduler = .{};
+    self.last_rumble_ns = 0;
+    if (dcfg) |cfg| {
+        _ = emitRumbleFrame(devices, alloc, cfg, 0, 0, tag);
+    }
+}
+
 /// Fire a CHORD_SWITCH command at the daemon's own control socket.
 /// Best-effort, fire-and-forget — runs on the device thread, the supervisor
 /// performs the actual mapping switch on its own thread. Failure to connect
@@ -814,6 +835,16 @@ pub const EventLoop = struct {
         _ = posix.write(self.stop_w, &[_]u8{1}) catch {};
     }
 
+    pub fn quiesceTimersAndRumble(
+        self: *EventLoop,
+        devices: []DeviceIO,
+        alloc: std.mem.Allocator,
+        dcfg: ?*const DeviceConfig,
+        tag: []const u8,
+    ) void {
+        quiesceTimersAndRumbleImpl(self, devices, alloc, dcfg, tag);
+    }
+
     pub fn deinit(self: *EventLoop) void {
         posix.close(self.signal_fd);
         posix.close(self.stop_r);
@@ -999,6 +1030,28 @@ test "event_loop: armTimer / disarmTimer: arm then disarm does not leave fd read
     var pfd = [1]posix.pollfd{.{ .fd = loop.timer_fd, .events = posix.POLL.IN, .revents = 0 }};
     const ready = try posix.poll(&pfd, 0);
     try testing.expectEqual(@as(usize, 0), ready);
+}
+
+test "event_loop: quiesceTimersAndRumble disarms layer macro and rumble timers" {
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    armTimer(loop.timer_fd, 5000);
+    armTimer(loop.macro_timer_fd, 5000);
+    armRumbleStopFd(loop.rumble_stop_fd, monotonicNs() + 5 * std.time.ns_per_s);
+    loop.last_rumble_ns = monotonicNs();
+    _ = loop.rumble_scheduler.onPlay(0, 1000, loop.last_rumble_ns);
+
+    loop.quiesceTimersAndRumble(&.{}, testing.allocator, null, "test");
+
+    var pfds = [_]posix.pollfd{
+        .{ .fd = loop.timer_fd, .events = posix.POLL.IN, .revents = 0 },
+        .{ .fd = loop.macro_timer_fd, .events = posix.POLL.IN, .revents = 0 },
+        .{ .fd = loop.rumble_stop_fd, .events = posix.POLL.IN, .revents = 0 },
+    };
+    const ready = try posix.poll(&pfds, 0);
+    try testing.expectEqual(@as(usize, 0), ready);
+    try testing.expectEqual(@as(i128, 0), loop.last_rumble_ns);
 }
 
 test "event_loop: armTimer: fires after timeout" {

--- a/src/io/ffb_forwarder.zig
+++ b/src/io/ffb_forwarder.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const posix = std.posix;
 const OutputReport = @import("uhid.zig").OutputReport;
+const write_exact = @import("write_exact.zig");
 
 /// Writes UHID_OUTPUT bytes byte-faithfully to the physical wheel hidraw fd.
 ///
@@ -20,7 +21,7 @@ pub const FfbForwarder = struct {
     /// Errors are classified and logged; none escape to the caller.
     pub fn forward(self: *FfbForwarder, report: OutputReport) void {
         if (self.state == .disabled) return;
-        _ = posix.write(self.physical_fd, report.data) catch |err| switch (err) {
+        write_exact.writeExact(self.physical_fd, report.data) catch |err| switch (err) {
             error.WouldBlock => {
                 self.drops_eagain += 1;
                 std.log.debug("ffb forwarder: EAGAIN (drop #{d})", .{self.drops_eagain});
@@ -34,6 +35,11 @@ pub const FfbForwarder = struct {
             error.NoDevice => {
                 // Device unplugged; supervisor unbind handles cleanup.
                 std.log.warn("ffb forwarder: hidraw ENODEV, disabling", .{});
+                self.state = .disabled;
+                return;
+            },
+            error.ShortWrite => {
+                std.log.warn("ffb forwarder: hidraw short write, disabling", .{});
                 self.state = .disabled;
                 return;
             },

--- a/src/io/hidraw.zig
+++ b/src/io/hidraw.zig
@@ -3,6 +3,7 @@ const linux = std.os.linux;
 const posix = std.posix;
 const io = @import("device_io.zig");
 const ioctl = @import("ioctl_constants.zig");
+const write_exact = @import("write_exact.zig");
 
 pub const DeviceIO = io.DeviceIO;
 
@@ -221,7 +222,7 @@ pub const HidrawDevice = struct {
 
     fn write(ptr: *anyopaque, data: []const u8) DeviceIO.WriteError!void {
         const self: *HidrawDevice = @ptrCast(@alignCast(ptr));
-        _ = posix.write(self.fd, data) catch |err| switch (err) {
+        write_exact.writeExact(self.fd, data) catch |err| switch (err) {
             error.BrokenPipe, error.ConnectionResetByPeer => return DeviceIO.WriteError.Disconnected,
             else => return DeviceIO.WriteError.Io,
         };

--- a/src/io/uhid.zig
+++ b/src/io/uhid.zig
@@ -21,6 +21,7 @@ const state = @import("../core/state.zig");
 const uinput = @import("uinput.zig");
 const device_cfg = @import("../config/device.zig");
 const descriptor = @import("uhid_descriptor.zig");
+const write_exact = @import("write_exact.zig");
 
 // --- Kernel protocol constants ---------------------------------------------
 
@@ -119,7 +120,7 @@ pub fn uhidCreate(
     var buf: [UHID_EVENT_SIZE]u8 = std.mem.zeroes([UHID_EVENT_SIZE]u8);
     const copy_len = @min(bytes.len, UHID_EVENT_SIZE);
     @memcpy(buf[0..copy_len], bytes[0..copy_len]);
-    _ = try posix.write(fd, &buf);
+    try write_exact.writeExact(fd, &buf);
 }
 
 /// Send a `UHID_INPUT2` event carrying an input report payload. Rejects
@@ -139,7 +140,7 @@ pub fn uhidInput(fd: posix.fd_t, data: []const u8) !void {
     var buf: [UHID_EVENT_SIZE]u8 = std.mem.zeroes([UHID_EVENT_SIZE]u8);
     const copy_len = @min(bytes.len, UHID_EVENT_SIZE);
     @memcpy(buf[0..copy_len], bytes[0..copy_len]);
-    _ = try posix.write(fd, &buf);
+    try write_exact.writeExact(fd, &buf);
 }
 
 /// Send a `UHID_DESTROY` event on the given fd. Best-effort (errors
@@ -147,7 +148,7 @@ pub fn uhidInput(fd: posix.fd_t, data: []const u8) !void {
 pub fn uhidDestroy(fd: posix.fd_t) void {
     var buf: [UHID_EVENT_SIZE]u8 = std.mem.zeroes([UHID_EVENT_SIZE]u8);
     std.mem.writeInt(u32, buf[0..4], UHID_DESTROY, .little);
-    _ = posix.write(fd, &buf) catch {};
+    write_exact.writeExact(fd, &buf) catch {};
 }
 
 // --- UHID_OUTPUT types -------------------------------------------------------
@@ -349,7 +350,7 @@ pub const UhidDevice = struct {
         var buf: [UHID_EVENT_SIZE]u8 = std.mem.zeroes([UHID_EVENT_SIZE]u8);
         const copy_len = @min(bytes.len, UHID_EVENT_SIZE);
         @memcpy(buf[0..copy_len], bytes[0..copy_len]);
-        _ = posix.write(fd, &buf) catch return error.UhidCreateFailed;
+        write_exact.writeExact(fd, &buf) catch return error.UhidCreateFailed;
     }
 
     /// Expose this device through the shared `OutputDevice` vtable.

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -11,6 +11,7 @@ const c = @cImport({
 });
 
 const ioctl_constants = @import("ioctl_constants.zig");
+const write_exact = @import("write_exact.zig");
 const UI_SET_EVBIT = ioctl_constants.UI_SET_EVBIT;
 const UI_SET_KEYBIT = ioctl_constants.UI_SET_KEYBIT;
 const UI_SET_RELBIT = ioctl_constants.UI_SET_RELBIT;
@@ -365,7 +366,7 @@ pub const UinputDevice = struct {
         if (n > 0) {
             events[n] = .{ .type = c.EV_SYN, .code = c.SYN_REPORT, .value = 0, .time = std.mem.zeroes(c.timeval) };
             n += 1;
-            _ = try std.posix.write(self.fd, std.mem.sliceAsBytes(events[0..n]));
+            try write_exact.writeExact(self.fd, std.mem.sliceAsBytes(events[0..n]));
         }
 
         self.prev = s;
@@ -569,7 +570,7 @@ pub const AuxDevice = struct {
         if (n > 0) {
             buf[n] = .{ .type = c.EV_SYN, .code = c.SYN_REPORT, .value = 0, .time = std.mem.zeroes(c.timeval) };
             n += 1;
-            _ = try std.posix.write(self.fd, std.mem.sliceAsBytes(buf[0..n]));
+            try write_exact.writeExact(self.fd, std.mem.sliceAsBytes(buf[0..n]));
         }
     }
 
@@ -723,7 +724,7 @@ pub const TouchpadDevice = struct {
         if (n > 0) {
             events[n] = .{ .type = c.EV_SYN, .code = c.SYN_REPORT, .value = 0, .time = std.mem.zeroes(c.timeval) };
             n += 1;
-            _ = try std.posix.write(self.fd, std.mem.sliceAsBytes(events[0..n]));
+            try write_exact.writeExact(self.fd, std.mem.sliceAsBytes(events[0..n]));
         }
     }
 
@@ -840,7 +841,7 @@ pub const GenericUinputDevice = struct {
         if (n > 0) {
             events[n] = .{ .type = c.EV_SYN, .code = c.SYN_REPORT, .value = 0, .time = std.mem.zeroes(c.timeval) };
             n += 1;
-            _ = try std.posix.write(self.fd, std.mem.sliceAsBytes(events[0..n]));
+            try write_exact.writeExact(self.fd, std.mem.sliceAsBytes(events[0..n]));
         }
         gs.prev_values = gs.values;
     }

--- a/src/io/write_exact.zig
+++ b/src/io/write_exact.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const posix = std.posix;
+
+pub const WriteExactError = posix.WriteError || error{ShortWrite};
+
+pub fn writeExact(fd: posix.fd_t, bytes: []const u8) WriteExactError!void {
+    const n = try posix.write(fd, bytes);
+    if (n != bytes.len) return error.ShortWrite;
+}
+
+pub fn writeExactWith(
+    ctx: anytype,
+    comptime writeFn: fn (@TypeOf(ctx), []const u8) WriteExactError!usize,
+    bytes: []const u8,
+) WriteExactError!void {
+    const n = try writeFn(ctx, bytes);
+    if (n != bytes.len) return error.ShortWrite;
+}
+
+const testing = std.testing;
+
+const TestWriter = struct {
+    result: union(enum) {
+        bytes: usize,
+        err: WriteExactError,
+    },
+
+    fn write(self: *TestWriter, bytes: []const u8) WriteExactError!usize {
+        return switch (self.result) {
+            .bytes => |n| @min(n, bytes.len),
+            .err => |err| err,
+        };
+    }
+};
+
+test "writeExactWith succeeds on full write" {
+    var writer = TestWriter{ .result = .{ .bytes = 3 } };
+    try writeExactWith(&writer, TestWriter.write, "abc");
+}
+
+test "writeExactWith rejects short write" {
+    var writer = TestWriter{ .result = .{ .bytes = 2 } };
+    try testing.expectError(error.ShortWrite, writeExactWith(&writer, TestWriter.write, "abc"));
+}
+
+test "writeExactWith rejects zero write" {
+    var writer = TestWriter{ .result = .{ .bytes = 0 } };
+    try testing.expectError(error.ShortWrite, writeExactWith(&writer, TestWriter.write, "abc"));
+}
+
+test "writeExactWith propagates write errors" {
+    var writer = TestWriter{ .result = .{ .err = error.WouldBlock } };
+    try testing.expectError(error.WouldBlock, writeExactWith(&writer, TestWriter.write, "abc"));
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -75,6 +75,7 @@ pub const io = struct {
     pub const uhid_descriptor = @import("io/uhid_descriptor.zig");
     pub const uniq = @import("io/uniq.zig");
     pub const ioctl_constants = @import("io/ioctl_constants.zig");
+    pub const write_exact = @import("io/write_exact.zig");
     pub const netlink = @import("io/netlink.zig");
     pub const ffb_forwarder = @import("io/ffb_forwarder.zig");
 };

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -69,6 +69,8 @@ const SwitchTx = struct {
     committed: bool = false,
 };
 
+threadlocal var test_fail_next_restart_managed: bool = false;
+
 fn parseChordSwitchConfig(maybe_cfg: ?user_config_mod.ChordSwitchConfig) ?chord_detector_mod.Config {
     return chord_detector_mod.fromUserConfig(maybe_cfg);
 }
@@ -450,6 +452,7 @@ pub const Supervisor = struct {
             std.log.info("device suspended: \"{s}\" {s} (grace {d}s)", .{ m.instance.device_cfg.device.name, devname, self.suspend_grace_sec });
             m.instance.stop();
             m.thread.join();
+            m.instance.quiesceOutputs(.{ .reset_input_state = true, .reset_mapper_state = true });
             m.instance.closeDeviceIO();
             m.suspended = true;
             // Schedule grace deadline. Saturating add keeps us safe against
@@ -570,6 +573,7 @@ pub const Supervisor = struct {
             if (std.mem.eql(u8, m.phys_key, phys_key)) {
                 m.instance.stop();
                 m.thread.join();
+                m.instance.quiesceOutputs(.{ .reset_input_state = true, .reset_mapper_state = true });
                 self.teardownManaged(m);
                 _ = self.managed.swapRemove(i);
                 return;
@@ -648,10 +652,18 @@ pub const Supervisor = struct {
     }
 
     fn restartManagedThread(m: *ManagedInstance) !void {
+        if (builtin.is_test and test_fail_next_restart_managed) {
+            test_fail_next_restart_managed = false;
+            return error.TestInjectedRestartFailure;
+        }
         @atomicStore(bool, &m.instance.stopped, false, .release);
         @atomicStore(bool, &m.instance.loop.running, true, .release);
         @atomicStore(bool, &m.instance.loop.disconnected, false, .release);
-        m.thread = try std.Thread.spawn(.{}, threadEntry, .{m.instance});
+        m.thread = std.Thread.spawn(.{}, threadEntry, .{m.instance}) catch |err| {
+            @atomicStore(bool, &m.instance.stopped, true, .release);
+            @atomicStore(bool, &m.instance.loop.running, false, .release);
+            return err;
+        };
     }
 
     fn rerunInitAfterRebind(m: *ManagedInstance) !void {
@@ -725,8 +737,8 @@ pub const Supervisor = struct {
             found = true;
             m.instance.stop();
             m.thread.join();
+            m.instance.quiesceOutputs(.{});
             if (m.instance.mapper) |*cur| {
-                m.instance.releaseMapperAux(cur);
                 cur.deinit();
                 m.instance.mapper = null;
             }
@@ -774,6 +786,10 @@ pub const Supervisor = struct {
 
         m.instance.mapper = tx.old_mapper;
         m.instance.mapping_cfg = tx.old_mapping_cfg;
+        if (m.instance.mapper) |*old| {
+            old.resetRuntimeState();
+            old.seedInputState(m.instance.loop.gamepad_state);
+        }
         m.switch_mapping = tx.old_switch_mapping;
         m.switch_mapping_stem = tx.old_switch_mapping_stem;
         restartManagedThread(m) catch |err| {
@@ -796,6 +812,7 @@ pub const Supervisor = struct {
             const m = &self.managed.items[tx.idx];
             m.instance.stop();
             m.thread.join();
+            m.instance.quiesceOutputs(.{});
             self.restoreSwitchTarget(tx, m, true);
         }
     }
@@ -835,10 +852,8 @@ pub const Supervisor = struct {
             return error.SwitchFailed;
         }
 
+        m.instance.quiesceOutputs(.{});
         if (tx.new_mapper) |*new_mapper| {
-            if (tx.old_mapper) |*old_mapper| {
-                m.instance.releaseMapperAux(old_mapper);
-            }
             new_mapper.seedInputState(m.instance.loop.gamepad_state);
         }
         m.instance.mapper = tx.new_mapper.?;
@@ -861,6 +876,10 @@ pub const Supervisor = struct {
             }
             m.instance.mapper = tx.old_mapper;
             m.instance.mapping_cfg = tx.old_mapping_cfg;
+            if (m.instance.mapper) |*old| {
+                old.resetRuntimeState();
+                old.seedInputState(m.instance.loop.gamepad_state);
+            }
             m.switch_mapping = tx.old_switch_mapping;
             m.switch_mapping_stem = tx.old_switch_mapping_stem;
             restartManagedThread(m) catch |rollback_err| {
@@ -948,6 +967,9 @@ pub const Supervisor = struct {
         for (self.managed.items) |*m| {
             if (!m.suspended) m.thread.join();
         }
+        for (self.managed.items) |*m| {
+            if (!m.suspended) m.instance.quiesceOutputs(.{ .reset_input_state = true, .reset_mapper_state = true });
+        }
         for (self.managed.items) |*m| self.teardownManaged(m);
         self.managed.clearRetainingCapacity();
     }
@@ -976,6 +998,7 @@ pub const Supervisor = struct {
             if (!m.suspended) {
                 m.instance.stop();
                 m.thread.join();
+                m.instance.quiesceOutputs(.{ .reset_input_state = true, .reset_mapper_state = true });
             }
             self.teardownManaged(m);
             _ = self.managed.swapRemove(idx);
@@ -996,37 +1019,60 @@ pub const Supervisor = struct {
             } else if (nc.mapping_cfg) |new_map| {
                 const m = found.?;
                 if (m.suspended) continue;
+
+                var new_mapping_arena = std.heap.ArenaAllocator.init(self.allocator);
+                errdefer new_mapping_arena.deinit();
+                const new_arena_alloc = new_mapping_arena.allocator();
+                const map_copy = try new_arena_alloc.create(MappingConfig);
+                map_copy.* = new_map.*;
+
+                // Build the new mapper before touching the old arena so a
+                // failed reload leaves the running mapping intact.
+                var new_mapper = try Mapper.init(map_copy, m.instance.loop.macro_timer_fd, self.allocator);
+                var new_mapper_installed = false;
+                errdefer if (!new_mapper_installed) new_mapper.deinit();
+
                 // Stop-Swap-Restart: stop thread before touching arena
                 m.instance.stop();
                 m.thread.join();
+                m.instance.quiesceOutputs(.{});
 
                 var old_mapper = m.instance.mapper;
                 const old_mapping_cfg = m.instance.mapping_cfg;
-                if (old_mapper) |*mapper| {
-                    m.instance.releaseMapperAux(mapper);
-                }
-                self.clearSwitchMapping(m);
-                _ = m.mapping_arena.reset(.retain_capacity);
-                const arena_alloc = m.mapping_arena.allocator();
-                const map_copy = try arena_alloc.create(MappingConfig);
-                map_copy.* = new_map.*;
+                var old_mapping_arena = m.mapping_arena;
 
                 // Rebuild the mapper so layer state/timers do not keep slices into
-                // the old mapping arena after the reset above.
-                var new_mapper = try Mapper.init(map_copy, m.instance.loop.macro_timer_fd, self.allocator);
+                // the old mapping arena after the swap below.
                 new_mapper.seedInputState(m.instance.loop.gamepad_state);
                 m.instance.mapper = new_mapper;
+                new_mapper_installed = true;
                 m.instance.mapping_cfg = map_copy;
                 self.installChordDetector(m);
                 m.instance.rebuildAuxIfChanged(map_copy, old_mapping_cfg) catch |err| {
                     std.log.warn("rebuildAuxIfChanged: {}", .{err});
                 };
                 restartManagedThread(m) catch |err| {
+                    if (old_mapping_cfg) |old_cfg| {
+                        m.instance.rebuildAuxIfChanged(old_cfg, map_copy) catch |rollback_aux_err| {
+                            std.log.warn("rebuildAuxIfChanged rollback: {}", .{rollback_aux_err});
+                        };
+                    }
+                    if (old_mapper) |*mapper| {
+                        mapper.resetRuntimeState();
+                        mapper.seedInputState(m.instance.loop.gamepad_state);
+                    }
                     m.instance.mapper = old_mapper;
                     m.instance.mapping_cfg = old_mapping_cfg;
                     new_mapper.deinit();
+                    restartManagedThread(m) catch |rollback_err| {
+                        std.log.err("reload rollback restart failed for {s}: {}", .{ m.phys_key, rollback_err });
+                    };
                     return err;
                 };
+
+                m.mapping_arena = new_mapping_arena;
+                old_mapping_arena.deinit();
+                self.clearSwitchMapping(m);
 
                 if (old_mapper) |*mapper| {
                     mapper.deinit();
@@ -1036,8 +1082,8 @@ pub const Supervisor = struct {
                 if (m.suspended) continue;
                 m.instance.stop();
                 m.thread.join();
+                m.instance.quiesceOutputs(.{});
                 if (m.instance.mapper) |*mapper| {
-                    m.instance.releaseMapperAux(mapper);
                     mapper.deinit();
                     m.instance.mapper = null;
                 }
@@ -2114,6 +2160,7 @@ const mapper_mod = @import("core/mapper.zig");
 const device_mod = @import("config/device.zig");
 const EventLoop = @import("event_loop.zig").EventLoop;
 const MockDeviceIO = @import("test/mock_device_io.zig").MockDeviceIO;
+const MockOutput = @import("test/mock_output.zig").MockOutput;
 const uinput = @import("io/uinput.zig");
 const state_mod = @import("core/state.zig");
 
@@ -2447,11 +2494,66 @@ test "supervisor: hotplug duplicate precheck catches active devname and live phy
     try testing.expect(!sup.hasLiveDuplicate("hidraw1", "phys1", &parsed_dev.value));
 }
 
+test "supervisor: detach quiesces primary output before suspension" {
+    const allocator = testing.allocator;
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+    const parsed_map = try mapping_mod.parseString(allocator,
+        \\[[layer]]
+        \\name = "held"
+        \\trigger = "LT"
+        \\activation = "hold"
+    );
+    defer parsed_map.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    var out = MockOutput.init(allocator);
+    defer out.deinit();
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+
+    const inst = try makeTestInstance(allocator, &mock, &parsed_dev.value);
+    const held = state_mod.GamepadState{
+        .ax = 77,
+        .buttons = @as(u64, 1) << @intFromEnum(state_mod.ButtonId.A),
+    };
+    inst.primary_output = out.outputDevice();
+    inst.loop.gamepad_state = held;
+    out.prev = held;
+    inst.mapper = try mapper_mod.Mapper.init(&parsed_map.value, inst.loop.macro_timer_fd, allocator);
+    inst.mapping_cfg = &parsed_map.value;
+    _ = inst.mapper.?.layer.onTriggerPress("held", 200, 1_000);
+    inst.mapper.?.state.buttons = @as(u64, 1) << @intFromEnum(state_mod.ButtonId.LT);
+
+    try testing.expect(try sup.attachWithInstanceResult("hidraw0", "phys0", inst, null));
+    sup.detach("hidraw0");
+
+    try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
+    try testing.expect(sup.managed.items[0].suspended);
+    try testing.expectEqual(@as(usize, 1), out.emitted.items.len);
+    try testing.expect(std.meta.eql(state_mod.GamepadState{}, out.emitted.items[0]));
+    try testing.expect(std.meta.eql(state_mod.GamepadState{}, inst.loop.gamepad_state));
+    try testing.expect(inst.mapper.?.layer.tap_hold == null);
+    try testing.expect(std.meta.eql(state_mod.GamepadState{}, inst.mapper.?.state));
+}
+
 test "supervisor: Supervisor: global SWITCH rolls back all devices on failure" {
     const allocator = testing.allocator;
 
     const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
     defer parsed_dev.deinit();
+    const old_parsed = try mapping_mod.parseString(allocator,
+        \\[[layer]]
+        \\name = "old"
+        \\trigger = "LT"
+        \\activation = "toggle"
+    );
+    defer old_parsed.deinit();
 
     const base_dir = "/tmp/padctl_supervisor_test_switch";
     std.fs.deleteTreeAbsolute(base_dir) catch {};
@@ -2493,6 +2595,11 @@ test "supervisor: Supervisor: global SWITCH rolls back all devices on failure" {
     defer mock_b.deinit();
 
     const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
+    inst_a.mapper = try mapper_mod.Mapper.init(&old_parsed.value, inst_a.loop.macro_timer_fd, allocator);
+    inst_a.mapping_cfg = &old_parsed.value;
+    try inst_a.mapper.?.layer.toggled.put("old", {});
+    inst_a.mapper.?.state.buttons = @as(u64, 1) << @intFromEnum(state_mod.ButtonId.A);
+    inst_a.loop.gamepad_state.buttons = @as(u64, 1) << @intFromEnum(state_mod.ButtonId.RB);
     const inst_b = try makeTestInstance(allocator, &mock_b, &parsed_dev.value);
     try sup.spawnInstance("usb-1-1", inst_a, null);
     try sup.spawnInstance("usb-1-2", inst_b, null);
@@ -2506,10 +2613,12 @@ test "supervisor: Supervisor: global SWITCH rolls back all devices on failure" {
     const n = try posix.read(resp_fds[1], &resp_buf);
     try testing.expectEqualStrings("ERR switch-failed\n", resp_buf[0..n]);
     try testing.expectEqual(@as(usize, 2), sup.managed.items.len);
-    try testing.expect(sup.managed.items[0].instance.mapper == null);
+    try testing.expect(sup.managed.items[0].instance.mapper != null);
     try testing.expect(sup.managed.items[1].instance.mapper == null);
-    try testing.expect(sup.managed.items[0].instance.mapping_cfg == null);
+    try testing.expectEqual(@as(?*const mapping_mod.MappingConfig, &old_parsed.value), sup.managed.items[0].instance.mapping_cfg);
     try testing.expect(sup.managed.items[1].instance.mapping_cfg == null);
+    try testing.expectEqual(@as(usize, 0), sup.managed.items[0].instance.mapper.?.layer.toggled.count());
+    try testing.expectEqual(@as(u64, @as(u64, 1) << @intFromEnum(state_mod.ButtonId.RB)), sup.managed.items[0].instance.mapper.?.state.buttons);
     try testing.expect(sup.managed.items[0].switch_mapping == null);
     try testing.expect(sup.managed.items[1].switch_mapping == null);
     try testing.expectEqual(false, @atomicLoad(bool, &sup.managed.items[0].instance.stopped, .acquire));
@@ -2763,6 +2872,57 @@ test "supervisor: Supervisor: two rapid reloads serialize — no race condition"
     try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
     try testing.expect(sup.managed.items[0].instance.mapper != null);
     try testing.expectEqual(@as(u32, 1), sup.managed.items[0].instance.mapper.?.next_token);
+}
+
+test "supervisor: reload restart failure preserves switch mapping and restarts old mapper" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+    const new_parsed = try mapping_mod.parseString(allocator, "name = \"new\"");
+    defer new_parsed.deinit();
+
+    const switch_pr = try allocator.create(mapping_mod.ParseResult);
+    switch_pr.* = try mapping_mod.parseString(allocator,
+        \\name = "switch"
+        \\[[layer]]
+        \\name = "old"
+        \\trigger = "LT"
+        \\activation = "toggle"
+    );
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    var sup = try Supervisor.initForTest(allocator);
+
+    const inst = try makeTestInstance(allocator, &mock, &parsed_dev.value);
+    inst.mapper = try mapper_mod.Mapper.init(&switch_pr.value, inst.loop.macro_timer_fd, allocator);
+    inst.mapping_cfg = &switch_pr.value;
+    inst.loop.gamepad_state.buttons = @as(u64, 1) << @intFromEnum(state_mod.ButtonId.RB);
+    try inst.mapper.?.layer.toggled.put("old", {});
+    try sup.spawnInstance("usb-1-1", inst, null);
+    sup.managed.items[0].switch_mapping = switch_pr;
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+
+    var new_map = new_parsed.value;
+    const entry = ConfigEntry{
+        .phys_key = "usb-1-1",
+        .device_cfg = &parsed_dev.value,
+        .mapping_cfg = &new_map,
+    };
+    test_fail_next_restart_managed = true;
+    try testing.expectError(error.TestInjectedRestartFailure, sup.reload(&.{entry}, testInitFn));
+
+    const managed = &sup.managed.items[0];
+    try testing.expect(managed.switch_mapping == switch_pr);
+    try testing.expectEqual(@as(?*const mapping_mod.MappingConfig, &switch_pr.value), managed.instance.mapping_cfg);
+    try testing.expect(managed.instance.mapper != null);
+    try testing.expectEqual(@as(usize, 0), managed.instance.mapper.?.layer.toggled.count());
+    try testing.expectEqual(@as(u64, @as(u64, 1) << @intFromEnum(state_mod.ButtonId.RB)), managed.instance.mapper.?.state.buttons);
+    try testing.expectEqual(false, @atomicLoad(bool, &managed.instance.stopped, .acquire));
 }
 
 test "supervisor: Supervisor: reload null mapping clears existing mapper" {

--- a/src/test/harness/uhid_simulator.zig
+++ b/src/test/harness/uhid_simulator.zig
@@ -31,12 +31,14 @@ const posix = std.posix;
 // module-import edge.
 const uhid = @import("../../io/uhid.zig");
 const ioctl_constants = @import("../../io/ioctl_constants.zig");
+const write_exact = @import("../../io/write_exact.zig");
 const cleanup = @import("../uhid_test_cleanup.zig");
 
 pub const SimulatorError = error{
     SkipZigTest,
     HidrawNotFound,
     KernelBusy,
+    ShortWrite,
 } || posix.OpenError || posix.WriteError || posix.ReadError || posix.PollError;
 
 pub const CreateOptions = struct {
@@ -87,7 +89,10 @@ pub const UhidSimulator = struct {
             else => |e| return e,
         };
         cleanup.registerUhidFd(fd);
-        errdefer posix.close(fd);
+        errdefer {
+            cleanup.unregisterUhidFd(fd);
+            posix.close(fd);
+        }
 
         sendCreate(fd, opts) catch |err| switch (err) {
             error.SkipZigTest => return error.SkipZigTest,
@@ -179,7 +184,7 @@ pub const UhidSimulator = struct {
         var buf: [uhid.UHID_EVENT_SIZE]u8 = std.mem.zeroes([uhid.UHID_EVENT_SIZE]u8);
         const copy_len = @min(bytes.len, uhid.UHID_EVENT_SIZE);
         @memcpy(buf[0..copy_len], bytes[0..copy_len]);
-        _ = try posix.write(fd, &buf);
+        try write_exact.writeExact(fd, &buf);
     }
 };
 


### PR DESCRIPTION
## Summary

- add exact-write handling for UHID, uinput, hidraw, and PID FFB forwarding paths
- quiesce virtual outputs, aux state, timers, rumble, and mapper runtime state during suspend/teardown/reload/switch lifecycles
- make reload mapping swaps transactional with a temporary mapping arena and explicit rollback restart coverage

## Verification

- `/home/jim_z/.local/bin/zig build --cache-dir /tmp/padctl-output-lifecycle-zig-cache --global-cache-dir /tmp/padctl-output-lifecycle-zig-global-cache test -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false --summary all`
- `PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test --summary all`
- `PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test-tsan --summary all`
- pre-push Docker `test-tsan`

## Review

- independent subagent review completed; blocker/high findings were fixed before opening


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced device state cleanup during attachment, detachment, and hot-swap operations
  * Improved reliability of writes to device drivers by ensuring full write completion
  * Better handling and recovery of failed device mapping reload operations with proper state rollback

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->