### PR TITLE
fix(scripts): bazzite-setup fails loudly when local repo did not actually update (issue #320)

### DIFF
--- a/scripts/bazzite-setup.sh
+++ b/scripts/bazzite-setup.sh
@@ -194,9 +194,13 @@ update_existing_repo() {
     local branch="$2"
     local auto_managed="$3"
 
+    local before_sha expected_sha after_sha
+    before_sha="$(git -C "$repo" rev-parse HEAD 2>/dev/null || true)"
+
     repo_updated=false
     if [[ -n "$branch" ]]; then
         git -C "$repo" fetch origin >/dev/null 2>&1
+        expected_sha="$(git -C "$repo" rev-parse "origin/$branch" 2>/dev/null || true)"
         if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
             git -C "$repo" checkout "$branch" >/dev/null 2>&1 || warn "checkout $branch failed"
         elif git -C "$repo" show-ref --verify --quiet "refs/remotes/origin/$branch"; then
@@ -216,6 +220,8 @@ update_existing_repo() {
     else
         # Only pull if on a branch that tracks a remote (skip for local-only branches).
         if git -C "$repo" rev-parse --abbrev-ref '@{upstream}' &>/dev/null; then
+            git -C "$repo" fetch origin >/dev/null 2>&1
+            expected_sha="$(git -C "$repo" rev-parse '@{upstream}' 2>/dev/null || true)"
             if timeout 10 git -C "$repo" pull --ff-only >/dev/null 2>&1; then
                 repo_updated=true
             else
@@ -226,11 +232,27 @@ update_existing_repo() {
                 fi
             fi
         elif $auto_managed; then
+            git -C "$repo" fetch origin >/dev/null 2>&1
+            expected_sha="$(git -C "$repo" rev-parse "$(origin_head_ref "$repo")" 2>/dev/null || true)"
             sync_managed_repo_to_remote "$repo" ""
             repo_updated=true
         else
             info "Local branch with no upstream — skipping pull"
         fi
+    fi
+
+    # Verify the repo actually advanced to the expected remote commit.
+    # git pull can return success ("Already up to date") while HEAD stays behind
+    # when the working tree had local changes that prevented a real fast-forward,
+    # or when the upstream ref was not fetched yet on a prior run.
+    # Only enforce this when auto_managed is true — user-managed repos are allowed
+    # to stay on local branches that differ from origin.
+    after_sha="$(git -C "$repo" rev-parse HEAD 2>/dev/null || true)"
+    if $auto_managed && [[ -n "$expected_sha" && "$after_sha" != "$expected_sha" ]]; then
+        err "padctl repo was not updated: local HEAD ${after_sha:0:7} does not match remote ${expected_sha:0:7}"
+        err "Local changes may be blocking the update. Resolve with:"
+        err "  cd $repo && git stash && git pull --ff-only"
+        return 1
     fi
 }
 

--- a/scripts/test-bazzite-setup.sh
+++ b/scripts/test-bazzite-setup.sh
@@ -60,6 +60,7 @@ case "$cmd" in
         case "${1:-}" in
             HEAD) read_state head ;;
             origin/main) read_state origin ;;
+            '@{upstream}') read_state origin ;;
             *) exit 1 ;;
         esac
         ;;
@@ -112,6 +113,10 @@ case "$cmd" in
     pull)
         if [[ -f "$(state_dir)/pull-fails" ]]; then
             exit 1
+        fi
+        if [[ -f "$(state_dir)/pull-noop" ]]; then
+            # Simulates "Already up to date" — exits 0 but HEAD does not move.
+            exit 0
         fi
         read_state origin >"$(state_dir)/head"
         printf 'new\n' >"$repo/version.txt"
@@ -301,7 +306,38 @@ test_user_branch_is_not_reset_to_remote() {
     fi
 }
 
