### PR TITLE
fix(install): apply block_kernel_drivers changes to connected devices and across install modes

### DIFF
--- a/src/cli/install/phase.zig
+++ b/src/cli/install/phase.zig
@@ -361,6 +361,25 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
     }
 
+    // /etc udev rules and modules-load.d shadow the {prefix}/lib copies, so an
+    // immutable-mode install can leave them behind even on a normal uninstall.
+    // Remove them unconditionally (the systemd /etc entries stay immutable-gated).
+    const etc_rules = [_][]const u8{
+        "/etc/udev/rules.d/60-padctl.rules",
+        "/etc/udev/rules.d/61-padctl-driver-block.rules",
+        "/etc/udev/rules.d/90-padctl.rules",
+        "/etc/udev/rules.d/99-padctl.rules",
+        "/etc/modules-load.d/padctl.conf",
+    };
+    for (etc_rules) |suffix| {
+        const path = try std.fmt.allocPrint(allocator, "{s}{s}", .{ destdir, suffix });
+        defer allocator.free(path);
+        std.fs.deleteFileAbsolute(path) catch continue;
+        _ = std.posix.write(std.posix.STDOUT_FILENO, "  removed ") catch {};
+        _ = std.posix.write(std.posix.STDOUT_FILENO, path) catch {};
+        _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
+    }
+
     // Drop the service-enabled sentinel so a future replug of a
     // block_kernel_drivers device is not unbound by a stale udev rule.
     udev.removeServiceSentinel(allocator, destdir);
@@ -442,11 +461,6 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
             "/etc/systemd/system/padctl.service",
             "/etc/systemd/system/padctl.service.d/immutable.conf",
             "/etc/systemd/user/padctl.service",
