### PR TITLE
fix(supervisor): forfeit grace for stale suspended on phys-key change (#236)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -144,6 +144,7 @@ pub const testing_support = struct {
     pub const uhid_simulator = @import("test/harness/uhid_simulator.zig");
     pub const uhid_test_cleanup = @import("test/uhid_test_cleanup.zig");
     pub const device_instance_imu_ownership_test = @import("test/device_instance_imu_ownership_test.zig");
+    pub const supervisor_suspended_attach_takeover_test = @import("test/supervisor_suspended_attach_takeover_test.zig");
     // Permanent canary — proves test discovery walks into testing_support.
     // If the discovery mechanism breaks again, this test stops running and
     // we can prove the regression with a deliberate failure.

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -379,8 +379,21 @@ pub const Supervisor = struct {
         return false;
     }
 
-    fn attachWithInstanceResult(self: *Supervisor, devname: []const u8, phys_key: []const u8, instance: *DeviceInstance, default_pr: ?*mapping_cfg.ParseResult) !bool {
+    pub fn attachWithInstanceResult(self: *Supervisor, devname: []const u8, phys_key: []const u8, instance: *DeviceInstance, default_pr: ?*mapping_cfg.ParseResult) !bool {
         if (self.devname_map.contains(devname)) return false;
+        // issue #236: forfeit grace for stale suspended entries sharing this
+        // device's VID:PID but parked under a different phys_key. The grace
+        // window's contract is "same controller will return at the same
+        // physical topology"; once a fresh ADD arrives for the same VID:PID at
+        // a different phys (dongle re-enumeration, USB renumber, PR #304's
+        // cold-scan retry replay after boot), the old uinput is stale — and
+        // leaving it alive in parallel with the new one causes consumers
+        // (Steam) to keep reading inputs from the now-dead device.
+        self.pruneStaleSuspendedForId(
+            @intCast(instance.device_cfg.device.vid),
+            @intCast(instance.device_cfg.device.pid),
+            phys_key,
+        );
         // Dedup by phys_key. Race guard: when a controller is unplugged and
         // replugged within the detach-delay window (or a USB re-enumeration
         // skips the REMOVE uevent entirely), an ADD can reach this path while
@@ -660,6 +673,25 @@ pub const Supervisor = struct {
             .switch_mapping = null,
             .default_mapping_pr = default_pr,
         });
+    }
+
+    fn pruneStaleSuspendedForId(self: *Supervisor, vid: u16, pid: u16, keep_phys: []const u8) void {
+        var i: usize = self.managed.items.len;
+        var pruned: bool = false;
+        while (i > 0) {
+            i -= 1;
+            const m = &self.managed.items[i];
+            if (!m.suspended) continue;
+            const m_vid: u16 = @intCast(m.instance.device_cfg.device.vid);
+            const m_pid: u16 = @intCast(m.instance.device_cfg.device.pid);
+            if (m_vid != vid or m_pid != pid) continue;
+            if (std.mem.eql(u8, m.phys_key, keep_phys)) continue;
+            std.log.info("hotplug: forfeiting grace for stale suspended phys \"{s}\" (VID={x:0>4} PID={x:0>4}); new attach at \"{s}\"", .{ m.phys_key, vid, pid, keep_phys });
+            self.teardownManaged(m);
+            _ = self.managed.swapRemove(i);
+            pruned = true;
+        }
+        if (pruned) self.armGraceTimer();
     }
 
     fn teardownManaged(self: *Supervisor, m: *ManagedInstance) void {

--- a/src/test/supervisor_suspended_attach_takeover_test.zig
+++ b/src/test/supervisor_suspended_attach_takeover_test.zig
@@ -1,0 +1,110 @@
+// Regression for issue #236 (Steam stops registering inputs after game close on
+// Bazzite + Vader 5 Pro). Asserts that a fresh hotplug attach with same
+// VID:PID but a different phys_key forces a teardown of the stale suspended
+// entry instead of spawning a parallel uinput device that ends up holding the
+// uniq Steam already latched onto.
+
+const std = @import("std");
+const testing = std.testing;
+
+const device_mod = @import("../config/device.zig");
+const EventLoop = @import("../event_loop.zig").EventLoop;
+const DeviceInstance = @import("../device_instance.zig").DeviceInstance;
+const Interpreter = @import("../core/interpreter.zig").Interpreter;
+const MockDeviceIO = @import("mock_device_io.zig").MockDeviceIO;
+const DeviceIO = @import("../io/device_io.zig").DeviceIO;
+const Supervisor = @import("../supervisor.zig").Supervisor;
+
+const minimal_device_toml =
+    \\[device]
+    \\name = "T"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 3
+    \\[report.match]
+    \\offset = 0
+    \\expect = [0x01]
+    \\[report.fields]
+    \\left_x = { offset = 1, type = "i16le" }
+;
+
+fn makeInstance(
+    allocator: std.mem.Allocator,
+    mock: *MockDeviceIO,
+    cfg: *const device_mod.DeviceConfig,
+) !*DeviceInstance {
+    const devices = try allocator.alloc(DeviceIO, 1);
+    devices[0] = mock.deviceIO();
+    var loop = try EventLoop.initManaged();
+    errdefer loop.deinit();
+    try loop.addDevice(devices[0]);
+    const inst = try allocator.create(DeviceInstance);
+    inst.* = .{
+        .allocator = allocator,
+        .devices = devices,
+        .loop = loop,
+        .interp = Interpreter.init(cfg),
+        .mapper = null,
+        .owner = .none,
+        .primary_output = null,
+        .imu_output = null,
+        .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
+        .device_cfg = cfg,
+        .pending_mapping = null,
+        .stopped = false,
+        .poll_timeout_ms = 100,
+    };
+    return inst;
+}
+
+test "issue-236: fresh attach with same VID:PID but new phys_key forfeits stale suspended grace" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed.deinit();
+
+    var mock_old = try MockDeviceIO.init(allocator, &.{});
+    defer mock_old.deinit();
+    var mock_new = try MockDeviceIO.init(allocator, &.{});
+    defer mock_new.deinit();
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+    sup.suspend_grace_sec = 15;
+
+    const old_inst = try makeInstance(allocator, &mock_old, &parsed.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", old_inst, null);
+
+    sup.detach("hidraw3");
+    try testing.expect(sup.managed.items[0].suspended);
+    try testing.expect(sup.managed.items[0].grace_deadline_ns != null);
+
+    const new_inst = try makeInstance(allocator, &mock_new, &parsed.value);
+    var new_attached = false;
+    defer if (!new_attached) {
+        new_inst.deinit();
+        allocator.destroy(new_inst);
+    };
+
+    new_attached = try sup.attachWithInstanceResult("hidraw5", "usb-9-9", new_inst, null);
+
+    try testing.expect(new_attached);
+    try testing.expectEqual(@as(usize, 1), sup.managed.items.len);
+    try testing.expectEqual(new_inst, sup.managed.items[0].instance);
+    try testing.expect(!sup.managed.items[0].suspended);
+    try testing.expectEqualStrings("usb-9-9", sup.managed.items[0].phys_key);
+    try testing.expectEqualStrings("hidraw5", sup.managed.items[0].devname.?);
+    try testing.expect(sup.devname_map.contains("hidraw5"));
+}


### PR DESCRIPTION
## Summary
- New helper `pruneStaleSuspendedForId(vid, pid, keep_phys)` tears down suspended `ManagedInstance` entries matching VID:PID at a different `phys_key` before a fresh attach proceeds
- Called at the top of `attachWithInstanceResult`; comment block in `supervisor.zig` documents the grace-window invariant
- Layer 1 regression test (`src/test/supervisor_suspended_attach_takeover_test.zig`, 110 LoC) using `MockDeviceIO` — no `/dev/uhid`, no `/dev/uinput`
- TDD-proven falsifiable: without the supervisor change, the test fails (`expected 1, found 2` — duplicate `ManagedInstance` spawned)

Refs #236

## Test plan
- [x] `./scripts/padctl-docker test` — 1494/1500 passed, 6 UHID L2 skipped
- [x] `./scripts/padctl-docker build test-safe` clean
- [x] `./scripts/padctl-docker build test-tsan` clean
- [x] `./scripts/padctl-docker build check-fmt` clean
- [x] Falsifiability re-proven by dispatcher: stash `src/supervisor.zig` → test fails (1 failed) → unstash → test passes (EXIT=0)

## Residual risk
The user-visible Bazzite + Vader 5 Pro + Steam game-close scenario (#236 primary symptom) still needs reporter validation in a real release. The 60-120s timing in reports is longer than the 15s default `suspend_grace_sec`, suggesting either Steam-side handle retention or additional cycles not exercised by the Layer 1 test. This PR covers the dongle-replug class of trigger; reporter retest is the authoritative check for full coverage.

## Files changed
- `src/supervisor.zig` — `pruneStaleSuspendedForId` helper + call site (+33/-1)
- `src/main.zig` — register test in `testing_support` (+1)
- `src/test/supervisor_suspended_attach_takeover_test.zig` — new (110 LoC)