### PR TITLE
test(install): make reprobe test guard the block-list skip regression

### DIFF
--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -3728,10 +3728,14 @@ test "install: reprobe writes only driverless interfaces" {
         defer f.close();
     }
 
+    // Non-empty block list mirrors the real Vader 5: re-probe must rebind a
+    // driverless interface regardless of block_kernel_drivers, so this fixture
+    // also guards against a `block_kernel_drivers.len != 0` skip in the path.
     const entries = [_]UdevEntry{.{
         .name = "Test Device",
         .vid = 0x37d7,
         .pid = 0x2401,
+        .block_kernel_drivers = &.{"xpad"},
     }};
     probeAndReprobeDrivers(allocator, &entries, tmp_path);
 


### PR DESCRIPTION
## Summary
Surfaced by an adversarial review of the #355 install-migration hardening (#365). The reprobe unit test was green-but-blind to the exact regression it should catch.

- `install: reprobe writes only driverless interfaces` used a fixture entry with an empty `block_kernel_drivers`.
- A `block_kernel_drivers.len != 0` skip in `probeAndReprobeDrivers` (the guard explicitly rejected during #365 review, because it would strand the real Vader 5 whose block list is `["xpad"]`) would NOT skip an empty-block entry — so the test passed even with that regression present.
- Pin the fixture's block list to `["xpad"]` so it mirrors production and fails on that skip.

Test-only change; no production behavior change.

## Test plan
Verified in the canonical Docker image (`zig 0.15.2`):
- Clean: `zig build test -Dtest-filter="install: reprobe"` passes.
- Inject `if (entry.block_kernel_drivers.len != 0) continue;` into `probeAndReprobeDrivers` → the test fails at the `1-1.4:1.1` write assertion (falsifiability confirmed).
- Remove the skip → passes.
- `zig build test-tsan -Dtest-filter="install: reprobe"` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to ensure correct validation of reprobe behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->