### PR TITLE
test(vader5): pin block_kernel_drivers to xpad only (regression #355)

### DIFF
--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -641,6 +641,23 @@ test "device: vader5 IF1 is claimed via libusb (vendor transport)" {
     try std.testing.expect(init_cfg.enable != null);
 }
 
+test "device: vader5 blocks only xpad (regression #355)" {
+    const allocator = std.testing.allocator;
+    const result = try parseFile(allocator, "devices/flydigi/vader5.toml");
+    defer result.deinit();
+
+    // Blocking hid_generic/usbhid removed the hidraw node that discovery needs;
+    // padctl self-detaches the kernel HID driver at libusb claim, so only xpad
+    // must be blocked.
+    const blocked = result.value.device.block_kernel_drivers orelse return error.MissingBlockList;
+    try std.testing.expectEqual(@as(usize, 1), blocked.len);
+    try std.testing.expectEqualStrings("xpad", blocked[0]);
+    for (blocked) |drv| {
+        try std.testing.expect(!std.mem.eql(u8, drv, "hid_generic"));
+        try std.testing.expect(!std.mem.eql(u8, drv, "usbhid"));
+    }
+}
+
 test "device: usesLibusb true for vendor/suppress, false for hid-only" {
     const allocator = std.testing.allocator;
 


### PR DESCRIPTION
## What

Add a regression test asserting the shipped `devices/flydigi/vader5.toml` blocks only `xpad` and never `hid_generic`/`usbhid`.

## Why

#362 fixed #355 by changing the device file's `block_kernel_drivers` value, but added no test. The existing install tests use inline TOML, so they cannot catch a value regression in the real shipped file. This test parses the actual file via `parseFile("devices/flydigi/vader5.toml")` and pins the fix — re-adding the HID-driver block would fail CI.

## Changes

- `src/config/device.zig`: new test `device: vader5 blocks only xpad (regression #355)`.

## Test plan

- `zig build test` green in the canonical Docker image (full suite EXIT=0).

Refs #355, #362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to verify the Flydigi Vader5 controller properly manages kernel driver blocking configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->