### PR TITLE
release: bump version to 0.1.11

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.10",
+    .version = "0.1.11",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
Summary:
- Bump build.zig.zon to 0.1.11 so the next release tag can publish the merged fixes.

Local Docker evidence:
- ./scripts/padctl-docker build test --summary all --cache-dir /tmp/padctl-release-011-cache --global-cache-dir /tmp/padctl-release-011-global
- ./scripts/padctl-docker build check-fmt --summary all --cache-dir /tmp/padctl-release-011-fmt-cache --global-cache-dir /tmp/padctl-release-011-fmt-global

Note:
- Host pre-commit build was skipped with SKIP_BUILD=1 because Zig 0.15.x cannot link this host glibc .sframe startup objects; Docker and CI remain the build gates.