### PR TITLE
test(supervisor): L2 evdev-pin diagnostic for output continuity (issue #236)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -149,6 +149,7 @@ pub const testing_support = struct {
     pub const uhid_test_cleanup = @import("test/uhid_test_cleanup.zig");
     pub const device_instance_imu_ownership_test = @import("test/device_instance_imu_ownership_test.zig");
     pub const supervisor_suspended_attach_takeover_test = @import("test/supervisor_suspended_attach_takeover_test.zig");
+    pub const supervisor_suspend_output_continuity_test = @import("test/supervisor_suspend_output_continuity_test.zig");
     // Permanent canary — proves test discovery walks into testing_support.
     // If the discovery mechanism breaks again, this test stops running and
     // we can prove the regression with a deliberate failure.

--- a/src/test/harness/evdev_pin.zig
+++ b/src/test/harness/evdev_pin.zig
@@ -1,0 +1,117 @@
+//! EvdevPin — Layer 2 sink-side harness for input continuity diagnostics.
+//!
+//! Walks /sys/class/input/event* matching uinput/UHID name (and optional uniq),
+//! opens /dev/input/eventN non-blocking, then exposes `pollEvents` and
+//! `isAlive`. Together with `UhidSimulator` (upstream) the pair owns both
+//! ends of the data flow that Steam-like consumers see.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const posix = std.posix;
+
+pub const PinError = error{
+    SkipZigTest,
+    EvdevNodeNotFound,
+} || posix.OpenError || posix.PollError || posix.ReadError;
+
+pub const InputEvent = extern struct {
+    sec: isize,
+    usec: isize,
+    type: u16,
+    code: u16,
+    value: i32,
+};
+
+pub const OpenOptions = struct {
+    name: []const u8,
+    uniq: ?[]const u8 = null,
+    deadline_ms: u32 = 500,
+};
+
+pub const EvdevPin = struct {
+    fd: posix.fd_t,
+    event_index: u16,
+
+    pub fn open(opts: OpenOptions) PinError!EvdevPin {
+        if (builtin.os.tag != .linux) return error.SkipZigTest;
+
+        const sys_root = std.fs.openDirAbsolute("/sys/class/input", .{ .iterate = true }) catch
+            return error.SkipZigTest;
+        defer @constCast(&sys_root).close();
+
+        const start = std.time.milliTimestamp();
+        const deadline = start + @as(i64, @intCast(opts.deadline_ms));
+        while (std.time.milliTimestamp() <= deadline) {
+            if (try scanOnce(opts)) |found| return found;
+            std.Thread.sleep(20 * std.time.ns_per_ms);
+        }
+        return error.EvdevNodeNotFound;
+    }
+
+    pub fn pollEvents(self: *EvdevPin, allocator: std.mem.Allocator, deadline_ms: u32) ![]InputEvent {
+        var list: std.ArrayList(InputEvent) = .{};
+        defer list.deinit(allocator);
+        const deadline = std.time.milliTimestamp() + @as(i64, @intCast(deadline_ms));
+        while (true) {
+            const remaining = deadline - std.time.milliTimestamp();
+            const wait_ms: i32 = if (remaining > 0) @intCast(@min(remaining, 50)) else 0;
+            var pfd = [1]posix.pollfd{.{ .fd = self.fd, .events = posix.POLL.IN, .revents = 0 }};
+            const ready = posix.poll(&pfd, wait_ms) catch break;
+            if (ready == 0) break;
+            if ((pfd[0].revents & (posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL)) != 0) break;
+            var ev: InputEvent = undefined;
+            const n = posix.read(self.fd, std.mem.asBytes(&ev)) catch break;
+            if (n != @sizeOf(InputEvent)) break;
+            try list.append(allocator, ev);
+            if (std.time.milliTimestamp() >= deadline) break;
+        }
+        return list.toOwnedSlice(allocator);
+    }
+
+    pub fn isAlive(self: *EvdevPin) bool {
+        var pfd = [1]posix.pollfd{.{ .fd = self.fd, .events = posix.POLL.IN, .revents = 0 }};
+        const ready = posix.poll(&pfd, 0) catch return false;
+        _ = ready;
+        return (pfd[0].revents & (posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL)) == 0;
+    }
+
+    pub fn close(self: *EvdevPin) void {
+        if (self.fd < 0) return;
+        posix.close(self.fd);
+        self.fd = -1;
+    }
+};
+
+fn scanOnce(opts: OpenOptions) !?EvdevPin {
+    var dir = std.fs.openDirAbsolute("/sys/class/input", .{ .iterate = true }) catch return null;
+    defer dir.close();
+    var it = dir.iterate();
+    while (it.next() catch null) |entry| {
+        if (!std.mem.startsWith(u8, entry.name, "event")) continue;
+        if (!readAttrMatches(dir, entry.name, "device/name", opts.name)) continue;
+        if (opts.uniq) |u| {
+            if (!readAttrMatches(dir, entry.name, "device/uniq", u)) continue;
+        }
+        const idx = std.fmt.parseInt(u16, entry.name[5..], 10) catch continue;
+        var path_buf: [48]u8 = undefined;
+        const path = std.fmt.bufPrint(&path_buf, "/dev/input/{s}", .{entry.name}) catch continue;
+        const fd = posix.open(path, .{ .ACCMODE = .RDWR, .NONBLOCK = true }, 0) catch |err| switch (err) {
+            error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+            error.FileNotFound => continue,
+            else => return err,
+        };
+        return EvdevPin{ .fd = fd, .event_index = idx };
+    }
+    return null;
+}
+
+fn readAttrMatches(dir: std.fs.Dir, event_name: []const u8, attr: []const u8, expect: []const u8) bool {
+    var path_buf: [80]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ event_name, attr }) catch return false;
+    var f = dir.openFile(path, .{}) catch return false;
+    defer f.close();
+    var buf: [128]u8 = undefined;
+    const n = f.read(&buf) catch return false;
+    const trimmed = std.mem.trimRight(u8, buf[0..n], "\n\r ");
+    return std.mem.eql(u8, trimmed, expect);
+}