-            "/etc/udev/rules.d/60-padctl.rules",
-            "/etc/udev/rules.d/61-padctl-driver-block.rules",
-            "/etc/udev/rules.d/90-padctl.rules",
-            "/etc/udev/rules.d/99-padctl.rules",
-            "/etc/modules-load.d/padctl.conf",
         };
         for (etc_files) |suffix| {
             const path = try std.fmt.allocPrint(allocator, "{s}{s}", .{ destdir, suffix });

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -45,6 +45,7 @@ const UdevEntry = udev_mod.UdevEntry;
 const isValidIdentifier = udev_mod.isValidIdentifier;
 const probeAndUnbindDrivers = udev_mod.probeAndUnbindDrivers;
 const probeAndRebindDrivers = udev_mod.probeAndRebindDrivers;
+const probeAndReprobeDrivers = udev_mod.probeAndReprobeDrivers;
 const readSysHex = udev_mod.readSysHex;
 const findDevicesSourceDir = udev_mod.findDevicesSourceDir;
 const imu_udev_rules_content = udev_mod.imu_udev_rules_content;
@@ -3670,6 +3671,131 @@ test "uninstall: probeAndRebindDrivers binds unbound matching interface only" {
     // Only the unbound interface 1-1.4:1.0 is written; the already-bound
     // 1-1.4:1.1 and non-matching 2-2.1:1.0 must be absent.
     try testing.expectEqualStrings("1-1.4:1.0", written);
+}
+
+// Re-probe must write only the driverless interface to drivers_probe, skip
+// already-bound interfaces, and ignore non-matching devices. Falsifiability:
+// dropping the `accessAbsolute(driver_link)` skip in reprobeInterfaces makes
+// 1.0 appear; dropping the VID:PID match makes the non-matching iface appear.
+test "install: reprobe writes only driverless interfaces" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    try tmp.dir.makePath("sys/bus/usb/drivers/xpad");
+    // Matching device 37d7:2401 with one bound (1.0) and one driverless (1.1) iface.
+    try tmp.dir.makePath("sys/bus/usb/devices/1-1.4/1-1.4:1.0");
+    try tmp.dir.makePath("sys/bus/usb/devices/1-1.4/1-1.4:1.1");
+    // Non-matching device with a driverless interface.
+    try tmp.dir.makePath("sys/bus/usb/devices/2-2.1/2-2.1:1.0");
+
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/1-1.4/idVendor", .{});
+        defer f.close();
+        try f.writeAll("37d7\n");
+    }
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/1-1.4/idProduct", .{});
+        defer f.close();
+        try f.writeAll("2401\n");
+    }
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/2-2.1/idVendor", .{});
+        defer f.close();
+        try f.writeAll("0000\n");
+    }
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/2-2.1/idProduct", .{});
+        defer f.close();
+        try f.writeAll("0000\n");
+    }
+
+    // Mark 1-1.4:1.0 as already bound.
+    {
+        const drv = try std.fmt.allocPrint(allocator, "{s}/sys/bus/usb/devices/1-1.4/1-1.4:1.0/driver", .{tmp_path});
+        defer allocator.free(drv);
+        try std.posix.symlink("../../../drivers/xpad", drv);
+    }
+
+    // Global drivers_probe write target.
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/drivers_probe", .{});
+        defer f.close();
+    }
+
+    const entries = [_]UdevEntry{.{
+        .name = "Test Device",
+        .vid = 0x37d7,
+        .pid = 0x2401,
+    }};
+    probeAndReprobeDrivers(allocator, &entries, tmp_path);
+
+    const probe_path = try std.fmt.allocPrint(allocator, "{s}/sys/bus/usb/drivers_probe", .{tmp_path});
+    defer allocator.free(probe_path);
+    var pf = try std.fs.openFileAbsolute(probe_path, .{});
+    defer pf.close();
+    const written = try pf.readToEndAlloc(allocator, 128);
+    defer allocator.free(written);
+
+    try testing.expect(std.mem.indexOf(u8, written, "1-1.4:1.1") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "1-1.4:1.0") == null);
+    try testing.expect(std.mem.indexOf(u8, written, "2-2.1:1.0") == null);
+}
+
+// Re-probe is a no-op when every interface is bound and silently returns when
+// the sysfs tree is absent (non-root / staging). Guards the best-effort
+// catch+continue discipline.
+test "install: reprobe no-ops when all bound / missing tree" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    try tmp.dir.makePath("sys/bus/usb/drivers/xpad");
+    try tmp.dir.makePath("sys/bus/usb/devices/1-1.4/1-1.4:1.0");
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/1-1.4/idVendor", .{});
+        defer f.close();
+        try f.writeAll("37d7\n");
+    }
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/devices/1-1.4/idProduct", .{});
+        defer f.close();
+        try f.writeAll("2401\n");
+    }
+    // The single interface is already bound.
+    {
+        const drv = try std.fmt.allocPrint(allocator, "{s}/sys/bus/usb/devices/1-1.4/1-1.4:1.0/driver", .{tmp_path});
+        defer allocator.free(drv);
+        try std.posix.symlink("../../../drivers/xpad", drv);
+    }
+    {
+        var f = try tmp.dir.createFile("sys/bus/usb/drivers_probe", .{});
+        defer f.close();
+    }
+
+    const entries = [_]UdevEntry{.{ .name = "Test Device", .vid = 0x37d7, .pid = 0x2401 }};
+    probeAndReprobeDrivers(allocator, &entries, tmp_path);
+
+    const probe_path = try std.fmt.allocPrint(allocator, "{s}/sys/bus/usb/drivers_probe", .{tmp_path});
+    defer allocator.free(probe_path);
+    var pf = try std.fs.openFileAbsolute(probe_path, .{});
+    defer pf.close();
+    const written = try pf.readToEndAlloc(allocator, 128);
+    defer allocator.free(written);
+    try testing.expectEqual(@as(usize, 0), written.len);
+
+    // Absent sys_root must not error.
+    const missing = try std.fmt.allocPrint(allocator, "{s}/nonexistent", .{tmp_path});
+    defer allocator.free(missing);
+    probeAndReprobeDrivers(allocator, &entries, missing);
 }
 
 // Uninstall must remove 61-padctl-driver-block.rules symmetrically with

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -46,6 +46,7 @@ const isValidIdentifier = udev_mod.isValidIdentifier;
 const probeAndUnbindDrivers = udev_mod.probeAndUnbindDrivers;
 const probeAndRebindDrivers = udev_mod.probeAndRebindDrivers;
 const probeAndReprobeDrivers = udev_mod.probeAndReprobeDrivers;
+const cleanupLegacyUdevFiles = udev_mod.cleanupLegacyUdevFiles;
 const readSysHex = udev_mod.readSysHex;
 const findDevicesSourceDir = udev_mod.findDevicesSourceDir;
 const imu_udev_rules_content = udev_mod.imu_udev_rules_content;
