### PR TITLE
fix: restore Vader 5 M2 Steam paddle label

### DIFF
--- a/devices/flydigi/vader5.toml
+++ b/devices/flydigi/vader5.toml
@@ -102,8 +102,11 @@ Z      = "BTN_TRIGGER_HAPPY2"
 LM     = "BTN_TRIGGER_HAPPY3"
 RM     = "BTN_TRIGGER_HAPPY4"
 M1     = "BTN_TRIGGER_HAPPY5"
-M2     = "BTN_TRIGGER_HAPPY6"
-M3     = "BTN_TRIGGER_HAPPY7"
+# Steam labels SDL paddle slots in Xbox Elite order: usage 22 is P3 and
+# usage 23 is P2. Keep M2/M3 swapped at the evdev-code level so Vader M2
+# appears as the expected lower-right paddle instead of P3.
+M2     = "BTN_TRIGGER_HAPPY7"
+M3     = "BTN_TRIGGER_HAPPY6"
 M4     = "BTN_TRIGGER_HAPPY8"
 O      = "BTN_TRIGGER_HAPPY9"
 

--- a/src/io/uhid_descriptor.zig
+++ b/src/io/uhid_descriptor.zig
@@ -1453,18 +1453,24 @@ test "descriptor: unknown output button keys do not create undefined usage slots
     try expectButtonUsages(desc, &.{1});
 }
 
-test "descriptor: Vader 5 paddles emit Xbox Elite trigger-happy usages" {
+test "descriptor: Vader 5 keeps Steam/SDL M2 and M3 paddle order" {
     const alloc = testing.allocator;
     const parsed = try device.parseFile(alloc, "devices/flydigi/vader5.toml");
     defer parsed.deinit();
     const out = parsed.value.output orelse return error.MissingOutputSection;
+
+    const buttons = out.buttons orelse return error.MissingButtons;
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY5", buttons.map.get("M1") orelse return error.MissingM1);
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY7", buttons.map.get("M2") orelse return error.MissingM2);
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY6", buttons.map.get("M3") orelse return error.MissingM3);
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY8", buttons.map.get("M4") orelse return error.MissingM4);
 
     const desc = try UhidDescriptorBuilder.buildFromOutput(alloc, out);
     defer alloc.free(desc);
 
     try expectButtonUsages(desc, &.{
         1,  2,  4,  5,  7,  8,  12, 11, 13, 14,
-        15, 21, 22, 23, 24, 17, 18, 19, 20, 25,
+        15, 21, 23, 22, 24, 17, 18, 19, 20, 25,
     });
 }
 


### PR DESCRIPTION
## Summary
- restore the Vader 5 M2/M3 trigger-happy ordering that Steam/SDL expects for Xbox Elite paddle labels
- pin the Vader 5 output mapping and HID Button usages with a regression test so M2 no longer appears as P3

Fixes #322

## Tests
- docker: ./scripts/padctl-docker test -Dtest-filter=Vader --cache-dir /tmp/padctl-docker-filter-cache --global-cache-dir /tmp/padctl-docker-filter-global
- docker: ./scripts/padctl-docker test --cache-dir /tmp/padctl-docker-full-cache --global-cache-dir /tmp/padctl-docker-full-global
- docker: ./scripts/padctl-docker build test-safe --cache-dir /tmp/padctl-docker-safe-cache --global-cache-dir /tmp/padctl-docker-safe-global
- docker: ./scripts/padctl-docker build check-fmt --cache-dir /tmp/padctl-docker-fmt-cache --global-cache-dir /tmp/padctl-docker-fmt-global
- docker: zig build test-tsan --summary all --cache-dir /tmp/padctl-docker-tsan-cache --global-cache-dir /tmp/padctl-docker-tsan-global

Note: native host zig build still hits the known Zig 0.15/glibc .sframe linker issue, so validation was done in the canonical Docker image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect paddle button mapping on Flydigi Vader 5 Pro controller. The M2 and M3 buttons now respond correctly and align with their physical positions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->