### PR TITLE
fix(vader5): map M1..M4 to BTN_TRIGGER_HAPPY1..4 (Steam Elite paddle slots)

### DIFF
--- a/devices/flydigi/vader5.toml
+++ b/devices/flydigi/vader5.toml
@@ -98,18 +98,16 @@ Start  = "BTN_START"
 Home   = "BTN_MODE"
 LS     = "BTN_THUMBL"
 RS     = "BTN_THUMBR"
-C      = "BTN_TRIGGER_HAPPY1"
-Z      = "BTN_TRIGGER_HAPPY2"
-LM     = "BTN_TRIGGER_HAPPY3"
-RM     = "BTN_TRIGGER_HAPPY4"
-M1     = "BTN_TRIGGER_HAPPY5"
-# Steam labels SDL paddle slots in Xbox Elite order: usage 22 is P3 and
-# usage 23 is P2. Keep M2/M3 swapped at the evdev-code level so Vader M2
-# appears as the expected lower-right paddle instead of P3.
-M2     = "BTN_TRIGGER_HAPPY7"
-M3     = "BTN_TRIGGER_HAPPY6"
-M4     = "BTN_TRIGGER_HAPPY8"
-O      = "BTN_TRIGGER_HAPPY9"
+M1     = "BTN_TRIGGER_HAPPY1"
+# Steam Xbox Elite order: usage 22 = P3, usage 23 = P2; swap M2/M3 so Vader M2 lands at P3.
+M2     = "BTN_TRIGGER_HAPPY3"
+M3     = "BTN_TRIGGER_HAPPY2"
+M4     = "BTN_TRIGGER_HAPPY4"
+C      = "BTN_TRIGGER_HAPPY9"
+Z      = "BTN_TRIGGER_HAPPY10"
+LM     = "BTN_TRIGGER_HAPPY11"
+RM     = "BTN_TRIGGER_HAPPY12"
+O      = "BTN_TRIGGER_HAPPY13"
 
 [output.dpad]
 type = "hat"

--- a/src/io/uhid_descriptor.zig
+++ b/src/io/uhid_descriptor.zig
@@ -1460,17 +1460,17 @@ test "descriptor: Vader 5 keeps Steam/SDL M2 and M3 paddle order" {
     const out = parsed.value.output orelse return error.MissingOutputSection;
 
     const buttons = out.buttons orelse return error.MissingButtons;
-    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY5", buttons.map.get("M1") orelse return error.MissingM1);
-    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY7", buttons.map.get("M2") orelse return error.MissingM2);
-    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY6", buttons.map.get("M3") orelse return error.MissingM3);
-    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY8", buttons.map.get("M4") orelse return error.MissingM4);
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY1", buttons.map.get("M1") orelse return error.MissingM1);
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY3", buttons.map.get("M2") orelse return error.MissingM2);
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY2", buttons.map.get("M3") orelse return error.MissingM3);
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY4", buttons.map.get("M4") orelse return error.MissingM4);
 
     const desc = try UhidDescriptorBuilder.buildFromOutput(alloc, out);
     defer alloc.free(desc);
 
     try expectButtonUsages(desc, &.{
         1,  2,  4,  5,  7,  8,  12, 11, 13, 14,
-        15, 21, 23, 22, 24, 17, 18, 19, 20, 25,
+        15, 17, 19, 18, 20, 25, 26, 27, 28, 29,
     });
 }
 

--- a/src/test/validate_e2e_test.zig
+++ b/src/test/validate_e2e_test.zig
@@ -237,3 +237,38 @@ test "validate: all device TOMLs have at least one report" {
         try testing.expect(parsed.value.report.len >= 1);
     }
 }
+
+// --- 6. vader5 paddle slot invariants (regression for PR #235) ---
+
+test "vader5: M1..M4 occupy BTN_TRIGGER_HAPPY1..4 (Steam Elite paddle slots)" {
+    const allocator = testing.allocator;
+    const parsed = try device_mod.parseFile(allocator, "devices/flydigi/vader5.toml");
+    defer parsed.deinit();
+
+    const buttons = parsed.value.output.?.buttons.?.map;
+
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY1", buttons.get("M1") orelse return error.MissingM1);
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY3", buttons.get("M2") orelse return error.MissingM2);
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY2", buttons.get("M3") orelse return error.MissingM3);
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY4", buttons.get("M4") orelse return error.MissingM4);
+}
+
+test "vader5: C/Z/LM/RM/O do not occupy BTN_TRIGGER_HAPPY1..4" {
+    const allocator = testing.allocator;
+    const parsed = try device_mod.parseFile(allocator, "devices/flydigi/vader5.toml");
+    defer parsed.deinit();
+
+    const buttons = parsed.value.output.?.buttons.?.map;
+    const paddle_slots = [_][]const u8{
+        "BTN_TRIGGER_HAPPY1", "BTN_TRIGGER_HAPPY2",
+        "BTN_TRIGGER_HAPPY3", "BTN_TRIGGER_HAPPY4",
+    };
+    const face_extras = [_][]const u8{ "C", "Z", "LM", "RM", "O" };
+
+    for (face_extras) |btn| {
+        const code = buttons.get(btn) orelse continue;
+        for (paddle_slots) |slot| {
+            try testing.expect(!std.mem.eql(u8, code, slot));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Xbox Elite Series 2 evdev spec reserves `BTN_TRIGGER_HAPPY1..4` for back paddles P1..P4. padctl masquerades Vader 5 Pro as Xbox Elite Series 2 (vid=0x045e pid=0x0b00), so the same slot reservation applies.
- PR #235 (1535d8a) enabled `C`/`Z`/`LM`/`RM` in `[output.buttons]` and placed them at `HAPPY1..4`, displacing the real back paddles `M1..M4` to `HAPPY5..8` which Steam/games do not recognize as paddles.
- User-observed regression on Flydigi Vader 5 Pro hardware: pressing the extra face buttons (C/Z) appeared as back-paddle input; pressing the actual back paddles produced no input.
- Move `M1..M4` to `HAPPY1..4` (preserving the M2/M3 swap so Vader M2 lands at the Steam Elite P3 slot per PR #323's intent). Push `C/Z/LM/RM/O` to `HAPPY9..13` — they keep stable evdev codes but no longer collide with the paddle reserved range.
- Update `src/io/uhid_descriptor.zig` companion test that asserted the old hard-coded HAPPY values and propagated USAGE-number offsets (HAPPY1=usage 17, HAPPY9=usage 25, etc.).
- Add regression test in `src/test/validate_e2e_test.zig`:
  1. M1..M4 occupy `BTN_TRIGGER_HAPPY1..4` (positive lock, including M2/M3 swap)
  2. None of C/Z/LM/RM/O fall in `BTN_TRIGGER_HAPPY1..4` (structural invariant — catches the PR #235 class of regression)

## Test plan

- [x] `zig build test` green in canonical Docker image (1558 tests, 7 skipped) — pre-push hook
- [x] Falsifiability: setting `M1 = BTN_TRIGGER_HAPPY5` in TOML fires the new positive-lock test and the existing uhid_descriptor test (2 failures, both reverted)
- [x] User local hardware verification with `evtest /dev/input/event26` — physical M1..M4 → HAPPY1..4 confirmed; physical C/Z/LM/RM → HAPPY9..12 confirmed
- [ ] CI matrix: check / coverage / lean / e2e / install / pkg / systemd hardening / distro-check / tsan

Refs #235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected button mappings for the Flydigi Vader 5 Pro controller to ensure proper Steam and console button label recognition.

* **Tests**
  * Added validation tests for paddle button assignments to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->