### PR TITLE
feat(ipc): daemon-advertised socket path (issue #216 root cause)

### DIFF
--- a/src/cli/socket_client.zig
+++ b/src/cli/socket_client.zig
@@ -1,23 +1,80 @@
 const std = @import("std");
 const posix = std.posix;
 const linux = std.os.linux;
+const control_socket = @import("../io/control_socket.zig");
 
 pub const DEFAULT_SOCKET_PATH = "/run/padctl/padctl.sock";
+pub const SYSTEM_RUNTIME_DIR = "/run/padctl";
 
-/// Non-root user with XDG_RUNTIME_DIR set → use XDG socket path
-/// (daemon binds there before the file exists; no existence check here).
-/// Root or missing XDG_RUNTIME_DIR → system path for system-service compatibility.
+/// Resolution order (first match wins):
+///   1. $PADCTL_SOCKET env override
+///   2. $XDG_RUNTIME_DIR/socket.advertised (user-scope daemon)
+///   3. /run/padctl/socket.advertised (system-scope daemon)
+///   4. Backward-compat fallback (old uid-relative paths)
+///
+/// Step 2 has no `padctl/` segment: the user-scope daemon binds at
+/// `$XDG_RUNTIME_DIR/padctl.sock`, so `dirname()` is `$XDG_RUNTIME_DIR` and
+/// `writeAdvertisedFile` produces `$XDG_RUNTIME_DIR/socket.advertised`.
 pub fn resolveSocketPath(buf: []u8) []const u8 {
-    if (posix.geteuid() != 0) {
-        if (posix.getenv("XDG_RUNTIME_DIR")) |xrd| {
-            return resolveSocketPathForXrd(buf, xrd);
+    const env_override = blk: {
+        if (posix.getenv("PADCTL_SOCKET")) |v| {
+            if (v.len > 0) break :blk v;
+        }
+        break :blk null;
+    };
+    const xrd = posix.getenv("XDG_RUNTIME_DIR");
+    return resolveSocketPathFor(buf, env_override, xrd, SYSTEM_RUNTIME_DIR, posix.geteuid() == 0);
+}
+
+/// Pure resolver; takes injectable env/runtime-dir parameters so tests can
+/// exercise every branch without mutating the process environment.
+pub fn resolveSocketPathFor(
+    buf: []u8,
+    env_override: ?[]const u8,
+    xdg_runtime_dir: ?[]const u8,
+    system_runtime_dir: []const u8,
+    is_root: bool,
+) []const u8 {
+    if (env_override) |v| {
+        if (v.len > 0) return copyOrDefault(buf, v);
+    }
+
+    if (xdg_runtime_dir) |xrd| {
+        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const adv = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ xrd, control_socket.ADVERTISED_FILE_NAME }) catch null;
+        if (adv) |p| if (readAdvertised(buf, p)) |out| return out;
+    }
+
+    {
+        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const adv = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ system_runtime_dir, control_socket.ADVERTISED_FILE_NAME }) catch null;
+        if (adv) |p| if (readAdvertised(buf, p)) |out| return out;
+    }
+
+    // Backward-compat fallback so a new CLI still reaches an old daemon.
+    if (!is_root) {
+        if (xdg_runtime_dir) |xrd| {
+            return std.fmt.bufPrint(buf, "{s}/padctl.sock", .{xrd}) catch DEFAULT_SOCKET_PATH;
         }
     }
     return DEFAULT_SOCKET_PATH;
 }
 
