### PR TITLE
fix(macro): dispatch LT/RT analog axis from macro steps (issue #99)

### DIFF
--- a/src/core/macro_player.zig
+++ b/src/core/macro_player.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const macro_mod = @import("macro.zig");
 const remap = @import("remap.zig");
 const timer_queue_mod = @import("timer_queue.zig");
+const state_mod = @import("state.zig");
 
 const Macro = macro_mod.Macro;
 const MacroStep = macro_mod.MacroStep;
@@ -9,6 +10,30 @@ const aux_event_mod = @import("aux_event.zig");
 const AuxEventList = aux_event_mod.AuxEventList;
 const TimerQueue = timer_queue_mod.TimerQueue;
 const RemapTargetResolved = remap.RemapTargetResolved;
+const ButtonId = state_mod.ButtonId;
+
+/// Analog floor contributed by macros for LT/RT. Mapper merges this into
+/// emit_state.lt/rt via @max so a physical press always wins over the macro
+/// when stronger (issue #99 — digital BTN_TL2 alone is not seen by SDL/games).
+pub const AxisInjection = struct {
+    lt: u8 = 0,
+    rt: u8 = 0,
+};
+
+fn axisFloorOf(target: RemapTargetResolved) ?struct { lt: u8, rt: u8 } {
+    return switch (target) {
+        .gamepad_button => |b| switch (b) {
+            .LT => .{ .lt = 255, .rt = 0 },
+            .RT => .{ .lt = 0, .rt = 255 },
+            else => null,
+        },
+        else => null,
+    };
+}
+
+fn raiseAxis(dst: *u8, value: u8) void {
+    if (value > dst.*) dst.* = value;
+}
 
 pub const MacroPlayer = struct {
     macro: *const Macro,
@@ -17,6 +42,10 @@ pub const MacroPlayer = struct {
     timer_token: u32,
     trigger_src_idx: u6,
     held_gamepad_buttons: u64,
+    // Analog axis floor contributed by an outstanding `.down LT/RT` step,
+    // cleared by the matching `.up` or emitPendingReleases on cancel.
+    held_axis_lt: u8,
+    held_axis_rt: u8,
     // Deadline at which the next step becomes eligible. While now_ns is below
     // this, step() must yield the frame so per-poll Mapper.apply calls do not
     // race past delay= boundaries.
@@ -38,6 +67,8 @@ pub const MacroPlayer = struct {
             .timer_token = token,
             .trigger_src_idx = src_idx,
             .held_gamepad_buttons = 0,
+            .held_axis_lt = 0,
+            .held_axis_rt = 0,
             .next_step_eligible_at_ns = 0,
             .trigger_held = true,
             .awaiting_restart_at_ns = null,
@@ -51,14 +82,28 @@ pub const MacroPlayer = struct {
     ///   of a .gamepad_button target set or clear bits here.
     /// pending_tap_release: tap bits ORed by this frame; mapper clears them next frame
     ///   (same cadence as the remap tap path — see mapper.emitTapEvent).
+    /// axes: analog LT/RT floor for this frame (issue #99). `.tap` raises the
+    ///   floor for one frame; `.down`/`.up` flip the player's held-axis state
+    ///   which is re-asserted every frame until cancelled.
     pub fn step(
         self: *MacroPlayer,
         aux: *AuxEventList,
         queue: *TimerQueue,
         injected_buttons: *u64,
         pending_tap_release: *u64,
+        axes: *AxisInjection,
         now_ns: i128,
     ) !bool {
+        // Re-assert the held axis floor on every frame, even when the early
+        // returns below short-circuit step execution (delay window,
+        // pause_for_release). The same-frame `.up` path clears held_axis_*
+        // before its final raiseAxis at function exit, so a release wins over
+        // a stale floor.
+        defer {
+            raiseAxis(&axes.lt, self.held_axis_lt);
+            raiseAxis(&axes.rt, self.held_axis_rt);
+        }
+
         if (self.waiting_for_release) return false;
         // Prevent same-frame double-emit — only the macro timerfd expiry
         // advances state past a delay boundary.
@@ -80,14 +125,26 @@ pub const MacroPlayer = struct {
                 .tap => |name| {
                     const target = resolveTargetSafe(name) orelse continue;
                     remap.applyTarget(target, .tap, aux, injected_buttons, pending_tap_release, null);
+                    if (axisFloorOf(target)) |f| {
+                        raiseAxis(&axes.lt, f.lt);
+                        raiseAxis(&axes.rt, f.rt);
+                    }
                 },
                 .down => |name| {
                     const target = resolveTargetSafe(name) orelse continue;
                     remap.applyTarget(target, .press, aux, injected_buttons, null, &self.held_gamepad_buttons);
+                    if (axisFloorOf(target)) |f| {
+                        raiseAxis(&self.held_axis_lt, f.lt);
+                        raiseAxis(&self.held_axis_rt, f.rt);
+                    }
                 },
                 .up => |name| {
                     const target = resolveTargetSafe(name) orelse continue;
                     remap.applyTarget(target, .release, aux, injected_buttons, null, &self.held_gamepad_buttons);
+                    if (axisFloorOf(target)) |f| {
+                        if (f.lt != 0) self.held_axis_lt = 0;
+                        if (f.rt != 0) self.held_axis_rt = 0;
+                    }
                 },
                 .delay => |ms| {
                     const deadline = now_ns + @as(i128, ms) * std.time.ns_per_ms;
@@ -171,6 +228,8 @@ pub const MacroPlayer = struct {
 
         injected_buttons.* &= ~self.held_gamepad_buttons;
         self.held_gamepad_buttons = 0;
+        self.held_axis_lt = 0;
+        self.held_axis_rt = 0;
     }
 };
 
@@ -195,6 +254,7 @@ const StepCtx = struct {
     queue: TimerQueue,
     injected: u64 = 0,
     tap_release: u64 = 0,
+    axes: AxisInjection = .{},
 
     fn init(allocator: std.mem.Allocator) StepCtx {
         return .{ .queue = dummyQueue(allocator) };
@@ -205,7 +265,7 @@ const StepCtx = struct {
     }
 
     fn step(self: *StepCtx, p: *MacroPlayer) !bool {
-        return p.step(&self.aux, &self.queue, &self.injected, &self.tap_release, 0);
+        return p.step(&self.aux, &self.queue, &self.injected, &self.tap_release, &self.axes, 0);
     }
 };
 
@@ -267,7 +327,7 @@ test "macro_player: delay arms timer queue returns not-done" {
     ctx.aux = .{};
     // now_ns must be past the delay deadline before step resumes.
     const after_delay: i128 = 50 * std.time.ns_per_ms + 1;
-    const done2 = try player.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, after_delay);
+    const done2 = try player.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, &ctx.axes, after_delay);
     try testing.expect(done2);
     try testing.expectEqual(@as(usize, 2), ctx.aux.len);
 }
@@ -373,7 +433,7 @@ test "macro_player: repeat_delay_ms — held trigger reschedules; release stops"
     const t0: i128 = 0;
 
     // First iteration: tap fires (press+release events), player not done, restart armed.
-    const done0 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, t0);
+    const done0 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, &ctx.axes, t0);
     try testing.expect(!done0);
     try testing.expectEqual(@as(usize, 2), ctx.aux.len);
     try testing.expectEqual(@as(usize, 1), ctx.queue.heap.count());
@@ -381,21 +441,21 @@ test "macro_player: repeat_delay_ms — held trigger reschedules; release stops"
 
     // Mid-restart-window: must not advance.
     ctx.aux = .{};
-    const done_mid = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, t0 + 20 * ns_per_ms);
+    const done_mid = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, &ctx.axes, t0 + 20 * ns_per_ms);
     try testing.expect(!done_mid);
     try testing.expectEqual(@as(usize, 0), ctx.aux.len);
 
     // Restart deadline reached, trigger still held: second iteration fires.
     ctx.aux = .{};
     p.setTriggerHeld(true);
-    const done1 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, t0 + 50 * ns_per_ms);
+    const done1 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, &ctx.axes, t0 + 50 * ns_per_ms);
     try testing.expect(!done1);
     try testing.expectEqual(@as(usize, 2), ctx.aux.len); // press + release of KEY_A again
 
     // Release trigger; reach next restart deadline → player completes (returns true).
     ctx.aux = .{};
     p.setTriggerHeld(false);
