### PR TITLE
fix(usbraw): release claimed interface on open() error paths

### DIFF
--- a/src/io/usbraw.zig
+++ b/src/io/usbraw.zig
@@ -113,6 +113,15 @@ pub const UsbrawDevice = struct {
             return error.ClaimFailed;
         }
 
+        // Claim succeeded; release it and restore the kernel driver on any later
+        // failure so the interface is never leaked claimed-but-unowned.
+        errdefer {
+            _ = c.libusb_release_interface(handle, interface_id);
+            _ = c.libusb_attach_kernel_driver(handle, interface_id);
+            c.libusb_close(handle);
+            c.libusb_exit(ctx.?);
+        }
+
         const pipe_fds = try std.posix.pipe2(.{ .NONBLOCK = true, .CLOEXEC = true });
         errdefer std.posix.close(pipe_fds[0]);
         errdefer std.posix.close(pipe_fds[1]);
@@ -133,11 +142,6 @@ pub const UsbrawDevice = struct {
             .thread = undefined,
             .allocator = alloc,
         };
-        errdefer {
-            _ = c.libusb_release_interface(handle, interface_id);
-            c.libusb_close(handle);
-            c.libusb_exit(ctx.?);
-        }
         self.thread = try std.Thread.spawn(.{}, readLoop, .{self});
         return self;
     }
@@ -284,6 +288,7 @@ pub const UsbrawSuppress = struct {
 
         const self = alloc.create(UsbrawSuppress) catch |err| {
             _ = c.libusb_release_interface(handle, interface_id);
+            _ = c.libusb_attach_kernel_driver(handle, interface_id);
             c.libusb_close(handle);
             c.libusb_exit(ctx);
             return err;


### PR DESCRIPTION
## Summary
Resource-leak fix surfaced by an adversarial review of the #355 work.

`UsbrawDevice.open()` registered its `release_interface` + `close` + `exit` errdefer only *after* `self.*` was populated. A `pipe2` (`std.posix.pipe2`) or allocator (`alloc.create`) failure between a successful `libusb_claim_interface` and that point returned an error without releasing the interface or exiting the context — leaking the claim and leaving the USB device ownerless (no kernel driver, not claimed by us).

## Fix
- Move the cleanup errdefer to immediately after the successful claim so it covers the `pipe2` and `alloc.create` failure paths, and re-attach the kernel driver in it (matching `close()` and the `BUSY`/`ClaimFailed` branches).
- `UsbrawSuppress.openSuppress()` already released on alloc failure but did not re-attach the kernel driver; add the re-attach for the same consistency.

Error-path only; no change to the success path.

## Test plan
- `zig build -Dlibusb=true` compiles clean; `zig build test -Dlibusb=true` (full suite) green in the canonical Docker image.
- `zig build test-tsan -Dlibusb=true` green in Docker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in USB device operations to ensure proper cleanup of interfaces and kernel driver reattachment during failure scenarios, improving reliability and preventing resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->