### PR TITLE
fix(vader5): block only xpad so the pad stays discoverable (#355)

### DIFF
--- a/devices/flydigi/vader5.toml
+++ b/devices/flydigi/vader5.toml
@@ -2,15 +2,14 @@
 name = "Flydigi Vader 5 Pro"
 vid = 0x37d7
 pid = 0x2401
-block_kernel_drivers = ["xpad", "hid_generic", "usbhid"]
+block_kernel_drivers = ["xpad"]
 
-# The pad exposes three HID interfaces (IF1 vendor 0xffa0, IF2 Mouse, IF3
-# vendor 0xffee), each producing a hidraw node via hid-generic. padctl claims
-# all three so the kernel exposes no hidraw/evdev node for the physical pad;
-# Steam reads hidraw directly, so any kernel-owned node would still surface
-# the pad as a generic Xbox controller. IF1 is read for input + rumble + init;
-# IF2/IF3 are claimed suppress-only — never read or written, only evicted from
-# hid-generic so their hidraw nodes vanish.
+# The pad exposes a vendor interface (IF0, no driver) plus three HID interfaces
+# (IF1 input, IF2 mouse, IF3 vendor HID). padctl claims IF1 via libusb (read EP
+# 0x82 / write EP 0x06) and IF2/IF3 suppress-only; libusb_claim detaches the
+# kernel HID driver, so their hidraw nodes vanish and Steam sees only the
+# virtual Elite pad. Only xpad is blocked at udev — hid_generic/usbhid must keep
+# binding so a hidraw node exists for discovery before padctl claims it.
 [[device.interface]]
 id = 1
 class = "vendor"   # EP2 IN 32B extended input, EP6 OUT 32B config commands


### PR DESCRIPTION
## What

Revert the `block_kernel_drivers` expansion from #357: block only `xpad`, not `hid_generic`/`usbhid`. IF1 (vendor) and IF2/IF3 (suppress) are still claimed via libusb.

## Why

#357 added `hid_generic`/`usbhid` to `block_kernel_drivers` so the physical pad's hidraw nodes would vanish. But padctl already calls `libusb_detach_kernel_driver` before `libusb_claim_interface` (`src/io/usbraw.zig`), so it self-detaches the kernel HID driver at claim time — the udev block was redundant.

It was also harmful: device discovery is hidraw-only (`HidrawDevice.discoverAllWithRoot`). Blocking `usbhid`/`hid_generic` at udev means the kernel never creates a hidraw node, so discovery finds nothing and the daemon reports "no devices connected" (#355, reported by two users on Bazzite).

With `block = ["xpad"]`: usbhid binds -> hidraw node exists -> discovery finds the pad -> the libusb claim detaches usbhid and removes the nodes -> Steam sees only the virtual Elite pad. No reintroduction of the double-input that a full hidraw rollback would cause.

## Changes

- `devices/flydigi/vader5.toml`: `block_kernel_drivers` `["xpad","hid_generic","usbhid"]` -> `["xpad"]`; updated the interface comment. No code change (`block_kernel_drivers` is install-time-only input to udev generation).

## Test plan

- `zig build test` green in the canonical Docker image.
- Real hardware (Flydigi Vader 5 Pro, USB 37d7:2401), daemon run as root:
  - Before: hidraw15/16/17 + evdev "Flydigi Vader 5 Pro" visible.
  - After: all three hidraw nodes gone, virtual "Xbox Elite Series 2" present, physical evdev hidden, `padctl status` -> `device=Flydigi Vader 5 Pro state=active`.
  - SIGTERM: usbhid re-attaches, pad restored.
- #361 raw-USB-node uaccess grant still applies (interfaces stay vendor/suppress, so `usesLibusb()` stays true).

## Notes

- Known cosmetic log noise: after claim, the netlink listener logs "hotplug: giving up on hidrawN after 3 retries" for the now-removed nodes. Harmless (device stays active); a follow-up can suppress these for libusb-claimed interfaces.

Refs #355, #357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Flydigi Vader 5 Pro controller device initialization and detection. Enhanced configuration ensures more reliable recognition during startup and better overall system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->