+# Regression test for issue #320: managed repo where git pull returns success (exit 0)
+# but HEAD does not advance to origin's SHA ("Already up to date" silent no-op).
+# Before the fix, the script continued to the build step using the stale checkout.
+# After the fix, update_existing_repo must return non-zero with a clear error.
+test_managed_silent_noop_pull_is_detected() {
+    local fakebin="$tmpdir/fakebin-noop"
+    local old_path="$PATH"
+    write_fake_git "$fakebin"
+    export PATH="$fakebin:$PATH"
+
+    local repo="$tmpdir/fake-managed-noop"
+    # Local HEAD is old; origin has advanced. pull returns 0 but does NOT move HEAD.
+    create_fake_repo "$repo" "old-head" "new-head" "old content" false
+    # create_fake_repo adds pull-fails; remove it so pull returns 0 (the silent-noop case).
+    rm -f "$repo/.fakegit/pull-fails"
+    touch "$repo/.fakegit/pull-noop"
+
+    local update_exit=0
+    update_existing_repo "$repo" "" true || update_exit=$?
+
+    export PATH="$old_path"
+
+    if [[ "$update_exit" -eq 0 ]]; then
+        echo "FAIL: update_existing_repo returned 0 on silent-noop pull (issue #320 regression)" >&2
+        exit 1
+    fi
+    # HEAD must still be old-head (we did not silently proceed)
+    [[ "$(PATH="$fakebin:$PATH" git -C "$repo" rev-parse HEAD)" == "old-head" ]] || true
+}
+
 bash -n "$SCRIPT_DIR/bazzite-setup.sh"
+test_managed_silent_noop_pull_is_detected
 if command -v git >/dev/null 2>&1; then
     test_managed_dirty_repo_recovers_from_pull_failure
     test_user_repo_is_not_reset_after_pull_failure


### PR DESCRIPTION
## Summary
PR #321 added a fallback for `git pull` failure but did not detect the silent-no-op case: `git pull --ff-only` returns exit 0 with "Already up to date" even when the local checkout did not advance to the actual remote tip (e.g. stale local working tree matches stale remote tracking ref while `origin` has moved further ahead between runs). On that path `repo_updated` stayed false yet the script proceeded to `zig build` from the stale checkout — reporter ended up with an old binary believing they had updated.

## Fix
- Capture `before_sha` (local HEAD) at function entry
- Capture `expected_sha` from remote tracking ref immediately after `git fetch` (covers both `branch`/no-branch/`@{upstream}` paths)
- After the update step, compare `after_sha` to `expected_sha`
- If they differ AND `auto_managed=true` (the path padctl officially manages): error with a clear message naming both SHAs and suggesting `git stash && git pull --ff-only`

Refs #320

## Scope note
The guard runs only on `auto_managed=true` (the default `bazzite-setup.sh` codepath that manages the clone at `~/Games/padctl`). User-managed checkouts (`auto_managed=false`, e.g. someone running the script from inside their own clone) still warn-and-continue — padctl does not own that working tree, so silent forwarding is the right semantics there.

## Test plan
- [x] New regression test `test_managed_silent_noop_pull_is_detected` in `scripts/test-bazzite-setup.sh`
- [x] TDD falsifiable: pre-fix, test asserts `update_existing_repo` returned non-zero → FAILS with `FAIL: update_existing_repo returned 0 on silent-noop pull (issue #320 regression)`
- [x] Post-fix, guard error fires with `local HEAD old-hea does not match remote new-hea`, function returns 1, test asserts and passes
- [x] All other 4 bazzite-setup tests still pass
- [x] `./scripts/padctl-docker build test-tsan` — 1517/1523 passed, 6 skipped

## Files changed
- `scripts/bazzite-setup.sh` (+22) — `before_sha`/`expected_sha`/`after_sha` guard in `update_existing_repo`
- `scripts/test-bazzite-setup.sh` (+36) — fake-git `pull-noop` mode + `rev-parse @{upstream}` support + new regression case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved repository update validation to detect and report when updates claim success but fail to actually advance the codebase, with remediation guidance.

* **Tests**
  * Enhanced test coverage for repository update edge cases, including scenarios where pull operations return success without completing the update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->