### PR TITLE
fix: keep Bazzite setup script on latest checkout

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -171,6 +171,11 @@ pub fn build(b: *std.Build) void {
     if (coverage) capture_tests.setExecCmd(&.{ "kcov", "--include-path=src/", "kcov-output", null });
     test_step.dependOn(&b.addRunArtifact(capture_tests).step);
 
+    const bazzite_setup_tests = b.addSystemCommand(&.{ "bash", "scripts/test-bazzite-setup.sh" });
+    const bazzite_setup_test_step = b.step("test-bazzite-setup", "Run Bazzite setup script regression tests");
+    bazzite_setup_test_step.dependOn(&bazzite_setup_tests.step);
+    test_step.dependOn(&bazzite_setup_tests.step);
+
     // cli_smoke: run the just-built artifact, not a possibly stale zig-out binary.
     const smoke_version = b.addRunArtifact(exe);
     smoke_version.addArg("--version");

--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -18,6 +18,7 @@ BRANCH="${BRANCH:-}"
 PREFIX="/usr/local"
 BREW_PREFIX="/home/linuxbrew/.linuxbrew"
 PADCTL_GIT_URL="${PADCTL_GIT_URL:-https://github.com/BANANASJIM/padctl.git}"
+PADCTL_REPO_AUTO_MANAGED=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -42,6 +43,7 @@ while [[ $# -gt 0 ]]; do
         *)
             if [[ -z "$PADCTL_REPO" ]]; then
                 PADCTL_REPO="$1"
+                PADCTL_REPO_AUTO_MANAGED=false
             fi
             shift
             ;;
@@ -59,6 +61,118 @@ info()  { echo -e "${BLUE}[INFO]${NC} $*"; }
 ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
 err()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+repo_is_dirty() {
+    local repo="$1"
+    ! git -C "$repo" diff --quiet \
+        || ! git -C "$repo" diff --cached --quiet \
+        || [[ -n "$(git -C "$repo" ls-files --others --exclude-standard)" ]]
+}
+
+origin_head_ref() {
+    local repo="$1"
+    local ref
+    ref="$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+    if [[ -n "$ref" ]]; then
+        echo "$ref"
+    else
+        echo "origin/main"
+    fi
+}
+
+current_upstream_ref() {
+    local repo="$1"
+    git -C "$repo" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true
+}
+
+sync_managed_repo_to_remote() {
+    local repo="$1"
+    local branch="$2"
+    local target_ref current_branch
+
+    git -C "$repo" fetch origin >/dev/null 2>&1
+
+    if [[ -n "$branch" ]]; then
+        target_ref="origin/$branch"
+        if ! git -C "$repo" show-ref --verify --quiet "refs/remotes/$target_ref"; then
+            err "remote branch not found: $target_ref"
+            return 1
+        fi
+        current_branch="$branch"
+    else
+        target_ref="$(current_upstream_ref "$repo")"
+        if [[ -z "$target_ref" ]]; then
+            target_ref="$(origin_head_ref "$repo")"
+        fi
+        current_branch="$(git -C "$repo" branch --show-current 2>/dev/null || true)"
+        if [[ -z "$current_branch" && "$target_ref" == origin/* ]]; then
+            current_branch="${target_ref#origin/}"
+        fi
+    fi
+
+    warn "Fast-forward update failed; resetting managed checkout to $target_ref"
+    if repo_is_dirty "$repo"; then
+        warn "Preserving local changes in git stash before reset"
+        git -C "$repo" stash push --include-untracked \
+            -m "padctl bazzite setup auto-stash before update $(date -u +%Y%m%dT%H%M%SZ)" >/dev/null
+    fi
+
+    if [[ -n "$current_branch" ]]; then
+        git -C "$repo" checkout -B "$current_branch" "$target_ref" >/dev/null 2>&1
+    else
+        git -C "$repo" checkout --detach "$target_ref" >/dev/null 2>&1
+    fi
+    git -C "$repo" reset --hard "$target_ref" >/dev/null 2>&1
+}
+
+update_existing_repo() {
+    local repo="$1"
+    local branch="$2"
+    local auto_managed="$3"
+
+    repo_updated=false
+    if [[ -n "$branch" ]]; then
+        git -C "$repo" fetch origin >/dev/null 2>&1
+        if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
+            git -C "$repo" checkout "$branch" >/dev/null 2>&1 || warn "checkout $branch failed"
+        elif git -C "$repo" show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+            git -C "$repo" checkout -B "$branch" "origin/$branch" >/dev/null 2>&1 || warn "checkout $branch failed"
+        else
+            warn "branch not found locally or on origin: $branch"
+        fi
+        if timeout 10 git -C "$repo" pull --ff-only >/dev/null 2>&1; then
+            repo_updated=true
+        else
+            warn "git pull failed (might have local changes)"
+            if $auto_managed; then
+                sync_managed_repo_to_remote "$repo" "$branch"
+                repo_updated=true
+            fi
+        fi
+    else
+        # Only pull if on a branch that tracks a remote (skip for local-only branches).
+        if git -C "$repo" rev-parse --abbrev-ref '@{upstream}' &>/dev/null; then
+            if timeout 10 git -C "$repo" pull --ff-only >/dev/null 2>&1; then
+                repo_updated=true
+            else
+                warn "git pull failed (might have local changes)"
+                if $auto_managed; then
+                    sync_managed_repo_to_remote "$repo" ""
+                    repo_updated=true
+                fi
+            fi
+        elif $auto_managed; then
+            sync_managed_repo_to_remote "$repo" ""
+            repo_updated=true
+        else
+            info "Local branch with no upstream — skipping pull"
+        fi
+    fi
+}
+
+if [[ "${PADCTL_BAZZITE_TEST_LIB_ONLY:-}" == "1" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
 
 # --- 1. OS Detection ---
 info "Detecting OS..."
@@ -172,32 +286,13 @@ if [[ -z "$PADCTL_REPO" ]]; then
         PADCTL_REPO="$(cd .. && pwd)"
     else
         PADCTL_REPO="$HOME/Games/padctl"
+        PADCTL_REPO_AUTO_MANAGED=true
     fi
 fi
 
 if [[ -d "$PADCTL_REPO/.git" ]]; then
     info "Updating existing repo at $PADCTL_REPO..."
-    repo_updated=false
-    if [[ -n "$BRANCH" ]]; then
-        git -C "$PADCTL_REPO" fetch origin 2>/dev/null || true
-        git -C "$PADCTL_REPO" checkout "$BRANCH" 2>/dev/null || warn "checkout $BRANCH failed"
-        if timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null; then
-            repo_updated=true
-        else
-            warn "git pull failed (might have local changes)"
-        fi
-    else
-        # Only pull if on a branch that tracks a remote (skip for local-only branches).
-        if git -C "$PADCTL_REPO" rev-parse --abbrev-ref '@{upstream}' &>/dev/null; then
-            if timeout 10 git -C "$PADCTL_REPO" pull --ff-only 2>/dev/null; then
-                repo_updated=true
-            else
-                warn "git pull failed (might have local changes)"
-            fi
-        else
-            info "Local branch with no upstream — skipping pull"
-        fi
-    fi
+    update_existing_repo "$PADCTL_REPO" "$BRANCH" "$PADCTL_REPO_AUTO_MANAGED"
     if $repo_updated; then
         ok "Repo up to date"
     else

--- a/scripts/test-bazzite-setup.sh
+++ b/scripts/test-bazzite-setup.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PADCTL_BAZZITE_TEST_LIB_ONLY=1
+set --
+# shellcheck source=scripts/bazzite-setup.sh
+source "$SCRIPT_DIR/bazzite-setup.sh"
+unset PADCTL_BAZZITE_TEST_LIB_ONLY
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+write_fake_git() {
+    local fakebin="$1"
+    mkdir -p "$fakebin"
+    cat >"$fakebin/git" <<'FAKE_GIT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=""
+if [[ "${1:-}" == "-C" ]]; then
+    repo="$2"
+    shift 2
+fi
+
+cmd="${1:-}"
+[[ $# -gt 0 ]] && shift
+
+state_dir() { printf '%s/.fakegit' "$repo"; }
+read_state() { cat "$(state_dir)/$1"; }
+write_state() { printf '%s\n' "$2" >"$(state_dir)/$1"; }
+
+case "$cmd" in
+    diff)
+        if [[ -f "$(state_dir)/dirty" ]]; then
+            exit 1
+        fi
+        exit 0
+        ;;
+    ls-files)
+        if [[ -f "$(state_dir)/untracked" ]]; then
+            echo "untracked.txt"
+        fi
+        exit 0
+        ;;
+    symbolic-ref)
+        echo "origin/main"
+        exit 0
+        ;;
+    rev-parse)
+        if [[ "${1:-}" == "--abbrev-ref" ]]; then
+            if [[ -f "$(state_dir)/upstream" ]]; then
+                read_state upstream
+                exit 0
+            fi
+            exit 1
+        fi
+        case "${1:-}" in
+            HEAD) read_state head ;;
+            origin/main) read_state origin ;;
+            *) exit 1 ;;
+        esac
+        ;;
+    branch)
+        if [[ "${1:-}" == "--show-current" ]]; then
+            read_state branch
+            exit 0
+        fi
+        exit 1
+        ;;
+    fetch)
+        exit 0
+        ;;
+    show-ref)
+        ref="${*: -1}"
+        case "$ref" in
+            refs/heads/main) test -f "$(state_dir)/local-main" ;;
+            refs/remotes/origin/main) test -f "$(state_dir)/remote-main" ;;
+            *) exit 1 ;;
+        esac
+        ;;
+    stash)
+        touch "$(state_dir)/stashed"
+        rm -f "$(state_dir)/dirty" "$(state_dir)/untracked"
+        exit 0
+        ;;
+    checkout)
+        if [[ "${1:-}" == "-B" ]]; then
+            branch="$2"
+            target="$3"
+            write_state branch "$branch"
+            touch "$(state_dir)/local-$branch"
+            if [[ "$target" == "origin/main" ]]; then
+                read_state origin >"$(state_dir)/head"
+                printf 'new\n' >"$repo/version.txt"
+            fi
+            exit 0
+        fi
+        write_state branch "$1"
+        exit 0
+        ;;
+    reset)
+        if [[ "${2:-}" == "origin/main" ]]; then
+            read_state origin >"$(state_dir)/head"
+            printf 'new\n' >"$repo/version.txt"
+            exit 0
+        fi
+        exit 1
+        ;;
+    pull)
+        if [[ -f "$(state_dir)/pull-fails" ]]; then
+            exit 1
+        fi
+        read_state origin >"$(state_dir)/head"
+        printf 'new\n' >"$repo/version.txt"
+        exit 0
+        ;;
+    *)
+        echo "fake git: unsupported command: $cmd $*" >&2
+        exit 127
+        ;;
+esac
+FAKE_GIT
+    chmod +x "$fakebin/git"
+}
+
+create_fake_repo() {
+    local repo="$1"
+    local head="$2"
+    local origin="$3"
+    local content="$4"
+    local dirty="${5:-false}"
+
+    mkdir -p "$repo/.fakegit"
+    printf '%s\n' "$head" >"$repo/.fakegit/head"
+    printf '%s\n' "$origin" >"$repo/.fakegit/origin"
+    printf 'main\n' >"$repo/.fakegit/branch"
+    printf 'origin/main\n' >"$repo/.fakegit/upstream"
+    touch "$repo/.fakegit/local-main" "$repo/.fakegit/remote-main" "$repo/.fakegit/pull-fails"
+    printf '%s\n' "$content" >"$repo/version.txt"
+    if [[ "$dirty" == "true" ]]; then
+        touch "$repo/.fakegit/dirty"
+    fi
+}
+
+run_fake_git_tests() {
+    local fakebin="$tmpdir/fakebin"
+    local old_path="$PATH"
+    write_fake_git "$fakebin"
+    export PATH="$fakebin:$PATH"
+
+    local repo="$tmpdir/fake-managed"
+    create_fake_repo "$repo" "old-head" "new-head" "local edit" true
+    update_existing_repo "$repo" "" true
+    assert_file_equals "$repo/version.txt" "new"
+    [[ "$(git -C "$repo" rev-parse HEAD)" == "new-head" ]] || {
+        echo "fake managed repo did not reset to origin/main" >&2
+        exit 1
+    }
+    [[ -f "$repo/.fakegit/stashed" ]] || {
+        echo "fake managed repo did not stash local changes" >&2
+        exit 1
+    }
+
+    repo="$tmpdir/fake-user"
+    create_fake_repo "$repo" "old-head" "new-head" "local edit" true
+    update_existing_repo "$repo" "" false
+    assert_file_equals "$repo/version.txt" "local edit"
+    [[ "$(git -C "$repo" rev-parse HEAD)" == "old-head" ]] || {
+        echo "fake user repo was unexpectedly reset" >&2
+        exit 1
+    }
+
+    repo="$tmpdir/fake-user-branch"
+    create_fake_repo "$repo" "local-head" "new-head" "local commit" false
+    update_existing_repo "$repo" "main" false
+    [[ "$(git -C "$repo" rev-parse HEAD)" == "local-head" ]] || {
+        echo "fake user branch was unexpectedly reset" >&2
+        exit 1
+    }
+
+    export PATH="$old_path"
+}
+
+git_quiet() {
+    git "$@" >/dev/null 2>&1
+}
+
+configure_repo() {
+    local repo="$1"
+    git_quiet -C "$repo" config user.name "padctl test"
+    git_quiet -C "$repo" config user.email "padctl-test@example.invalid"
+}
+
+create_origin_with_clone() {
+    local origin="$1"
+    local seed="$2"
+    local clone="$3"
+
+    git_quiet init --bare --initial-branch=main "$origin"
+    git_quiet clone "$origin" "$seed"
+    configure_repo "$seed"
+    printf 'old\n' >"$seed/version.txt"
+    git_quiet -C "$seed" add version.txt
+    git_quiet -C "$seed" commit -m "initial"
+    git_quiet -C "$seed" push -u origin main
+    git_quiet --git-dir="$origin" symbolic-ref HEAD refs/heads/main
+
+    git_quiet clone "$origin" "$clone"
+    configure_repo "$clone"
+}
+
+advance_origin() {
+    local seed="$1"
+    printf 'new\n' >"$seed/version.txt"
+    git_quiet -C "$seed" commit -am "advance"
+    git_quiet -C "$seed" push
+}
+
+assert_file_equals() {
+    local path="$1"
+    local expected="$2"
+    local actual
+    actual="$(cat "$path")"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "expected $path to contain '$expected', got '$actual'" >&2
+        exit 1
+    fi
+}
+
+test_managed_dirty_repo_recovers_from_pull_failure() {
+    local root="$tmpdir/managed"
+    local origin="$root/origin.git"
+    local seed="$root/seed"
+    local repo="$root/home/Games/padctl"
+
+    mkdir -p "$(dirname "$repo")"
+    create_origin_with_clone "$origin" "$seed" "$repo"
+    printf 'local edit\n' >"$repo/version.txt"
+    advance_origin "$seed"
+
+    # This is the #320 failure mode: the old script ran this pull, warned, and
+    # then kept building the stale checkout.
+    if timeout 10 git -C "$repo" pull --ff-only >/dev/null 2>&1; then
+        echo "bug fixture invalid: dirty checkout unexpectedly fast-forwarded" >&2
+        exit 1
+    fi
+
+    update_existing_repo "$repo" "" true
+
+    assert_file_equals "$repo/version.txt" "new"
+    if [[ "$(git -C "$repo" rev-parse HEAD)" != "$(git -C "$repo" rev-parse origin/main)" ]]; then
+        echo "managed repo did not reset to origin/main" >&2
+        exit 1
+    fi
+    if ! git -C "$repo" stash list | grep -q "padctl bazzite setup auto-stash before update"; then
+        echo "managed repo local changes were not preserved in a stash" >&2
+        exit 1
+    fi
+}
+
+test_user_repo_is_not_reset_after_pull_failure() {
+    local root="$tmpdir/user"
+    local origin="$root/origin.git"
+    local seed="$root/seed"
+    local repo="$root/repo"
+
+    create_origin_with_clone "$origin" "$seed" "$repo"
+    printf 'local edit\n' >"$repo/version.txt"
+    advance_origin "$seed"
+
+    update_existing_repo "$repo" "" false
+
+    assert_file_equals "$repo/version.txt" "local edit"
+    if [[ "$(git -C "$repo" rev-parse HEAD)" == "$(git -C "$repo" rev-parse origin/main)" ]]; then
+        echo "user-managed repo was unexpectedly reset to origin/main" >&2
+        exit 1
+    fi
+}
+
+test_user_branch_is_not_reset_to_remote() {
+    local root="$tmpdir/user-branch"
+    local origin="$root/origin.git"
+    local seed="$root/seed"
+    local repo="$root/repo"
+    local local_head
+
+    create_origin_with_clone "$origin" "$seed" "$repo"
+    printf 'local commit\n' >"$repo/version.txt"
+    git_quiet -C "$repo" commit -am "local commit"
+    local_head="$(git -C "$repo" rev-parse HEAD)"
+    advance_origin "$seed"
+
+    update_existing_repo "$repo" "main" false
+
+    if [[ "$(git -C "$repo" rev-parse HEAD)" != "$local_head" ]]; then
+        echo "user-managed branch was unexpectedly reset to origin/main" >&2
+        exit 1
+    fi
+}
+
+bash -n "$SCRIPT_DIR/bazzite-setup.sh"
+if command -v git >/dev/null 2>&1; then
+    test_managed_dirty_repo_recovers_from_pull_failure
+    test_user_repo_is_not_reset_after_pull_failure
+    test_user_branch_is_not_reset_to_remote
+else
+    run_fake_git_tests
+fi
+
+echo "bazzite setup regression tests passed"


### PR DESCRIPTION
Fixes #320.\n\n## Summary\n- make the Bazzite setup script recover auto-managed ~/Games/padctl checkouts when fast-forward pull fails\n- preserve local changes in a stash before resetting only the auto-managed checkout\n- keep explicitly supplied user repos conservative: failed pulls leave their checkout untouched\n- add a shell regression test wired into zig build test\n- add git to the canonical Docker image so the regression test runs in Docker/CI\n\n## Test evidence\n- bash scripts/test-bazzite-setup.sh\n- /home/jim_z/.local/bin/zig build test-bazzite-setup --cache-dir /tmp/padctl-issue320-zig-cache --global-cache-dir /tmp/padctl-issue320-zig-global\n- ./scripts/padctl-docker test\n- pre-push Docker test-tsan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added regression test coverage for setup script behavior, including repository synchronization scenarios.

* **Chores**
  * Enhanced Docker build environment with Git package support.
  * Integrated new regression tests into the build pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->