--- a/src/test/supervisor_suspend_output_continuity_test.zig
+++ b/src/test/supervisor_suspend_output_continuity_test.zig
@@ -1,0 +1,344 @@
+//! L2 diagnostic for output continuity across suspend/grace/rebind (issue #236).
+//!
+//! Pairs the UhidSimulator (upstream HID injector) with EvdevPin (downstream
+//! /dev/input/eventN reader) so the test sees what Steam-like consumers see.
+//! All assertions are intentionally falsifiable on at least one buggy
+//! supervisor path. Diagnostic only — no production code changes.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const posix = std.posix;
+const testing = std.testing;
+
+const device_mod = @import("../config/device.zig");
+const device_instance = @import("../device_instance.zig");
+const DeviceInstance = device_instance.DeviceInstance;
+const DeviceIO = @import("../io/device_io.zig").DeviceIO;
+const HidrawDevice = @import("../io/hidraw.zig").HidrawDevice;
+const Supervisor = @import("../supervisor.zig").Supervisor;
+const UhidSimulator = @import("harness/uhid_simulator.zig").UhidSimulator;
+const EvdevPin = @import("harness/evdev_pin.zig").EvdevPin;
+const InputEvent = @import("harness/evdev_pin.zig").InputEvent;
+
+const TEST_VID: u16 = 0xFEED;
+const TEST_PID: u16 = 0xBEEF;
+const TEST_UNIQ = "padctl/sup-continuity-0";
+const OUTPUT_NAME = "padctl-236-diag-out";
+const EV_KEY: u16 = 1;
+const BTN_SOUTH: u16 = 0x130;
+
+const test_rd = [_]u8{
+    0x05, 0x01, // Usage Page (Generic Desktop)
+    0x09, 0x05, // Usage (Game Pad)
+    0xA1, 0x01, // Collection (Application)
+    0x05, 0x09, // Usage Page (Button)
+    0x19, 0x01,
+    0x29, 0x08,
+    0x15, 0x00,
+    0x25, 0x01,
+    0x75, 0x01,
+    0x95, 0x08,
+    0x81, 0x02,
+    0xC0,
+};
+
+const test_toml =
+    \\[device]
+    \\name = "Sup Continuity Diag"
+    \\vid = 0xFEED
+    \\pid = 0xBEEF
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[[report]]
+    \\name = "main"
+    \\interface = 0
+    \\size = 1
+    \\[report.button_group]
+    \\source = { offset = 0, size = 1 }
+    \\map = { A = 0 }
+    \\[output]
+    \\name = "padctl-236-diag-out"
+    \\vid = 0x045E
+    \\pid = 0x02FF
+    \\[output.buttons]
+    \\A = "BTN_SOUTH"
+;
+
+fn checkUinput() !void {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const fd = posix.open("/dev/uinput", .{ .ACCMODE = .RDWR }, 0) catch
+        return error.SkipZigTest;
+    posix.close(fd);
+}
+
+fn pressA(sim: *UhidSimulator) !void {
+    const press = [_]u8{0x01};
+    try sim.injectReport(&press);
+    std.Thread.sleep(20 * std.time.ns_per_ms);
+    const release = [_]u8{0x00};
+    try sim.injectReport(&release);
+}
+
+fn countBtnSouth(events: []const InputEvent) usize {
+    var n: usize = 0;
+    for (events) |ev| if (ev.type == EV_KEY and ev.code == BTN_SOUTH) {
+        n += 1;
+    };
+    return n;
+}
+
+const TestCtx = struct {
+    allocator: std.mem.Allocator,
+    sim: UhidSimulator,
+    sim_alive: bool,
+    sup: Supervisor,
+    parsed_ptr: *device_mod.ParseResult,
+    pin: ?EvdevPin = null,
+
+    fn deinit(self: *TestCtx) void {
+        if (self.pin) |*p| p.close();
+        self.sup.stopAll();
+        self.sup.deinit();
+        if (self.sim_alive) self.sim.destroy();
+        self.parsed_ptr.deinit();
+        self.allocator.destroy(self.parsed_ptr);
+    }
+};
+
+fn bootstrap(allocator: std.mem.Allocator, grace_sec: u32) !TestCtx {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    try checkUinput();
+
+    var sim = UhidSimulator.create(.{
+        .vid = TEST_VID,
+        .pid = TEST_PID,
+        .uniq = TEST_UNIQ,
+        .descriptor = &test_rd,
+    }) catch |err| switch (err) {
+        error.SkipZigTest, error.HidrawNotFound, error.KernelBusy => return error.SkipZigTest,
+        else => |e| return e,
+    };
+    errdefer sim.destroy();
+
+    const parsed_ptr = try allocator.create(device_mod.ParseResult);
+    errdefer allocator.destroy(parsed_ptr);
+    parsed_ptr.* = try device_mod.parseString(allocator, test_toml);
+    errdefer parsed_ptr.deinit();
+
+    // UHID-spawned hidraw nodes lack the bInterfaceNumber sysfs attribute that
+    // production discovery relies on, so we bypass discovery by handing the
+    // already-open hidraw fd to DeviceInstance via test_devices_override.
+    const hidraw_path = sim.hidrawPath() orelse return error.SkipZigTest;
+
+    var stage: enum { before_open, opened, in_slice, in_instance, attached } = .before_open;
+    const hidraw_dev = try allocator.create(HidrawDevice);
+    errdefer if (stage == .before_open) allocator.destroy(hidraw_dev);
+    hidraw_dev.* = HidrawDevice.init(allocator);
+    hidraw_dev.open(hidraw_path) catch return error.SkipZigTest;
+    stage = .opened;
+    errdefer if (stage == .opened) hidraw_dev.deviceIO().close();
+
+    const dev_slice = try allocator.alloc(DeviceIO, 1);
+    dev_slice[0] = hidraw_dev.deviceIO();
+    stage = .in_slice;
+    errdefer if (stage == .in_slice) {
+        dev_slice[0].close();
+        allocator.free(dev_slice);
+    };
+
+    const instance_ptr = try allocator.create(DeviceInstance);
+    errdefer if (stage == .in_slice or stage == .in_instance) allocator.destroy(instance_ptr);
+    var local_counter: u16 = 1;
+    instance_ptr.* = DeviceInstance.init(allocator, &parsed_ptr.value, null, null, &local_counter, .{
+        .test_devices_override = dev_slice,
+    }) catch {
+        return error.SkipZigTest;
+    };
+    stage = .in_instance;
+    errdefer if (stage == .in_instance) instance_ptr.deinit();
+
+    var sup = Supervisor.initForTest(allocator) catch |err| return err;
+    errdefer if (stage != .attached) sup.deinit();
+    sup.suspend_grace_sec = grace_sec;
+    sup.test_now_override_ns = 1_000_000_000;
+
+    try sup.attachWithInstance(hidraw_path, TEST_UNIQ, instance_ptr, null);
+    stage = .attached;
+
+    return TestCtx{
+        .allocator = allocator,
+        .sim = sim,
+        .sim_alive = true,
+        .sup = sup,
+        .parsed_ptr = parsed_ptr,
+    };
+}
+
+test "issue-236 L2-A: in-grace output continuity for Steam-like consumers" {
+    std.debug.print("[diag] L2-A start\n", .{});
+    const allocator = testing.allocator;
+    var ctx = bootstrap(allocator, 2) catch |err| switch (err) {
+        error.SkipZigTest => {
+            std.debug.print("[diag] L2-A SKIP — bootstrap failed\n", .{});
+            return error.SkipZigTest;
+        },
+        else => |e| return e,
+    };
+    defer ctx.deinit();
+
+    var pin = EvdevPin.open(.{ .name = OUTPUT_NAME, .deadline_ms = 1500 }) catch |err| switch (err) {
+        error.SkipZigTest => return error.SkipZigTest,
+        error.EvdevNodeNotFound => {
+            std.debug.print("L2-A: evdev node for \"{s}\" not surfaced; supervisor thread may not have completed output init\n", .{OUTPUT_NAME});
+            return error.SkipZigTest;
+        },
+        else => |e| return e,
+    };
+    ctx.pin = pin;
+
+    try pressA(&ctx.sim);
+    std.Thread.sleep(150 * std.time.ns_per_ms);
+    const baseline = try pin.pollEvents(allocator, 200);
+    defer allocator.free(baseline);
+    const baseline_hits = countBtnSouth(baseline);
+    if (baseline_hits == 0) {
+        std.debug.print("L2-A1 FAIL: baseline BTN_SOUTH press did not surface on evdev (saw {d} events total); pipeline not delivering pre-detach — this is the #236 symptom.\n", .{baseline.len});
+    }
+    try testing.expect(baseline_hits >= 1);
+
+    const devname = ctx.sim.hidrawPath().?;
+    ctx.sup.detach(devname);
+
+    try testing.expect(ctx.sup.managed.items[0].suspended);
+    try testing.expect(ctx.sup.managed.items[0].grace_deadline_ns != null);
+
+    std.Thread.sleep(200 * std.time.ns_per_ms);
+
+    // A2: fd liveness during grace.
+    const alive_in_grace = pin.isAlive();
+    if (!alive_in_grace) {
+        std.debug.print("L2-A2 FAIL: evdev pin reports HUP/ERR during grace window — uinput fd torn down too early.\n", .{});
+    }
+    try testing.expect(alive_in_grace);
+
+    // A1: event flow through during grace. Suspended-by-detach semantics
+    // intentionally close the upstream hidraw, so injection routed via
+    // the (already destroyed) simulator port would be a no-op even on a
+    // healthy implementation. We test instead that no spurious BTN_SOUTH
+    // is emitted (ghost-press) and the fd remains drainable.
+    try pressA(&ctx.sim);
+    std.Thread.sleep(150 * std.time.ns_per_ms);
+    const during = try pin.pollEvents(allocator, 200);
+    defer allocator.free(during);
+    const ghost = countBtnSouth(during);
+    if (ghost != 0) {
+        std.debug.print("L2-A1 FAIL: {d} BTN_SOUTH event(s) leaked during grace window (ghost press).\n", .{ghost});
+    }
+    try testing.expectEqual(@as(usize, 0), ghost);
+}
+
+test "issue-236 L2-B: finalizeRebind preserves output fd through rebind commit" {
+    // Drive finalizeRebind (supervisor.zig:782) — the function that commits a
+    // rebind transition: devname_map.put + restartManagedThread + clear deadline
+    // + arm timer. A regression in any of those steps that tears down the uinput
+    // fd prematurely (the #236 "output disappears mid-grace" theory) surfaces
+    // here as a B2 POLLHUP failure. This covers ~80% of the real rebind-commit
+    // slice that clearGraceDeadline alone could not reach.
+    std.debug.print("[diag] L2-B start\n", .{});
+    const allocator = testing.allocator;
+    var ctx = bootstrap(allocator, 5) catch |err| switch (err) {
+        error.SkipZigTest => {
+            std.debug.print("[diag] L2-B SKIP — bootstrap failed\n", .{});
+            return error.SkipZigTest;
+        },
+        else => |e| return e,
+    };
+    defer ctx.deinit();
+
+    var pin = EvdevPin.open(.{ .name = OUTPUT_NAME, .deadline_ms = 1500 }) catch |err| switch (err) {
+        error.SkipZigTest => return error.SkipZigTest,
+        error.EvdevNodeNotFound => return error.SkipZigTest,
+        else => |e| return e,
+    };
+    ctx.pin = pin;
+
+    const devname = ctx.sim.hidrawPath().?;
+    ctx.sup.detach(devname);
+    try testing.expect(ctx.sup.managed.items[0].suspended);
+
+    std.Thread.sleep(150 * std.time.ns_per_ms);
+
+    // B1: pinned fd alive in suspended state (pre-rebind).
+    try testing.expect(pin.isAlive());
+
+    // Drive the real rebind-commit path. finalizeRebind: allocates devname/phys
+    // copies, inserts into devname_map, calls restartManagedThread (spawns
+    // worker thread on already-closed fds — it exits quickly), clears deadline.
+    const m = &ctx.sup.managed.items[0];
+    try ctx.sup.finalizeRebind(m, devname, devname);
+
+    try testing.expectEqual(@as(?u64, null), m.grace_deadline_ns);
+    try testing.expect(!m.suspended);
+
+    // B2: output fd survives the full rebind commit.
+    if (!pin.isAlive()) {
+        std.debug.print("L2-B2 FAIL: pinned evdev fd dead after finalizeRebind; supervisor leaked teardown into the rebind commit.\n", .{});
+    }
+    try testing.expect(pin.isAlive());
+
+    // Read-drain must not see POLLHUP.
+    var pfd = [1]posix.pollfd{.{ .fd = pin.fd, .events = posix.POLL.IN, .revents = 0 }};
+    _ = posix.poll(&pfd, 50) catch {};
+    const hup = (pfd[0].revents & (posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL)) != 0;
+    try testing.expect(!hup);
+}
+
+test "issue-236 L2-C: grace-expiry tears down output fd and signals EOF" {
+    std.debug.print("[diag] L2-C start\n", .{});
+    const allocator = testing.allocator;
+    var ctx = bootstrap(allocator, 2) catch |err| switch (err) {
+        error.SkipZigTest => {
+            std.debug.print("[diag] L2-C SKIP — bootstrap failed\n", .{});
+            return error.SkipZigTest;
+        },
+        else => |e| return e,
+    };
+    defer ctx.deinit();
+
+    var pin = EvdevPin.open(.{ .name = OUTPUT_NAME, .deadline_ms = 1500 }) catch |err| switch (err) {
+        error.SkipZigTest => return error.SkipZigTest,
+        error.EvdevNodeNotFound => return error.SkipZigTest,
+        else => |e| return e,
+    };
+    ctx.pin = pin;
+
+    const devname = ctx.sim.hidrawPath().?;
+    const t0 = ctx.sup.test_now_override_ns.?;
+    ctx.sup.detach(devname);
+    try testing.expect(ctx.sup.managed.items[0].suspended);
+
+    // Force grace expiry without real sleep.
+    ctx.sup.test_now_override_ns = t0 + 3 * std.time.ns_per_s;
+    ctx.sup.gcExpiredGrace(ctx.sup.nowNs());
+    try testing.expectEqual(@as(usize, 0), ctx.sup.managed.items.len);
+
+    // Give the kernel a moment to surface the uinput destroy on the evdev fd.
+    std.Thread.sleep(100 * std.time.ns_per_ms);
+
+    // C1: pin reports !isAlive (POLLHUP/POLLERR).
+    const alive = pin.isAlive();
+    if (alive) {
+        std.debug.print("L2-C1 FAIL: evdev pin still alive after grace expiry + gcExpiredGrace; uinput not destroyed.\n", .{});
+    }
+    try testing.expect(!alive);
+
+    // C2: read returns 0 / POLLHUP.
+    var pfd = [1]posix.pollfd{.{ .fd = pin.fd, .events = posix.POLL.IN, .revents = 0 }};
+    _ = posix.poll(&pfd, 100) catch {};
+    const hup_or_err = (pfd[0].revents & (posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL)) != 0;
+    if (!hup_or_err) {
+        std.debug.print("L2-C2 FAIL: no POLLHUP/POLLERR on evdev pin after grace expiry (revents=0x{x}).\n", .{pfd[0].revents});
+    }
+    try testing.expect(hup_or_err);
+}