-fn resolveSocketPathForXrd(buf: []u8, xrd: []const u8) []const u8 {
-    return std.fmt.bufPrint(buf, "{s}/padctl.sock", .{xrd}) catch DEFAULT_SOCKET_PATH;
+fn copyOrDefault(buf: []u8, s: []const u8) []const u8 {
+    if (s.len > buf.len) return DEFAULT_SOCKET_PATH;
+    @memcpy(buf[0..s.len], s);
+    return buf[0..s.len];
+}
+
+fn readAdvertised(out: []u8, advertised_path: []const u8) ?[]const u8 {
+    var file = std.fs.openFileAbsolute(advertised_path, .{}) catch return null;
+    defer file.close();
+    var raw: [256]u8 = undefined;
+    const n = file.readAll(&raw) catch return null;
+    const trimmed = std.mem.trim(u8, raw[0..n], " \t\r\n");
+    if (trimmed.len == 0 or trimmed.len > out.len) return null;
+    @memcpy(out[0..trimmed.len], trimmed);
+    return out[0..trimmed.len];
 }
 
 pub const ConnectError = posix.SocketError || posix.ConnectError || error{ PathTooLong, InvalidPath };
@@ -77,21 +134,64 @@ test "resolveSocketPath: root returns system path" {
     try testing.expectEqualStrings("/run/padctl/padctl.sock", DEFAULT_SOCKET_PATH);
 }
 
-test "resolveSocketPath: XDG path returned even when socket does not exist" {
-    // Regression for chicken-and-egg: old code called accessAbsolute, which
-    // caused fall-through to DEFAULT_SOCKET_PATH when the socket didn't exist yet.
-    // Test the pure helper directly to avoid env manipulation in the test suite.
+// Test A: env override wins over every advertised file and fallback.
+test "resolveSocketPathFor: PADCTL_SOCKET env override wins" {
     var buf: [256]u8 = undefined;
-    const result = resolveSocketPathForXrd(&buf, "/nonexistent/padctl-test-xdg");
-    try testing.expectEqualStrings("/nonexistent/padctl-test-xdg/padctl.sock", result);
+    const got = resolveSocketPathFor(&buf, "/custom/path.sock", "/run/user/1000", "/run/padctl", false);
+    try testing.expectEqualStrings("/custom/path.sock", got);
 }
 
-test "resolveSocketPath: buf large enough for XDG path" {
-    // Verify bufPrint won't overflow for a typical XDG_RUNTIME_DIR length.
+// Falsifiability: drop the XDG advertised-read branch in resolveSocketPathFor
+// and this test must FAIL — the resolver will hit the backward-compat
+// fallback and return the XDG socket path instead of the advertised value.
+// Fixture writes at `$XDG_RUNTIME_DIR/socket.advertised` (no `padctl/`
+// segment) to match the daemon writer: dirname($XDG/padctl.sock) is $XDG.
+test "resolveSocketPathFor: XDG advertised file is honored" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const xrd = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(xrd);
+
+    var f = try tmp.dir.createFile(control_socket.ADVERTISED_FILE_NAME, .{ .truncate = true });
+    try f.writeAll("/tmp/foo.sock\n");
+    f.close();
+
     var buf: [256]u8 = undefined;
-    const fake_xrd = "/run/user/1000";
-    const result = std.fmt.bufPrint(&buf, "{s}/padctl.sock", .{fake_xrd}) catch unreachable;
-    try testing.expectEqualStrings("/run/user/1000/padctl.sock", result);
+    const got = resolveSocketPathFor(&buf, null, xrd, "/nonexistent-system", false);
+    try testing.expectEqualStrings("/tmp/foo.sock", got);
+}
+
+// Test C: system advertised file picked when XDG is missing.
+test "resolveSocketPathFor: system advertised file is honored when XDG absent" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const sys_root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(sys_root);
+
+    var f = try tmp.dir.createFile(control_socket.ADVERTISED_FILE_NAME, .{ .truncate = true });
+    try f.writeAll("/run/padctl/padctl.sock");
+    f.close();
+
+    var buf: [256]u8 = undefined;
+    const got = resolveSocketPathFor(&buf, null, null, sys_root, true);
+    try testing.expectEqualStrings("/run/padctl/padctl.sock", got);
+}
+
+// Test D: backward-compat fallback when no env, no advertised files.
+test "resolveSocketPathFor: fallback returns XDG path for non-root user" {
+    var buf: [256]u8 = undefined;
+    const got = resolveSocketPathFor(&buf, null, "/run/user/1000", "/nonexistent-system", false);
+    try testing.expectEqualStrings("/run/user/1000/padctl.sock", got);
+}
+
+test "resolveSocketPathFor: fallback returns system path for root" {
+    var buf: [256]u8 = undefined;
+    const got = resolveSocketPathFor(&buf, null, null, "/nonexistent-system", true);
+    try testing.expectEqualStrings(DEFAULT_SOCKET_PATH, got);
 }
 
 test "formatSwitch: global" {

--- a/src/io/control_socket.zig
+++ b/src/io/control_socket.zig
@@ -5,11 +5,15 @@ const linux = std.os.linux;
 const MAX_CLIENTS = 4;
 const BUF_SIZE = 256;
 
+/// Suffix joined to the socket's parent directory to advertise the bound path.
+pub const ADVERTISED_FILE_NAME = "socket.advertised";
+
 pub const ControlSocket = struct {
     listen_fd: posix.fd_t,
     client_fds: [MAX_CLIENTS]posix.fd_t,
     client_count: usize,
     path: []const u8,
+    advertised_path: ?[]const u8 = null,
     allocator: std.mem.Allocator,
 
     pub const InitError = posix.SocketError || posix.BindError || posix.ListenError || std.fs.Dir.MakeError || std.mem.Allocator.Error || error{ AlreadyRunning, ChmodFailed, PathTooLong };
@@ -56,12 +60,19 @@ pub const ControlSocket = struct {
         try posix.listen(fd, 4);
 
         const path_owned = try allocator.dupe(u8, path);
+        errdefer allocator.free(path_owned);
+
+        const advertised_path = writeAdvertisedFile(allocator, path) catch |err| blk: {
+            std.log.warn("control socket: advertised file write failed: {}", .{err});
+            break :blk null;
+        };
 
         return .{
             .listen_fd = fd,
             .client_fds = .{ -1, -1, -1, -1 },
             .client_count = 0,
             .path = path_owned,
+            .advertised_path = advertised_path,
             .allocator = allocator,
         };
     }
@@ -75,6 +86,11 @@ pub const ControlSocket = struct {
         }
         self.client_count = 0;
         posix.close(self.listen_fd);
+        if (self.advertised_path) |ap| {
+            std.fs.deleteFileAbsolute(ap) catch {};
+            self.allocator.free(ap);
+            self.advertised_path = null;
+        }
         std.fs.deleteFileAbsolute(self.path) catch {};
         self.allocator.free(self.path);
     }
@@ -201,6 +217,23 @@ pub fn parseCommand(raw: []const u8) Command {
         return .{ .tag = .unknown };
     }
     return .{ .tag = .unknown };
+}
+
+/// Returns the absolute advertised-file path for a given socket path
+/// (`<dirname>/socket.advertised`). Caller owns the returned memory.
+pub fn advertisedFilePath(allocator: std.mem.Allocator, socket_path: []const u8) ![]u8 {
+    const dir = std.fs.path.dirname(socket_path) orelse "/";
+    return std.fs.path.join(allocator, &.{ dir, ADVERTISED_FILE_NAME });
+}
+
+fn writeAdvertisedFile(allocator: std.mem.Allocator, socket_path: []const u8) ![]u8 {
+    const ap = try advertisedFilePath(allocator, socket_path);
+    errdefer allocator.free(ap);
+
+    var file = try std.fs.createFileAbsolute(ap, .{ .truncate = true, .mode = 0o644 });
+    defer file.close();
+    try file.writeAll(socket_path);
+    return ap;
 }
 
 fn containsPathTraversal(s: []const u8) bool {
@@ -450,4 +483,61 @@ test "control_socket: ControlSocket: init rejects overly long unix socket path" 
     defer allocator.free(socket_path);
 
     try testing.expectError(error.PathTooLong, ControlSocket.init(allocator, socket_path));
+}
+
+// Falsifiability: delete the writeAdvertisedFile call in ControlSocket.init,
+// and this test must FAIL — the advertised file will not exist and
+// accessAbsolute returns error.FileNotFound.
+test "control_socket: ControlSocket: init writes advertised file with socket path" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    const socket_path = try std.fs.path.join(allocator, &.{ root, "adv.sock" });
+    defer allocator.free(socket_path);
+
+    var cs = ControlSocket.init(allocator, socket_path) catch |err| {
+        if (err == error.AccessDenied) return;
+        return err;
+    };
+    defer cs.deinit();
+
+    const expected_ap = try advertisedFilePath(allocator, socket_path);
+    defer allocator.free(expected_ap);
+    try std.fs.accessAbsolute(expected_ap, .{});
+
+    var file = try std.fs.openFileAbsolute(expected_ap, .{});
+    defer file.close();
+    var buf: [256]u8 = undefined;
+    const n = try file.readAll(&buf);
+    try testing.expectEqualStrings(socket_path, buf[0..n]);
+}
+
+// Falsifiability: drop the deleteFileAbsolute(self.advertised_path) branch in
+// deinit, and this test must FAIL — accessAbsolute will succeed.
+test "control_socket: ControlSocket: deinit removes advertised file" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    const socket_path = try std.fs.path.join(allocator, &.{ root, "advd.sock" });
+    defer allocator.free(socket_path);
+
+    var cs = ControlSocket.init(allocator, socket_path) catch |err| {
+        if (err == error.AccessDenied) return;
+        return err;
+    };
+
+    const expected_ap = try advertisedFilePath(allocator, socket_path);
+    defer allocator.free(expected_ap);
+    try std.fs.accessAbsolute(expected_ap, .{});
+
+    cs.deinit();
+    try testing.expectError(error.FileNotFound, std.fs.accessAbsolute(expected_ap, .{}));
 }


