### PR TITLE
feat(supervisor): hidraw wedge instrumentation (Bug E / PR-ε.1)

### DIFF
--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -19,6 +19,7 @@ const uhid_descriptor = @import("io/uhid_descriptor.zig");
 const uniq_mod = @import("io/uniq.zig");
 const ffb_mod = @import("io/ffb_forwarder.zig");
 const FfbForwarder = ffb_mod.FfbForwarder;
+const WedgeAtomics = @import("io/wedge_atomics.zig").WedgeAtomics;
 const device_cfg = @import("config/device.zig");
 const generic = @import("core/generic.zig");
 const EventLoop = @import("event_loop.zig").EventLoop;
@@ -205,6 +206,9 @@ pub const DeviceInstance = struct {
     poll_timeout_ms: ?u32 = null,
     /// Active only when force_feedback.backend="uhid" + kind="pid".
     ffb_forwarder: ?FfbForwarder = null,
+    /// PR-ε.1 wedge instrumentation. Bumped by hidraw + ffb_forwarder; read by
+    /// Supervisor.handleStatus. Inert until consumers attach (see attachWedges).
+    wedge: WedgeAtomics = .{},
     // Test-only: counts rebuildAuxIfChanged invocations so tests can verify
     // the switch path rebuilds aux caps without relying on /dev/uinput.
     rebuild_aux_calls: if (builtin.is_test) usize else void = if (builtin.is_test) 0 else {},
@@ -488,6 +492,21 @@ pub const DeviceInstance = struct {
             .stopped = false,
             .ffb_forwarder = ffb_fwd,
         };
+    }
+
+    /// Wire wedge instrumentation into hidraw devices and the FFB forwarder.
+    /// Safe to call only AFTER the DeviceInstance is heap-stable (Supervisor
+    /// allocates it via allocator.create before spawnInstance). Idempotent.
+    pub fn attachWedges(self: *DeviceInstance) void {
+        const Hidraw = @import("io/hidraw.zig").HidrawDevice;
+        const tag = Hidraw.vtablePtr();
+        for (self.devices) |dev| {
+            if (dev.vtable == tag) {
+                const h: *Hidraw = @ptrCast(@alignCast(dev.ptr));
+                h.attachWedge(&self.wedge);
+            }
+        }
+        if (self.ffb_forwarder) |*fwd| fwd.attachWedge(&self.wedge);
     }
 
     pub fn deinit(self: *DeviceInstance) void {

--- a/src/io/ffb_forwarder.zig
+++ b/src/io/ffb_forwarder.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const posix = std.posix;
 const OutputReport = @import("uhid.zig").OutputReport;
 const write_exact = @import("write_exact.zig");
+const WedgeAtomics = @import("wedge_atomics.zig").WedgeAtomics;
 
 /// Writes UHID_OUTPUT bytes byte-faithfully to the physical wheel hidraw fd.
 ///
@@ -12,15 +13,23 @@ pub const FfbForwarder = struct {
     state: enum { active, disabled } = .active,
     writes_total: u64 = 0,
     drops_eagain: u64 = 0,
+    /// Optional borrowed wedge instrumentation; see hidraw.zig.
+    wedge: ?*WedgeAtomics = null,
 
     pub fn init(physical_fd: posix.fd_t) FfbForwarder {
         return .{ .physical_fd = physical_fd };
+    }
+
+    pub fn attachWedge(self: *FfbForwarder, wedge: *WedgeAtomics) void {
+        self.wedge = wedge;
     }
 
     /// Write report.data to the physical hidraw fd, byte-for-byte unchanged.
     /// Errors are classified and logged; none escape to the caller.
     pub fn forward(self: *FfbForwarder, report: OutputReport) void {
         if (self.state == .disabled) return;
+        if (self.wedge) |w| w.beginWrite();
+        defer if (self.wedge) |w| w.endWrite();
         write_exact.writeExact(self.physical_fd, report.data) catch |err| switch (err) {
             error.WouldBlock => {
                 self.drops_eagain += 1;
@@ -50,6 +59,7 @@ pub const FfbForwarder = struct {
             },
         };
         self.writes_total += 1;
+        if (self.wedge) |w| w.bumpOutbound();
     }
 
     pub fn deinit(_: *FfbForwarder) void {}

--- a/src/io/hidraw.zig
+++ b/src/io/hidraw.zig
@@ -4,6 +4,7 @@ const posix = std.posix;
 const io = @import("device_io.zig");
 const ioctl = @import("ioctl_constants.zig");
 const write_exact = @import("write_exact.zig");
+const WedgeAtomics = @import("wedge_atomics.zig").WedgeAtomics;
 
 pub const DeviceIO = io.DeviceIO;
 
@@ -30,6 +31,10 @@ pub const HidrawDevice = struct {
     fd: posix.fd_t,
     evdev_fds: BoundedArray(posix.fd_t, MAX_EVDEV_GRABS),
     allocator: std.mem.Allocator,
+    /// Optional wedge instrumentation. Borrowed pointer; lifetime owned by the
+    /// enclosing DeviceInstance. When non-null, read/write/feature_report bump
+    /// the corresponding atomics for PR-ε.2 watchdog consumption.
+    wedge: ?*WedgeAtomics = null,
 
     pub fn init(allocator: std.mem.Allocator) HidrawDevice {
         return .{
@@ -37,6 +42,10 @@ pub const HidrawDevice = struct {
             .evdev_fds = .{},
             .allocator = allocator,
         };
+    }
+
+    pub fn attachWedge(self: *HidrawDevice, wedge: *WedgeAtomics) void {
+        self.wedge = wedge;
     }
 
     /// Scan /dev/hidraw0..hidraw63 for a device matching vid/pid.
@@ -201,6 +210,12 @@ pub const HidrawDevice = struct {
         return .{ .ptr = self, .vtable = &vtable };
     }
 
+    /// Vtable address used as a runtime type tag so DeviceInstance can detect
+    /// hidraw-backed DeviceIO entries (e.g. to attach wedge instrumentation).
+    pub fn vtablePtr() *const DeviceIO.VTable {
+        return &vtable;
+    }
+
     const vtable = DeviceIO.VTable{
         .read = read,
         .write = write,
@@ -217,27 +232,34 @@ pub const HidrawDevice = struct {
             else => return DeviceIO.ReadError.Io,
         };
         if (n == 0) return DeviceIO.ReadError.Disconnected;
+        if (self.wedge) |w| w.bumpInbound();
         return n;
     }
 
     fn write(ptr: *anyopaque, data: []const u8) DeviceIO.WriteError!void {
         const self: *HidrawDevice = @ptrCast(@alignCast(ptr));
+        if (self.wedge) |w| w.beginWrite();
+        defer if (self.wedge) |w| w.endWrite();
         write_exact.writeExact(self.fd, data) catch |err| switch (err) {
             error.BrokenPipe, error.ConnectionResetByPeer => return DeviceIO.WriteError.Disconnected,
             else => return DeviceIO.WriteError.Io,
         };
+        if (self.wedge) |w| w.bumpOutbound();
     }
 
     fn featureReport(ptr: *anyopaque, data: []const u8) DeviceIO.WriteError!void {
         const self: *HidrawDevice = @ptrCast(@alignCast(ptr));
         const len: u14 = @intCast(@min(data.len, 0x3fff));
         const req = ioctl.HIDIOCSFEATURE(len);
+        if (self.wedge) |w| w.beginWrite();
+        defer if (self.wedge) |w| w.endWrite();
         const rc = linux.ioctl(self.fd, req, @intFromPtr(data.ptr));
         if (rc < 0) {
             const errno = posix.errno(rc);
             if (errno == .NODEV or errno == .PIPE) return DeviceIO.WriteError.Disconnected;
             return DeviceIO.WriteError.Io;
         }
+        if (self.wedge) |w| w.bumpOutbound();
     }
 
     fn pollfd(ptr: *anyopaque) posix.pollfd {

--- a/src/io/wedge_atomics.zig
+++ b/src/io/wedge_atomics.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const posix = std.posix;
+
+/// Per-managed-instance monotonic-ns atomics used by PR-ε.2 watchdog to detect
+/// kernel-side D-state hangs in hidraw write/ioctl paths. Pure observability;
+/// nothing in this struct triggers recovery.
+pub const WedgeAtomics = struct {
+    last_inbound_ns: u64 = 0,
+    last_outbound_ns: u64 = 0,
+    write_in_flight_since_ns: u64 = 0,
+
+    pub fn nowNs() u64 {
+        const ts = posix.clock_gettime(.MONOTONIC) catch return 0;
+        const sec: u64 = @intCast(ts.sec);
+        const nsec: u64 = @intCast(ts.nsec);
+        return sec *| std.time.ns_per_s +| nsec;
+    }
+
+    pub fn bumpInbound(self: *WedgeAtomics) void {
+        @atomicStore(u64, &self.last_inbound_ns, nowNs(), .release);
+    }
+
+    pub fn bumpOutbound(self: *WedgeAtomics) void {
+        @atomicStore(u64, &self.last_outbound_ns, nowNs(), .release);
+    }
+
+    pub fn beginWrite(self: *WedgeAtomics) void {
+        @atomicStore(u64, &self.write_in_flight_since_ns, nowNs(), .release);
+    }
+
+    pub fn endWrite(self: *WedgeAtomics) void {
+        @atomicStore(u64, &self.write_in_flight_since_ns, 0, .release);
+    }
+
+    pub fn loadInbound(self: *const WedgeAtomics) u64 {
+        return @atomicLoad(u64, &self.last_inbound_ns, .acquire);
+    }
+
+    pub fn loadOutbound(self: *const WedgeAtomics) u64 {
+        return @atomicLoad(u64, &self.last_outbound_ns, .acquire);
+    }
+
+    pub fn loadInFlight(self: *const WedgeAtomics) u64 {
+        return @atomicLoad(u64, &self.write_in_flight_since_ns, .acquire);
+    }
+};

--- a/src/main.zig
+++ b/src/main.zig
@@ -150,6 +150,7 @@ pub const testing_support = struct {
     pub const device_instance_imu_ownership_test = @import("test/device_instance_imu_ownership_test.zig");
     pub const supervisor_suspended_attach_takeover_test = @import("test/supervisor_suspended_attach_takeover_test.zig");
     pub const supervisor_suspend_output_continuity_test = @import("test/supervisor_suspend_output_continuity_test.zig");
+    pub const wedge_instrumentation_test = @import("test/wedge_instrumentation_test.zig");
     // Permanent canary — proves test discovery walks into testing_support.
     // If the discovery mechanism breaks again, this test stops running and
     // we can prove the regression with a deliberate failure.

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -678,6 +678,10 @@ pub const Supervisor = struct {
     }
 
     fn spawnInstance(self: *Supervisor, phys_key: []const u8, instance: *DeviceInstance, default_pr: ?*mapping_cfg.ParseResult) !void {
+        // Wire wedge atomics through the chokepoint so all 4 spawn call
+        // sites (run() initial_configs, doReload, hotplug retry,
+        // attachWithInstanceResult) get Bug E instrumentation uniformly.
+        instance.attachWedges();
         // Install chord detector before spawning the thread so the mapper sees
         // the cfg from the very first frame.
         if (self.chord_detector_cfg) |cfg| {
@@ -1778,7 +1782,7 @@ pub const Supervisor = struct {
         return resolveEvdevNodesAt("/sys/class/input", vid, pid, out);
     }
 
-    fn handleStatus(self: *Supervisor, fd: posix.fd_t) void {
+    pub fn handleStatus(self: *Supervisor, fd: posix.fd_t) void {
         var cs = &self.ctrl_sock.?;
         var buf: [4096]u8 = undefined;
         var stream = std.io.fixedBufferStream(&buf);
@@ -1825,6 +1829,19 @@ pub const Supervisor = struct {
             w.print(" evdev_node={s}", .{evdev_node}) catch {};
 
             w.print(" hotplug_pending={d}", .{self.hotplug_pending.items.len}) catch {};
+
+            // PR-ε.1 wedge instrumentation. write_in_flight_ms=0 when no write is
+            // currently blocked; a sustained non-zero value (hundreds of ms) is the
+            // smoking gun for a kernel-side D-state hang on usb_control_msg.
+            const inb = m.instance.wedge.loadInbound();
+            const outb = m.instance.wedge.loadOutbound();
+            const ifs = m.instance.wedge.loadInFlight();
+            const inb_ago_ms: u64 = if (inb == 0 or now_ns < inb) 0 else (now_ns - inb) / std.time.ns_per_ms;
+            const outb_ago_ms: u64 = if (outb == 0 or now_ns < outb) 0 else (now_ns - outb) / std.time.ns_per_ms;
+            const inflight_ms: u64 = if (ifs == 0 or now_ns < ifs) 0 else (now_ns - ifs) / std.time.ns_per_ms;
+            w.print(" last_inbound_ms_ago={d} last_outbound_ms_ago={d} write_in_flight_ms={d}", .{
+                inb_ago_ms, outb_ago_ms, inflight_ms,
+            }) catch {};
         }
         w.writeByte('\n') catch return;
         cs.sendResponse(fd, stream.getWritten());

--- a/src/test/wedge_instrumentation_test.zig
+++ b/src/test/wedge_instrumentation_test.zig
@@ -1,0 +1,324 @@
+const std = @import("std");
+const testing = std.testing;
+const posix = std.posix;
+
+const wedge_mod = @import("../io/wedge_atomics.zig");
+const WedgeAtomics = wedge_mod.WedgeAtomics;
+const HidrawDevice = @import("../io/hidraw.zig").HidrawDevice;
+const FfbForwarder = @import("../io/ffb_forwarder.zig").FfbForwarder;
+const OutputReport = @import("../io/uhid.zig").OutputReport;
+
+// Test A: write enter sets write_in_flight_since_ns, exit clears it (success path).
+// Falsifiability: removing the `defer w.endWrite()` in hidraw.write makes the
+// post-call expectEqual fail with the begin timestamp instead of 0.
+test "wedge: hidraw write clears write_in_flight_since_ns on success" {
+    const fds = try posix.pipe2(.{});
+    defer posix.close(fds[0]);
+    defer posix.close(fds[1]);
+
+    var wedge = WedgeAtomics{};
+
+    var dev = HidrawDevice{
+        .fd = fds[1],
+        .evdev_fds = .{},
+        .allocator = testing.allocator,
+        .wedge = &wedge,
+    };
+    const io = dev.deviceIO();
+
+    try testing.expectEqual(@as(u64, 0), wedge.loadInFlight());
+    const payload = [_]u8{ 0x01, 0x02, 0x03 };
+    try io.write(&payload);
+    try testing.expectEqual(@as(u64, 0), wedge.loadInFlight());
+    try testing.expect(wedge.loadOutbound() != 0);
+
+    // Drain the pipe to avoid leaking blocked bytes.
+    var drain: [16]u8 = undefined;
+    _ = posix.read(fds[0], &drain) catch {};
+}
+
+// Test B: error path still clears write_in_flight_since_ns.
+// Falsifiability: same as Test A — defer guarantees the clear runs regardless
+// of the write outcome. Without the defer, the error path leaves the field set.
+test "wedge: hidraw write clears write_in_flight_since_ns on error" {
+    // Closed write-end → BrokenPipe → DeviceIO.WriteError.Disconnected.
+    const fds = try posix.pipe2(.{});
+    posix.close(fds[0]);
+    defer posix.close(fds[1]);
+
+    var wedge = WedgeAtomics{};
+
+    var dev = HidrawDevice{
+        .fd = fds[1],
+        .evdev_fds = .{},
+        .allocator = testing.allocator,
+        .wedge = &wedge,
+    };
+    const io = dev.deviceIO();
+
+    const payload = [_]u8{0x99};
+    // Either Disconnected or Io is acceptable — the point is that the call
+    // returns an error and the in-flight slot must still be cleared.
+    const result = io.write(&payload);
+    try testing.expect(std.meta.isError(result));
+    try testing.expectEqual(@as(u64, 0), wedge.loadInFlight());
+}
+
+// Test B2: FfbForwarder forward() clears write_in_flight_since_ns even when
+// the forwarder hits an error path that returns without writing.
+test "wedge: ffb_forwarder clears write_in_flight_since_ns after closed-fd error" {
+    const fds = try posix.pipe2(.{});
+    defer posix.close(fds[0]);
+
+    var wedge = WedgeAtomics{};
+    var fwd = FfbForwarder.init(fds[1]);
+    fwd.attachWedge(&wedge);
+
+    posix.close(fds[1]);
+
+    const payload = [_]u8{0x01};
+    fwd.forward(.{ .report_id = 0x01, .data = &payload });
+    try testing.expectEqual(@as(u64, 0), wedge.loadInFlight());
+}
+
+// Test: hidraw read bumps last_inbound_ns on success.
+test "wedge: hidraw read bumps last_inbound_ns" {
+    const fds = try posix.pipe2(.{});
+    defer posix.close(fds[0]);
+    defer posix.close(fds[1]);
+
+    var wedge = WedgeAtomics{};
+    var dev = HidrawDevice{
+        .fd = fds[0],
+        .evdev_fds = .{},
+        .allocator = testing.allocator,
+        .wedge = &wedge,
+    };
+    const io = dev.deviceIO();
+
+    const payload = [_]u8{ 0x10, 0x20 };
+    _ = try posix.write(fds[1], &payload);
+
+    var buf: [16]u8 = undefined;
+    const n = try io.read(&buf);
+    try testing.expectEqual(@as(usize, 2), n);
+    try testing.expect(wedge.loadInbound() != 0);
+}
+
+// Test C + D: STATUS output contains the 3 new fields, and write_in_flight_ms
+// reports a sensible non-zero when the atomic is pre-armed.
+// Falsifiability for C: removing any of the three writes in handleStatus
+// causes the corresponding indexOf assertion to fail.
+// Falsifiability for D: dropping the `(now_ns - ifs) / ns_per_ms` formula
+// in favour of a constant breaks the ±tolerance assertion.
+test "wedge: STATUS surfaces last_inbound_ms_ago, last_outbound_ms_ago, write_in_flight_ms" {
+    const Supervisor = @import("../supervisor.zig").Supervisor;
+    const device_mod = @import("../config/device.zig");
+    const MockDeviceIO = @import("mock_device_io.zig").MockDeviceIO;
+    const DeviceInstance = @import("../device_instance.zig").DeviceInstance;
+    const DeviceIO = @import("../io/device_io.zig").DeviceIO;
+    const EventLoop = @import("../event_loop.zig").EventLoop;
+    const Interpreter = @import("../core/interpreter.zig").Interpreter;
+
+    const allocator = testing.allocator;
+    const minimal_toml =
+        \\[device]
+        \\name = "WedgeT"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 1
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x01]
+    ;
+
+    const parsed = try device_mod.parseString(allocator, minimal_toml);
+    defer parsed.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+
+    var sup = try Supervisor.initForTest(allocator);
+
+    const devices = try allocator.alloc(DeviceIO, 1);
+    devices[0] = mock.deviceIO();
+    var loop = try EventLoop.initManaged();
+    errdefer loop.deinit();
+    try loop.addDevice(devices[0]);
+
+    const inst = try allocator.create(DeviceInstance);
+    inst.* = .{
+        .allocator = allocator,
+        .devices = devices,
+        .loop = loop,
+        .interp = Interpreter.init(&parsed.value),
+        .mapper = null,
+        .owner = .none,
+        .primary_output = null,
+        .imu_output = null,
+        .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
+        .device_cfg = &parsed.value,
+        .pending_mapping = null,
+        .stopped = false,
+        .poll_timeout_ms = 100,
+    };
+
+    try sup.attachWithInstance("wedge0", "usb-1-1", inst, null);
+
+    const resp_fds = blk: {
+        var fds: [2]posix.fd_t = undefined;
+        if (std.c.socketpair(posix.AF.UNIX, posix.SOCK.STREAM | posix.SOCK.CLOEXEC, 0, &fds) != 0) {
+            return posix.unexpectedErrno(posix.errno(0));
+        }
+        break :blk fds;
+    };
+    defer posix.close(resp_fds[0]);
+    defer posix.close(resp_fds[1]);
+    sup.ctrl_sock = .{
+        .listen_fd = -1,
+        .client_fds = .{ -1, -1, -1, -1 },
+        .client_count = 0,
+        .path = "",
+        .allocator = allocator,
+    };
+
+    // Pin a fake "now" so we can prove the write_in_flight_ms math.
+    const fake_now: u64 = 10 * std.time.ns_per_s;
+    sup.test_now_override_ns = fake_now;
+    // Pre-arm: write started 500ms ago.
+    @atomicStore(u64, &inst.wedge.write_in_flight_since_ns, fake_now - 500 * std.time.ns_per_ms, .release);
+    @atomicStore(u64, &inst.wedge.last_inbound_ns, fake_now - 1500 * std.time.ns_per_ms, .release);
+    @atomicStore(u64, &inst.wedge.last_outbound_ns, fake_now - 250 * std.time.ns_per_ms, .release);
+
+    sup.handleStatus(resp_fds[0]);
+    var resp_buf: [4096]u8 = undefined;
+    const n = try posix.read(resp_fds[1], &resp_buf);
+    const resp = resp_buf[0..n];
+
+    try testing.expect(std.mem.indexOf(u8, resp, "last_inbound_ms_ago=") != null);
+    try testing.expect(std.mem.indexOf(u8, resp, "last_outbound_ms_ago=") != null);
+    try testing.expect(std.mem.indexOf(u8, resp, "write_in_flight_ms=") != null);
+    // Exact value proof: 500ms in-flight, 1500ms inbound, 250ms outbound.
+    try testing.expect(std.mem.indexOf(u8, resp, "write_in_flight_ms=500") != null);
+    try testing.expect(std.mem.indexOf(u8, resp, "last_inbound_ms_ago=1500") != null);
+    try testing.expect(std.mem.indexOf(u8, resp, "last_outbound_ms_ago=250") != null);
+
+    defer {
+        sup.stopAll();
+        sup.ctrl_sock = null;
+        sup.deinit();
+    }
+}
+
+// Sanity: WedgeAtomics defaults are zero (so STATUS reports 0 ms_ago for fresh devices).
+test "wedge: default values are all zero" {
+    const w = WedgeAtomics{};
+    try testing.expectEqual(@as(u64, 0), w.loadInbound());
+    try testing.expectEqual(@as(u64, 0), w.loadOutbound());
+    try testing.expectEqual(@as(u64, 0), w.loadInFlight());
+}
+
+// Test E (BLOCKING fix follow-up): spawnInstance is the single wedge-wiring
+// chokepoint. Every production attach path (run() bootstrap, doReload, hotplug
+// retry, attachWithInstance) routes through spawnInstance, so wiring there
+// must wire the wedge pointer on a hidraw-backed DeviceIO without any
+// per-call-site attachWedges() invocation.
+//
+// Falsifiability: deleting `instance.attachWedges()` from spawnInstance makes
+// this test fail with `hidraw.wedge == null`. The reviewer's BLOCKING
+// observation (run() and doReload bypasses) is structurally prevented as long
+// as this test guards the chokepoint.
+test "wedge: spawnInstance wires hidraw wedge pointer via single chokepoint" {
+    const Supervisor = @import("../supervisor.zig").Supervisor;
+    const device_mod = @import("../config/device.zig");
+    const DeviceInstance = @import("../device_instance.zig").DeviceInstance;
+    const DeviceIO = @import("../io/device_io.zig").DeviceIO;
+    const EventLoop = @import("../event_loop.zig").EventLoop;
+    const Interpreter = @import("../core/interpreter.zig").Interpreter;
+
+    const allocator = testing.allocator;
+    const minimal_toml =
+        \\[device]
+        \\name = "WedgeChokepoint"
+        \\vid = 1
+        \\pid = 3
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 1
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x01]
+    ;
+
+    const parsed = try device_mod.parseString(allocator, minimal_toml);
+    defer parsed.deinit();
+
+    // Pipe acts as a tame hidraw fd: the polling thread sees no data and
+    // idles until sup.stopAll() signals shutdown. HidrawDevice.close()
+    // destroys the heap allocation, so allocate via the testing allocator.
+    const fds = try posix.pipe2(.{});
+    defer posix.close(fds[1]);
+
+    const hidraw = try allocator.create(HidrawDevice);
+    hidraw.* = .{
+        .fd = fds[0],
+        .evdev_fds = .{},
+        .allocator = allocator,
+        .wedge = null,
+    };
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.deinit();
+    }
+
+    const devices = try allocator.alloc(DeviceIO, 1);
+    devices[0] = hidraw.deviceIO();
+    var loop = try EventLoop.initManaged();
+    errdefer loop.deinit();
+    try loop.addDevice(devices[0]);
+
+    const inst = try allocator.create(DeviceInstance);
+    inst.* = .{
+        .allocator = allocator,
+        .devices = devices,
+        .loop = loop,
+        .interp = Interpreter.init(&parsed.value),
+        .mapper = null,
+        .owner = .none,
+        .primary_output = null,
+        .imu_output = null,
+        .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
+        .device_cfg = &parsed.value,
+        .pending_mapping = null,
+        .stopped = false,
+        .poll_timeout_ms = 100,
+    };
+
+    // Pre-condition: HidrawDevice wedge is unwired before attach.
+    try testing.expect(hidraw.wedge == null);
+
+    // Drive the same path production uses; spawnInstance must auto-wire.
+    try sup.attachWithInstance("wedge-chokepoint0", "usb-1-3", inst, null);
+
+    // Post-condition: wedge pointer is wired to the instance's own atomics.
+    try testing.expect(hidraw.wedge != null);
+    try testing.expectEqual(@as(*WedgeAtomics, &inst.wedge), hidraw.wedge.?);
+}


### PR DESCRIPTION
## Summary
PR-ε.1 of 2 for Bug E (kernel D-state recovery). **Instrumentation only — zero behavior change.** Adds three per-managed-device monotonic-ns atomics that PR-ε.2's watchdog will read to detect hung USB control transfers to wedged firmware.

Bug E lives in `~/.../tasks/a5e5f0b0636ed43ac.output` (researcher's design memo): kernel `usb_control_msg` parks `TASK_UNINTERRUPTIBLE` waiting for firmware response that never comes. Affects every hidraw `write`/`HIDIOCSFEATURE`/`FFB forward`. Tonight verified live on maintainer's Vader 5 (USB `events_unbound` kworker stuck D). Issue #65 reports: many "stuck rumble" / "stuck button" / "firmware crash 5min" are same class.

Refs #65

## Atomics added (new `src/io/wedge_atomics.zig` module)
- `write_in_flight_since_ns` — set BEFORE hidraw write/SFEATURE/FFB-forward, cleared via `defer` on return (success or error). Non-zero >300ms = wedge candidate.
- `last_inbound_ns` — bumped after successful hidraw read returns >0 bytes.
- `last_outbound_ns` — bumped after successful write/SFEATURE/forward.

All atomics use `.monotonic` ordering, `u64` ns.

## STATUS surfacing (per-instance)
- `last_inbound_ms_ago=<N>`
- `last_outbound_ms_ago=<N>`
- `write_in_flight_ms=<N>` (0 if no write in flight) ← **gold-standard wedge indicator**

Buffer accommodates (already 4096 bytes after PR #344).

## Test plan
- [x] 6 falsifiable tests in `src/test/wedge_instrumentation_test.zig`:
  - hidraw write success path clears `write_in_flight`
  - hidraw write error path clears `write_in_flight`
  - ffb closed-fd error path clears `write_in_flight`
  - hidraw read bumps `last_inbound_ns`
  - STATUS exact-ms surfacing via `test_now_override_ns` pinning
  - default zero values sanity check
- [x] TDD falsifiable: remove `defer endWrite()` → tests fail with `expected 0, found <nonzero>`. Remove STATUS field write → `indexOf("write_in_flight_ms=") == null` assertion fails
- [x] `./scripts/padctl-docker test` — EXIT 0
- [x] `./scripts/padctl-docker build test-tsan` — EXIT 0 (1520 passed, 9 skipped)
- [x] `./scripts/padctl-docker build check-fmt` — clean (no `docgen.zig` drift)

## Files changed (7, +342/-1)
- `src/io/wedge_atomics.zig` — new module, `WedgeAtomics` struct + 4 helper methods (+46)
- `src/io/hidraw.zig` — optional `wedge` field + atomic bumps in read/write/SFEATURE (+22)
- `src/io/ffb_forwarder.zig` — optional `wedge` field + atomic bumps in `forward()` (+10)
- `src/device_instance.zig` — `wedge: WedgeAtomics` field + `attachWedges()` walks `devices[]` via vtable tag (+19)
- `src/supervisor.zig` — `handleStatus` extended with 3 new fields; both spawn paths call `attachWedges()` (+17/-1)
- `src/main.zig` — test registration (+1)
- `src/test/wedge_instrumentation_test.zig` — 6 cases (+228 new)

## What this PR does NOT do
- No watchdog timerfd
- No L1/L2/L3/L4 recovery
- No `USBDEVFS_RESET` / unbind / `usb_kill_urb`
- Zero behavior change beyond observability

All of the above is PR-ε.2 (next PR), which reads these atomics on a 500ms timerfd tick + escalates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-device I/O instrumentation added to monitor inbound/outbound activity and in-flight writes.
  * Outbound forwarding and raw device I/O now report/write lifecycle events so successful and failed writes are tracked.
  * Supervisor status now exposes three new metrics: last inbound ms ago, last outbound ms ago, and write-in-flight ms.

* **Tests**
  * Added unit and integration tests covering instrumentation, lifecycle clearing on errors/success, and status output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->