@@ -3796,6 +3797,106 @@ test "install: reprobe no-ops when all bound / missing tree" {
     const missing = try std.fmt.allocPrint(allocator, "{s}/nonexistent", .{tmp_path});
     defer allocator.free(missing);
     probeAndReprobeDrivers(allocator, &entries, missing);
+}
+
+// A mode switch must sweep the stale war-rule from the non-active tree while
+// leaving the freshly written active rule intact. Falsifiability: removing the
+// std.mem.eql guard would delete the active /usr/lib copy too.
+test "install: mode switch sweeps stale rule from non-target tree" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(destdir);
+
+    // Stale immutable-mode rule in /etc shadows the normal-mode rule.
+    const etc_dir = try std.fmt.allocPrint(allocator, "{s}/etc/udev/rules.d", .{destdir});
+    defer allocator.free(etc_dir);
+    try ensureDirAll(allocator, etc_dir);
+    const etc_rule = try std.fmt.allocPrint(allocator, "{s}/61-padctl-driver-block.rules", .{etc_dir});
+    defer allocator.free(etc_rule);
+    {
+        var f = try std.fs.createFileAbsolute(etc_rule, .{ .truncate = true });
+        defer f.close();
+        try f.writeAll("# stale: unbinds usbhid\n");
+    }
+
+    const opts = InstallOptions{ .destdir = destdir, .prefix = "/usr", .user_service = false };
+    const env = EnvSnapshot{ .uid = 0, .home = "/root", .sudo_user = null, .sudo_uid = null };
+    const plan = try InstallPlan.compute(allocator, opts, env);
+    defer plan.deinit(allocator);
+    try ensureDirAll(allocator, plan.udev_dir);
+
+    // Active normal-mode rule in {prefix}/lib (xpad-only).
+    const lib_rule = try std.fmt.allocPrint(allocator, "{s}/61-padctl-driver-block.rules", .{plan.udev_dir});
+    defer allocator.free(lib_rule);
+    {
+        var f = try std.fs.createFileAbsolute(lib_rule, .{ .truncate = true });
+        defer f.close();
+        try f.writeAll("# active: unbinds xpad\n");
+    }
+
+    try cleanupLegacyUdevFiles(allocator, &plan);
+
+    try testing.expectError(error.FileNotFound, std.fs.accessAbsolute(etc_rule, .{}));
+    try std.fs.accessAbsolute(lib_rule, .{});
+}
+
+// Normal-mode uninstall must remove the /etc udev rules and modules-load.d
+// conf even though they are not immutable-gated. Falsifiability: dropping the
+// always-run /etc sweep in uninstall() leaves these files behind.
+test "uninstall: removes /etc udev rules in normal mode" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const staging = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(staging);
+
+    const etc_rules_dir = try std.fmt.allocPrint(allocator, "{s}/etc/udev/rules.d", .{staging});
+    defer allocator.free(etc_rules_dir);
+    try ensureDirAll(allocator, etc_rules_dir);
+    const etc_modules_dir = try std.fmt.allocPrint(allocator, "{s}/etc/modules-load.d", .{staging});
+    defer allocator.free(etc_modules_dir);
+    try ensureDirAll(allocator, etc_modules_dir);
+
+    const seeded = [_][]const u8{
+        "/etc/udev/rules.d/60-padctl.rules",
+        "/etc/udev/rules.d/61-padctl-driver-block.rules",
+        "/etc/udev/rules.d/90-padctl.rules",
+        "/etc/modules-load.d/padctl.conf",
+    };
+    for (seeded) |suffix| {
+        const path = try std.fmt.allocPrint(allocator, "{s}{s}", .{ staging, suffix });
+        defer allocator.free(path);
+        var f = try std.fs.createFileAbsolute(path, .{ .truncate = true });
+        defer f.close();
+        try f.writeAll("# padctl generated\n");
+    }
+
+    const opts = InstallOptions{
+        .prefix = "/usr",
+        .destdir = staging,
+        .immutable = false,
+        .user_service = false,
+    };
+    {
+        var silencer = try SilencedStdout.begin();
+        defer silencer.end();
+        try uninstall(allocator, opts);
+    }
+
+    for (seeded) |suffix| {
+        const path = try std.fmt.allocPrint(allocator, "{s}{s}", .{ staging, suffix });
+        defer allocator.free(path);
+        if (std.fs.accessAbsolute(path, .{})) |_| {
+            std.debug.print("uninstall did not remove: {s}\n", .{path});
+            return error.EtcFileNotRemoved;
+        } else |_| {}
+    }
 }
 
 // Uninstall must remove 61-padctl-driver-block.rules symmetrically with

