### PR TITLE
feat(mapping): macro_step_delay + per-macro step_delay (issue #333)

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -331,6 +331,35 @@ Macro fields:
 | `name` | Identifier referenced from remap as `macro:<name>` |
 | `steps` | Ordered step list |
 | `repeat_delay_ms` | Optional. While the trigger button is held, restart the macro `N` ms after the previous run finishes. Releasing the trigger lets the current iteration finish naturally and stops further restarts. Omit for single-shot (legacy) behaviour. |
+| `step_delay` | Optional. Per-macro implicit delay (ms) inserted between adjacent emitting steps (`tap`/`down`/`up`). Overrides the top-level `macro_step_delay`. Explicit `delay` steps and `pause_for_release` neighbours suppress insertion. `0` disables (explicit zero wins over the global default). |
+
+### Implicit step delays
+
+The top-level `macro_step_delay = N` (ms) sets a global default that is inserted between every pair of adjacent emitting steps (`tap` / `down` / `up`) in every macro. A per-macro `step_delay` overrides the global. Both default to `0` (no insertion, byte-identical to legacy behaviour).
+
+Insertion rules:
+
+- Only inserted between two adjacent **emitting** steps (`tap`/`down`/`up`).
+- Never inserted adjacent to an explicit `{ delay = N }` step (it already is a delay).
+- Never inserted adjacent to `"pause_for_release"` (treat it as a synchronization point).
+- Per-macro `step_delay` (including explicit `0`) wins over global `macro_step_delay`.
+
+```toml
+macro_step_delay = 50   # global default for every macro
+
+[[macro]]
+name = "unarmed"
+# step_delay omitted → inherits global 50
+steps = [
+    { down = "RB" },
+    { down = "X" },
+    "pause_for_release",
+    { up = "X" },
+    { up = "RB" },
+]
+# Effective after parse:
+#   down RB, delay 50, down X, pause_for_release, up X, delay 50, up RB
+```
 
 > **Note:** `hold_timeout` is a `[[layer]]` field (see above, default 200 ms). It is **not** a `[[macro]]` field — placing it under `[[macro]]` has no effect (the schema linter warns about it). To make a hold-activated layer respond faster, set `hold_timeout` on the `[[layer]]` block, e.g. `hold_timeout = 50`.
 

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -321,6 +321,11 @@ pub const MappingConfig = struct {
     macro: ?[]const Macro = null,
     adaptive_trigger: ?AdaptiveTriggerConfig = null,
     trigger_threshold: ?u8 = null,
+    // Global default for implicit delay (ms) between adjacent emitting macro
+    // steps. Per-macro `step_delay` overrides this. null / 0 → no insertion
+    // (byte-identical to pre-issue-333 behaviour). Applied via parse-time AST
+    // rewrite in `parseString` — see `expandMacroStepDelays`.
+    macro_step_delay: ?u32 = null,
 };
 
 pub const ParseResult = toml.Parsed(MappingConfig);
@@ -328,7 +333,9 @@ pub const ParseResult = toml.Parsed(MappingConfig);
 pub fn parseString(allocator: std.mem.Allocator, content: []const u8) !ParseResult {
     var parser = toml.Parser(MappingConfig).init(allocator);
     defer parser.deinit();
-    const result = try parser.parseString(content);
+    var result = try parser.parseString(content);
+    errdefer result.deinit();
+    try expandMacroStepDelays(&result);
     if (lintUnknownFields(allocator, content)) |findings| {
         defer {
             var f = findings;
@@ -337,6 +344,52 @@ pub fn parseString(allocator: std.mem.Allocator, content: []const u8) !ParseResu
         warnLintFindings(findings.items);
     } else |_| {} // lint failure (OOM) must not break parsing
     return result;
+}
+
+fn isEmittingStep(s: MacroStep) bool {
+    return switch (s) {
+        .tap, .down, .up => true,
+        .delay, .pause_for_release => false,
+    };
+}
+
+// Parse-time AST rewrite: between every pair of adjacent EMITTING steps
+// (tap/down/up) insert a `delay` step. Per-macro `step_delay` wins over the
+// global `macro_step_delay`. Explicit `delay` and `pause_for_release` are not
+// considered emitting, so they suppress insertion against either neighbour.
+// Effective delay 0 (default 0, or explicit `step_delay = 0`) → identity.
+fn expandMacroStepDelays(result: *ParseResult) !void {
+    const macros = result.value.macro orelse return;
+    if (macros.len == 0) return;
+    const global = result.value.macro_step_delay;
+    const arena = result.arena.allocator();
+
+    var rewritten = try arena.alloc(Macro, macros.len);
+    for (macros, 0..) |m, i| {
+        const eff: u32 = m.step_delay orelse (global orelse 0);
+        rewritten[i] = m;
+        if (eff == 0 or m.steps.len < 2) continue;
+
+        var count: usize = m.steps.len;
+        for (m.steps[0 .. m.steps.len - 1], m.steps[1..]) |a, b| {
+            if (isEmittingStep(a) and isEmittingStep(b)) count += 1;
+        }
+        if (count == m.steps.len) continue;
+
+        var out = try arena.alloc(MacroStep, count);
+        var k: usize = 0;
+        for (m.steps, 0..) |s, j| {
+            out[k] = s;
+            k += 1;
+            if (j + 1 < m.steps.len and isEmittingStep(s) and isEmittingStep(m.steps[j + 1])) {
+                out[k] = .{ .delay = eff };
+                k += 1;
+            }
+        }
+        std.debug.assert(k == count);
+        rewritten[i].steps = out;
+    }
+    result.value.macro = rewritten;
 }
 
 pub fn parseFile(allocator: std.mem.Allocator, path: []const u8) !ParseResult {

--- a/src/core/macro.zig
+++ b/src/core/macro.zig
@@ -16,6 +16,11 @@ pub const Macro = struct {
     // Releasing the trigger lets the current iteration finish naturally and stops
     // further restarts. Absent / null = single-shot behaviour.
     repeat_delay_ms: ?u32 = null,
+    // Per-macro override for implicit delay (ms) inserted between adjacent
+    // emitting steps (down/up/tap). Overrides MappingConfig.macro_step_delay.
+    // Explicit `delay` / `pause_for_release` neighbours suppress insertion.
+    // Resolved at parse-time AST rewrite — the player never sees this field.
+    step_delay: ?u32 = null,
 };
 
 // --- tests ---

--- a/src/main.zig
+++ b/src/main.zig
@@ -102,6 +102,7 @@ pub const testing_support = struct {
     pub const gyro_stick_e2e_test = @import("test/gyro_stick_e2e_test.zig");
     pub const macro_e2e_test = @import("test/macro_e2e_test.zig");
     pub const macro_gamepad_button_test = @import("test/macro_gamepad_button_test.zig");
+    pub const macro_step_delay_test = @import("test/macro_step_delay_test.zig");
     pub const capture_e2e_test = @import("test/capture_e2e_test.zig");
     pub const supervisor_e2e_test = @import("test/supervisor_e2e_test.zig");
     pub const wasm_e2e_test = @import("test/wasm_e2e_test.zig");

--- a/src/test/macro_step_delay_test.zig
+++ b/src/test/macro_step_delay_test.zig
@@ -1,0 +1,205 @@
+// Parse-time AST rewrite: implicit `delay` steps between adjacent emitting
+// macro steps. Driven by `macro_step_delay` (global) and `[[macro]].step_delay`
+// (per-macro override). See `docs/src/mapping-config.md` — "Implicit step delays".
+
+const std = @import("std");
+const testing = std.testing;
+const mapping = @import("../config/mapping.zig");
+const macro_mod = @import("../core/macro.zig");
+
+const MacroStep = macro_mod.MacroStep;
+
+fn expectTap(step: MacroStep, want: []const u8) !void {
+    try testing.expectEqualStrings(want, step.tap);
+}
+fn expectDown(step: MacroStep, want: []const u8) !void {
+    try testing.expectEqualStrings(want, step.down);
+}
+fn expectUp(step: MacroStep, want: []const u8) !void {
+    try testing.expectEqualStrings(want, step.up);
+}
+fn expectDelay(step: MacroStep, want: u32) !void {
+    try testing.expectEqual(want, step.delay);
+}
+fn expectPause(step: MacroStep) !void {
+    _ = step.pause_for_release;
+}
+
+test "macro_step_delay: case A — step_delay = 0 produces identity transform" {
+    const allocator = testing.allocator;
+    const src =
+        \\[[macro]]
+        \\name = "m"
+        \\step_delay = 0
+        \\steps = [
+        \\    { tap = "B" },
+        \\    { tap = "A" },
+        \\]
+    ;
+    const result = try mapping.parseString(allocator, src);
+    defer result.deinit();
+
+    const m = result.value.macro.?[0];
+    try testing.expectEqual(@as(usize, 2), m.steps.len);
+    try expectTap(m.steps[0], "B");
+    try expectTap(m.steps[1], "A");
+}
+
+test "macro_step_delay: case B — step_delay = 50 inserts between emitting steps" {
+    const allocator = testing.allocator;
+    const src =
+        \\[[macro]]
+        \\name = "m"
+        \\step_delay = 50
+        \\steps = [
+        \\    { down = "RB" },
+        \\    { down = "X" },
+        \\    { up = "X" },
+        \\    { up = "RB" },
+        \\]
+    ;
+    const result = try mapping.parseString(allocator, src);
+    defer result.deinit();
+
+    const m = result.value.macro.?[0];
+    try testing.expectEqual(@as(usize, 7), m.steps.len);
+    try expectDown(m.steps[0], "RB");
+    try expectDelay(m.steps[1], 50);
+    try expectDown(m.steps[2], "X");
+    try expectDelay(m.steps[3], 50);
+    try expectUp(m.steps[4], "X");
+    try expectDelay(m.steps[5], 50);
+    try expectUp(m.steps[6], "RB");
+}
+
+test "macro_step_delay: case C — explicit delay suppresses adjacent auto-insertion" {
+    const allocator = testing.allocator;
+    const src =
+        \\[[macro]]
+        \\name = "m"
+        \\step_delay = 50
+        \\steps = [
+        \\    { tap = "B" },
+        \\    { delay = 200 },
+        \\    { tap = "A" },
+        \\    { tap = "C" },
+        \\]
+    ;
+    const result = try mapping.parseString(allocator, src);
+    defer result.deinit();
+
+    const m = result.value.macro.?[0];
+    // tap B, explicit delay 200, tap A, auto delay 50, tap C → 5 entries
+    try testing.expectEqual(@as(usize, 5), m.steps.len);
+    try expectTap(m.steps[0], "B");
+    try expectDelay(m.steps[1], 200);
+    try expectTap(m.steps[2], "A");
+    try expectDelay(m.steps[3], 50);
+    try expectTap(m.steps[4], "C");
+}
+
+test "macro_step_delay: case D — pause_for_release blocks adjacent auto-insertion" {
+    const allocator = testing.allocator;
+    const src =
+        \\[[macro]]
+        \\name = "m"
+        \\step_delay = 50
+        \\steps = [
+        \\    { down = "X" },
+        \\    "pause_for_release",
+        \\    { up = "X" },
+        \\]
+    ;
+    const result = try mapping.parseString(allocator, src);
+    defer result.deinit();
+
+    const m = result.value.macro.?[0];
+    try testing.expectEqual(@as(usize, 3), m.steps.len);
+    try expectDown(m.steps[0], "X");
+    try expectPause(m.steps[1]);
+    try expectUp(m.steps[2], "X");
+}
+
+test "macro_step_delay: case E — global default applies when per-macro unset" {
+    const allocator = testing.allocator;
+    const src =
+        \\macro_step_delay = 30
+        \\
+        \\[[macro]]
+        \\name = "m"
+        \\steps = [
+        \\    { tap = "B" },
+        \\    { tap = "A" },
+        \\]
+    ;
+    const result = try mapping.parseString(allocator, src);
+    defer result.deinit();
+
+    try testing.expectEqual(@as(?u32, 30), result.value.macro_step_delay);
+    const m = result.value.macro.?[0];
+    try testing.expectEqual(@as(usize, 3), m.steps.len);
+    try expectTap(m.steps[0], "B");
+    try expectDelay(m.steps[1], 30);
+    try expectTap(m.steps[2], "A");
+}
+
+test "macro_step_delay: case F — per-macro step_delay = 0 wins over global" {
+    const allocator = testing.allocator;
+    const src =
+        \\macro_step_delay = 30
+        \\
+        \\[[macro]]
+        \\name = "m"
+        \\step_delay = 0
+        \\steps = [
+        \\    { tap = "B" },
+        \\    { tap = "A" },
+        \\]
+    ;
+    const result = try mapping.parseString(allocator, src);
+    defer result.deinit();
+
+    const m = result.value.macro.?[0];
+    try testing.expectEqual(@as(usize, 2), m.steps.len);
+    try expectTap(m.steps[0], "B");
+    try expectTap(m.steps[1], "A");
+}
+
+test "macro_step_delay: case G — neither field set is byte-identical to pre-fix" {
+    const allocator = testing.allocator;
+    const src =
+        \\[[macro]]
+        \\name = "dodge_roll"
+        \\steps = [
+        \\    { tap = "B" },
+        \\    { delay = 50 },
+        \\    { tap = "LEFT" },
+        \\]
+        \\
+        \\[[macro]]
+        \\name = "shift_hold"
+        \\steps = [
+        \\    { down = "KEY_LEFTSHIFT" },
+        \\    "pause_for_release",
+        \\    { up = "KEY_LEFTSHIFT" },
+        \\]
+    ;
+    const result = try mapping.parseString(allocator, src);
+    defer result.deinit();
+
+    try testing.expectEqual(@as(?u32, null), result.value.macro_step_delay);
+
+    const dodge = result.value.macro.?[0];
+    try testing.expectEqual(@as(?u32, null), dodge.step_delay);
+    try testing.expectEqual(@as(usize, 3), dodge.steps.len);
+    try expectTap(dodge.steps[0], "B");
+    try expectDelay(dodge.steps[1], 50);
+    try expectTap(dodge.steps[2], "LEFT");
+
+    const shift = result.value.macro.?[1];
+    try testing.expectEqual(@as(?u32, null), shift.step_delay);
+    try testing.expectEqual(@as(usize, 3), shift.steps.len);
+    try expectDown(shift.steps[0], "KEY_LEFTSHIFT");
+    try expectPause(shift.steps[1]);
+    try expectUp(shift.steps[2], "KEY_LEFTSHIFT");
+}


### PR DESCRIPTION
## Summary
- Add top-level `macro_step_delay = N` (ms) global default for implicit delays between adjacent emitting macro steps (`tap`/`down`/`up`)
- Add per-macro `step_delay` field that overrides the global (explicit `0` opts out)
- Parse-time AST rewrite — `macro_player.zig` is unchanged
- Both defaults are `0` (byte-identical to pre-change AST)

Refs #333

## Test plan
- [x] 7 new cases (A-G): identity, simple insertion, explicit `delay` neighbour, `pause_for_release` neighbour, global default, per-macro override of `0`, legacy backward-compat
- [x] `./scripts/padctl-docker test` — 1500/1506 passed, 6 UHID L2 skipped
- [x] `./scripts/padctl-docker build test-safe` — 1496/1502 passed
- [x] `./scripts/padctl-docker build test-tsan` — 1489 + 7 passed
- [x] `./scripts/padctl-docker build check-fmt` clean
- [x] `macro_player.zig` untouched (verified `git diff origin/main -- src/core/macro_player.zig` empty)

## Files changed
- `src/config/mapping.zig` — `macro_step_delay` field + `expandMacroStepDelays` helper (+54/-1)
- `src/core/macro.zig` — `Macro.step_delay` field (+5)
- `src/main.zig` — register test in `testing_support` (+1)
- `src/test/macro_step_delay_test.zig` — 7 test cases (new, 205 LoC)
- `docs/src/mapping-config.md` — "Implicit step delays" section + row in macro field table (+29)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable implicit delays between adjacent macro steps via global `macro_step_delay` setting and per-macro `step_delay` override

* **Documentation**
  * Documented macro step delay configuration options and interaction rules with explicit delays

* **Tests**
  * Added comprehensive test coverage for macro step delay behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->