-    const done2 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, t0 + 100 * ns_per_ms + 1);
+    const done2 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, &ctx.axes, t0 + 100 * ns_per_ms + 1);
     try testing.expect(done2);
     try testing.expectEqual(@as(usize, 0), ctx.aux.len); // no further taps after release
 }
@@ -416,7 +476,7 @@ test "macro_player: repeat_delay_ms — release mid-iteration completes current 
     const ns_per_ms: i128 = std.time.ns_per_ms;
 
     // Frame 0: trigger held, first tap fires, then delay arms.
-    const done0 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, 0);
+    const done0 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, &ctx.axes, 0);
     try testing.expect(!done0);
     try testing.expectEqual(@as(usize, 2), ctx.aux.len); // KEY_A press+release
 
@@ -427,7 +487,7 @@ test "macro_player: repeat_delay_ms — release mid-iteration completes current 
     // Delay expires: second tap fires AND end-of-steps reached. trigger_held=false
     // means the macro completes (returns true) — no restart armed.
     ctx.aux = .{};
-    const done1 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, 10 * ns_per_ms + 1);
+    const done1 = try p.step(&ctx.aux, &ctx.queue, &ctx.injected, &ctx.tap_release, &ctx.axes, 10 * ns_per_ms + 1);
     try testing.expect(done1);
     try testing.expectEqual(@as(usize, 2), ctx.aux.len); // KEY_B press+release
     try testing.expect(p.awaiting_restart_at_ns == null);

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -574,6 +574,7 @@ pub const Mapper = struct {
         }
 
         var macro_tap_release: u64 = 0;