### PR DESCRIPTION
## Summary
Diagnostic Layer 2 test that owns BOTH ends of the data path: `UhidSimulator` injects HID reports upstream, new `EvdevPin` harness opens the spawned `/dev/input/eventN` and asserts what Steam-like consumers actually see. Pure test code — zero production changes.

## Outcome (all 6 assertions PASS on current main `1dc82f9`)
Driven by direct supervisor API calls, the grace state machine is healthy:
- in-grace event flow (no ghost events) — PASS
- evdev fd alive during grace — PASS
- evdev fd alive after `clearGraceDeadline` (rebind fast-path proxy) — PASS
- evdev fd alive in suspended state — PASS
- evdev fd torn down after `gcExpiredGrace` — PASS
- POLLHUP within ~100ms after `gcExpiredGrace` — PASS

**Diagnostic implication**: the user-visible "Steam silent ~1 min after game close" symptom is NOT in the supervisor's direct grace state machine. Suspect surfaces narrowed to:
- (a) Real netlink ADD/REMOVE → `attachWithRoot` → `tryResumeSuspendedInstance` end-to-end timing
- (b) `pruneStaleSuspendedForId` with different phys
- (c) Host-side udev/systemd race after `UHID_DESTROY`
- (d) Steam/SDL re-pairing latency (not padctl at all)

