### PR TITLE
fix(config): guard against out-of-bounds device dir index when HOME is unset

### DIFF
--- a/src/cli/config/init.zig
+++ b/src/cli/config/init.zig
@@ -120,7 +120,7 @@ pub fn run(allocator: std.mem.Allocator, device_arg: ?[]const u8, preset_arg: ?[
         const scan_dir: []const u8 = blk: {
             const dev_dirs = paths.resolveDeviceConfigDirs(allocator) catch break :blk "/usr/share/padctl/devices";
             defer paths.freeConfigDirs(allocator, dev_dirs);
-            const duped = allocator.dupe(u8, dev_dirs[2]) catch break :blk "/usr/share/padctl/devices";
+            const duped = allocator.dupe(u8, paths.builtinDir(dev_dirs)) catch break :blk "/usr/share/padctl/devices";
             scan_dir_owned = true;
             break :blk duped;
         };

--- a/src/config/paths.zig
+++ b/src/config/paths.zig
@@ -99,6 +99,13 @@ fn resolveSubdirDirs(allocator: Allocator, subdir: []const u8) ![][]const u8 {
     return @ptrCast(dirs);
 }
 
+/// The builtin (data) dir is always the last element of a resolved dirs slice,
+/// regardless of whether the user dir was present. Safe for the NoHomeDir case
+/// where the slice has only two entries.
+pub fn builtinDir(dirs: []const []const u8) []const u8 {
+    return dirs[dirs.len - 1];
+}
+
 pub fn freeConfigDirs(allocator: Allocator, dirs: [][]const u8) void {
     for (dirs) |d| allocator.free(d);
     allocator.free(dirs);
@@ -170,6 +177,26 @@ test "resolveDeviceConfigDirs: priority order" {
     );
     try std.testing.expectEqualStrings("/etc/padctl/devices", dirs[1]);
     try std.testing.expectEqualStrings("/usr/share/padctl/devices", dirs[2]);
+}
+
+test "builtinDir: returns last element for a three-entry slice" {
+    const dirs = [_][]const u8{
+        "/home/u/.config/padctl/devices",
+        "/etc/padctl/devices",
+        "/usr/share/padctl/devices",
+    };
+    try std.testing.expectEqualStrings("/usr/share/padctl/devices", builtinDir(&dirs));
+}
+
+test "builtinDir: NoHomeDir two-entry slice stays in bounds (regression: init indexed [2])" {
+    // Mirrors the resolveSubdirDirs NoHomeDir branch shape: [system, data].
+    // Old init.zig used dirs[2], which is out of bounds here and panics in
+    // ReleaseSafe. builtinDir must return the data dir (element [1]) instead.
+    const dirs = [_][]const u8{
+        "/etc/padctl/devices",
+        "/usr/share/padctl/devices",
+    };
+    try std.testing.expectEqualStrings("/usr/share/padctl/devices", builtinDir(&dirs));
 }
 
 test "findConfig: returns null when no dir contains the file" {


### PR DESCRIPTION
## What

`src/config/paths.zig` `resolveSubdirDirs` returns a **2-element** slice (`[system, data]`) in the `error.NoHomeDir` branch (neither `XDG_CONFIG_HOME` nor `HOME` set), but a **3-element** slice (`[user, system, data]`) otherwise. `src/cli/config/init.zig` indexed `dev_dirs[2]` unconditionally.

## Why

When `HOME` is unset (containers, headless boxes, some systemd units), `dev_dirs.len == 2`, so `dev_dirs[2]` is out of bounds -> ReleaseSafe panic / ReleaseFast UB. The trailing `catch` cannot rescue it: the index panic fires before the `dupe` error is evaluated.

## Fix

The builtin (data) dir is always the **last** element in both branches. Added a pure `paths.builtinDir(dirs)` helper returning `dirs[dirs.len - 1]` and used it in `init.zig`.

## Test plan

- New Layer-0 tests in `paths.zig`:
  - `builtinDir` over a 3-element slice returns the data dir.
  - `builtinDir` over a NoHomeDir-shaped 2-element slice stays in bounds and returns the data dir (regression: old `dirs[2]` panics here).
- Falsifiability: an isolated ReleaseSafe repro shows `dirs[2]` on a 2-element slice panics `index out of bounds: index 2, len 2`, while `builtinDir` returns `/usr/share/padctl/devices`.
- Full suite green via `scripts/padctl-docker test` (EXIT=0).

refs: audit HIGH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal device directory selection logic for improved reliability during initialization.

* **Tests**
  * Added regression tests to verify device directory selection behaves correctly across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->