+        var macro_axes: macro_player_mod.AxisInjection = .{};
         var i: usize = 0;
         while (i < self.active_macros.items.len) {
             // Re-assert macro-held gamepad bits each frame; injected_buttons is reset
@@ -589,6 +590,7 @@ pub const Mapper = struct {
                 &self.timer_queue,
                 &self.injected_buttons,
                 &macro_tap_release,
+                &macro_axes,
                 now_ns,
             ) catch |err| blk: {
                 std.log.warn("macro step failed: {}", .{err});
@@ -608,6 +610,10 @@ pub const Mapper = struct {
         // assemble emit state
         var emit_state = self.state;
         emit_state.buttons = (self.state.buttons & ~self.suppressed_buttons) | self.injected_buttons;
+        // issue #99: macros driving LT/RT raise the analog axis floor; physical
+        // input still wins when the user presses harder than the macro.
+        if (macro_axes.lt > emit_state.lt) emit_state.lt = macro_axes.lt;
+        if (macro_axes.rt > emit_state.rt) emit_state.rt = macro_axes.rt;
         emit_state.synthesizeDpadAxes();
         if (suppress_dpad_hat) {
             emit_state.dpad_x = 0;
@@ -871,6 +877,9 @@ pub const Mapper = struct {
     pub fn onMacroTimerExpired(self: *Mapper, now_ns: i128) AuxEventList {
         var aux = AuxEventList{};
         var macro_tap_release: u64 = 0;
+        // Axis floor on timer-driven resume is discarded; the next Mapper.apply()
+        // frame re-walks active macros and recomputes from held_axis_*.
+        var macro_axes: macro_player_mod.AxisInjection = .{};
         var buf: [16]timer_queue_mod.Deadline = undefined;
         const expired = self.timer_queue.drainExpired(now_ns, &buf);
         for (expired) |d| {
@@ -893,6 +902,7 @@ pub const Mapper = struct {
                         &self.timer_queue,
                         &self.injected_buttons,
                         &macro_tap_release,
+                        &macro_axes,
                         now_ns,
                     ) catch |err| blk: {
                         std.log.warn("macro step failed: {}", .{err});

--- a/src/main.zig
+++ b/src/main.zig
@@ -103,6 +103,7 @@ pub const testing_support = struct {
     pub const macro_e2e_test = @import("test/macro_e2e_test.zig");
     pub const macro_gamepad_button_test = @import("test/macro_gamepad_button_test.zig");
     pub const macro_step_delay_test = @import("test/macro_step_delay_test.zig");
+    pub const macro_axis_dispatch_test = @import("test/macro_axis_dispatch_test.zig");
     pub const capture_e2e_test = @import("test/capture_e2e_test.zig");
     pub const supervisor_e2e_test = @import("test/supervisor_e2e_test.zig");
     pub const wasm_e2e_test = @import("test/wasm_e2e_test.zig");
@@ -1112,6 +1113,7 @@ test {
     // hid_hw_open in the kernel, which can deadlock under SIGKILL/OOM (the
     // SIGTERM handler has no SIGKILL path). Run via: zig build test-uhid
     _ = @import("test/macro_gamepad_button_test.zig");
+    _ = @import("test/macro_axis_dispatch_test.zig");
     _ = @import("test/macro_e2e_test.zig");
     _ = @import("test/properties/config_props.zig");
     _ = @import("test/properties/contract_props.zig");

--- a/src/test/macro_axis_dispatch_test.zig
+++ b/src/test/macro_axis_dispatch_test.zig
@@ -1,0 +1,154 @@
+// Regression for issue #99: macros must drive the LT/RT *analog* axis, not
+// only the LT/RT button bit. PR #152 set the bit in injected_buttons (which
+// emits BTN_TL2/BTN_TR2 digital), but downstream consumers reading the analog
+// axis (ABS_Z / ABS_RZ — what SDL, Steam Input, and most games read) saw the
+// axis stuck at the raw input value. These tests assert the axis saturates
+// while a macro is holding LT/RT and follows the raw value otherwise.
+
+const std = @import("std");
+const testing = std.testing;
+
+const state_mod = @import("../core/state.zig");
+const h = @import("helpers.zig");
+
+const ButtonId = state_mod.ButtonId;
+
+fn btnBit(id: ButtonId) u64 {
+    return @as(u64, 1) << @as(u6, @intCast(@intFromEnum(id)));
+}
+
+test "macro #99: tap LT saturates lt axis for one frame then releases" {
+    const allocator = testing.allocator;
+
+    var ctx = try h.makeMapper(
+        \\[remap]
+        \\M1 = "macro:full_brake"
+        \\
+        \\[[macro]]
+        \\name = "full_brake"
+        \\steps = [
+        \\  { tap = "LT" },
+        \\]
+    , allocator);
+    defer ctx.deinit();
+
+    const m1_bit = btnBit(.M1);
+
+    const frame1 = try ctx.mapper.apply(.{ .buttons = m1_bit }, 16, 0);
+    try testing.expectEqual(@as(u8, 255), frame1.gamepad.lt);
+
+    const frame2 = try ctx.mapper.apply(.{ .buttons = m1_bit }, 16, 16 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(u8, 0), frame2.gamepad.lt);
+}
+
+test "macro #99: down LT holds lt at max across frames until up" {
+    const allocator = testing.allocator;
+
+    var ctx = try h.makeMapper(
+        \\[remap]
+        \\M1 = "macro:hold_lt"
+        \\
+        \\[[macro]]
+        \\name = "hold_lt"
+        \\steps = [
+        \\  { down = "LT" },
+        \\  { delay = 20 },
+        \\  { up = "LT" },
+        \\]
+    , allocator);
+    defer ctx.deinit();
+
+    const m1_bit = btnBit(.M1);
+    const ns_per_ms: i128 = std.time.ns_per_ms;
+
+    const frame1 = try ctx.mapper.apply(.{ .buttons = m1_bit }, 16, 0);
+    try testing.expectEqual(@as(u8, 255), frame1.gamepad.lt);
+
+    const frame2 = try ctx.mapper.apply(.{ .buttons = m1_bit }, 16, 10 * ns_per_ms);
+    try testing.expectEqual(@as(u8, 255), frame2.gamepad.lt);
+
+    const frame3 = try ctx.mapper.apply(.{ .buttons = m1_bit }, 16, 25 * ns_per_ms);
+    try testing.expectEqual(@as(u8, 0), frame3.gamepad.lt);
+}
+
+test "macro #99: down RT drives rt axis without touching lt" {
+    const allocator = testing.allocator;
+
+    var ctx = try h.makeMapper(
+        \\[remap]
+        \\M1 = "macro:rt_only"
+        \\
+        \\[[macro]]
+        \\name = "rt_only"
+        \\steps = [
+        \\  { down = "RT" },
+        \\  { delay = 20 },
+        \\  { up = "RT" },
+        \\]
+    , allocator);
+    defer ctx.deinit();
+
+    const m1_bit = btnBit(.M1);
+
+    const frame1 = try ctx.mapper.apply(.{ .buttons = m1_bit }, 16, 0);
+    try testing.expectEqual(@as(u8, 255), frame1.gamepad.rt);
+    try testing.expectEqual(@as(u8, 0), frame1.gamepad.lt);
+}
+
+test "macro #99: macro axis floor cannot lower physical input" {
+    const allocator = testing.allocator;
+
+    var ctx = try h.makeMapper(
+        \\[remap]
+        \\M1 = "macro:full_brake"
+        \\
+        \\[[macro]]
+        \\name = "full_brake"
+        \\steps = [
+        \\  { down = "LT" },
+        \\  { delay = 50 },
+        \\  { up = "LT" },
+        \\]
+    , allocator);
+    defer ctx.deinit();
+
+    const m1_bit = btnBit(.M1);
+
+    // User physically holding LT at 200; macro requests max (255) — max wins.
+    const frame1 = try ctx.mapper.apply(.{ .buttons = m1_bit, .lt = 200 }, 16, 0);
+    try testing.expectEqual(@as(u8, 255), frame1.gamepad.lt);
+}
+
+test "macro #99: emitPendingReleases clears held axis on cancel" {
+    const allocator = testing.allocator;
+
+    const macro_mod = @import("../core/macro.zig");
+    const macro_player_mod = @import("../core/macro_player.zig");
+    const timer_queue_mod = @import("../core/timer_queue.zig");
+    const aux_event_mod = @import("../core/aux_event.zig");
+
+    const steps = [_]macro_mod.MacroStep{
+        .{ .down = "LT" },
+        .{ .delay = 1000 },
+        .{ .up = "LT" },
+    };
+    const m = macro_mod.Macro{ .name = "hold_lt", .steps = &steps };
+    var player = macro_player_mod.MacroPlayer.init(&m, 1, 0);
+
+    var aux = aux_event_mod.AuxEventList{};
+    var q = timer_queue_mod.TimerQueue.init(allocator, -1);
+    defer q.deinit();
+    var injected: u64 = 0;
+    var tap_release: u64 = 0;
+    var axes = macro_player_mod.AxisInjection{};
+
+    _ = try player.step(&aux, &q, &injected, &tap_release, &axes, 0);
+    try testing.expectEqual(@as(u8, 255), axes.lt);
+    try testing.expectEqual(@as(u8, 255), player.held_axis_lt);
+
+    // Cancel via emitPendingReleases — clears held floor.
+    var aux2 = aux_event_mod.AuxEventList{};
+    player.emitPendingReleases(&aux2, &injected);
+    try testing.expectEqual(@as(u8, 0), player.held_axis_lt);
+    try testing.expectEqual(@as(u8, 0), player.held_axis_rt);
+}

--- a/src/test/macro_e2e_test.zig
+++ b/src/test/macro_e2e_test.zig
@@ -25,6 +25,7 @@ const ButtonId = state_mod.ButtonId;
 const MacroStep = macro_mod.MacroStep;
 const Macro = macro_mod.Macro;
 const MacroPlayer = macro_player_mod.MacroPlayer;
+const AxisInjection = macro_player_mod.AxisInjection;
 const TimerQueue = timer_queue_mod.TimerQueue;
 
 const KEY_B = h.KEY_B;
@@ -168,7 +169,8 @@ test "macro: macro playback — tap B, delay 50, tap LEFT sequence" {
     var aux1 = AuxEventList{};
     var injected1: u64 = 0;
     var tap_rel1: u64 = 0;
-    const done1 = try player.step(&aux1, &q, &injected1, &tap_rel1, 0);
+    var axes1 = AxisInjection{};
+    const done1 = try player.step(&aux1, &q, &injected1, &tap_rel1, &axes1, 0);
     try testing.expect(!done1);
     // Two events: KEY_B press + release.
     try testing.expectEqual(@as(usize, 2), aux1.len);
@@ -193,9 +195,10 @@ test "macro: macro playback — tap B, delay 50, tap LEFT sequence" {
     var aux2 = AuxEventList{};
     var injected2: u64 = 0;
     var tap_rel2: u64 = 0;
+    var axes2 = AxisInjection{};
     // Advance now_ns past the 50ms delay deadline so the step can proceed.
     const after_delay: i128 = 50 * std.time.ns_per_ms + 1;
-    const done2 = try player.step(&aux2, &q, &injected2, &tap_rel2, after_delay);
+    const done2 = try player.step(&aux2, &q, &injected2, &tap_rel2, &axes2, after_delay);
     try testing.expect(done2);
     try testing.expectEqual(@as(usize, 2), aux2.len);
     switch (aux2.get(0)) {
@@ -231,7 +234,8 @@ test "macro: pause_for_release — down LSHIFT, pause, no output until released"
     var aux1 = AuxEventList{};
     var injected1: u64 = 0;
     var tap_rel1: u64 = 0;
-    const done1 = try player.step(&aux1, &q, &injected1, &tap_rel1, 0);
+    var axes1 = AxisInjection{};
+    const done1 = try player.step(&aux1, &q, &injected1, &tap_rel1, &axes1, 0);
     try testing.expect(!done1);
     try testing.expectEqual(@as(usize, 1), aux1.len);
     switch (aux1.get(0)) {
@@ -247,7 +251,8 @@ test "macro: pause_for_release — down LSHIFT, pause, no output until released"
     var aux2 = AuxEventList{};
     var injected2: u64 = 0;
     var tap_rel2: u64 = 0;
-    const done2 = try player.step(&aux2, &q, &injected2, &tap_rel2, 0);
+    var axes2 = AxisInjection{};
+    const done2 = try player.step(&aux2, &q, &injected2, &tap_rel2, &axes2, 0);
     try testing.expect(!done2);
     try testing.expectEqual(@as(usize, 0), aux2.len);
 
@@ -256,7 +261,8 @@ test "macro: pause_for_release — down LSHIFT, pause, no output until released"
     var aux3 = AuxEventList{};
     var injected3: u64 = 0;
     var tap_rel3: u64 = 0;
-    const done3 = try player.step(&aux3, &q, &injected3, &tap_rel3, 0);
+    var axes3 = AxisInjection{};
+    const done3 = try player.step(&aux3, &q, &injected3, &tap_rel3, &axes3, 0);
     try testing.expect(done3);
     try testing.expectEqual(@as(usize, 1), aux3.len);
     switch (aux3.get(0)) {

--- a/src/test/macro_gamepad_button_test.zig
+++ b/src/test/macro_gamepad_button_test.zig
@@ -24,6 +24,7 @@ const ButtonId = state_mod.ButtonId;
 const MacroStep = macro_mod.MacroStep;
 const Macro = macro_mod.Macro;
 const MacroPlayer = macro_player_mod.MacroPlayer;
+const AxisInjection = macro_player_mod.AxisInjection;
 const TimerQueue = timer_queue_mod.TimerQueue;
 const AuxEventList = aux_event_mod.AuxEventList;
 
@@ -42,8 +43,9 @@ test "macro: tap LT sets LT bit and schedules release next frame" {
     defer q.deinit();
     var injected: u64 = 0;
     var tap_release: u64 = 0;
+    var axes = AxisInjection{};
 
-    const done = try player.step(&aux, &q, &injected, &tap_release, 0);
+    const done = try player.step(&aux, &q, &injected, &tap_release, &axes, 0);
     try testing.expect(done);
     try testing.expectEqual(@as(usize, 0), aux.len);
     try testing.expectEqual(btnBit(.LT), injected & btnBit(.LT));
@@ -65,8 +67,9 @@ test "macro: down A then up A toggles A bit" {
     defer q.deinit();
     var injected: u64 = 0;
     var tap_release: u64 = 0;
+    var axes = AxisInjection{};
 
-    const done = try player.step(&aux, &q, &injected, &tap_release, 0);
+    const done = try player.step(&aux, &q, &injected, &tap_release, &axes, 0);
     try testing.expect(done);
     // down + up in one step call → net-zero; tap_release should stay clean.
     try testing.expectEqual(@as(u64, 0), injected & btnBit(.A));
@@ -84,15 +87,16 @@ test "macro: down A with delay holds A bit between frames" {
     defer q.deinit();
     var injected: u64 = 0;
     var tap_release: u64 = 0;
+    var axes = AxisInjection{};
 
-    const done1 = try player.step(&aux, &q, &injected, &tap_release, 0);
+    const done1 = try player.step(&aux, &q, &injected, &tap_release, &axes, 0);
     try testing.expect(!done1);
     try testing.expectEqual(btnBit(.A), injected & btnBit(.A));
 
     aux = .{};
     // now_ns must advance past the 10ms delay deadline before the step proceeds.
     const after_delay: i128 = 10 * std.time.ns_per_ms + 1;
-    const done2 = try player.step(&aux, &q, &injected, &tap_release, after_delay);
+    const done2 = try player.step(&aux, &q, &injected, &tap_release, &axes, after_delay);
     try testing.expect(done2);
     try testing.expectEqual(@as(u64, 0), injected & btnBit(.A));
 }
@@ -108,8 +112,9 @@ test "macro: down RT then cancel clears RT via emitPendingReleases" {
     defer q.deinit();
     var injected: u64 = 0;
     var tap_release: u64 = 0;
+    var axes = AxisInjection{};
 
-    _ = try player.step(&aux, &q, &injected, &tap_release, 0);
+    _ = try player.step(&aux, &q, &injected, &tap_release, &axes, 0);
     try testing.expectEqual(btnBit(.RT), injected & btnBit(.RT));
 
     // Simulate layer switch / macro cancel.
@@ -131,8 +136,9 @@ test "macro: tap mouse_left emits mouse_button aux events" {
     defer q.deinit();
     var injected: u64 = 0;
     var tap_release: u64 = 0;
+    var axes = AxisInjection{};
 
-    const done = try player.step(&aux, &q, &injected, &tap_release, 0);
+    const done = try player.step(&aux, &q, &injected, &tap_release, &axes, 0);
     try testing.expect(done);
     try testing.expectEqual(@as(usize, 2), aux.len);
     switch (aux.get(0)) {
@@ -163,8 +169,9 @@ test "macro: unknown target name silently skipped" {
     defer q.deinit();
     var injected: u64 = 0;
     var tap_release: u64 = 0;
+    var axes = AxisInjection{};
 
-    const done = try player.step(&aux, &q, &injected, &tap_release, 0);
+    const done = try player.step(&aux, &q, &injected, &tap_release, &axes, 0);
     try testing.expect(done);
     // Unknown target produced nothing; KEY_A tap produced press+release.
     try testing.expectEqual(@as(usize, 2), aux.len);


### PR DESCRIPTION
## Summary
- Macro player tracks per-player `held_axis_lt/rt` for `{ down = "LT" }` / `{ up = "LT" }`
- New per-frame `AxisInjection` floor for `{ tap = "LT" }`
- Mapper merges the floor into `emit_state.lt/rt` with max-semantics (physical pressure wins when stronger than the macro)
- 5 regression tests in `src/test/macro_axis_dispatch_test.zig`: tap saturate, down-hold, up-release, physical-override, layer-cancel clearing
- TDD-proven falsifiable: pre-fix all 5 cases fail with `expected 255, found 0`

Refs #99

## Test plan
- [x] `./scripts/padctl-docker test` — EXIT 0
- [x] `./scripts/padctl-docker build test-safe` — EXIT 0
- [x] `./scripts/padctl-docker build test-tsan` — EXIT 0 (1489 + 7 passed)
- [x] `./scripts/padctl-docker build check-fmt` clean

## Residual risk
- Only LT/RT covered. Stick axis macros are an unsolved DSL gap (`RemapTargetResolved` has no stick-axis variant today), not a regression.
- Multi-macro on same axis uses `@max` floor, not additive — issue #99 only asks about LT/RT.

## Files changed
- `src/core/macro_player.zig` — `held_axis_lt/rt` state + `AxisInjection` plumbing (+76/-20)
- `src/core/mapper.zig` — axis floor merge with max-semantics (+10)
- `src/main.zig` — register test (+1)
- `src/test/macro_axis_dispatch_test.zig` — new, 5 cases (~154 LoC)
- `src/test/macro_e2e_test.zig`, `src/test/macro_gamepad_button_test.zig` — signature threading for new `*AxisInjection` parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Macros now support analog trigger (LT/RT) axis injection, allowing macro-driven triggers to reach maximum values when held and properly reset upon release. Macro-driven analog values take precedence over physical inputs when greater.

* **Tests**
  * Added comprehensive test coverage for analog axis macro dispatch, including tap, hold, release, and interaction scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->