### PR TITLE
fix: post-merge CodeRabbit cleanups (PRs #340 #341 #343)

### DIFF
--- a/scripts/test-bazzite-setup.sh
+++ b/scripts/test-bazzite-setup.sh
@@ -333,7 +333,12 @@ test_managed_silent_noop_pull_is_detected() {
         exit 1
     fi
     # HEAD must still be old-head (we did not silently proceed)
-    [[ "$(PATH="$fakebin:$PATH" git -C "$repo" rev-parse HEAD)" == "old-head" ]] || true
+    local actual_head
+    actual_head="$(PATH="$fakebin:$PATH" git -C "$repo" rev-parse HEAD)"
+    if [[ "$actual_head" != "old-head" ]]; then
+        echo "FAIL: HEAD changed silently in noop test (expected old-head, got $actual_head)" >&2
+        exit 1
+    fi
 }
 
 bash -n "$SCRIPT_DIR/bazzite-setup.sh"

--- a/src/test/macro_press_sugar_test.zig
+++ b/src/test/macro_press_sugar_test.zig
@@ -125,6 +125,19 @@ test "macro_press: case E — press conflicts with explicit up on same button" {
     try testing.expectError(error.PressConflict, mapping.parseString(allocator, src));
 }
 
+test "macro_press: case G — press conflicts with explicit down on same button" {
+    const allocator = testing.allocator;
+    const src =
+        \\[[macro]]
+        \\name = "m"
+        \\steps = [
+        \\    { press = "RB" },
+        \\    { down = "RB" },
+        \\]
+    ;
+    try testing.expectError(error.PressConflict, mapping.parseString(allocator, src));
+}
+
 // F — backward compat: existing macros without press are byte-identical.
 test "macro_press: case F — macro without press is byte-identical pre/post" {
     const allocator = testing.allocator;


### PR DESCRIPTION
## Summary
Three small follow-ups from CodeRabbit post-merge reviews of recently-merged PRs. All independent — bundled because each is tiny and in a different file.

### A — `scripts/test-bazzite-setup.sh` (PR #343)
Dropped `|| true` from the silent-noop test's HEAD assertion. Previously the `[[ ... ]] || true` made the check dead; now the function emits a FAIL message + exits 1 if HEAD changed unexpectedly. Falsifiable: temp-flip the fake-git to advance HEAD → test now bites.

### B — `src/config/mapping.zig` validateGyroConfig (PR #340)
PR #340 description claimed `validateGyroConfig` warns when `minimum_output < deadzone` (effectively no-op) — but only the `> 1.0` branch was implemented. Added the missing warn with the runtime invariant from `gyro.zig`: when `mo < deadzone`, deadzone filters everything before snap could fire.

### C — `src/test/macro_press_sugar_test.zig` (PR #341)
`expandMacroPress` validates BOTH `press + down` and `press + up` conflicts via the same switch arm, but only the `up` side was tested. Added case G mirroring case E for the `down` side. Falsifiable: temp-revert the `.down` switch arm to no-op → case G fails with `expected error.PressConflict, found void`.

## Test plan
- [x] `./scripts/padctl-docker test` — EXIT 0 (1521 passed, 6 skipped)
- [x] `./scripts/padctl-docker build test-tsan` — EXIT 0
- [x] `./scripts/padctl-docker build check-fmt` — clean
- [x] Bazzite tests still pass: `bash scripts/test-bazzite-setup.sh` — EXIT 0

## Files changed
- `scripts/test-bazzite-setup.sh` (+6/-1) — drop dead `|| true`
- `src/config/mapping.zig` (+17) — add `< deadzone` warn + regression test
- `src/test/macro_press_sugar_test.zig` (+14) — case G for press+down conflict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Gyro configuration validation now issues a warning instead of failing when `minimum_output` is configured below `deadzone`, allowing affected configurations to proceed.

* **Tests**
  * Improved regression test verification for silent operations.
  * Enhanced test coverage for detecting conflicting macro press configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->