### PR TITLE
fix(install): ignore ambient DESTDIR env var; honor only --destdir flag (#355)

### DIFF
--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -210,6 +210,27 @@ jobs:
                 exit 1
               fi
 
+              # ---- Scenario A2 (#355): ambient DESTDIR must NOT suppress the sentinel ----
+              # Re-run an enabled install with DESTDIR exported in the environment
+              # (as a parent build shell might). Scope detection must honor only the
+              # --destdir flag, never the ambient env var, so the sentinel written by
+              # Scenario A must survive. Before the #355 fix this install silently
+              # entered staging mode and removed the sentinel.
+              su - testuser -c "sudo DESTDIR=/tmp/ambient SUDO_USER=testuser SUDO_UID=$(id -u testuser) \
+                HOME=/home/testuser \
+                /usr/local/bin/padctl install --prefix /usr/local 2>&1"
+
+              echo "=== sentinel mechanism invariants (Scenario A2: ambient DESTDIR, #355) ==="
+              FAIL=0
+
+              check "ambient DESTDIR does not suppress sentinel (#355)" \
+                "[ -e \"\$SENTINEL\" ]"
+
+              if [ $FAIL -ne 0 ]; then
+                echo "=== SCENARIO A2 FAILED ==="
+                exit 1
+              fi
+
               # ---- Scenario B: --no-enable install => no sentinel => predicate-false skips unbind ----
               su - testuser -c "sudo SUDO_USER=testuser SUDO_UID=$(id -u testuser) \
                 HOME=/home/testuser \

--- a/src/cli/install/phase.zig
+++ b/src/cli/install/phase.zig
@@ -282,7 +282,6 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         .destdir = opts.destdir,
         .forced_scope = opts.scope,
         .install_phase_env = std.posix.getenv("PADCTL_INSTALL_PHASE"),
-        .destdir_env = std.posix.getenv("DESTDIR"),
         .euid = effective_uid,
         .sudo_user_env = std.posix.getenv("SUDO_USER"),
         .prefix = opts.prefix,

--- a/src/cli/install/plan.zig
+++ b/src/cli/install/plan.zig
@@ -318,7 +318,6 @@ pub const EnvSnapshot = struct {
     sudo_user: ?[]const u8,
     sudo_uid: ?[]const u8,
     install_phase: ?[]const u8 = null,
-    destdir_env: ?[]const u8 = null,
 
     pub fn fromProcess() EnvSnapshot {
         return .{
@@ -327,7 +326,6 @@ pub const EnvSnapshot = struct {
             .sudo_user = std.posix.getenv("SUDO_USER"),
             .sudo_uid = std.posix.getenv("SUDO_UID"),
             .install_phase = std.posix.getenv("PADCTL_INSTALL_PHASE"),
-            .destdir_env = std.posix.getenv("DESTDIR"),
         };
     }
 };
@@ -379,7 +377,6 @@ pub const InstallPlan = struct {
             .destdir = destdir,
             .forced_scope = opts.scope,
             .install_phase_env = env.install_phase,
-            .destdir_env = env.destdir_env,
             .euid = @intCast(env.uid),
             .sudo_user_env = env.sudo_user,
             .prefix = opts.prefix,

--- a/src/cli/install/scope.zig
+++ b/src/cli/install/scope.zig
@@ -25,7 +25,6 @@ pub const DetectInput = struct {
     destdir: []const u8 = "",
     forced_scope: ?LifecycleScope = null,
     install_phase_env: ?[]const u8 = null,
-    destdir_env: ?[]const u8 = null,
     euid: u32,
     sudo_user_env: ?[]const u8 = null,
     prefix: []const u8 = "/usr/local",
@@ -42,14 +41,11 @@ fn rejectsSystemPrefix(prefix: []const u8) bool {
 
 pub fn detect(input: DetectInput) ScopeError!LifecycleScope {
     // 1. Package mode is unconditional — any packager-set signal wins.
-    //    Empty-but-set env vars (common in Makefiles: `export DESTDIR=`) do
-    //    NOT count as a signal; require non-empty content.
+    //    Only the explicit --destdir flag selects it; an empty --destdir ""
+    //    does NOT count as a signal. The ambient DESTDIR env var is ignored.
     if (input.destdir.len > 0) return .package;
     if (input.install_phase_env) |v| {
         if (std.mem.eql(u8, v, "package")) return .package;
-    }
-    if (input.destdir_env) |v| {
-        if (v.len > 0) return .package;
     }
 
     // 2. Explicit --scope override, validated against current privilege.
@@ -83,9 +79,17 @@ test "scope: package via PADCTL_INSTALL_PHASE env" {
     try std.testing.expectEqual(LifecycleScope.package, got);
 }
 
-test "scope: package via DESTDIR env" {
-    const got = try detect(.{ .destdir_env = "/tmp/staging", .euid = 0 });
-    try std.testing.expectEqual(LifecycleScope.package, got);
+// Regression #355: only --destdir flag or PADCTL_INSTALL_PHASE=package may produce .package.
+// Root + empty destdir + no phase env must resolve to .system (not .package).
+test "scope: flag-only contract — ambient env cannot force .package (#355)" {
+    const system_scope = try detect(.{ .euid = 0, .prefix = "/usr", .destdir = "" });
+    try std.testing.expectEqual(LifecycleScope.system, system_scope);
+
+    const pkg_via_flag = try detect(.{ .euid = 0, .prefix = "/usr", .destdir = "/tmp/staging" });
+    try std.testing.expectEqual(LifecycleScope.package, pkg_via_flag);
+
+    const pkg_via_phase = try detect(.{ .euid = 0, .prefix = "/usr", .install_phase_env = "package" });
+    try std.testing.expectEqual(LifecycleScope.package, pkg_via_phase);
 }
 
 test "scope: system auto when root" {
@@ -134,10 +138,10 @@ test "scope: forced package always works regardless of euid" {
     try std.testing.expectEqual(LifecycleScope.package, got_user);
 }
 
-test "scope: empty DESTDIR env does not force .package" {
+test "scope: empty destdir does not force .package" {
     const got = try detect(.{
         .euid = 0,
-        .destdir_env = "",
+        .destdir = "",
         .prefix = "/usr",
     });
     try std.testing.expectEqual(LifecycleScope.system, got);


### PR DESCRIPTION
## Summary
Hardening fix surfaced while investigating #355. Scope detection treated the ambient `DESTDIR` **environment variable** as a package/staging signal; this PR makes it honor only the explicit `--destdir` flag or `PADCTL_INSTALL_PHASE=package`.

## Scope / honesty note
This is **not confirmed to fix the symptom reported in #355.** Investigation (Debian/ostree Docker sandbox) showed:
- A normal Bazzite-style install (`sudo padctl install --prefix /usr/local --immutable`, no `DESTDIR`) already writes the xpad-unbind sentinel and the driver-block rule correctly.
- The ambient-`DESTDIR` path is not reachable through the normal `sudo` install flow: `sudo` scrubs `DESTDIR` via `env_reset`, and `bazzite-setup.sh` never sets it.

So this closes a real latent footgun (reachable e.g. in a non-`sudo` root build context that exports `DESTDIR`), but the reporter's "generic X-Box pad not hidden" most likely has a different root cause (stale/partial install, etc.), pending reporter diagnostics.

## What changed
- Remove `destdir_env` from `DetectInput`/`EnvSnapshot`; stop reading `getenv("DESTDIR")` in `plan.zig`/`phase.zig`.
- Delete the `destdir_env -> .package` branch in `detect()`.
- Add a unit test locking the flag-only scope contract, plus `install-flow.yml` Scenario A2 asserting an ambient `DESTDIR` does not suppress the sentinel.

## Test plan
- `zig build test` (0.15.2): 1571/1576 pass, 5 skipped.
- Docker e2e: with the fix the sentinel survives a forced `DESTDIR`-in-env install; legitimate `--destdir` flag staging still avoids touching real `/etc`.

refs #355