### PR TITLE
fix: recover Vader 5 init failures after Bazzite update

### DIFF
--- a/devices/flydigi/vader5.toml
+++ b/devices/flydigi/vader5.toml
@@ -20,6 +20,7 @@ commands = [
     "5aa5 0402 06",
 ]
 response_prefix = [0x5a, 0xa5]
+require_response = true
 enable  = "5aa5 1107 ff01 ffff ff15 00"
 disable = "5aa5 1107 ff00 ffff ff14 00"
 

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -33,6 +33,7 @@ Optional initialization sequence sent after device open.
 | `disable` | string | no | Hex byte string sent on shutdown |
 | `interface` | integer | no | Interface to send init commands on |
 | `report_size` | integer | no | Expected report size after init |
+| `require_response` | bool | no | When `true`, a missing `response_prefix` ACK fails init/re-init instead of continuing. Use for devices whose input reports are valid only after an acknowledged mode switch. |
 | `feature_report` | integer[] | no | HID feature report sent via `HIDIOCSFEATURE` immediately after `commands`. Encoded as a list of byte values (0–255); `byte[0]` is the report ID. |
 
 ## `[[report]]`

--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -85,6 +85,70 @@ current_upstream_ref() {
     git -C "$repo" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true
 }
 
+run_user_systemctl() {
+    local output status
+    if output="$(systemctl --user "$@" 2>&1 >/dev/null)"; then
+        return 0
+    fi
+    status=$?
+    if [[ "$output" != *"Failed to connect to bus"* && "$output" != *"No medium found"* ]]; then
+        return "$status"
+    fi
+
+    local uid user runtime bus
+    uid="$(id -u 2>/dev/null || true)"
+    user="$(id -un 2>/dev/null || true)"
+    [[ -n "$uid" && -n "$user" ]] || return 1
+
+    runtime="/run/user/$uid"
+    bus="$runtime/bus"
+    [[ -S "$bus" ]] || return 1
+    command -v sudo >/dev/null 2>&1 || return 1
+
+    sudo -u "$user" \
+        env XDG_RUNTIME_DIR="$runtime" DBUS_SESSION_BUS_ADDRESS="unix:path=$bus" \
+        systemctl --user "$@" >/dev/null 2>&1
+}
+
+legacy_system_service_present() {
+    systemctl is-active --quiet padctl.service >/dev/null 2>&1 \
+        || systemctl is-enabled --quiet padctl.service >/dev/null 2>&1
+}
+
+stop_existing_padctl_services() {
+    if run_user_systemctl is-active padctl.service; then
+        info "Stopping existing user padctl service..."
+        if run_user_systemctl stop padctl.service; then
+            ok "User service stopped"
+        else
+            warn "Could not stop user padctl.service; install will still try to restart it"
+        fi
+    fi
+
+    if legacy_system_service_present; then
+        warn "Stopping legacy system padctl.service to avoid a stale daemon grabbing the controller"
+        sudo systemctl stop padctl.service >/dev/null 2>&1 || warn "Could not stop legacy system padctl.service"
+        sudo systemctl disable padctl.service >/dev/null 2>&1 || warn "Could not disable legacy system padctl.service"
+        sudo systemctl daemon-reload >/dev/null 2>&1 || true
+    fi
+}
+
+ensure_user_padctl_service() {
+    if ! run_user_systemctl daemon-reload; then
+        warn "Could not reload user systemd manager"
+    fi
+    if ! run_user_systemctl enable padctl.service; then
+        warn "Could not enable user padctl.service"
+    fi
+    if run_user_systemctl restart padctl.service; then
+        ok "User service restarted"
+    elif run_user_systemctl start padctl.service; then
+        ok "User service started"
+    else
+        warn "Could not start user padctl.service — check 'systemctl --user status padctl.service'"
+    fi
+}
+
 sync_managed_repo_to_remote() {
     local repo="$1"
     local branch="$2"
@@ -322,12 +386,8 @@ fi
 zig build "${build_args[@]}"
 ok "Build complete"
 
-# --- 6. Stop existing service (if running) ---
-if systemctl --user is-active padctl.service &>/dev/null; then
-    info "Stopping existing padctl service..."
-    systemctl --user stop padctl.service 2>/dev/null || true
-    ok "Service stopped"
-fi
+# --- 6. Stop existing services before overwriting the binary ---
+stop_existing_padctl_services
 
 # --- 6b. Prompt for mapping if not specified ---
 if [[ -z "$MAPPING" && -d "$PADCTL_REPO/mappings" ]]; then
@@ -371,9 +431,7 @@ ok "padctl installed to $PREFIX"
 # freshly-installed unit files take effect and the IPC socket is bound
 # before we apply the mapping and verify.
 info "Ensuring daemon is running as user..."
-systemctl --user daemon-reload 2>/dev/null || true
-systemctl --user enable padctl.service &>/dev/null || true
-systemctl --user restart padctl.service 2>/dev/null || true
+ensure_user_padctl_service
 
 # --- 7c. Apply mapping to the running daemon (config.toml persists for future boots,
 #         but the already-running daemon needs an explicit switch for the current session).
@@ -423,13 +481,13 @@ else
 fi
 
 # Check service
-if systemctl --user is-enabled padctl.service &>/dev/null; then
+if run_user_systemctl is-enabled padctl.service; then
     ok "Service: enabled"
 else
     warn "Service: not enabled (may need manual enable)"
 fi
 
-if systemctl --user is-active padctl.service &>/dev/null; then
+if run_user_systemctl is-active padctl.service; then
     ok "Service: running"
 else
     # The daemon should always be running after a successful install — it

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -18,6 +18,7 @@ pub const InitConfig = struct {
     response_prefix: ?[]const i64 = null,
     enable: ?[]const u8 = null,
     disable: ?[]const u8 = null,
+    require_response: bool = false,
     interface: ?i64 = null,
     report_size: ?i64 = null,
     /// HID feature report to send via HIDIOCSFEATURE immediately after commands.

--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -837,6 +837,28 @@ const init_toml =
     \\expect = [0x01]
 ;
 
+const strict_init_toml =
+    \\[device]
+    \\name = "StrictInitDevice"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[device.init]
+    \\interface = 0
+    \\commands = ["0101"]
+    \\response_prefix = [0x5a]
+    \\require_response = true
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 1
+    \\[report.match]
+    \\offset = 0
+    \\expect = [0x01]
+;
+
 const feature_init_toml =
     \\[device]
     \\name = "FeatureInitDevice"
@@ -908,6 +930,26 @@ test "DeviceInstance.init propagates init write errors" {
     try testing.expectError(DeviceIO.WriteError.Io, result);
 }
 
+test "DeviceInstance.init propagates required init ack failures" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, strict_init_toml);
+    defer parsed.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    const devices = try allocator.alloc(DeviceIO, 1);
+    defer allocator.free(devices);
+    devices[0] = mock.deviceIO();
+
+    var uniq_counter: u16 = 1;
+    const result = DeviceInstance.init(allocator, &parsed.value, null, null, &uniq_counter, .{
+        .test_devices_override = devices,
+    });
+
+    try testing.expectError(error.InitFailed, result);
+}
+
 test "DeviceInstance.init propagates feature_report init errors" {
     const allocator = testing.allocator;
 
@@ -962,6 +1004,44 @@ test "DeviceInstance: rerunInitSequence propagates init write errors" {
     };
 
     try testing.expectError(DeviceIO.WriteError.Io, inst.rerunInitSequence());
+}
+
+test "DeviceInstance: rerunInitSequence propagates required init ack failures" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, strict_init_toml);
+    defer parsed.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    const devices = try allocator.alloc(DeviceIO, 1);
+    defer allocator.free(devices);
+    devices[0] = mock.deviceIO();
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+    try loop.addDevice(devices[0]);
+
+    var inst = DeviceInstance{
+        .allocator = allocator,
+        .devices = devices,
+        .loop = loop,
+        .interp = Interpreter.init(&parsed.value),
+        .mapper = null,
+        .owner = .none,
+        .primary_output = null,
+        .imu_output = null,
+        .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
+        .device_cfg = &parsed.value,
+        .pending_mapping = null,
+        .stopped = false,
+        .poll_timeout_ms = 100,
+    };
+
+    try testing.expectError(error.InitFailed, inst.rerunInitSequence());
 }
 
 test "DeviceInstance: rerunInitSequence propagates feature_report errors" {

--- a/src/init.zig
+++ b/src/init.zig
@@ -70,6 +70,7 @@ pub fn runInitSequence(
     defer if (init_config.response_prefix != null) allocator.free(prefix);
 
     const report_size: usize = if (init_config.report_size) |rs| @intCast(rs) else 0;
+    const require_response = init_config.require_response;
 
     var total: usize = 0;
 
@@ -79,6 +80,7 @@ pub fn runInitSequence(
             defer allocator.free(bytes);
             sendAndWaitPrefix(device, bytes, prefix, 50, report_size) catch |err| {
                 if (err == error.InitFailed) {
+                    if (require_response) return err;
                     std.log.debug("init command got no ack, continuing", .{});
                 } else return err;
             };
@@ -91,6 +93,7 @@ pub fn runInitSequence(
         defer allocator.free(bytes);
         sendAndWaitPrefix(device, bytes, prefix, 50, report_size) catch |err| {
             if (err == error.InitFailed) {
+                if (require_response) return err;
                 std.log.debug("enable command got no ack, continuing", .{});
             } else return err;
         };
@@ -210,6 +213,22 @@ test "init: runInitSequence: exhausted retries logs warning and continues" {
     };
 
     try runInitSequence(allocator, dev, init_cfg);
+}
+
+test "init: runInitSequence: require_response fails on missing ack" {
+    const allocator = std.testing.allocator;
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    const dev = mock.deviceIO();
+
+    const init_cfg = device_mod.InitConfig{
+        .commands = &[_][]const u8{"0101"},
+        .response_prefix = &[_]i64{0x5a},
+        .require_response = true,
+    };
+
+    try std.testing.expectError(error.InitFailed, runInitSequence(allocator, dev, init_cfg));
 }
 
 test "init: runInitSequence: enable command sent after commands" {

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -2025,6 +2025,7 @@ pub const Supervisor = struct {
             error.NoDevice,
             error.NotFound,
             error.Disconnected,
+            error.InitFailed,
             error.Io,
             => true,
             else => false,
@@ -2261,6 +2262,28 @@ const init_device_toml =
     \\[device.init]
     \\interface = 0
     \\commands = ["0101"]
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 1
+    \\[report.match]
+    \\offset = 0
+    \\expect = [0x01]
+;
+
+const strict_init_device_toml =
+    \\[device]
+    \\name = "StrictInitDevice"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[device.init]
+    \\interface = 0
+    \\commands = ["0101"]
+    \\response_prefix = [0x5a]
+    \\require_response = true
     \\[[report]]
     \\name = "r"
     \\interface = 0
@@ -3580,6 +3603,50 @@ test "supervisor: failed re-init after suspended rebind preserves grace state" {
     try m.instance.rebindDeviceIO(&new_devs);
     try testing.expectError(DeviceIO.WriteError.Io, Supervisor.rerunInitAfterRebind(m));
 
+    try testing.expect(m.suspended);
+    try testing.expectEqual(original_deadline, m.grace_deadline_ns.?);
+    try testing.expectEqual(@as(?[]const u8, null), m.devname);
+    try testing.expect(!sup.devname_map.contains("hidraw3"));
+    try testing.expectEqual(@as(posix.fd_t, -1), m.instance.devices[0].pollfd().fd);
+}
+
+test "supervisor: required init ack failure after suspended rebind preserves grace state" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, strict_init_device_toml);
+    defer parsed_dev.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+    sup.suspend_grace_sec = 5;
+    sup.test_now_override_ns = 10 * std.time.ns_per_s;
+
+    const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", inst_a, null);
+
+    sup.detach("hidraw3");
+    try testing.expect(sup.managed.items[0].suspended);
+    const original_deadline = sup.managed.items[0].grace_deadline_ns.?;
+
+    var mock_b = try MockDeviceIO.init(allocator, &.{});
+    defer mock_b.deinit();
+    var new_devs = [_]DeviceIO{mock_b.deviceIO()};
+    var opener = TestRebindOpenCtx{ .devices = &new_devs };
+    try testing.expectError(error.HotplugTransient, sup.tryResumeSuspendedInstance(
+        "hidraw5",
+        "usb-1-1",
+        1,
+        2,
+        &opener,
+        TestRebindOpenCtx.open,
+    ));
+
+    const m = &sup.managed.items[0];
     try testing.expect(m.suspended);
     try testing.expectEqual(original_deadline, m.grace_deadline_ns.?);
     try testing.expectEqual(@as(?[]const u8, null), m.devname);

--- a/src/test/bugfix_regression_test.zig
+++ b/src/test/bugfix_regression_test.zig
@@ -51,6 +51,7 @@ test "isTransientOpenError: transient errors are retried" {
     try testing.expect(Supervisor.isTransientOpenError(error.NoDevice));
     try testing.expect(Supervisor.isTransientOpenError(error.NotFound));
     try testing.expect(Supervisor.isTransientOpenError(error.Disconnected));
+    try testing.expect(Supervisor.isTransientOpenError(error.InitFailed));
     try testing.expect(Supervisor.isTransientOpenError(error.Io));
 }
 


### PR DESCRIPTION
Refs #320
Refs #236

Summary:
- Add a strict init response requirement for Vader 5 extended-mode setup so missing ACKs fail instead of leaving the controller treated as resumed.
- Treat required init ACK failures as transient hotplug failures, preserving the suspended grace state for retry instead of finalizing a broken instance.
- Harden the Bazzite setup flow so the updated user service is daemon-reloaded and restarted, while stale legacy system services are stopped/disabled.

Docker test evidence:
- ./scripts/padctl-docker build test -Dtest-filter=require_response --summary all
- ./scripts/padctl-docker build test -Dtest-filter="required init ack" --summary all
- ./scripts/padctl-docker build test -Dtest-filter=isTransientOpenError --summary all
- ./scripts/padctl-docker build test-bazzite-setup --summary all
- ./scripts/padctl-docker build test --summary all
- ./scripts/padctl-docker build test-safe --summary all
- ./scripts/padctl-docker build test-tsan --summary all
- ./scripts/padctl-docker build check-fmt --summary all