### PR TITLE
chore(release): bump 0.1.10

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.9",
+    .version = "0.1.10",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
## Summary

- bump `build.zig.zon` from `0.1.9` to `0.1.10`
- prepare `main` for the next annotated release tag, `v0.1.10`

## Verification

- `/home/jim_z/.local/bin/zig build --cache-dir /tmp/padctl-release-0.1.10-zig-cache --global-cache-dir /tmp/padctl-release-0.1.10-zig-global-cache test -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false --summary all`
- `/home/jim_z/.local/bin/zig build --cache-dir /tmp/padctl-release-0.1.10-zig-cache --global-cache-dir /tmp/padctl-release-0.1.10-zig-global-cache -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-musl -Dlibusb=false --summary all`
- `./zig-out/bin/padctl --version`
- pre-push Docker `test-tsan`
