### PR TITLE
release: bump version to 0.1.13

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.12",
+    .version = "0.1.13",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
## Summary

Bump `build.zig.zon` from 0.1.12 to 0.1.13. Tagging `v0.1.13` after this merges triggers `release.yml` to publish GitHub release assets and sync the `padctl-bin` AUR PKGBUILD.

## Highlights since v0.1.12 (17 PRs)

**Architecture / install**
- PR #348 daemon-advertised socket path (issue #216 root cause)
- PR #350 uninstall probes + stops daemon before unlinking live socket (issue #216)
- PR #351 LifecycleScope SSOT install refactor
- PR #352 system unit hands `/run/padctl` lifecycle to systemd via `RuntimeDirectory=` (Wave 4 R0)

**Bug fixes**
- PR #353 fix(vader5) M1..M4 → BTN_TRIGGER_HAPPY1..4 (Steam Elite paddle slots; regresses PR #235)
- PR #338 supervisor forfeit grace for stale suspended on phys-key change (issue #236)
- PR #339 macro LT/RT analog axis dispatch (issue #99)
- PR #342 macro pause_for_release drained on layer deactivation (issue #330)
- PR #343 bazzite-setup fails loudly when local repo did not actually update (issue #320)
- PR #346 supervisor evdev_node multi-match + clarify trace devname (issue #236)
- PR #347 post-merge CodeRabbit cleanups (PRs #341 #343)

**Features**
- PR #340 gyro `minimum_output` snap for in-game deadzone compensation (issue #311)
- PR #341 macro `press` step as parse-time sugar for down/up pairs (issue #335)
- PR #337 `macro_step_delay` + per-macro `step_delay` (issue #333)
- PR #349 hidraw wedge instrumentation (Bug E / PR-ε.1)

**Observability**
- PR #344 `PADCTL_TRACE_LIFECYCLE` env + STATUS runtime fields (issue #236)
- PR #345 supervisor L2 evdev-pin diagnostic for output continuity (issue #236)
- PR #336 docs: clarify `hold_timeout` belongs on `[[layer]]` (issue #331)

## Test plan

- [x] `zig build test-tsan` green in Docker (pre-push hook)
- [ ] CI: build / coverage / lean / e2e / install / pkg / systemd hardening compat / distro-check / tsan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.1.13

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/padctl/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->