--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -313,14 +313,31 @@ pub fn installUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan, 
 }
 
 pub fn cleanupLegacyUdevFiles(allocator: std.mem.Allocator, plan: *const InstallPlan) !void {
-    // Legacy 99-padctl.rules was renamed to 60- for correct priority.
-    const legacy = try std.fmt.allocPrint(allocator, "{s}{s}/lib/udev/rules.d/99-padctl.rules", .{ plan.opts.destdir, plan.prefix });
-    defer allocator.free(legacy);
-    std.fs.deleteFileAbsolute(legacy) catch {};
+    // padctl rules live in two trees: {prefix}/lib/udev/rules.d (normal) and
+    // /etc/udev/rules.d (immutable). /etc shadows /usr/lib, so a leftover rule in
+    // the non-active tree silently overrides the freshly written one after a mode
+    // switch. Sweep every padctl basename from whichever tree is NOT the active
+    // one; the std.mem.eql guard ensures the just-written rules are never deleted.
+    // 99-padctl.rules is the historical 60- name, kept here for upgrade hygiene.
+    const basenames = [_][]const u8{
+        "60-padctl.rules",
+        "61-padctl-driver-block.rules",
+        "90-padctl.rules",
+        "99-padctl.rules",
+    };
+    const etc_dir = try std.fmt.allocPrint(allocator, "{s}/etc/udev/rules.d", .{plan.opts.destdir});
+    defer allocator.free(etc_dir);
+    const lib_dir = try std.fmt.allocPrint(allocator, "{s}{s}/lib/udev/rules.d", .{ plan.opts.destdir, plan.prefix });
+    defer allocator.free(lib_dir);
 
-    const legacy_etc = try std.fmt.allocPrint(allocator, "{s}/etc/udev/rules.d/99-padctl.rules", .{plan.opts.destdir});
-    defer allocator.free(legacy_etc);
-    std.fs.deleteFileAbsolute(legacy_etc) catch {};
+    for ([_][]const u8{ etc_dir, lib_dir }) |dir| {
+        if (std.mem.eql(u8, dir, plan.udev_dir)) continue;
+        for (basenames) |name| {
+            const path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir, name });
+            defer allocator.free(path);
+            std.fs.deleteFileAbsolute(path) catch {};
+        }
+    }
 }
 
 /// Scan all device TOML files in dirs, extract VID/PID/name/block_kernel_drivers,

--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -300,6 +300,16 @@ pub fn installUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan, 
     if (!plan.staging_mode and plan.is_root and shouldProactiveUnbind(plan)) {
         probeAndUnbindDrivers(allocator, entries, "");
     }
