### PR TITLE
Release v0.1.12

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.11",
+    .version = "0.1.12",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
## Summary
- bump build.zig.zon to 0.1.12
- prepare release artifacts with the staged udev sentinel path fix from PR #328

## Tests
- `./scripts/padctl-docker build --cache-dir /tmp/padctl-release-012-cache --global-cache-dir /tmp/padctl-release-012-global --summary all`
- `./scripts/padctl-docker build check-fmt --cache-dir /tmp/padctl-release-012-cache --global-cache-dir /tmp/padctl-release-012-global --summary all`
- `./zig-out/bin/padctl --version` -> `padctl 0.1.12`

Refs package release update after PR #328.