### PR DESCRIPTION
## Summary
First of 5 PRs in padctl's install/uninstall/lifecycle structural redesign. Fixes issue #216 root cause: daemon (as root) binds `/run/padctl/padctl.sock` while user CLI looks at `$XDG_RUNTIME_DIR/padctl.sock` — paths never agreed. Now daemon writes the bound socket path to `<runtime_dir>/socket.advertised` after a successful `listen()`; CLI reads it as the truth source.

## Resolution order in new `resolveSocketPath`
1. `$PADCTL_SOCKET` env override
2. `$XDG_RUNTIME_DIR/padctl/socket.advertised` (user-scope daemon)
3. `/run/padctl/socket.advertised` (system-scope daemon)
4. Backward-compat fallback to old uid-relative paths (new CLI works against old daemons)

Refs #216

## Test plan
- [x] Test A (env override wins), B (XDG advertised), C (system advertised), D (root fallback), E (non-root fallback) in `socket_client.zig` test block — 5 cases
- [x] Test F (init writes advertised), G (deinit removes) in `control_socket.zig` test block
- [x] TDD falsifiable: pre-fix (advertised-read commented out) Test B fails `expectEqualStrings("/tmp/foo.sock", got)`; pre-fix (advertised-write disabled) Test F fails `accessAbsolute → error.FileNotFound`
- [x] `./scripts/padctl-docker test` — EXIT 0 (full suite passes)
- [x] `./scripts/padctl-docker build test-tsan` — EXIT 0 (1519/1535, 9 skipped)
- [x] `./scripts/padctl-docker build check-fmt` — clean (no `docgen.zig` drift)

## Files changed
- `src/io/control_socket.zig` (+87) — `ADVERTISED_FILE_NAME` const + `advertisedFilePath`/`writeAdvertisedFile` helpers + `advertised_path: ?[]const u8` field + init/deinit wiring + 2 tests. Best-effort write (warn-on-fail) so daemon never aborts startup on advertised-file IO error.
- `src/cli/socket_client.zig` (+114/-19) — `resolveSocketPathFor(env_override, xdg_root, system_root)` pure inner function for testability + 5 tests covering the 4-step resolution chain.

## Compatibility
- Default-`null` `advertised_path` field keeps all 11 existing struct-literal constructions of `ControlSocket` compiling unchanged.
- Step 4 backward-compat fallback means new CLI works against old daemons; old CLI still works against new daemons (socket file at the canonical path unchanged).
- No `install/`, `supervisor.zig`, `main.zig` touched — supervisor compatibility purely via default value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Honor PADCTL_SOCKET environment override for connecting to the service
  * Service writes an “advertised” file next to its socket so clients can discover the socket path

* **Improvements**
  * Multi-step socket discovery with advertised-file and system/runtime fallbacks for more reliable connections
  * Cleaner cleanup of advertised files when the service stops

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->