+
+    // Re-probe interfaces left driverless by an earlier install whose block
+    // list this install no longer covers. udevadm trigger only re-runs rules;
+    // it does not make the kernel re-evaluate drivers for an already-attached
+    // device, so a previously-unbound interface stays ownerless until replug.
+    // Runs even when the block list is empty/reduced, hence not gated by
+    // shouldProactiveUnbind.
+    if (!plan.staging_mode and plan.is_root) {
+        probeAndReprobeDrivers(allocator, entries, "");
+    }
 }
 
 pub fn cleanupLegacyUdevFiles(allocator: std.mem.Allocator, plan: *const InstallPlan) !void {
@@ -708,6 +718,103 @@ fn rebindInterfaces(
         } else |err| {
             std.log.warn("could not rebind {s} to kernel driver '{s}' (replug or run `modprobe {s}` to restore it): {}", .{ child.name, driver, driver, err });
         }
+    }
+}
+
+/// Walk <sys_root>/sys/bus/usb/devices/ and, for any USB device whose
+/// idVendor:idProduct matches an entry, ask the kernel to re-probe every
+/// interface child that currently has no `driver` symlink by writing its name
+/// to the global <sys_root>/sys/bus/usb/drivers_probe. The kernel selects the
+/// correct driver from the descriptor, so no driver name is hard-coded.
+/// Best-effort: catch+continue on every fs error; silent no-op when the tree is
+/// absent or non-root. `sys_root` is "" in production; tests inject a tmpDir.
+pub fn probeAndReprobeDrivers(allocator: std.mem.Allocator, entries: []const UdevEntry, sys_root: []const u8) void {
+    const devices_path = std.fmt.allocPrint(
+        allocator,
+        "{s}/sys/bus/usb/devices",
+        .{sys_root},
+    ) catch return;
+    defer allocator.free(devices_path);
+
+    var devices_dir = std.fs.openDirAbsolute(devices_path, .{ .iterate = true }) catch return;
+    defer devices_dir.close();
+
+    const probe_path = std.fmt.allocPrint(
+        allocator,
+        "{s}/sys/bus/usb/drivers_probe",
+        .{sys_root},
+    ) catch return;
+    defer allocator.free(probe_path);
+
+    for (entries) |entry| {
+        var it = devices_dir.iterate();
+        while (it.next() catch null) |de| {
+            if (de.kind != .sym_link and de.kind != .directory) continue;
+            if (de.name.len == 0 or de.name[0] < '0' or de.name[0] > '9') continue;
+            // Skip interface nodes ("1-1.4:1.0"); only match top-level devices.
+            if (std.mem.indexOfScalar(u8, de.name, ':') != null) continue;
+
+            const vendor_path = std.fmt.allocPrint(
+                allocator,
+                "{s}/sys/bus/usb/devices/{s}/idVendor",
+                .{ sys_root, de.name },
+            ) catch continue;
+            defer allocator.free(vendor_path);
+
+            const product_path = std.fmt.allocPrint(
+                allocator,
+                "{s}/sys/bus/usb/devices/{s}/idProduct",
+                .{ sys_root, de.name },
+            ) catch continue;
+            defer allocator.free(product_path);
+
+            const vid = readSysHex(vendor_path) catch continue;
+            const pid = readSysHex(product_path) catch continue;
+            if (vid != entry.vid or pid != entry.pid) continue;
+
+            reprobeInterfaces(allocator, sys_root, de.name, probe_path);
+        }
+    }
+}
+
+/// For each interface child of USB device `dev_name` ("<dev_name>:N.M") that has
+/// no `driver` symlink, write its name to the global `drivers_probe` attribute.
+fn reprobeInterfaces(
+    allocator: std.mem.Allocator,
+    sys_root: []const u8,
+    dev_name: []const u8,
+    probe_path: []const u8,
+) void {
+    const dev_dir_path = std.fmt.allocPrint(
+        allocator,
+        "{s}/sys/bus/usb/devices/{s}",
+        .{ sys_root, dev_name },
+    ) catch return;
+    defer allocator.free(dev_dir_path);
+
+    var dev_dir = std.fs.openDirAbsolute(dev_dir_path, .{ .iterate = true }) catch return;
+    defer dev_dir.close();
+
+    var it = dev_dir.iterate();
+    while (it.next() catch null) |child| {
+        if (child.kind != .directory and child.kind != .sym_link) continue;
+        if (!std.mem.startsWith(u8, child.name, dev_name)) continue;
+        if (child.name.len <= dev_name.len or child.name[dev_name.len] != ':') continue;
+
+        const driver_link = std.fmt.allocPrint(
+            allocator,
+            "{s}/sys/bus/usb/devices/{s}/{s}/driver",
+            .{ sys_root, dev_name, child.name },
+        ) catch continue;
+        defer allocator.free(driver_link);
+
+        // Already bound to some driver — nothing to re-probe.
+        if (std.fs.accessAbsolute(driver_link, .{})) |_| continue else |_| {}
+
+        if (std.fs.openFileAbsolute(probe_path, .{ .mode = .write_only })) |f| {
+            defer f.close();
+            f.writeAll(child.name) catch {};
+        } else |_| {}
     }
 }
 

--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -291,24 +291,27 @@ pub fn installUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan, 
         _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch {};
     };
 
-    // Evict already-attached devices without waiting for reboot.
-    // udevadm trigger only sends add events; bind rules fire on the next
-    // plug cycle. Proactively writing to sysfs unbind covers devices that
-    // are already claimed by a blocking driver at install time — but only
-    // when this install actually starts a runnable service,
-    // otherwise an unbound device would be left ownerless.
-    if (!plan.staging_mode and plan.is_root and shouldProactiveUnbind(plan)) {
-        probeAndUnbindDrivers(allocator, entries, "");
-    }
-
     // Re-probe interfaces left driverless by an earlier install whose block
