### PR TITLE
fix(install): uninstall probes + stops daemon before unlinking live socket (issue #216)

### DIFF
--- a/src/cli/install/phase.zig
+++ b/src/cli/install/phase.zig
@@ -4,6 +4,68 @@ const services = @import("services.zig");
 const udev = @import("udev.zig");
 const migration = @import("migration.zig");
 const mappings = @import("mappings.zig");
+const control_socket = @import("../../io/control_socket.zig");
+
+/// Test hook: when non-null, `probeSocketAlive` calls this instead of probing.
+/// Lets uninstall tests simulate a live daemon (and toggle aliveness between
+/// the pre-stop and post-stop probes) without binding a real socket.
+pub var test_probe_alive_override: ?*const fn (path: []const u8) bool = null;
+
+fn probeSocketAlive(path: []const u8) bool {
+    if (test_probe_alive_override) |f| return f(path);
+    return control_socket.probeAlive(path);
+}
+
+/// Probe-guarded unlink: if a live daemon is bound to `path`, stop it in both
+/// systemctl scopes and re-probe before deleting. Refuses (returns error) when
+/// the daemon survives the stop. Silent unlink when no daemon is present.
+fn unlinkRuntimePath(allocator: std.mem.Allocator, path: []const u8) !void {
+    if (probeSocketAlive(path)) {
+        _ = std.posix.write(std.posix.STDERR_FILENO, "  warn: padctl daemon is bound to ") catch {};
+        _ = std.posix.write(std.posix.STDERR_FILENO, path) catch {};
+        _ = std.posix.write(std.posix.STDERR_FILENO, "; stopping before unlink\n") catch {};
+        services.stopDaemonScope(allocator, .both) catch {
+            _ = std.posix.write(std.posix.STDERR_FILENO,
+                \\  error: failed to stop padctl daemon; refusing to unlink live socket.
+                \\  Manually: sudo systemctl stop padctl.service && systemctl --user stop padctl.service
+                \\
+            ) catch {};
+            return error.DaemonStopFailed;
+        };
+        std.Thread.sleep(500 * std.time.ns_per_ms);
+        if (probeSocketAlive(path)) {
+            _ = std.posix.write(std.posix.STDERR_FILENO,
+                \\  error: padctl daemon still alive after stop; refusing to unlink live socket
+                \\
+            ) catch {};
+            return error.DaemonStillAlive;
+        }
+    }
+    std.fs.deleteFileAbsolute(path) catch {};
+}
+
+/// Remove `*.wants/padctl.service` symlinks whose target unit file no longer
+/// exists on disk — left dangling after the stop+unlink cycle on some installs.
+fn gcDanglingWantsLinks(allocator: std.mem.Allocator, destdir: []const u8) void {
+    const candidates = [_][]const u8{
+        "/etc/systemd/system/multi-user.target.wants/padctl.service",
+        "/etc/systemd/user/default.target.wants/padctl.service",
+    };
+    for (candidates) |suffix| {
+        const path = std.fmt.allocPrint(allocator, "{s}{s}", .{ destdir, suffix }) catch continue;
+        defer allocator.free(path);
+        migration.removeBrokenSymlink(path);
+    }
+    if (std.posix.getenv("HOME")) |home| {
+        const user_path = std.fmt.allocPrint(
+            allocator,
+            "{s}/.config/systemd/user/default.target.wants/padctl.service",
+            .{home},
+        ) catch return;
+        defer allocator.free(user_path);
+        migration.removeBrokenSymlink(user_path);
+    }
+}
 
 const InstallOptions = plan_mod.InstallOptions;
 const InstallPlan = plan_mod.InstallPlan;
@@ -223,6 +285,12 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         opts.prefix;
 
     if (destdir.len == 0) {
+        // Stop+disable in both scopes so a system-scope install (which
+        // pre-#216 the user-only path never touched) is also shut down.
+        if (is_root) {
+            services.runSystemctlSystem(&.{ "stop", "padctl.service" });
+            services.runSystemctlSystem(&.{ "disable", "padctl.service" });
+        }
         const stop_plan = services.currentPlanFromEnv();
         if (stop_plan.mode == .skip) {
             const groups = [_][]const []const u8{
@@ -375,15 +443,18 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
     }
 
     {
-        const path = try std.fmt.allocPrint(allocator, "{s}/run/padctl/padctl.pid", .{destdir});
-        defer allocator.free(path);
-        std.fs.deleteFileAbsolute(path) catch {};
+        // Socket liveness is the canonical signal — the same daemon owns the
+        // pid file. Probe-and-stop on the socket gates both unlinks.
+        const sock_path = try std.fmt.allocPrint(allocator, "{s}/run/padctl/padctl.sock", .{destdir});
+        defer allocator.free(sock_path);
+        try unlinkRuntimePath(allocator, sock_path);
+
+        const pid_path = try std.fmt.allocPrint(allocator, "{s}/run/padctl/padctl.pid", .{destdir});
+        defer allocator.free(pid_path);
+        std.fs.deleteFileAbsolute(pid_path) catch {};
     }
-    {
-        const path = try std.fmt.allocPrint(allocator, "{s}/run/padctl/padctl.sock", .{destdir});
-        defer allocator.free(path);
-        std.fs.deleteFileAbsolute(path) catch {};
-    }
+
+    gcDanglingWantsLinks(allocator, destdir);
 
     if (destdir.len == 0) {
         const reload_plan = services.currentPlanFromEnv();

--- a/src/cli/install/services.zig
+++ b/src/cli/install/services.zig
@@ -9,6 +9,17 @@ const runCmdWarn = plan_mod.runCmdWarn;
 const planSystemctlUser = plan_mod.planSystemctlUser;
 const atomicInstallBinary = plan_mod.atomicInstallBinary;
 
+pub const SystemctlScope = enum { system, user, both };
+
+/// Test hook: when non-null, `stopDaemonScope` records calls here instead of
+/// invoking real systemctl. Set to a non-null pointer in tests; reset to null
+/// in `defer`. Each call appends the scope and verbs (verbs are not duped).
+pub const TestStopCall = struct { scope: SystemctlScope, verbs: []const []const u8 };
+pub var test_stop_calls: ?*std.ArrayList(TestStopCall) = null;
+/// Test hook: when non-null, `stopDaemonScope` returns this error before
+/// dispatching to systemctl. Lets tests simulate a failed stop.
+pub var test_stop_force_error: ?anyerror = null;
+
 /// Generate the systemd --user unit. SupplementaryGroups= is intentionally
 /// NOT emitted: a user-scope service manager runs unprivileged (no CAP_SETGID)
 /// and cannot apply it, so the directive aborts startup with status=216/GROUP
@@ -348,6 +359,27 @@ pub fn runSystemctlSystem(verbs: []const []const u8) void {
     };
     defer freeArgv(allocator, argv);
     runCmd(argv);
+}
+
+/// Stop the padctl service in the requested systemctl scope(s) before any
+/// destructive op on daemon-owned runtime state (issue #216). On `.both`,
+/// stops are dispatched to both system and user scopes; either may report
+/// "not loaded" / "inactive" without surfacing as an error — the caller
+/// re-probes the socket afterwards to confirm the daemon released it.
+pub fn stopDaemonScope(allocator: std.mem.Allocator, scope: SystemctlScope) !void {
+    if (test_stop_force_error) |err| return err;
+    if (test_stop_calls) |list| {
+        try list.append(allocator, .{ .scope = scope, .verbs = &.{ "stop", "padctl.service" } });
+        return;
+    }
+    switch (scope) {
+        .system => runSystemctlSystem(&.{ "stop", "padctl.service" }),
+        .user => runSystemctlUser(&.{ "stop", "padctl.service" }),
+        .both => {
+            runSystemctlSystem(&.{ "stop", "padctl.service" });
+            runSystemctlUser(&.{ "stop", "padctl.service" });
+        },
+    }
 }
 
 fn buildSystemctlSystemArgv(allocator: std.mem.Allocator, verbs: []const []const u8) ![][]const u8 {

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -12,6 +12,7 @@ const phase_mod = @import("phase.zig");
 const user_config_mod = @import("../../config/user_config.zig");
 const paths = @import("../../config/paths.zig");
 const toml_extract = @import("../toml_extract.zig");
+const control_socket_mod = @import("../../io/control_socket.zig");
 
 // plan.zig
 const InstallOptions = plan_mod.InstallOptions;
@@ -889,6 +890,289 @@ test "install: uninstall applies destdir to runtime state paths" {
         std.debug.print("padctl.sock not cleaned up under destdir: {s}\n", .{sock_path});
         return error.RuntimeSockNotRemoved;
     } else |_| {}
+}
+
+// --- issue #216: probe-and-stop guard before unlinking live socket ---
+
+const ProbeRig = struct {
+    var alive_responses: [4]bool = .{ false, false, false, false };
+    var alive_call_count: usize = 0;
+    var calls: std.ArrayList(services_mod.TestStopCall) = .empty;
+
+    fn reset() void {
+        alive_responses = .{ false, false, false, false };
+        alive_call_count = 0;
+        calls = .empty;
+        services_mod.test_stop_calls = null;
+        services_mod.test_stop_force_error = null;
+        phase_mod.test_probe_alive_override = null;
+    }
+
+    fn probeAlive(_: []const u8) bool {
+        const i = alive_call_count;
+        alive_call_count += 1;
+        if (i >= alive_responses.len) return false;
+        return alive_responses[i];
+    }
+};
+
+test "uninstall: probes live daemon and stops in both scopes before unlink (issue #216)" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    ProbeRig.reset();
+    defer ProbeRig.reset();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const staging = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(staging);
+
+    const run_dir = try std.fmt.allocPrint(allocator, "{s}/run/padctl", .{staging});
+    defer allocator.free(run_dir);
+    try ensureDirAll(allocator, run_dir);
+
+    const sock_path = try std.fmt.allocPrint(allocator, "{s}/padctl.sock", .{run_dir});
+    defer allocator.free(sock_path);
+    {
+        var f = try std.fs.createFileAbsolute(sock_path, .{ .truncate = true });
+        defer f.close();
+    }
+
+    ProbeRig.alive_responses = .{ true, false, false, false }; // alive pre-stop, dead after
+    phase_mod.test_probe_alive_override = ProbeRig.probeAlive;
+    services_mod.test_stop_calls = &ProbeRig.calls;
+    defer ProbeRig.calls.deinit(allocator);
+
+    const opts = InstallOptions{
+        .prefix = "/usr/local",
+        .destdir = staging,
+        .immutable = false,
+        .user_service = false,
+    };
+    {
+        var silencer = try SilencedStdout.begin();
+        defer silencer.end();
+        try uninstall(allocator, opts);
+    }
+
+    try testing.expectEqual(@as(usize, 1), ProbeRig.calls.items.len);
+    try testing.expectEqual(services_mod.SystemctlScope.both, ProbeRig.calls.items[0].scope);
+    try testing.expectEqualStrings("stop", ProbeRig.calls.items[0].verbs[0]);
+    try testing.expectEqualStrings("padctl.service", ProbeRig.calls.items[0].verbs[1]);
+
+    // Pre-probe + post-probe both consumed; socket file gone.
+    try testing.expect(ProbeRig.alive_call_count >= 2);
+    try testing.expectError(error.FileNotFound, std.fs.accessAbsolute(sock_path, .{}));
+}
+
+test "uninstall: dead daemon triggers no stop call (issue #216)" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    ProbeRig.reset();
+    defer ProbeRig.reset();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const staging = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(staging);
+
+    const run_dir = try std.fmt.allocPrint(allocator, "{s}/run/padctl", .{staging});
+    defer allocator.free(run_dir);
+    try ensureDirAll(allocator, run_dir);
+
+    const sock_path = try std.fmt.allocPrint(allocator, "{s}/padctl.sock", .{run_dir});
+    defer allocator.free(sock_path);
+    {
+        var f = try std.fs.createFileAbsolute(sock_path, .{ .truncate = true });
+        defer f.close();
+    }
+
+    ProbeRig.alive_responses = .{ false, false, false, false };
+    phase_mod.test_probe_alive_override = ProbeRig.probeAlive;
+    services_mod.test_stop_calls = &ProbeRig.calls;
+    defer ProbeRig.calls.deinit(allocator);
+
+    const opts = InstallOptions{
+        .prefix = "/usr/local",
+        .destdir = staging,
+        .immutable = false,
+        .user_service = false,
+    };
+    {
+        var silencer = try SilencedStdout.begin();
+        defer silencer.end();
+        try uninstall(allocator, opts);
+    }
+
+    try testing.expectEqual(@as(usize, 0), ProbeRig.calls.items.len);
+    try testing.expectError(error.FileNotFound, std.fs.accessAbsolute(sock_path, .{}));
+}
+
+test "uninstall: stop failure refuses unlink and returns DaemonStopFailed (issue #216)" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    ProbeRig.reset();
+    defer ProbeRig.reset();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const staging = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(staging);
+
+    const run_dir = try std.fmt.allocPrint(allocator, "{s}/run/padctl", .{staging});
+    defer allocator.free(run_dir);
+    try ensureDirAll(allocator, run_dir);
+
+    const sock_path = try std.fmt.allocPrint(allocator, "{s}/padctl.sock", .{run_dir});
+    defer allocator.free(sock_path);
+    {
+        var f = try std.fs.createFileAbsolute(sock_path, .{ .truncate = true });
+        defer f.close();
+    }
+
+    ProbeRig.alive_responses = .{ true, false, false, false };
+    phase_mod.test_probe_alive_override = ProbeRig.probeAlive;
+    services_mod.test_stop_force_error = error.SystemctlFailed;
+
+    const opts = InstallOptions{
+        .prefix = "/usr/local",
+        .destdir = staging,
+        .immutable = false,
+        .user_service = false,
+    };
+    {
+        var silencer = try SilencedStdout.begin();
+        defer silencer.end();
+        try testing.expectError(error.DaemonStopFailed, uninstall(allocator, opts));
+    }
+
+    try std.fs.accessAbsolute(sock_path, .{});
+}
+
+test "uninstall: daemon survives stop returns DaemonStillAlive and keeps socket (issue #216)" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    ProbeRig.reset();
+    defer ProbeRig.reset();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const staging = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(staging);
+
+    const run_dir = try std.fmt.allocPrint(allocator, "{s}/run/padctl", .{staging});
+    defer allocator.free(run_dir);
+    try ensureDirAll(allocator, run_dir);
+
+    const sock_path = try std.fmt.allocPrint(allocator, "{s}/padctl.sock", .{run_dir});
+    defer allocator.free(sock_path);
+    {
+        var f = try std.fs.createFileAbsolute(sock_path, .{ .truncate = true });
+        defer f.close();
+    }
+
+    // Alive pre-stop AND alive post-stop+wait → daemon refused to die.
+    ProbeRig.alive_responses = .{ true, true, false, false };
+    phase_mod.test_probe_alive_override = ProbeRig.probeAlive;
+    services_mod.test_stop_calls = &ProbeRig.calls;
+    defer ProbeRig.calls.deinit(allocator);
+
+    const opts = InstallOptions{
+        .prefix = "/usr/local",
+        .destdir = staging,
+        .immutable = false,
+        .user_service = false,
+    };
+    {
+        var silencer = try SilencedStdout.begin();
+        defer silencer.end();
+        try testing.expectError(error.DaemonStillAlive, uninstall(allocator, opts));
+    }
+
+    try testing.expectEqual(@as(usize, 1), ProbeRig.calls.items.len);
+    try std.fs.accessAbsolute(sock_path, .{});
+}
+
+test "uninstall: GCs dangling *.wants/padctl.service symlinks" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    ProbeRig.reset();
+    defer ProbeRig.reset();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const staging = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(staging);
+
+    const wants_dir = try std.fmt.allocPrint(allocator, "{s}/etc/systemd/system/multi-user.target.wants", .{staging});
+    defer allocator.free(wants_dir);
+    try ensureDirAll(allocator, wants_dir);
+
+    const link_path = try std.fmt.allocPrint(allocator, "{s}/padctl.service", .{wants_dir});
+    defer allocator.free(link_path);
+    // Target deliberately does not exist — this is the dangling symlink case.
+    try std.posix.symlink("/usr/lib/systemd/system/padctl.service", link_path);
+
+    const opts = InstallOptions{
+        .prefix = "/usr/local",
+        .destdir = staging,
+        .immutable = false,
+        .user_service = false,
+    };
+    {
+        var silencer = try SilencedStdout.begin();
+        defer silencer.end();
+        try uninstall(allocator, opts);
+    }
+
+    // lstat does not follow the symlink — proves whether the link itself was unlinked.
+    var lbuf: [std.fs.max_path_bytes]u8 = undefined;
+    if (std.fs.readLinkAbsolute(link_path, &lbuf)) |_| {
+        return error.DanglingSymlinkNotRemoved;
+    } else |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    }
+}
+
+test "control_socket: probeAlive returns false for nonexistent path" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+
+    const missing = try std.fs.path.join(testing.allocator, &.{ root, "missing.sock" });
+    defer testing.allocator.free(missing);
+
+    try testing.expect(!control_socket_mod.probeAlive(missing));
+}
+
+test "control_socket: probeAlive returns true for live listener" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    const sock_path = try std.fs.path.join(allocator, &.{ root, "live.sock" });
+    defer allocator.free(sock_path);
+
+    var cs = control_socket_mod.ControlSocket.init(allocator, sock_path) catch |err| {
+        if (err == error.AccessDenied) return;
+        return err;
+    };
+    defer cs.deinit();
+
+    try testing.expect(control_socket_mod.probeAlive(sock_path));
 }
 
 test "install: generateReconnectScript has required commands" {

--- a/src/io/control_socket.zig
+++ b/src/io/control_socket.zig
@@ -8,6 +8,23 @@ const BUF_SIZE = 256;
 /// Suffix joined to the socket's parent directory to advertise the bound path.
 pub const ADVERTISED_FILE_NAME = "socket.advertised";
 
+const unix_path_len = @typeInfo(@TypeOf(@as(linux.sockaddr.un, undefined).path)).array.len;
+
+/// Returns true if a live daemon is bound to `path` (connect(AF_UNIX) succeeds).
+/// Used both by `ControlSocket.init` (refuse to start when another instance owns
+/// the socket) and by the install/uninstall flow (refuse to unlink under a
+/// running daemon — issue #216).
+pub fn probeAlive(path: []const u8) bool {
+    if (path.len == 0 or path.len >= unix_path_len) return false;
+    const probe_fd = posix.socket(posix.AF.UNIX, posix.SOCK.STREAM | posix.SOCK.CLOEXEC, 0) catch return false;
+    defer posix.close(probe_fd);
+    var addr: linux.sockaddr.un = .{ .family = posix.AF.UNIX, .path = undefined };
+    @memset(&addr.path, 0);
+    @memcpy(addr.path[0..path.len], path);
+    posix.connect(probe_fd, @ptrCast(&addr), @sizeOf(linux.sockaddr.un)) catch return false;
+    return true;
+}
+
 pub const ControlSocket = struct {
     listen_fd: posix.fd_t,
     client_fds: [MAX_CLIENTS]posix.fd_t,
@@ -28,17 +45,7 @@ pub const ControlSocket = struct {
             else => return err,
         };
 
-        // Probe: if a live daemon owns the socket, refuse to start.
-        // Skip for over-length paths (PathTooLong will be returned below).
-        if (path_z.len < @as(usize, @typeInfo(@TypeOf(@as(linux.sockaddr.un, undefined).path)).array.len)) probe: {
-            const probe_fd = posix.socket(posix.AF.UNIX, posix.SOCK.STREAM | posix.SOCK.CLOEXEC, 0) catch break :probe;
-            defer posix.close(probe_fd);
-            var probe_addr: linux.sockaddr.un = .{ .family = posix.AF.UNIX, .path = undefined };
-            @memset(&probe_addr.path, 0);
-            @memcpy(probe_addr.path[0..path_z.len], path_z[0..path_z.len]);
-            posix.connect(probe_fd, @ptrCast(&probe_addr), @sizeOf(linux.sockaddr.un)) catch break :probe;
-            return error.AlreadyRunning;
-        }
+        if (probeAlive(path)) return error.AlreadyRunning;
 
         // Unlink stale socket
         std.fs.deleteFileAbsolute(path) catch {};


### PR DESCRIPTION
## Summary
PR-2 of 5 in padctl install/lifecycle structural redesign. Fixes the orphan-daemon class bug verified live on maintainer's machine + same as T3sT3ro's #216 report on Ubuntu 26.04.

`padctl uninstall` used to unconditionally `deleteFileAbsolute` on `/run/padctl/padctl.sock` without probing whether the system daemon was bound to it, and only stopped the user-scope service via `runSystemctlUser` — leaving system-scope daemons running with valid kernel listen fds against unlinked paths. Every subsequent `connect()` returned ENOENT; `ss -lpx` still showed the listener; users got "cannot connect to padctl daemon" for the rest of the session.

Refs #216

## Fix
- Extract `probeAlive(path)` helper in `src/io/control_socket.zig` (shared with `init`'s `AlreadyRunning` probe — removes code duplication)
- Add `stopDaemonScope(allocator, .system|.user|.both)` in `src/cli/install/services.zig` (wraps system + user systemctl helpers, aggregates errors, treats "not loaded" as success)
- In `src/cli/install/phase.zig uninstall`:
  - New `unlinkRuntimePath(path, allocator)`: probe → if alive: stop both scopes → re-probe with 500ms wait → only then unlink. On stop failure return `error.DaemonStopFailed`; on re-probe-alive return `error.DaemonStillAlive`
  - Replace unconditional unlink of `/run/padctl/padctl.sock` + `/run/padctl/padctl.pid` with `unlinkRuntimePath` calls
  - Add `runSystemctlSystem({stop, disable, padctl.service})` call BEFORE existing user-scope stop block when running as root — fixes the system-install-installed daemon being abandoned
  - GC dangling `*.wants/padctl.service` symlinks via existing `migration.removeBrokenSymlink` helper

No env-gated legacy fallback per architect's design — current behavior was a structural bug, no legitimate use case to preserve.

## Test plan
- [x] 5 new tests + ProbeRig helper in `src/cli/install/tests.zig`:
  - A: probe live daemon → systemctl stop calls fire in BOTH scopes BEFORE any unlink
  - B: probe dead daemon → zero systemctl stop calls + direct unlink
  - C: stop fails → `error.DaemonStopFailed`, socket file STILL EXISTS
  - D: dangling `*.wants/padctl.service` symlink GC'd
  - E: re-probe after stop catches "daemon still alive" race → `error.DaemonStillAlive`, socket file STILL EXISTS
- [x] 2 control_socket.probeAlive smoke tests
- [x] TDD falsifiable: forcing `probeSocketAlive → false` makes Tests A/C/E fail with `expected as(usize, 1), found 0` / `expected error.DaemonStopFailed, found void`; commenting out `gcDanglingWantsLinks` makes Test D fail `DANGLING SYMLINK STILL PRESENT`
- [x] `./scripts/padctl-docker test` — EXIT 0 (**1532/1541 passed, 9 skipped**)
- [x] `./scripts/padctl-docker build test-tsan` — EXIT 0 (**1528/1537 passed**)
- [x] `./scripts/padctl-docker build check-fmt` — clean (no `docgen.zig` drift)

## Files changed (4, +413/-19)
- `src/io/control_socket.zig` (+18/-11) — `pub fn probeAlive` extracted from init's duplicated probe; init refactored to call it
- `src/cli/install/services.zig` (+32) — `SystemctlScope` enum + `stopDaemonScope` + 2 test hooks (`test_stop_calls`, `test_stop_force_error`)
- `src/cli/install/phase.zig` (+82/-5) — `probeSocketAlive` + `unlinkRuntimePath` (probe→stop→re-probe→unlink) + `gcDanglingWantsLinks` + dual-scope stop wired at line 290-293 (root path) + replace direct socket/pid unlinks
- `src/cli/install/tests.zig` (+284) — 5 new tests + ProbeRig

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Uninstall now verifies the daemon is stopped before removing runtime files and refuses to remove them if the daemon remains alive.
  * When run as root, uninstall properly stops and disables system-scoped services.
  * Cleans up leftover orphaned service symlinks from prior installations.

* **New Features**
  * Improved detection of an already-running control socket to avoid false "already running" errors during startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->