### PR TITLE
Fix staged udev sentinel path

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ yay -S padctl-bin   # prebuilt binary
 yay -S padctl-git   # build from source
 ```
 
+If you previously installed from source with `sudo padctl install`, remove that
+manual install before switching to AUR so pacman can own the files:
+
+```sh
+sudo padctl uninstall --prefix /usr --no-immutable
+yay -S padctl-bin   # or: yay -S padctl-git
+```
+
 ### Debian / Ubuntu
 
 ```sh

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -10,6 +10,14 @@ yay -S padctl-git
 
 A prebuilt binary package (`padctl-bin`) is also available in the AUR.
 
+If you previously installed from source with `sudo padctl install`, remove that
+manual install before switching to AUR so pacman can own the files:
+
+```sh
+sudo padctl uninstall --prefix /usr --no-immutable
+yay -S padctl-git   # or: yay -S padctl-bin
+```
+
 ### Debian / Ubuntu
 
 ```sh

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -58,6 +58,7 @@ const generateUdevRules = _udev.generateUdevRules;
 const generateDriverBlockRules = _udev.generateDriverBlockRules;
 const generateDriverBlockRulesFromEntries = _udev.generateDriverBlockRulesFromEntries;
 const sentinelPath = udev_mod.sentinelPath;
+const runtime_sentinel_path = udev_mod.runtime_sentinel_path;
 const writeServiceSentinel = udev_mod.writeServiceSentinel;
 const removeServiceSentinel = udev_mod.removeServiceSentinel;
 const shouldProactiveUnbind = udev_mod.shouldProactiveUnbind;
@@ -1510,6 +1511,43 @@ test "install: #137 generates ACTION==remove rebind line" {
 
     try testing.expect(std.mem.indexOf(u8, content, "ACTION==\"remove\"") != null);
     try testing.expect(std.mem.indexOf(u8, content, "/bind") != null);
+}
+
+test "install: staged driver-block udev rule uses runtime sentinel path" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(destdir);
+
+    const opts = InstallOptions{ .destdir = destdir, .prefix = "/usr", .user_service = false };
+    const env = EnvSnapshot{ .uid = 0, .home = "/root", .sudo_user = null, .sudo_uid = null };
+    const plan = try InstallPlan.compute(allocator, opts, env);
+    defer plan.deinit(allocator);
+    try ensureDirAll(allocator, plan.udev_dir);
+
+    const drivers = [_][]const u8{"xpad"};
+    const entries = [_]UdevEntry{.{
+        .name = "Test Pad",
+        .vid = 0x0f0d,
+        .pid = 0x00c1,
+        .block_kernel_drivers = &drivers,
+    }};
+    {
+        var silencer = try SilencedStdout.begin();
+        defer silencer.end();
+        try udev_mod.installUdevRules(allocator, &plan, &entries);
+    }
+
+    const rules_path = try std.fmt.allocPrint(allocator, "{s}/61-padctl-driver-block.rules", .{plan.udev_dir});
+    defer allocator.free(rules_path);
+    const content = try readRulesFile(allocator, rules_path);
+    defer allocator.free(content);
+
+    try testing.expect(std.mem.indexOf(u8, content, runtime_sentinel_path) != null);
+    try testing.expect(std.mem.indexOf(u8, content, destdir) == null);
 }
 
 // (3) FAILS if writeServiceSentinel stops writing or sentinelPath diverges

--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -47,8 +47,13 @@ pub const UdevEntry = struct {
     clone_vid_pid: bool = false,
 };
 
-/// Path to the service-enabled sentinel. `/etc/padctl` is the fixed FHS
-/// sysconfdir (consistent with the reconnect-script `/etc/padctl/mappings`
+/// Runtime path checked by installed udev rules. This must never include
+/// `destdir`: package managers stage files under DESTDIR, but udev executes the
+/// rule on the target system after installation.
+pub const runtime_sentinel_path = "/etc/padctl/service-enabled";
+
+/// Filesystem path to the service-enabled sentinel. `/etc/padctl` is the fixed
+/// FHS sysconfdir (consistent with the reconnect-script `/etc/padctl/mappings`
 /// path in services.zig), so only `destdir` is prefixed — never `prefix`.
 pub fn sentinelPath(allocator: std.mem.Allocator, destdir: []const u8) ![]u8 {
     return std.fmt.allocPrint(allocator, "{s}/etc/padctl/service-enabled", .{destdir});
@@ -279,9 +284,7 @@ pub fn installUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan, 
 
     const driver_rules_path = try std.fmt.allocPrint(allocator, "{s}/61-padctl-driver-block.rules", .{plan.udev_dir});
     defer allocator.free(driver_rules_path);
-    const sentinel = try sentinelPath(allocator, plan.opts.destdir);
-    defer allocator.free(sentinel);
-    generateDriverBlockRulesFromEntries(allocator, entries, driver_rules_path, sentinel) catch |err| {
+    generateDriverBlockRulesFromEntries(allocator, entries, driver_rules_path, runtime_sentinel_path) catch |err| {
         var errbuf: [256]u8 = undefined;
         const msg = std.fmt.bufPrint(&errbuf, "warning: driver block rules not generated: {}\n", .{err}) catch "warning: driver block rules error\n";
         _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch {};


### PR DESCRIPTION
## Summary
- keep driver-block udev rules pointed at the runtime sentinel `/etc/padctl/service-enabled`
- keep `DESTDIR` only for staged filesystem output
- document the manual-install to AUR migration path

## Tests
- `./scripts/padctl-docker test --cache-dir /tmp/padctl-full-test-cache --global-cache-dir /tmp/padctl-full-test-global --summary all`
- `./scripts/padctl-docker build test-safe --cache-dir /tmp/padctl-safe-cache --global-cache-dir /tmp/padctl-safe-global --summary all`
- Docker Arch `makepkg` using local branch source, then `pacman -U` install of `padctl-git r628.g9b3edf7-1`
- staged install content check: `61-padctl-driver-block.rules` contains `/etc/padctl/service-enabled` and no staging path

Refs packaging regression reported from AUR install logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Arch Linux (AUR) installation instructions to clarify the migration path for users previously installing from source; uninstallation via `sudo padctl uninstall --prefix /usr --no-immutable` is now recommended before switching to AUR packages.

* **Bug Fixes**
  * Fixed driver-block udev rules to correctly reference the target filesystem path during staged installations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->