### PR TITLE
docs: clarify hold_timeout belongs on [[layer]] (issue #331)

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -332,6 +332,8 @@ Macro fields:
 | `steps` | Ordered step list |
 | `repeat_delay_ms` | Optional. While the trigger button is held, restart the macro `N` ms after the previous run finishes. Releasing the trigger lets the current iteration finish naturally and stops further restarts. Omit for single-shot (legacy) behaviour. |
 
+> **Note:** `hold_timeout` is a `[[layer]]` field (see above, default 200 ms). It is **not** a `[[macro]]` field — placing it under `[[macro]]` has no effect (the schema linter warns about it). To make a hold-activated layer respond faster, set `hold_timeout` on the `[[layer]]` block, e.g. `hold_timeout = 50`.
+
 ```toml
 # Turbo: spam A while RM is held, 50 ms between presses.
 [[macro]]

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -387,6 +387,12 @@ steps = [
 
 Bind in remap: `M1 = "macro:dodge_roll"`
 
+> **Warning:** `hold_timeout` belongs on the `[[layer]]` block, not `[[macro]]`.
+> A `hold_timeout` value under `[[macro]]` is not recognized and the schema
+> linter will warn about it; the layer continues to use the default 200 ms.
+> To make a hold layer fire quickly, put `hold_timeout = 50` (or your chosen
+> value, 1–5000 ms) on the `[[layer]]` block itself.
+
 #### Repeat-while-held — turbo / combo (`repeat_delay_ms`)
 
 Add `repeat_delay_ms = N` to a `[[macro]]` block to make the macro restart while

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -1598,6 +1598,19 @@ test "lintUnknownFields: [[macro]] steps array does not mis-flag inline-table ke
     try std.testing.expectEqual(@as(usize, 0), findings.items.len);
 }
 
+test "lintUnknownFields: hold_timeout on [[macro]] is flagged (issue #331)" {
+    const allocator = std.testing.allocator;
+    const toml_str =
+        \\[[macro]]
+        \\name = "quick"
+        \\hold_timeout = 5
+        \\steps = [{ tap = "A" }]
+    ;
+    var findings = try lintUnknownFields(allocator, toml_str);
+    defer findings.deinit(allocator);
+    try std.testing.expect(findFinding(findings.items, "macro", "hold_timeout") != null);
+}
+
 test "lintUnknownFields: forward-compat field flagged once with table context" {
     const allocator = std.testing.allocator;
     const toml_str =


### PR DESCRIPTION
## Summary
- Add docs note clarifying `hold_timeout` is a `[[layer]]` field (default 200 ms), not a `[[macro]]` field
- Add regression test pinning schema-linter coverage: `hold_timeout` placed under `[[macro]]` is flagged as an unknown field

Refs #331

## Test plan
- [x] `./scripts/padctl-docker test` (1490/1496 pass, 6 UHID Layer 2 skipped)
- [x] `./scripts/padctl-docker build check-fmt` clean
- [x] `./scripts/padctl-docker build test-tsan` (1483 + 7 passed)
- [x] Regression test proven falsifiable: temporarily breaking `classifyTable` lookup made the new test fail; reverting restored pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `hold_timeout` is a layer-level configuration parameter (default 200 ms), not a macro-level setting
  * Added warnings explaining that placing `hold_timeout` in macro blocks triggers schema warnings and has no effect

* **Tests**
  * Added validation test to verify linter correctly flags invalid `hold_timeout` placement

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->