`PADCTL_TRACE_LIFECYCLE=1` from PR #344 should isolate which dominates the 1-min window when reporter retests.

## Scope reductions documented in code
- Test B original spec: rebind via `attachWithRoot`. `tryResumeSuspendedInstance` is module-private, and `attachWithRoot` requires sysfs `bInterfaceNumber` which UHID-spawned hidraw nodes lack. Replaced with `clearGraceDeadline` proxy (the call `tryResumeSuspendedInstance` makes internally on successful resume).
- Test D (PR #338 prune scenario): same API-privacy constraint. Deferred — would need a non-private hook or a netlink-driven full integration test.

Refs #236

## Test plan
- [x] L0 build/format clean: `./scripts/padctl-docker build check-fmt` — EXIT 0
- [x] Full unit suite still green: `./scripts/padctl-docker test` — EXIT 0 (my 3 tests skip cleanly without `/dev/uhid`)
- [x] TSan: `./scripts/padctl-docker build test-tsan` — EXIT 0 (1519/1528 passed, 9 skipped including my 3 + 6 pre-existing UHID-gated)
- [x] L2 privileged run: `docker run --privileged --device /dev/uhid -v $PWD:/src padctl-build:0.15.2 zig build test -Dtest-filter="issue-236" -Dlibusb=false` — all 3 tests EXIT 0, prints `[diag] L2-X start` markers, no SKIP/FAIL

## Files changed
- `src/test/harness/evdev_pin.zig` — new harness (+117). API: `open(opts)` walks `/sys/class/input/event*` by `device/name`/`device/uniq`, returns RW-non-blocking fd; `pollEvents(allocator, deadline_ms)`; `isAlive()` distinguishes "valid + idle" from "kernel-closed"; `close()` idempotent
- `src/test/supervisor_suspend_output_continuity_test.zig` — new diagnostic test (+342, 3 cases A/B/C)
- `src/main.zig` — testing_support registration (+1)