-    // list this install no longer covers. udevadm trigger only re-runs rules;
-    // it does not make the kernel re-evaluate drivers for an already-attached
-    // device, so a previously-unbound interface stays ownerless until replug.
-    // Runs even when the block list is empty/reduced, hence not gated by
-    // shouldProactiveUnbind.
+    // list this install no longer covers, BEFORE evicting currently-blocked
+    // drivers. udevadm trigger only re-runs rules; it does not make the kernel
+    // re-evaluate drivers for an already-attached device, so a previously
+    // unbound interface stays ownerless until replug. Running reprobe first
+    // means it only ever rebinds interfaces that are already driverless and
+    // skips bound ones, so it never re-binds a driver the unbind step below is
+    // about to evict. Not gated by shouldProactiveUnbind so it still recovers
+    // when the block list is empty/reduced.
     if (!plan.staging_mode and plan.is_root) {
         probeAndReprobeDrivers(allocator, entries, "");
+    }
+
+    // Evict already-attached devices without waiting for reboot. udevadm
+    // trigger only sends add events; bind rules fire on the next plug cycle.
+    // Proactively writing to sysfs unbind covers devices already claimed by a
+    // blocking driver at install time — but only when this install actually
+    // starts a runnable service, otherwise an unbound device is left ownerless.
+    // Runs last so the eviction is authoritative over the reprobe above.
+    if (!plan.staging_mode and plan.is_root and shouldProactiveUnbind(plan)) {
+        probeAndUnbindDrivers(allocator, entries, "");
     }
 }
 


### PR DESCRIPTION
## Problem

padctl discovery is hidraw-only. When an install changes a device's `block_kernel_drivers`, two gaps stop the change from taking effect:

1. **Connected device is not re-bound.** Install writes the udev rule then runs `udevadm control --reload-rules` + `udevadm trigger`, but `udevadm trigger` only re-runs udev rules — it does not make the kernel re-probe drivers for an already-attached device. An interface left driverless by a prior install's wider block list stays ownerless until a physical replug/reboot.
2. **A stale rule shadows the fix across install modes.** Install/uninstall only touch the current mode's udev tree. `61-padctl-driver-block.rules` exists in both `/etc/udev/rules.d` (immutable/ostree) and `{prefix}/lib/udev/rules.d` (normal), and `/etc` shadows `/usr/lib`. A mode switch leaves a stale rule in `/etc` overriding the freshly written one; uninstall orphans the `/etc` copies.

## Changes

- `probeAndReprobeDrivers` (udev.zig): after writing rules, for each configured VID:PID, write every currently-driverless interface to the global `/sys/bus/usb/drivers_probe` so the kernel re-binds it by descriptor. Runs before the proactive unbind so eviction stays authoritative; root + non-staging only; skips interfaces that already have a driver (an active libusb claim is untouched).
- `cleanupLegacyUdevFiles` (udev.zig): sweep all padctl rule basenames (`60/61/90/99-padctl.rules`) from the non-active udev tree, guarded by `std.mem.eql(dir, plan.udev_dir)` so the just-written rules are never deleted.
- uninstall (phase.zig): remove `/etc/udev/rules.d/{60,61,90,99}-padctl.rules` + `/etc/modules-load.d/padctl.conf` unconditionally (previously immutable-gated, so a normal-mode uninstall orphaned them).

## Tests

Four new zero-privilege tests (fake-sysfs + `--destdir` staging):
- reprobe writes only driverless interfaces
- reprobe no-ops when all bound / tree missing
- mode switch sweeps the stale rule from the non-target tree (active tree preserved)
- normal-mode uninstall removes the `/etc` rules

Full suite green in the canonical Docker image (`zig build test`, exit 0).

## Verification — real hardware (Flydigi Vader 5 Pro, 37d7:2401)

- Reproduced "no device": live war-rule (blocks usbhid) -> hidraw 3 -> 0.
- Reproduced the migration gap: swap to the fixed rule + reload+trigger -> still 0 (all four interfaces driverless).
- Validated the fix: `drivers_probe` re-probe -> hidraw 3, recovered without a replug.

Related: #355


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uninstall process to ensure all udev rules and module configuration are fully removed.
  * Enhanced driver recovery during installation to re-probe previously disconnected interfaces.
  * Refined cleanup of legacy udev rules across different system locations.

* **Tests**
  * Added comprehensive test coverage for driver reprobe and udev rule lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->