### PR TITLE
fix: pin padctl-git AUR build to Zig 0.15.2

### DIFF
--- a/contrib/aur/PKGBUILD
+++ b/contrib/aur/PKGBUILD
@@ -1,22 +1,28 @@
 # Maintainer: bananasjim <bananasjim1@gmail.com>
 pkgname=padctl-git
-pkgver=r0.unknown
+pkgver=r626.ge3ba80b
 pkgrel=1
 pkgdesc="HID gamepad daemon — declarative TOML device config, uinput output"
 arch=('x86_64' 'aarch64')
 url="https://github.com/BANANASJIM/padctl"
 license=('LGPL-2.1-or-later')
 depends=('libusb' 'systemd' 'gcc-libs' 'glibc')
-makedepends=('zig>=0.15' 'git')
+makedepends=('git')
 provides=('padctl')
 conflicts=('padctl' 'padctl-bin')
 
-_zig_toml_hash="toml-0.3.0-bV14Be6EAQDr0fkyURz4jYFyTAMPcwlNN0FEPVjDnXTR"
+_zig_version="0.15.2"
+_zig_toml_rev="24e0deeceaad1b7f1b12027ebae1c65ff1d86e33"
+_zig_toml_hash="toml-0.3.0-bV14BVqIAQANb68hDuVPZ72hrcIhT-fv_fcIbetQIAyg"
 
 source=("git+${url}.git"
-        "zig-toml::https://github.com/sam701/zig-toml/archive/refs/heads/main.tar.gz")
+        "zig-toml::https://github.com/sam701/zig-toml/archive/${_zig_toml_rev}.tar.gz")
+source_x86_64=("zig-${_zig_version}-x86_64-linux.tar.xz::https://ziglang.org/download/${_zig_version}/zig-x86_64-linux-${_zig_version}.tar.xz")
+source_aarch64=("zig-${_zig_version}-aarch64-linux.tar.xz::https://ziglang.org/download/${_zig_version}/zig-aarch64-linux-${_zig_version}.tar.xz")
 sha256sums=('SKIP'
             'SKIP')
+sha256sums_x86_64=('02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239')
+sha256sums_aarch64=('958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f')
 
 pkgver() {
     cd padctl
@@ -27,13 +33,25 @@ prepare() {
     # Seed zig package cache so the build works offline
     export ZIG_GLOBAL_CACHE_DIR="${srcdir}/zig-cache"
     mkdir -p "${ZIG_GLOBAL_CACHE_DIR}/p"
-    ln -sfn "${srcdir}/zig-toml-main" "${ZIG_GLOBAL_CACHE_DIR}/p/${_zig_toml_hash}"
+    local _toml_src
+    _toml_src="$(find "${srcdir}" -maxdepth 1 -type d -name 'zig-toml-*' | head -n1)"
+    [ -n "${_toml_src}" ] || {
+        echo "zig-toml source directory not found" >&2
+        return 1
+    }
+    ln -sfn "${_toml_src}" "${ZIG_GLOBAL_CACHE_DIR}/p/${_zig_toml_hash}"
 }
 
 build() {
     cd padctl
     export ZIG_GLOBAL_CACHE_DIR="${srcdir}/zig-cache"
-    zig build -Doptimize=ReleaseSafe
+    local _zig_arch
+    case "${CARCH}" in
+        x86_64) _zig_arch="x86_64-linux" ;;
+        aarch64) _zig_arch="aarch64-linux" ;;
+        *) echo "unsupported architecture: ${CARCH}" >&2; return 1 ;;
+    esac
+    "${srcdir}/zig-${_zig_arch}-${_zig_version}/zig" build -Doptimize=ReleaseSafe
 }
 
 package() {


### PR DESCRIPTION
Summary:
- Make padctl-git download and use verified Zig 0.15.2 tarballs instead of Arch system zig.
- Update the initial VCS pkgver from r0.unknown to the latest known main revision.
- Pin the zig-toml source to the build.zig.zon commit and package hash.

Evidence:
- makepkg --printsrcinfo shows pkgver = r626.ge3ba80b and no zig makedepends.
- makepkg -f --syncdeps --noconfirm completed successfully in /tmp/padctl-aur-git-build.pzjDRZ using the pinned Zig 0.15.2 tarball.
- Zig 0.15.2 x86_64 tarball SHA256 validation passed.