### PR TITLE
refactor(cli): address audit findings (dead-code, comment hygiene)

### DIFF
--- a/src/cli/config/test.zig
+++ b/src/cli/config/test.zig
@@ -58,20 +58,6 @@ fn openFirstHidraw() !posix.fd_t {
     return error.NoHidrawDevice;
 }
 
-fn mappingLabel(mapping: *const mapping_mod.MappingConfig, button: []const u8) ?[]const u8 {
-    if (mapping.remap) |remap| {
-        if (remap.map.get(button)) |target| {
-            switch (target) {
-                .string => |s| return s,
-                // Chord arrays don't have a single human label; callers fall
-                // back to the source button name.
-                else => return null,
-            }
-        }
-    }
-    return null;
-}
-
 pub fn run(allocator: std.mem.Allocator, config_path: ?[]const u8, mapping_path: ?[]const u8, writer: anytype) !void {
     // Load mapping
     const mapping: ?mapping_mod.ParseResult = blk: {
@@ -162,25 +148,6 @@ pub fn run(allocator: std.mem.Allocator, config_path: ?[]const u8, mapping_path:
 }
 
 // --- tests ---
-
-test "test: mappingLabel returns remap target" {
-    const allocator = std.testing.allocator;
-    const toml_str =
-        \\[remap]
-        \\A = "BTN_SOUTH"
-        \\B = "BTN_EAST"
-    ;
-    const parsed = try mapping_mod.parseString(allocator, toml_str);
-    defer parsed.deinit();
-    const label = mappingLabel(&parsed.value, "A");
-    try std.testing.expectEqualStrings("BTN_SOUTH", label.?);
-    try std.testing.expectEqual(@as(?[]const u8, null), mappingLabel(&parsed.value, "X"));
-}
-
-test "test: mappingLabel with no remap returns null" {
-    const m = mapping_mod.MappingConfig{};
-    try std.testing.expectEqual(@as(?[]const u8, null), mappingLabel(&m, "A"));
-}
 
 // "openFirstHidraw returns error when no device" test removed: openFirstHidraw
 // scans /dev/hidraw0..63 and on dev machines an orphaned UHID device causes

--- a/src/cli/dump.zig
+++ b/src/cli/dump.zig
@@ -87,8 +87,7 @@ pub fn runStatus(
         } else |_| {}
     } else |_| {
         // Daemon not running — fall back to config.
-        const user_cfg_mod2 = user_config_mod;
-        if (user_cfg_mod2.load(allocator)) |pr| {
+        if (user_config_mod.load(allocator)) |pr| {
             var ucpr = pr;
             defer ucpr.deinit();
             daemon_state = if (ucpr.value.diagnostics.dump) "enabled (from config)" else "disabled (from config)";

--- a/src/cli/scan.zig
+++ b/src/cli/scan.zig
@@ -7,7 +7,6 @@ const readPhysicalPath = hidraw.readPhysicalPath;
 const readInterfaceId = hidraw.readInterfaceId;
 const toml_extract = @import("toml_extract.zig");
 
-const DEFAULT_CONFIG_DIR = "/usr/share/padctl/devices";
 const MAX_HIDRAW = 64;
 const NAME_BUF_LEN = 128;
 


### PR DESCRIPTION
Dead-code and simplification cleanups from a codebase audit of the CLI subsystem.

- `src/cli/scan.zig`: remove unused `DEFAULT_CONFIG_DIR` const (zero references; default lives in `paths.zig`, scan dirs come in as a parameter).
- `src/cli/dump.zig`: drop pointless `user_cfg_mod2 = user_config_mod` alias in the daemon-down branch; call `user_config_mod.load` directly.
- `src/cli/config/test.zig`: remove `mappingLabel` helper — it is dead in production (the read loop iterates the remap map directly) and was only exercised by its own two tests, which are also removed.

Behavior-identical. No production logic changed.

Test plan:
- `./scripts/padctl-docker test` -> EXIT=0
- `zig fmt --check` (0.15.2) on all changed files -> clean

refs: codebase audit