### PR TITLE
fix(rumble): arm auto-stop deadline on throttled play frames (#65)

### DIFF
--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -169,7 +169,8 @@ fn slotStr(buf: *const [256]u8) []const u8 {
 /// device's `commands.rumble` (or alternate FF type) template. Used by
 /// both the uinput-FF-event path and the userspace auto-stop timerfd path.
 /// Returns true if the frame was successfully written to HID. Callers
-/// must only advance scheduler/throttle state when this returns true.
+/// must only advance the throttle clock (`last_rumble_ns`) when this returns
+/// true; scheduler accounting advances independently of emit.
 fn emitRumbleFrame(
     devices: []DeviceIO,
     alloc: std.mem.Allocator,
@@ -639,14 +640,12 @@ pub const EventLoop = struct {
                             }
                         } else {
                             // Play event: throttle applies to play frames.
-                            var forwarded = false;
                             const elapsed = now_ns - self.last_rumble_ns;
                             if (elapsed >= min_interval_ns) {
                                 if (ctx.allocator) |alloc| {
                                     if (ctx.device_config) |dcfg| {
                                         if (emitRumbleFrame(ctx.devices, alloc, dcfg, ff_ev.strong, ff_ev.weak, ctx.device_tag)) {
                                             self.last_rumble_ns = now_ns;
-                                            forwarded = true;
                                         } else {
                                             rumble_log.debug("[{s}] FF_PLAY: emitRumbleFrame FAILED id={d}", .{ ctx.device_tag, ff_ev.effect_id });
                                         }
@@ -658,7 +657,7 @@ pub const EventLoop = struct {
                                     @as(u64, @intCast(@min(elapsed, std.math.maxInt(u64)))),
                                 });
                             }
-                            if (scheduler_on and forwarded) {
+                            if (scheduler_on) {
                                 const next_dl = self.rumble_scheduler.onPlay(
                                     ff_ev.effect_id,
                                     ff_ev.duration_ms,

--- a/src/test/event_loop_rumble_test.zig
+++ b/src/test/event_loop_rumble_test.zig
@@ -942,3 +942,90 @@ test "event_loop: FF scheduler state identical with dump on vs off" {
     // HID writes must be identical (same bytes sent to device).
     try testing.expectEqualSlices(u8, r_off.write_log, r_on.write_log);
 }
+
+test "event_loop: throttled replay after stop still arms auto-stop deadline" {
+    // Regression test for #65 (stuck rumble).
+    //
+    // Sequence:
+    //   T0  FF_PLAY  effect 0, 100ms duration  → emitted, scheduler deadline armed
+    //   T1  FF_STOP  effect 0                  → slot cleared, timerfd disarmed
+    //   T2  FF_PLAY  effect 0, 100ms duration  → THROTTLED (T2-T0 < 10ms)
+    //                                             scheduler MUST still arm deadline
+    //
+    // Pre-fix: onPlay() was gated by `forwarded` (only true when a frame was
+    // emitted). A throttled replay skipped onPlay() → timerfd never rearmed
+    // → motor never stopped → stuck rumble.
+    // Post-fix: onPlay() runs unconditionally whenever scheduler_on.
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var mock_dev = try MockDeviceIO.init(allocator, &.{});
+    defer mock_dev.deinit();
+    const dev = mock_dev.deviceIO();
+    try loop.addDevice(dev);
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    // play, explicit stop, then a replay of effect 0; the replay is throttled.
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 100 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0, .weak = 0, .duration_ms = 0 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 100 },
+        null,
+    };
+    var ff_out = MockFfOutputSeq{ .allocator = allocator, .events = &seq };
+
+    const RunCtx3 = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        ff_out: *MockFfOutputSeq,
+        cfg: *const device_mod.DeviceConfig,
+        alloc: std.mem.Allocator,
+    };
+    var devs = [_]DeviceIO{dev};
+    var ctx = RunCtx3{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .ff_out = &ff_out,
+        .cfg = &parsed.value,
+        .alloc = allocator,
+    };
+    const T3 = struct {
+        fn run(c: *RunCtx3) !void {
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 100 });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T3.run, .{&ctx});
+
+    // The pipe byte is never drained, so the FF slot stays level-triggered:
+    // each ppoll iteration consumes one event, delivering all three within
+    // microseconds — far inside the 10ms throttle window.
+    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+
+    // Outlast the 100ms auto-stop deadline.
+    std.Thread.sleep(200 * std.time.ns_per_ms);
+    loop.stop();
+    thread.join();
+
+    // Three frames: play, explicit stop, and the auto-stop — the third only
+    // appears if the throttled replay rearmed the deadline.
+    const frame_size = 8;
+    try testing.expectEqual(@as(usize, 3 * frame_size), mock_dev.write_log.items.len);
+    const play_frame = mock_dev.write_log.items[0..frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, play_frame);
+    const explicit_stop = mock_dev.write_log.items[frame_size .. 2 * frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, explicit_stop);
+    const auto_stop = mock_dev.write_log.items[2 * frame_size .. 3 * frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, auto_stop);
+}


### PR DESCRIPTION
## What

The FF_PLAY handler gated the rumble scheduler's `onPlay()` call behind a local `forwarded` flag that was only set when a play frame passed the 10ms throttle and was emitted. A throttled play frame (e.g. the SDL stop-then-replay-within-10ms pattern) therefore skipped `onPlay()`, so the auto-stop deadline was never re-armed and the timerfd stayed disarmed — the motor never received a stop frame (stuck rumble).

This decouples scheduler accounting from frame emission: `onPlay()` now runs whenever `scheduler_on`. Throttling continues to suppress only redundant device writes; `last_rumble_ns` is still advanced only on emit, so the throttle window is unchanged.

## Changes

- `src/event_loop.zig`: remove the `forwarded` flag; call `rumble_scheduler.onPlay()` whenever `scheduler_on`.
- `src/test/event_loop_rumble_test.zig`: regression test — play → explicit stop → throttled replay must still arm the auto-stop timerfd and emit a stop frame when the deadline fires.

## Test plan

- New test fails on the pre-fix code (`expected 24, found 16` — auto-stop frame missing) and passes with the fix; verified in the canonical Docker image.
- Full `zig build test` suite: pass.
- `zig build test-tsan` (event_loop): pass.

## Refs

- Reported in #65. Diagnosis and patch by fendorix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rumble throttling now updates playback timing only when an output frame is actually emitted, while auto-stop scheduling proceeds even if a play frame is throttled or fails to emit.

* **Tests**
  * Added a regression test ensuring throttled replay still re-arms the auto-stop deadline and produces the expected stop frame sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->