### PR TITLE
docs(gyro): clarify joystick-mode sensitivity scaling (#359)

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -130,13 +130,13 @@ invert_y = true
 | `axis_y` | string | `"pitch"` | Source for virtual stick Y: `"yaw"`, `"pitch"`, `"roll"`, or `"none"`. |
 | `degrees_full` | float | `35.0` | In `"tilt"` response, the absolute tilt angle that maps to full stick deflection. Must be greater than `0` and no more than `180`. |
 | `activate` | string | — | Gate button: bare name (`"LS"`) or `hold_<BTN>` form (`"hold_RB"`) — both are equivalent. For analog triggers (`LT`/`RT`), also set `trigger_threshold`. Omit for always-active. |
-| `sensitivity` | float | — | Overall sensitivity multiplier |
+| `sensitivity` | float | — | Overall sensitivity multiplier. In `"mouse"` mode it scales relative cursor motion; in `"joystick"`/`"rate"` mode it scales an *absolute* stick deflection and typically needs a much larger value (≈50–150) — see the [gyro joystick guide](mapping-guide.md#joystick-mode). |
 | `sensitivity_x` | float | — | X-axis sensitivity override |
 | `sensitivity_y` | float | — | Y-axis sensitivity override |
 | `deadzone` | integer | — | Raw gyro deadzone threshold in `"rate"` response. In `"tilt"` response this is an output stick deadzone after angle conversion. |
 | `smoothing` | float | — | Smoothing factor (0–1) |
 | `curve` | float | — | Acceleration curve exponent |
-| `max_val` | float | — | Maximum output value cap |
+| `max_val` | float | `32767` | Input normalization ceiling: the raw gyro rate that normalizes to `1.0`, before `curve`, `sensitivity`, and output scaling are applied. Lowering it (e.g. `2000`) raises the normalized signal, so a moderate motion drives a larger output — equivalent to raising `sensitivity`, and useful in `"joystick"` mode to keep `sensitivity` numbers small. |
 | `invert_x` | bool | — | Invert X axis |
 | `invert_y` | bool | — | Invert Y axis |
 | `blend_stick` | bool | `false` | When `true`, gyro joystick output is **added** to the physical stick value (`clamp(physical + gyro, -32767..32767)`) instead of replacing it. Only applies when `mode = "joystick"`. Ignored for `mode = "mouse"`. |

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -190,11 +190,14 @@ Set `mode = "joystick"` to route the gyro signal to a virtual stick axis instead
 mode   = "joystick"
 target = "right_stick"   # "right_stick" (default) or "left_stick"
 deadzone    = 200
-sensitivity = 1.5
+sensitivity = 100        # stick mode needs a much larger value than mouse
+                         # mode — see the note below
 smoothing   = 0.3
 ```
 
-This is useful for games that read the right stick for camera control but do not natively support gyro input. In the default `response = "rate"` mode, the usual gyro fields (`sensitivity`, `deadzone`, `smoothing`, `curve`, `invert_x`, `invert_y`) apply in joystick mode the same way as in mouse mode.
+This is useful for games that read the right stick for camera control but do not natively support gyro input. In the default `response = "rate"` mode the same gyro fields (`deadzone`, `smoothing`, `curve`, `invert_x`, `invert_y`) behave as in mouse mode — but **`sensitivity` does not scale the same way.**
+
+Mouse mode integrates the gyro rate into relative cursor motion frame by frame, so even small values keep moving the pointer. Joystick mode instead emits an *absolute* stick deflection: the raw gyro rate is normalized against `max_val` (default `32767`, the full int16 range) before scaling. A normal hand motion produces a raw rate that is only a small fraction of `max_val`, so a mouse-style `sensitivity = 1.5` yields a stick deflection of just a few percent — usually inside the game's own deadzone, so it feels as if gyro is off. Start around **`sensitivity = 100`** and tune in the 50–150 range. Lowering `max_val` (for example `max_val = 2000`) raises the normalized signal and so increases the deflection for a given motion — it is an equivalent lever to `sensitivity`, useful if you would rather keep `sensitivity` small.
 
 For racing games, `response = "tilt"` maps controller tilt to an absolute stick
 position instead of treating gyro motion like stick velocity. `degrees_full`


### PR DESCRIPTION
## What

Issue #359 reports that gyro-to-stick (`mode = "joystick"`, `response = "rate"`) needs a sensitivity of ~100–150 to react, while the docs example used `1.5` and claimed sensitivity "applies the same way as in mouse mode." It does not — and this PR fixes the docs to match the actual code (`src/core/gyro.zig`).

Root cause: joystick mode emits an **absolute** stick deflection (`applyCurve(rate) * sensitivity * 20000`, clamped to ±32767), where `applyCurve` normalizes the raw gyro rate against `max_val` (default 32767). A normal motion is a small fraction of that ceiling, so a mouse-style `sensitivity = 1.5` yields only a few-percent deflection — inside most games' deadzone. Mouse mode instead integrates per-frame deltas via a sub-pixel accumulator, so small values still move the cursor.

## Changes (docs only)

- `mapping-guide.md`: remove the false "same as mouse mode" claim; explain absolute-stick vs relative-cursor scaling and the `max_val` normalization; bump the joystick example to `sensitivity = 100` with 50–150 tuning guidance and the lower-`max_val` alternative.
- `mapping-config.md`: clarify the `sensitivity` row for joystick mode; fix the `max_val` description (it is the input normalization ceiling, not an output cap) and document its `32767` default.

No code changed — existing tuned configs are unaffected.

## Test plan

- mdBook docs build (CI).
- Technical claims independently verified against `src/core/gyro.zig` (the `20000` scale + clamp, `max_val` as normalization divisor, mouse-only accumulator, `max_val` default, anchor link resolves).

Refs #359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified `sensitivity` behavior across input modes (mouse vs joystick), noting joystick/rate typically requires much larger values.
  * Reworded `max_val` as an “input normalization ceiling” and added an example showing how lowering it increases the normalized signal (effectively like raising sensitivity).
  * Updated gyroscope guide examples and practical tuning guidance for joystick mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->