### PR TITLE
Fix event loop fd slot invariants

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,3 +114,4 @@ zig build check-all
 | `-Dlibusb=false` | `true` | Disable libusb-1.0 linkage (hidraw-only path) |
 | `-Dwasm=false` | `true` | Disable WASM plugin runtime |
 | `-Dtest-coverage=true` | `false` | Run tests with kcov coverage |
+| `-Dtest-filter=<text>` | unset | Run only Zig tests whose names contain `<text>` across test targets |

--- a/build.zig
+++ b/build.zig
@@ -110,20 +110,10 @@ pub fn build(b: *std.Build) void {
 
     // test: Layer 0 + Layer 1 (CI); refAllDecls in main.zig pulls in debug/render.zig tests
     // test_root.zig sits at repo root so @embedFile("../../...") paths in src/ stay within package.
-    const unit_mod = b.createModule(.{
-        .root_source_file = b.path("test_root.zig"),
-        .target = target,
-        .optimize = optimize,
-        .sanitize_c = .trap,
-    });
-    unit_mod.addImport("toml", toml_mod);
-    unit_mod.addImport("analyse", capture_analyse_mod);
-    unit_mod.addImport("toml_gen", capture_toml_gen_mod);
-    unit_mod.addImport("capture_resolve", capture_resolve_mod);
-    unit_mod.addImport("build_options", build_opts.createModule());
+    const unit_mod = createTestRootModule(b, target, optimize, false, toml_mod, capture_analyse_mod, capture_toml_gen_mod, capture_resolve_mod, build_opts);
     if (use_wasm) addWasm3(b, unit_mod, wasm3_c_flags);
-    const unit_filters: []const []const u8 = if (test_filter) |f| &.{f} else &.{};
-    const unit_tests = b.addTest(.{ .root_module = unit_mod, .filters = unit_filters });
+    const test_filters: []const []const u8 = if (test_filter) |f| &.{f} else &.{};
+    const unit_tests = b.addTest(.{ .root_module = unit_mod, .filters = test_filters });
     if (use_libusb) {
         unit_tests.linkSystemLibrary("usb-1.0");
     } else {
@@ -135,20 +125,9 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(unit_tests).step);
 
     // test-tsan: ThreadSanitizer-enabled test run (local dev)
-    const tsan_mod = b.createModule(.{
-        .root_source_file = b.path("test_root.zig"),
-        .target = target,
-        .optimize = optimize,
-        .sanitize_c = .trap,
-        .sanitize_thread = true,
-    });
-    tsan_mod.addImport("toml", toml_mod);
-    tsan_mod.addImport("analyse", capture_analyse_mod);
-    tsan_mod.addImport("toml_gen", capture_toml_gen_mod);
-    tsan_mod.addImport("capture_resolve", capture_resolve_mod);
-    tsan_mod.addImport("build_options", build_opts.createModule());
+    const tsan_mod = createTestRootModule(b, target, optimize, true, toml_mod, capture_analyse_mod, capture_toml_gen_mod, capture_resolve_mod, build_opts);
     if (use_wasm) addWasm3(b, tsan_mod, wasm3_c_flags);
-    const tsan_tests = b.addTest(.{ .root_module = tsan_mod });
+    const tsan_tests = b.addTest(.{ .root_module = tsan_mod, .filters = test_filters });
     if (use_libusb) {
         tsan_tests.linkSystemLibrary("usb-1.0");
     } else {
@@ -159,19 +138,9 @@ pub fn build(b: *std.Build) void {
     tsan_step.dependOn(&b.addRunArtifact(tsan_tests).step);
 
     // test-safe: ReleaseSafe test run (catches UB under optimization)
-    const safe_mod = b.createModule(.{
-        .root_source_file = b.path("test_root.zig"),
-        .target = target,
-        .optimize = .ReleaseSafe,
-        .sanitize_c = .trap,
-    });
-    safe_mod.addImport("toml", toml_mod);
-    safe_mod.addImport("analyse", capture_analyse_mod);
-    safe_mod.addImport("toml_gen", capture_toml_gen_mod);
-    safe_mod.addImport("capture_resolve", capture_resolve_mod);
-    safe_mod.addImport("build_options", build_opts.createModule());
+    const safe_mod = createTestRootModule(b, target, .ReleaseSafe, false, toml_mod, capture_analyse_mod, capture_toml_gen_mod, capture_resolve_mod, build_opts);
     if (use_wasm) addWasm3(b, safe_mod, wasm3_c_flags);
-    const safe_tests = b.addTest(.{ .root_module = safe_mod });
+    const safe_tests = b.addTest(.{ .root_module = safe_mod, .filters = test_filters });
     if (use_libusb) {
         safe_tests.linkSystemLibrary("usb-1.0");
     } else {
@@ -198,7 +167,7 @@ pub fn build(b: *std.Build) void {
     fuzz_step.dependOn(&b.addRunArtifact(unit_tests).step);
 
     // capture L0 tests (analyse pure functions)
-    const capture_tests = b.addTest(.{ .root_module = capture_analyse_mod });
+    const capture_tests = b.addTest(.{ .root_module = capture_analyse_mod, .filters = test_filters });
     if (coverage) capture_tests.setExecCmd(&.{ "kcov", "--include-path=src/", "kcov-output", null });
     test_step.dependOn(&b.addRunArtifact(capture_tests).step);
 
@@ -237,7 +206,7 @@ pub fn build(b: *std.Build) void {
     });
     integ_mod.addImport("toml", toml_mod);
     integ_mod.addImport("src", src_mod);
-    const integ_tests = b.addTest(.{ .root_module = integ_mod });
+    const integ_tests = b.addTest(.{ .root_module = integ_mod, .filters = test_filters });
     if (use_libusb) {
         integ_tests.linkSystemLibrary("usb-1.0");
     } else {
@@ -255,7 +224,7 @@ pub fn build(b: *std.Build) void {
     });
     alldev_mod.addImport("toml", toml_mod);
     alldev_mod.addImport("src", src_mod);
-    const alldev_tests = b.addTest(.{ .root_module = alldev_mod });
+    const alldev_tests = b.addTest(.{ .root_module = alldev_mod, .filters = test_filters });
     if (use_libusb) {
         alldev_tests.linkSystemLibrary("usb-1.0");
     } else {
@@ -275,7 +244,7 @@ pub fn build(b: *std.Build) void {
     });
     deck_e2e_mod.addImport("toml", toml_mod);
     deck_e2e_mod.addImport("src", src_mod);
-    const deck_e2e_tests = b.addTest(.{ .root_module = deck_e2e_mod });
+    const deck_e2e_tests = b.addTest(.{ .root_module = deck_e2e_mod, .filters = test_filters });
     if (use_libusb) {
         deck_e2e_tests.linkSystemLibrary("usb-1.0");
     } else {
@@ -295,7 +264,7 @@ pub fn build(b: *std.Build) void {
     });
     grace_int_mod.addImport("toml", toml_mod);
     grace_int_mod.addImport("src", src_mod);
-    const grace_int_tests = b.addTest(.{ .root_module = grace_int_mod });
+    const grace_int_tests = b.addTest(.{ .root_module = grace_int_mod, .filters = test_filters });
     if (use_libusb) {
         grace_int_tests.linkSystemLibrary("usb-1.0");
     } else {
@@ -315,7 +284,7 @@ pub fn build(b: *std.Build) void {
     });
     routing_mod.addImport("toml", toml_mod);
     routing_mod.addImport("src", src_mod);
-    const routing_tests = b.addTest(.{ .root_module = routing_mod });
+    const routing_tests = b.addTest(.{ .root_module = routing_mod, .filters = test_filters });
     if (use_libusb) {
         routing_tests.linkSystemLibrary("usb-1.0");
     } else {
@@ -323,6 +292,10 @@ pub fn build(b: *std.Build) void {
     }
     routing_tests.linkLibC();
     test_step.dependOn(&b.addRunArtifact(routing_tests).step);
+    const routing_safe_tests = addSupervisorUhidRoutingTests(b, target, .ReleaseSafe, false, toml_mod, build_opts, use_wasm, wasm3_c_flags, use_libusb, test_filters);
+    safe_step.dependOn(&b.addRunArtifact(routing_safe_tests).step);
+    const routing_tsan_tests = addSupervisorUhidRoutingTests(b, target, optimize, true, toml_mod, build_opts, use_wasm, wasm3_c_flags, use_libusb, test_filters);
+    tsan_step.dependOn(&b.addRunArtifact(routing_tsan_tests).step);
 
     // uhid_output_dispatch_test and pidff_e2e_test are imported into
     // src/main.zig's test namespace and compiled into the main test artifact.
@@ -338,7 +311,7 @@ pub fn build(b: *std.Build) void {
         .sanitize_c = .trap,
     });
     e2e_mod.addImport("src", src_mod);
-    const e2e_tests = b.addTest(.{ .root_module = e2e_mod });
+    const e2e_tests = b.addTest(.{ .root_module = e2e_mod, .filters = test_filters });
     if (use_libusb) {
         e2e_tests.linkSystemLibrary("usb-1.0");
     } else {
@@ -356,7 +329,7 @@ pub fn build(b: *std.Build) void {
     });
     gen_e2e_mod.addImport("src", src_mod);
     gen_e2e_mod.addImport("toml", toml_mod);
-    const gen_e2e_tests = b.addTest(.{ .root_module = gen_e2e_mod });
+    const gen_e2e_tests = b.addTest(.{ .root_module = gen_e2e_mod, .filters = test_filters });
     if (use_libusb) {
         gen_e2e_tests.linkSystemLibrary("usb-1.0");
     } else {
@@ -378,7 +351,7 @@ pub fn build(b: *std.Build) void {
         .sanitize_c = .trap,
     });
     uhid_mod.addImport("toml", toml_mod);
-    const uhid_tests = b.addTest(.{ .root_module = uhid_mod });
+    const uhid_tests = b.addTest(.{ .root_module = uhid_mod, .filters = test_filters });
     if (use_libusb) {
         uhid_tests.linkSystemLibrary("usb-1.0");
     } else {
@@ -399,6 +372,89 @@ pub fn build(b: *std.Build) void {
         const spike_step = b.step("spike", "Run TOML spike");
         spike_step.dependOn(&b.addRunArtifact(spike_exe).step);
     } else |_| {}
+}
+
+fn createTestRootModule(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    sanitize_thread: bool,
+    toml_mod: *std.Build.Module,
+    capture_analyse_mod: *std.Build.Module,
+    capture_toml_gen_mod: *std.Build.Module,
+    capture_resolve_mod: *std.Build.Module,
+    build_opts: *std.Build.Step.Options,
+) *std.Build.Module {
+    const mod = b.createModule(.{
+        .root_source_file = b.path("test_root.zig"),
+        .target = target,
+        .optimize = optimize,
+        .sanitize_c = .trap,
+        .sanitize_thread = sanitize_thread,
+    });
+    mod.addImport("toml", toml_mod);
+    mod.addImport("analyse", capture_analyse_mod);
+    mod.addImport("toml_gen", capture_toml_gen_mod);
+    mod.addImport("capture_resolve", capture_resolve_mod);
+    mod.addImport("build_options", build_opts.createModule());
+    return mod;
+}
+
+fn createSrcModule(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    sanitize_thread: bool,
+    toml_mod: *std.Build.Module,
+    build_opts: *std.Build.Step.Options,
+    use_wasm: bool,
+    wasm3_c_flags: []const []const u8,
+    use_libusb: bool,
+) *std.Build.Module {
+    const mod = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+        .sanitize_c = .trap,
+        .sanitize_thread = sanitize_thread,
+    });
+    mod.addImport("toml", toml_mod);
+    mod.addImport("build_options", build_opts.createModule());
+    if (!use_libusb) mod.addIncludePath(b.path("compat"));
+    if (use_wasm) addWasm3(b, mod, wasm3_c_flags);
+    return mod;
+}
+
+fn addSupervisorUhidRoutingTests(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    sanitize_thread: bool,
+    toml_mod: *std.Build.Module,
+    build_opts: *std.Build.Step.Options,
+    use_wasm: bool,
+    wasm3_c_flags: []const []const u8,
+    use_libusb: bool,
+    test_filters: []const []const u8,
+) *std.Build.Step.Compile {
+    const src_mod = createSrcModule(b, target, optimize, sanitize_thread, toml_mod, build_opts, use_wasm, wasm3_c_flags, use_libusb);
+    const routing_mod = b.createModule(.{
+        .root_source_file = b.path("src/test/supervisor_uhid_routing_test.zig"),
+        .target = target,
+        .optimize = optimize,
+        .sanitize_c = .trap,
+        .sanitize_thread = sanitize_thread,
+    });
+    routing_mod.addImport("toml", toml_mod);
+    routing_mod.addImport("src", src_mod);
+    const routing_tests = b.addTest(.{ .root_module = routing_mod, .filters = test_filters });
+    if (use_libusb) {
+        routing_tests.linkSystemLibrary("usb-1.0");
+    } else {
+        routing_tests.addIncludePath(b.path("compat"));
+    }
+    routing_tests.linkLibC();
+    return routing_tests;
 }
 
 fn addWasm3(b: *std.Build, mod: *std.Build.Module, c_flags: []const []const u8) void {

--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -682,9 +682,10 @@ pub const DeviceInstance = struct {
     /// Replace physical device fds with new ones and re-register them in the
     /// event loop. Caller must provide the same number of DeviceIO entries as
     /// the original devices[] slice.
-    pub fn rebindDeviceIO(self: *DeviceInstance, new_devices: []DeviceIO) void {
+    pub fn rebindDeviceIO(self: *DeviceInstance, new_devices: []DeviceIO) !void {
+        if (new_devices.len != self.devices.len) return error.DeviceCountMismatch;
+        try self.loop.rebindDevices(new_devices);
         @memcpy(self.devices, new_devices);
-        self.loop.rebindDevices(self.devices);
     }
 
     /// Re-run the device init sequence (e.g. handshake packets) using the
@@ -1292,10 +1293,29 @@ test "DeviceInstance: rebindDeviceIO replaces device fds" {
     var mock_b = try MockDeviceIO.init(allocator, &.{});
     defer mock_b.deinit();
     var new_devs = [_]DeviceIO{mock_b.deviceIO()};
-    inst.rebindDeviceIO(&new_devs);
+    try inst.rebindDeviceIO(&new_devs);
 
     // Verify the device was replaced (new mock's pollfd)
     const pfd = inst.devices[0].pollfd();
     const expected_pfd = mock_b.deviceIO().pollfd();
     try testing.expectEqual(expected_pfd.fd, pfd.fd);
+}
+
+test "DeviceInstance: rebindDeviceIO rejects device count mismatch" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, minimal_toml);
+    defer parsed.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+
+    var inst = try testInstance(allocator, &mock, &parsed.value);
+    defer {
+        inst.loop.deinit();
+        allocator.free(inst.devices);
+    }
+
+    var empty = [_]DeviceIO{};
+    try testing.expectError(error.DeviceCountMismatch, inst.rebindDeviceIO(&empty));
 }

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -360,10 +360,11 @@ pub fn applyAdaptiveTrigger(
 pub const EventLoop = struct {
     pollfds: [MAX_FDS]posix.pollfd,
     fd_count: usize,
+    device_count: usize,
     signal_fd: posix.fd_t,
     stop_r: posix.fd_t,
     stop_w: posix.fd_t,
-    // device fds start at slot 5 (after signalfd + stop_pipe + timer_fd + rumble_stop_fd + macro_timer_fd)
+    // device fds start at Slots.device_base, after the fixed wakeup sources.
     device_base: usize,
     /// Dedicated timerfd for layer hold-trigger arm/disarm (slot 2).
     /// Written by `timer_request` returned from `Mapper.apply()`.
@@ -429,6 +430,7 @@ pub const EventLoop = struct {
         var loop = EventLoop{
             .pollfds = undefined,
             .fd_count = 0,
+            .device_count = 0,
             .signal_fd = sig_fd,
             .stop_r = stop_r,
             .stop_w = stop_w,
@@ -458,21 +460,28 @@ pub const EventLoop = struct {
     }
 
     pub fn addDevice(self: *EventLoop, device: DeviceIO) !void {
-        const slot = self.fd_count;
+        if (self.uinput_ff_slot != null or self.uhid_output_slot != null) return error.DeviceSlotsClosed;
+        if (self.device_count >= MAX_DEVICE_INTERFACES) return error.TooManyDevices;
+
+        const slot = self.device_base + self.device_count;
+        std.debug.assert(slot == self.fd_count);
         if (slot >= MAX_FDS) return error.TooManyFds;
         self.pollfds[slot] = device.pollfd();
+        self.device_count += 1;
         self.fd_count += 1;
     }
 
     /// Replace pollfd entries for device slots with fds from new DeviceIO
     /// slice. The number of devices must match the original count.
-    pub fn rebindDevices(self: *EventLoop, devices: []DeviceIO) void {
+    pub fn rebindDevices(self: *EventLoop, devices: []DeviceIO) !void {
+        if (devices.len != self.device_count) return error.DeviceCountMismatch;
         for (devices, 0..) |dev, i| {
             self.pollfds[self.device_base + i] = dev.pollfd();
         }
     }
 
     pub fn addUinputFf(self: *EventLoop, fd: posix.fd_t) !void {
+        if (self.uinput_ff_slot != null) return error.OutputSlotAlreadyRegistered;
         const slot = self.fd_count;
         if (slot >= MAX_FDS) return error.TooManyFds;
         self.pollfds[slot] = .{ .fd = fd, .events = posix.POLL.IN, .revents = 0 };
@@ -483,6 +492,7 @@ pub const EventLoop = struct {
     /// Register the primary UHID fd for `UHID_OUTPUT` polling.
     /// Only called when `[output.force_feedback].backend = "uhid"` and `kind = "pid"`.
     pub fn addUhidOutput(self: *EventLoop, fd: posix.fd_t) !void {
+        if (self.uhid_output_slot != null) return error.OutputSlotAlreadyRegistered;
         const slot = self.fd_count;
         if (slot >= MAX_FDS) return error.TooManyFds;
         self.pollfds[slot] = .{ .fd = fd, .events = posix.POLL.IN, .revents = 0 };
@@ -491,6 +501,11 @@ pub const EventLoop = struct {
     }
 
     pub fn run(self: *EventLoop, ctx: EventLoopContext) !void {
+        if (ctx.devices.len != self.device_count) {
+            self.running = false;
+            return error.DeviceCountMismatch;
+        }
+
         self.running = true;
         var buf: [512]u8 = undefined;
 
@@ -684,8 +699,9 @@ pub const EventLoop = struct {
 
             // Check device fds
             for (ctx.devices, 0..) |dev, i| {
+                if (i >= self.device_count) break;
                 const slot = self.device_base + i;
-                if (slot >= self.fd_count) break;
+                std.debug.assert(slot < self.fd_count);
 
                 const revents = self.pollfds[slot].revents;
                 const has_in = revents & posix.POLL.IN != 0;
@@ -898,6 +914,7 @@ test "event_loop: EventLoop.addUinputFf registers fd and increments fd_count" {
     // rumble_stop_fd, macro_timer_fd; the FF fd becomes slot 5,
     // fd_count goes 5 → 6.
     try testing.expectEqual(@as(usize, 6), loop.fd_count);
+    try testing.expectEqual(@as(usize, 0), loop.device_count);
     try testing.expectEqual(@as(?usize, 5), loop.uinput_ff_slot);
     try testing.expectEqual(pfds[0], loop.pollfds[Slots.device_base].fd);
 }
@@ -968,6 +985,7 @@ test "event_loop: EventLoop.initManaged creates eventfd and timerfds" {
     // slot 3 = rumble-stop timerfd, slot 4 = macro timerfd
     try testing.expect(loop.macro_timer_fd >= 0);
     try testing.expectEqual(@as(usize, 5), loop.fd_count);
+    try testing.expectEqual(@as(usize, 0), loop.device_count);
 }
 
 test "event_loop: EventLoop.stop wakes ppoll" {
@@ -993,30 +1011,144 @@ test "event_loop: EventLoop.addDevice registers fd" {
     // 3=rumble_stop_fd, 4=macro timerfd. First device lands at slot 5,
     // fd_count goes 5 → 6.
     try testing.expectEqual(@as(usize, 6), loop.fd_count);
+    try testing.expectEqual(@as(usize, 1), loop.device_count);
     try testing.expectEqual(mock.pipe_r, loop.pollfds[Slots.device_base].fd);
 }
 
-test "event_loop: EventLoop.addDevice rejects overflow" {
+test "event_loop: EventLoop.addDevice rejects beyond device interface limit" {
     const allocator = testing.allocator;
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
 
-    // Fill remaining slots (already have 5: signalfd + stop_pipe +
-    // layer timer_fd + rumble-stop timerfd + macro timerfd).
-    var mocks: [MAX_FDS - FIXED_SLOT_COUNT]MockDeviceIO = undefined;
-    for (0..MAX_FDS - FIXED_SLOT_COUNT) |i| {
+    var mocks: [MAX_DEVICE_INTERFACES]MockDeviceIO = undefined;
+    for (0..MAX_DEVICE_INTERFACES) |i| {
         mocks[i] = try MockDeviceIO.init(allocator, &.{});
     }
-    defer for (0..MAX_FDS - FIXED_SLOT_COUNT) |i| mocks[i].deinit();
+    defer for (0..MAX_DEVICE_INTERFACES) |i| mocks[i].deinit();
 
-    for (0..MAX_FDS - FIXED_SLOT_COUNT) |i| {
+    for (0..MAX_DEVICE_INTERFACES) |i| {
         const dev = mocks[i].deviceIO();
         try loop.addDevice(dev);
     }
+
+    try testing.expectEqual(MAX_DEVICE_INTERFACES, loop.device_count);
+    try testing.expectEqual(FIXED_SLOT_COUNT + MAX_DEVICE_INTERFACES, loop.fd_count);
+
     var extra = try MockDeviceIO.init(allocator, &.{});
     defer extra.deinit();
     const extra_dev = extra.deviceIO();
-    try testing.expectError(error.TooManyFds, loop.addDevice(extra_dev));
+    try testing.expectError(error.TooManyDevices, loop.addDevice(extra_dev));
+}
+
+test "event_loop: EventLoop.addDevice rejects after output slots are registered" {
+    const allocator = testing.allocator;
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    const pfds = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(pfds[0]);
+    defer posix.close(pfds[1]);
+    try loop.addUinputFf(pfds[0]);
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    try testing.expectError(error.DeviceSlotsClosed, loop.addDevice(mock.deviceIO()));
+}
+
+test "event_loop: EventLoop output slots append after device slots" {
+    const allocator = testing.allocator;
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+    var mock_b = try MockDeviceIO.init(allocator, &.{});
+    defer mock_b.deinit();
+    try loop.addDevice(mock_a.deviceIO());
+    try loop.addDevice(mock_b.deviceIO());
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    const uhid_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(uhid_pipe[0]);
+    defer posix.close(uhid_pipe[1]);
+
+    try loop.addUinputFf(ff_pipe[0]);
+    try loop.addUhidOutput(uhid_pipe[0]);
+
+    try testing.expectEqual(@as(usize, 2), loop.device_count);
+    try testing.expectEqual(@as(?usize, Slots.device_base + 2), loop.uinput_ff_slot);
+    try testing.expectEqual(@as(?usize, Slots.device_base + 3), loop.uhid_output_slot);
+    try testing.expectEqual(@as(usize, FIXED_SLOT_COUNT + 4), loop.fd_count);
+    try testing.expectEqual(ff_pipe[0], loop.pollfds[Slots.device_base + 2].fd);
+    try testing.expectEqual(uhid_pipe[0], loop.pollfds[Slots.device_base + 3].fd);
+}
+
+test "event_loop: EventLoop output slot registration rejects duplicates" {
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    const uhid_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(uhid_pipe[0]);
+    defer posix.close(uhid_pipe[1]);
+
+    try loop.addUinputFf(ff_pipe[0]);
+    try testing.expectError(error.OutputSlotAlreadyRegistered, loop.addUinputFf(ff_pipe[0]));
+
+    try loop.addUhidOutput(uhid_pipe[0]);
+    try testing.expectError(error.OutputSlotAlreadyRegistered, loop.addUhidOutput(uhid_pipe[0]));
+}
+
+test "event_loop: EventLoop.rebindDevices rejects device count mismatch" {
+    const allocator = testing.allocator;
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    try loop.addDevice(mock.deviceIO());
+
+    var empty = [_]DeviceIO{};
+    try testing.expectError(error.DeviceCountMismatch, loop.rebindDevices(&empty));
+}
+
+test "event_loop: EventLoop.run rejects device count mismatch before polling" {
+    const allocator = testing.allocator;
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    try loop.addDevice(mock.deviceIO());
+
+    const parsed = try device_mod.parseString(allocator, minimal_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    const NoopOutput = struct {
+        fn emit(_: *anyopaque, _: state.GamepadState) uinput.EmitError!void {}
+        fn pollFf(_: *anyopaque) uinput.PollFfError!?uinput.FfEvent {
+            return null;
+        }
+        fn close(_: *anyopaque) void {}
+        const vtable = uinput.OutputDevice.VTable{ .emit = emit, .poll_ff = pollFf, .close = close };
+    };
+    var noop_sentinel: u8 = 0;
+    const output = uinput.OutputDevice{ .ptr = &noop_sentinel, .vtable = &NoopOutput.vtable };
+
+    loop.running = true;
+    var empty = [_]DeviceIO{};
+    try testing.expectError(error.DeviceCountMismatch, loop.run(.{
+        .devices = &empty,
+        .interpreter = &interp,
+        .output = output,
+        .poll_timeout_ms = 1,
+    }));
+    try testing.expect(!loop.running);
 }
 
 test "event_loop: armTimer / disarmTimer: arm then disarm does not leave fd readable" {

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -26,6 +26,24 @@ const control_socket = @import("io/control_socket.zig");
 
 const socket_client = @import("cli/socket_client.zig");
 
+const RebindDeviceOpener = *const fn (
+    ctx: *anyopaque,
+    allocator: std.mem.Allocator,
+    iface: config_device.InterfaceConfig,
+    vid: u16,
+    pid: u16,
+) anyerror!DeviceIO;
+
+fn openDeviceWithRetryForRebind(
+    _: *anyopaque,
+    allocator: std.mem.Allocator,
+    iface: config_device.InterfaceConfig,
+    vid: u16,
+    pid: u16,
+) !DeviceIO {
+    return openDeviceWithRetry(allocator, iface, vid, pid);
+}
+
 /// One running device under Supervisor management.
 pub const ManagedInstance = struct {
     phys_key: []const u8,
@@ -373,9 +391,26 @@ pub const Supervisor = struct {
         // through to a fresh attach.
         var stale_devname_buf: [64]u8 = undefined;
         var stale_devname: ?[]const u8 = null;
-        for (self.managed.items) |m| {
+        var i: usize = 0;
+        while (i < self.managed.items.len) : (i += 1) {
+            const m = &self.managed.items[i];
             if (!std.mem.eql(u8, m.phys_key, phys_key)) continue;
-            if (managedInstanceAlive(&m)) return false;
+            const same_device_id =
+                m.instance.device_cfg.device.vid == instance.device_cfg.device.vid and
+                m.instance.device_cfg.device.pid == instance.device_cfg.device.pid;
+            if (m.suspended and !same_device_id) {
+                std.log.info("hotplug: replacing suspended {x:0>4}:{x:0>4} at phys \"{s}\" with {x:0>4}:{x:0>4}", .{
+                    @as(u16, @intCast(m.instance.device_cfg.device.vid)),
+                    @as(u16, @intCast(m.instance.device_cfg.device.pid)),
+                    phys_key,
+                    @as(u16, @intCast(instance.device_cfg.device.vid)),
+                    @as(u16, @intCast(instance.device_cfg.device.pid)),
+                });
+                self.teardownManaged(m);
+                _ = self.managed.swapRemove(i);
+                break;
+            }
+            if (managedInstanceAlive(m)) return false;
             // Dead fds. Capture devname for detachFull (detach frees it).
             if (m.devname) |dn| {
                 const n = @min(dn.len, stale_devname_buf.len);
@@ -2047,56 +2082,15 @@ pub const Supervisor = struct {
             devname, vid, pid, phys, iface_id,
         });
 
-        // Check for a suspended instance with the same VID:PID to rebind
-        for (self.managed.items) |*m| {
-            if (!m.suspended) continue;
-            const mcfg = m.instance.device_cfg;
-            std.log.debug("hotplug: suspended candidate vid={x:0>4} pid={x:0>4} phys_key=\"{s}\" new_phys=\"{s}\" phys_match={}", .{
-                @as(u16, @intCast(mcfg.device.vid)), @as(u16, @intCast(mcfg.device.pid)), m.phys_key, phys, std.mem.eql(u8, m.phys_key, phys),
-            });
-            // Match by physical topology path (stable across sleep/wake)
-            // rather than VID:PID (ambiguous with identical controllers)
-            if (!std.mem.eql(u8, m.phys_key, phys)) continue;
-
-            // Reopen all interface fds for the suspended instance
-            const new_devices = self.allocator.alloc(DeviceIO, mcfg.device.interface.len) catch return;
-            var opened: usize = 0;
-            errdefer {
-                for (new_devices[0..opened]) |dev| dev.close();
-                self.allocator.free(new_devices);
-            }
-            for (mcfg.device.interface, 0..) |iface, idx| {
-                new_devices[idx] = openDeviceWithRetry(self.allocator, iface, vid, pid) catch |err| {
-                    std.log.warn("rebind: open interface {d} failed: {}", .{ iface.id, err });
-                    for (new_devices[0..opened]) |dev| dev.close();
-                    self.allocator.free(new_devices);
-                    if (isTransientOpenError(err)) return error.HotplugTransient;
-                    std.log.warn("hotplug: suspended instance found but resume aborted: open failed", .{});
-                    return;
-                };
-                opened += 1;
-            }
-
-            m.instance.rebindDeviceIO(new_devices);
-            self.allocator.free(new_devices);
-            rerunInitAfterRebind(m) catch |err| {
-                std.log.warn("hotplug: suspended instance resume aborted: re-init failed: {}", .{err});
-                if (isTransientOpenError(err)) return error.HotplugTransient;
-                return;
-            };
-
-            // Commit bookkeeping only after every fallible step succeeds. On
-            // failure `m.suspended`/`m.grace_deadline_ns` stay as-is so the
-            // grace-window GC still reclaims the entry.
-            self.finalizeRebind(m, devname, phys) catch |err| {
-                m.instance.closeDeviceIO();
-                std.log.warn("hotplug: suspended instance resume aborted: {}", .{err});
-                return;
-            };
-            std.log.info("hotplug: resumed suspended instance (phys_key match) for {s}", .{devname});
-            std.log.info("device resumed: \"{s}\" {s}/{s}", .{ mcfg.device.name, dev_root, devname });
-            return;
-        }
+        var opener_ctx: u8 = 0;
+        if (try self.tryResumeSuspendedInstance(
+            devname,
+            phys,
+            vid,
+            pid,
+            &opener_ctx,
+            openDeviceWithRetryForRebind,
+        )) return;
 
         if (self.hasLiveDuplicate(devname, phys, cfg.?)) return;
 
@@ -2149,6 +2143,79 @@ pub const Supervisor = struct {
                 });
             }
         }
+    }
+
+    fn tryResumeSuspendedInstance(
+        self: *Supervisor,
+        devname: []const u8,
+        phys: []const u8,
+        vid: u16,
+        pid: u16,
+        opener_ctx: *anyopaque,
+        opener: RebindDeviceOpener,
+    ) !bool {
+        for (self.managed.items) |*m| {
+            if (!m.suspended) continue;
+            const mcfg = m.instance.device_cfg;
+            const mcfg_vid: u16 = @intCast(mcfg.device.vid);
+            const mcfg_pid: u16 = @intCast(mcfg.device.pid);
+            const phys_match = std.mem.eql(u8, m.phys_key, phys);
+            const id_match = mcfg_vid == vid and mcfg_pid == pid;
+            std.log.debug("hotplug: suspended candidate vid={x:0>4} pid={x:0>4} phys_key=\"{s}\" new_phys=\"{s}\" phys_match={} id_match={}", .{
+                mcfg_vid, mcfg_pid, m.phys_key, phys, phys_match, id_match,
+            });
+            // Match by physical topology path (stable across sleep/wake)
+            // plus VID:PID so a different controller plugged into the same
+            // port starts a fresh instance instead of inheriting stale state.
+            if (!phys_match or !id_match) continue;
+
+            const new_devices = try self.allocator.alloc(DeviceIO, mcfg.device.interface.len);
+            var opened: usize = 0;
+            var new_devices_owned = true;
+            errdefer {
+                if (new_devices_owned) {
+                    for (new_devices[0..opened]) |dev| dev.close();
+                    self.allocator.free(new_devices);
+                }
+            }
+            for (mcfg.device.interface, 0..) |iface, idx| {
+                new_devices[idx] = opener(opener_ctx, self.allocator, iface, vid, pid) catch |err| {
+                    std.log.warn("rebind: open interface {d} failed: {}", .{ iface.id, err });
+                    for (new_devices[0..opened]) |dev| dev.close();
+                    self.allocator.free(new_devices);
+                    new_devices_owned = false;
+                    if (isTransientOpenError(err)) return error.HotplugTransient;
+                    std.log.warn("hotplug: suspended instance found but resume aborted: open failed", .{});
+                    return true;
+                };
+                opened += 1;
+            }
+
+            try m.instance.rebindDeviceIO(new_devices);
+            new_devices_owned = false;
+            self.allocator.free(new_devices);
+            rerunInitAfterRebind(m) catch |err| {
+                m.instance.closeDeviceIO();
+                std.log.warn("hotplug: suspended instance resume aborted: re-init failed: {}", .{err});
+                if (isTransientOpenError(err)) return error.HotplugTransient;
+                return true;
+            };
+
+            // Commit bookkeeping only after every fallible step succeeds. On
+            // failure `m.suspended`/`m.grace_deadline_ns` stay as-is and
+            // physical fds are closed so a later ADD can try a fresh rebind.
+            self.finalizeRebind(m, devname, phys) catch |err| {
+                m.instance.closeDeviceIO();
+                std.log.warn("hotplug: suspended instance resume aborted: {}", .{err});
+                if (err == error.OutOfMemory) return err;
+                return true;
+            };
+            std.log.info("hotplug: resumed suspended instance (phys_key/VID/PID match) for {s}", .{devname});
+            std.log.info("device resumed: \"{s}\" {s}", .{ mcfg.device.name, devname });
+            return true;
+        }
+
+        return false;
     }
 };
 
@@ -2253,6 +2320,27 @@ const FailWriteDeviceIO = struct {
     }
 
     fn close(_: *anyopaque) void {}
+};
+
+const TestRebindOpenCtx = struct {
+    devices: []DeviceIO,
+    next: usize = 0,
+    fail: ?anyerror = null,
+
+    fn open(
+        ptr: *anyopaque,
+        _: std.mem.Allocator,
+        _: config_device.InterfaceConfig,
+        _: u16,
+        _: u16,
+    ) !DeviceIO {
+        const self: *TestRebindOpenCtx = @ptrCast(@alignCast(ptr));
+        if (self.fail) |err| return err;
+        if (self.next >= self.devices.len) return error.TestNoDevice;
+        const dev = self.devices[self.next];
+        self.next += 1;
+        return dev;
+    }
 };
 
 fn makeTestInstance(
@@ -3159,7 +3247,7 @@ test "supervisor: Supervisor: suspend preserves instance, resume rebinds device 
     var mock_b = try MockDeviceIO.init(allocator, &.{});
     defer mock_b.deinit();
     var new_devs = [_]DeviceIO{mock_b.deviceIO()};
-    inst_ptr.rebindDeviceIO(&new_devs);
+    try inst_ptr.rebindDeviceIO(&new_devs);
     sup.managed.items[0].suspended = false;
 
     const dn = try allocator.dupe(u8, "hidraw5");
@@ -3181,6 +3269,286 @@ test "supervisor: Supervisor: suspend preserves instance, resume rebinds device 
         sup.stopAll();
         sup.deinit();
     }
+}
+
+test "supervisor: suspended hotplug rebind helper resumes through production transaction" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+    var mock_b = try MockDeviceIO.init(allocator, &.{});
+    defer mock_b.deinit();
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+    const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", inst_a, null);
+    const inst_ptr = sup.managed.items[0].instance;
+
+    sup.detach("hidraw3");
+    try testing.expect(sup.managed.items[0].suspended);
+    const original_deadline = sup.managed.items[0].grace_deadline_ns.?;
+
+    var new_devs = [_]DeviceIO{mock_b.deviceIO()};
+    var opener = TestRebindOpenCtx{ .devices = &new_devs };
+    try testing.expect(try sup.tryResumeSuspendedInstance(
+        "hidraw5",
+        "usb-1-1",
+        1,
+        2,
+        &opener,
+        TestRebindOpenCtx.open,
+    ));
+
+    try testing.expectEqual(@as(usize, 1), opener.next);
+    try testing.expectEqual(inst_ptr, sup.managed.items[0].instance);
+    try testing.expect(!sup.managed.items[0].suspended);
+    try testing.expectEqual(@as(?u64, null), sup.managed.items[0].grace_deadline_ns);
+    try testing.expect(original_deadline > 0);
+    try testing.expectEqualStrings("hidraw5", sup.managed.items[0].devname.?);
+    try testing.expect(sup.devname_map.contains("hidraw5"));
+    try testing.expectEqual(mock_b.deviceIO().pollfd().fd, inst_ptr.devices[0].pollfd().fd);
+}
+
+test "supervisor: suspended hotplug rebind helper ignores same phys with different VID/PID" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+    const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", inst_a, null);
+
+    sup.detach("hidraw3");
+    try testing.expect(sup.managed.items[0].suspended);
+    const original_deadline = sup.managed.items[0].grace_deadline_ns.?;
+
+    var no_devices = [_]DeviceIO{};
+    var opener = TestRebindOpenCtx{ .devices = &no_devices };
+    try testing.expect(!try sup.tryResumeSuspendedInstance(
+        "hidraw5",
+        "usb-1-1",
+        9,
+        9,
+        &opener,
+        TestRebindOpenCtx.open,
+    ));
+
+    try testing.expectEqual(@as(usize, 0), opener.next);
+    try testing.expect(sup.managed.items[0].suspended);
+    try testing.expectEqual(original_deadline, sup.managed.items[0].grace_deadline_ns.?);
+    try testing.expectEqual(@as(?[]const u8, null), sup.managed.items[0].devname);
+    try testing.expect(!sup.devname_map.contains("hidraw5"));
+}
+
+test "supervisor: fresh hotplug attach replaces suspended entry with different VID/PID on same phys" {
+    const allocator = testing.allocator;
+
+    const parsed_old = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_old.deinit();
+
+    const parsed_new = try device_mod.parseString(allocator,
+        \\[device]
+        \\name = "Replacement"
+        \\vid = 9
+        \\pid = 9
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 3
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x01]
+        \\[report.fields]
+        \\left_x = { offset = 1, type = "i16le" }
+    );
+    defer parsed_new.deinit();
+
+    var mock_old = try MockDeviceIO.init(allocator, &.{});
+    defer mock_old.deinit();
+    var mock_new = try MockDeviceIO.init(allocator, &.{});
+    defer mock_new.deinit();
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+    const old_inst = try makeTestInstance(allocator, &mock_old, &parsed_old.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", old_inst, null);
+
+    sup.detach("hidraw3");
+    try testing.expect(sup.managed.items[0].suspended);
+
+    const new_inst = try makeTestInstance(allocator, &mock_new, &parsed_new.value);
+    var new_attached = false;
+    defer if (!new_attached) {
+        new_inst.deinit();
+        allocator.destroy(new_inst);
+    };
+    new_attached = try sup.attachWithInstanceResult("hidraw5", "usb-1-1", new_inst, null);
+
+    try testing.expect(new_attached);
+    try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
+    try testing.expectEqual(new_inst, sup.managed.items[0].instance);
+    try testing.expect(!sup.managed.items[0].suspended);
+    try testing.expectEqual(@as(i64, 9), sup.managed.items[0].instance.device_cfg.device.vid);
+    try testing.expectEqual(@as(i64, 9), sup.managed.items[0].instance.device_cfg.device.pid);
+    try testing.expectEqualStrings("hidraw5", sup.managed.items[0].devname.?);
+    try testing.expect(sup.devname_map.contains("hidraw5"));
+}
+
+test "supervisor: suspended hotplug rebind helper propagates allocation failure" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+    const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", inst_a, null);
+
+    sup.detach("hidraw3");
+    try testing.expect(sup.managed.items[0].suspended);
+    const original_deadline = sup.managed.items[0].grace_deadline_ns.?;
+
+    var no_devices = [_]DeviceIO{};
+    var opener = TestRebindOpenCtx{ .devices = &no_devices };
+    const result = blk: {
+        const real_alloc = sup.allocator;
+        var failing_alloc = testing.FailingAllocator.init(real_alloc, .{ .fail_index = 0 });
+        sup.allocator = failing_alloc.allocator();
+        defer sup.allocator = real_alloc;
+        break :blk sup.tryResumeSuspendedInstance(
+            "hidraw5",
+            "usb-1-1",
+            1,
+            2,
+            &opener,
+            TestRebindOpenCtx.open,
+        );
+    };
+
+    try testing.expectError(error.OutOfMemory, result);
+    try testing.expectEqual(@as(usize, 0), opener.next);
+    try testing.expect(sup.managed.items[0].suspended);
+    try testing.expectEqual(original_deadline, sup.managed.items[0].grace_deadline_ns.?);
+    try testing.expectEqual(@as(?[]const u8, null), sup.managed.items[0].devname);
+    try testing.expect(!sup.devname_map.contains("hidraw5"));
+}
+
+test "supervisor: suspended hotplug rebind helper propagates finalize allocation failure" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+    var mock_b = try MockDeviceIO.init(allocator, &.{});
+    defer mock_b.deinit();
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+    const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", inst_a, null);
+
+    sup.detach("hidraw3");
+    try testing.expect(sup.managed.items[0].suspended);
+    const original_deadline = sup.managed.items[0].grace_deadline_ns.?;
+
+    var new_devs = [_]DeviceIO{mock_b.deviceIO()};
+    var opener = TestRebindOpenCtx{ .devices = &new_devs };
+    const result = blk: {
+        const real_alloc = sup.allocator;
+        var failing_alloc = testing.FailingAllocator.init(real_alloc, .{ .fail_index = 1 });
+        sup.allocator = failing_alloc.allocator();
+        defer sup.allocator = real_alloc;
+        break :blk sup.tryResumeSuspendedInstance(
+            "hidraw5",
+            "usb-1-1",
+            1,
+            2,
+            &opener,
+            TestRebindOpenCtx.open,
+        );
+    };
+
+    try testing.expectError(error.OutOfMemory, result);
+    try testing.expectEqual(@as(usize, 1), opener.next);
+    try testing.expect(sup.managed.items[0].suspended);
+    try testing.expectEqual(original_deadline, sup.managed.items[0].grace_deadline_ns.?);
+    try testing.expectEqual(@as(?[]const u8, null), sup.managed.items[0].devname);
+    try testing.expect(!sup.devname_map.contains("hidraw5"));
+}
+
+test "supervisor: suspended hotplug rebind helper closes failed reinit fds and preserves grace" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, init_device_toml);
+    defer parsed_dev.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+    sup.suspend_grace_sec = 5;
+    sup.test_now_override_ns = 10 * std.time.ns_per_s;
+
+    const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", inst_a, null);
+
+    sup.detach("hidraw3");
+    try testing.expect(sup.managed.items[0].suspended);
+    const original_deadline = sup.managed.items[0].grace_deadline_ns.?;
+
+    var failing = FailWriteDeviceIO{};
+    var new_devs = [_]DeviceIO{failing.deviceIO()};
+    var opener = TestRebindOpenCtx{ .devices = &new_devs };
+    try testing.expectError(error.HotplugTransient, sup.tryResumeSuspendedInstance(
+        "hidraw5",
+        "usb-1-1",
+        1,
+        2,
+        &opener,
+        TestRebindOpenCtx.open,
+    ));
+
+    try testing.expect(sup.managed.items[0].suspended);
+    try testing.expectEqual(original_deadline, sup.managed.items[0].grace_deadline_ns.?);
+    try testing.expectEqual(@as(?[]const u8, null), sup.managed.items[0].devname);
+    try testing.expect(!sup.devname_map.contains("hidraw5"));
+    try testing.expectEqual(@as(posix.fd_t, -1), sup.managed.items[0].instance.devices[0].pollfd().fd);
 }
 
 test "supervisor: failed re-init after suspended rebind preserves grace state" {
@@ -3209,7 +3577,7 @@ test "supervisor: failed re-init after suspended rebind preserves grace state" {
     var failing = FailWriteDeviceIO{};
     var new_devs = [_]DeviceIO{failing.deviceIO()};
     const m = &sup.managed.items[0];
-    m.instance.rebindDeviceIO(&new_devs);
+    try m.instance.rebindDeviceIO(&new_devs);
     try testing.expectError(DeviceIO.WriteError.Io, Supervisor.rerunInitAfterRebind(m));
 
     try testing.expect(m.suspended);
@@ -3245,7 +3613,7 @@ test "supervisor: failed feature-report re-init after suspended rebind preserves
     var failing = FailWriteDeviceIO{};
     var new_devs = [_]DeviceIO{failing.deviceIO()};
     const m = &sup.managed.items[0];
-    m.instance.rebindDeviceIO(&new_devs);
+    try m.instance.rebindDeviceIO(&new_devs);
     try testing.expectError(DeviceIO.WriteError.Io, Supervisor.rerunInitAfterRebind(m));
 
     try testing.expect(m.suspended);


### PR DESCRIPTION
## Summary
- make event-loop FD slot ownership explicit with device_count and guarded output slots
- reject invalid device/output slot mutations before they corrupt fd layout
- make suspended hotplug rebind transactional and preserve the existing instance on failure
- wire focused test filtering through the test matrix and include routing tests in safe/tsan mirrors

## Verification
- hooks/pre-push without SKIP_TSAN: passed via canonical Docker test-tsan after rebuilding the Zig cache
- zig build test -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false --summary all: 1469/1473 passed, 4 skipped
- zig build test-safe -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false --summary all: 1465/1469 passed, 4 skipped
- zig build test-tsan -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false --summary all: 1465/1469 passed, 4 skipped
- zig build check-fmt -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false --summary all: passed

## Review
- Poincare reviewed the event-loop/rebind changes and found no remaining blockers after fixes
- Sartre audited the test framework coverage; this PR addresses the rebind-helper coverage, routing safe/tsan mirror, and broad test-filter gaps

Dev Vault docs were updated locally in the separate docs worktree for the slot-layout/test-discovery notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-Dtest-filter` build option to selectively run tests by matching text patterns in test names.

* **Bug Fixes**
  * Enhanced device validation to detect and prevent device count mismatches during rebinding.
  * Improved reliability of device hotplug resume with stricter error handling.

* **Tests**
  * Expanded test coverage for device count validation and rebinding scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->