### PR TITLE
fix(tools): address audit findings (docgen filename, allocator, cleanup)

### DIFF
--- a/src/debug/render.zig
+++ b/src/debug/render.zig
@@ -76,10 +76,6 @@ const GREEN = "\x1b[32m";
 const CYAN = "\x1b[36m";
 const YELLOW = "\x1b[33m";
 
-fn shortenLabel(label: []const u8) []const u8 {
-    return shortenEventCode(label);
-}
-
 pub fn shortenEventCode(label: []const u8) []const u8 {
     const map = .{
         .{ "BTN_SOUTH", "S" },
@@ -242,7 +238,7 @@ pub const RenderConfig = struct {
     }
 
     pub fn btnDisplayLabel(self: *const RenderConfig, btn: ButtonId, default: []const u8) []const u8 {
-        return shortenLabel(self.button_labels[@intFromEnum(btn)] orelse default);
+        return shortenEventCode(self.button_labels[@intFromEnum(btn)] orelse default);
     }
 
     pub fn deriveFromConfig(cfg: *const DeviceConfig) RenderConfig {

--- a/src/main.zig
+++ b/src/main.zig
@@ -877,8 +877,8 @@ pub fn main() !void {
                     const sys_dst = std.fmt.allocPrint(allocator, "{s}/config.toml", .{sys_dir}) catch null;
                     defer if (sys_dst) |b| allocator.free(b);
                     if (tmp_src != null and sys_dst != null) {
-                        if (runSudoMkdir(sys_dir, stderr_writer)) {
-                            if (runSudoCopy(tmp_src.?, sys_dst.?, stderr_writer)) {
+                        if (runSudoMkdir(allocator, sys_dir, stderr_writer)) {
+                            if (runSudoCopy(allocator, tmp_src.?, sys_dst.?, stderr_writer)) {
                                 config_written = true;
                             }
                         }
@@ -938,10 +938,8 @@ pub fn main() !void {
                 std.process.exit(1);
             }
             // Bare `padctl switch` — read default_mapping from user config.
-            // NOTE: with multiple connected controllers, this resolves
-            // against the first device in the STATUS response. A future
-            // version should require --device in multi-device setups or
-            // add a device-keyed daemon API.
+            // With multiple connected controllers, resolves against the first
+            // device in the STATUS response.
             break :blk resolveDefaultMapping(allocator, parsed.socket_path, stderr_writer);
         };
 
@@ -1293,7 +1291,7 @@ fn persistToSystemConfig(allocator: std.mem.Allocator, mapping_name: []const u8,
     var ok = true;
 
     // Ensure destination directories exist.
-    if (!runSudoMkdir("/etc/padctl/mappings", err_writer)) ok = false;
+    if (!runSudoMkdir(allocator, "/etc/padctl/mappings", err_writer)) ok = false;
 
     // Copy mapping file to /etc/padctl/mappings/
     const mapping_path = mapping_discovery.findMapping(allocator, mapping_name) catch null;
@@ -1302,7 +1300,7 @@ fn persistToSystemConfig(allocator: std.mem.Allocator, mapping_name: []const u8,
         const dst = std.fmt.allocPrint(allocator, "/etc/padctl/mappings/{s}.toml", .{mapping_name}) catch null;
         if (dst) |d| {
             defer allocator.free(d);
-            if (!runSudoCopy(src, d, err_writer)) ok = false;
+            if (!runSudoCopy(allocator, src, d, err_writer)) ok = false;
         } else ok = false;
     } else {
         err_writer.writeAll("warning: mapping file for '") catch {};
@@ -1319,7 +1317,7 @@ fn persistToSystemConfig(allocator: std.mem.Allocator, mapping_name: []const u8,
         defer if (user_config) |p| allocator.free(p);
         if (user_config) |src| {
             if (std.fs.accessAbsolute(src, .{})) |_| {
-                if (!runSudoCopy(src, "/etc/padctl/config.toml", err_writer)) ok = false;
+                if (!runSudoCopy(allocator, src, "/etc/padctl/config.toml", err_writer)) ok = false;
             } else |_| {
                 err_writer.writeAll("warning: no user config.toml to copy\n") catch {};
                 ok = false;
@@ -1352,9 +1350,9 @@ fn copyFileBestEffort(src: []const u8, dst: []const u8) !void {
     }
 }
 
-fn runSudoCopy(src: []const u8, dst: []const u8, err_writer: anytype) bool {
+fn runSudoCopy(allocator: std.mem.Allocator, src: []const u8, dst: []const u8, err_writer: anytype) bool {
     const argv = [_][]const u8{ "sudo", "cp", src, dst };
-    var child = std.process.Child.init(&argv, std.heap.page_allocator);
+    var child = std.process.Child.init(&argv, allocator);
     child.stdin_behavior = .Inherit;
     child.stdout_behavior = .Inherit;
     child.stderr_behavior = .Inherit;
@@ -1379,9 +1377,9 @@ fn runSudoCopy(src: []const u8, dst: []const u8, err_writer: anytype) bool {
     return true;
 }
 
-fn runSudoMkdir(dir: []const u8, err_writer: anytype) bool {
+fn runSudoMkdir(allocator: std.mem.Allocator, dir: []const u8, err_writer: anytype) bool {
     const argv = [_][]const u8{ "sudo", "mkdir", "-p", dir };
-    var child = std.process.Child.init(&argv, std.heap.page_allocator);
+    var child = std.process.Child.init(&argv, allocator);
     child.stdin_behavior = .Inherit;
     child.stdout_behavior = .Inherit;
     child.stderr_behavior = .Inherit;

--- a/src/tools/docgen.zig
+++ b/src/tools/docgen.zig
@@ -102,15 +102,20 @@ pub fn generateDevicePage(
         try writer.writeAll("|------|-----------|----------|\n");
         var it = cmds.map.iterator();
         while (it.next()) |entry| {
-            const c = entry.value_ptr.*;
             const tpl = entry.value_ptr.*.template;
-            const short = if (tpl.len > 60) tpl[0..60] else tpl;
-            _ = c;
-            try writer.print("| `{s}` | {d} | `{s}...` |\n", .{
-                entry.key_ptr.*,
-                entry.value_ptr.*.interface,
-                short,
-            });
+            if (tpl.len > 60) {
+                try writer.print("| `{s}` | {d} | `{s}...` |\n", .{
+                    entry.key_ptr.*,
+                    entry.value_ptr.*.interface,
+                    tpl[0..60],
+                });
+            } else {
+                try writer.print("| `{s}` | {d} | `{s}` |\n", .{
+                    entry.key_ptr.*,
+                    entry.value_ptr.*.interface,
+                    tpl,
+                });
+            }
         }
         try writer.writeByte('\n');
     }
@@ -166,6 +171,7 @@ fn outputFilename(
     toml_path: []const u8,
     dev_name: []const u8,
 ) ![]u8 {
+    _ = dev_name;
     // derive vendor from directory: devices/<vendor>/model.toml -> vendor
     var vendor: []const u8 = "unknown";
     const basename = std.fs.path.basename(toml_path);
@@ -184,24 +190,7 @@ fn outputFilename(
     else
         basename;
 
-    // slugify device name: lowercase, spaces -> hyphens, keep alphanum and hyphen
-    var slug = try allocator.alloc(u8, dev_name.len);
-    defer allocator.free(slug);
-    var slug_len: usize = 0;
-    for (dev_name) |c| {
-        if (std.ascii.isAlphanumeric(c)) {
-            slug[slug_len] = std.ascii.toLower(c);
-            slug_len += 1;
-        } else if (c == ' ' or c == '-' or c == '_') {
-            if (slug_len > 0 and slug[slug_len - 1] != '-') {
-                slug[slug_len] = '-';
-                slug_len += 1;
-            }
-        }
-    }
-    _ = stem;
-
-    return std.fmt.allocPrint(allocator, "{s}-{s}.md", .{ vendor, slug[0..slug_len] });
+    return std.fmt.allocPrint(allocator, "{s}-{s}.md", .{ vendor, stem });
 }
 
 pub fn runDocGen(
@@ -239,9 +228,9 @@ pub fn runDocGen(
         defer file.close();
         try file.writeAll(buf.items);
 
-        _ = std.posix.write(std.posix.STDOUT_FILENO, "wrote ") catch 0;
-        _ = std.posix.write(std.posix.STDOUT_FILENO, out_path) catch 0;
-        _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch 0;
+        const msg = try std.fmt.allocPrint(allocator, "wrote {s}\n", .{out_path});
+        defer allocator.free(msg);
+        _ = std.posix.write(std.posix.STDOUT_FILENO, msg) catch 0;
     }
 }
 
@@ -394,5 +383,5 @@ test "docgen: outputFilename derives vendor-slug" {
     const allocator = std.testing.allocator;
     const fname = try outputFilename(allocator, "devices/sony/dualsense.toml", "Sony DualSense");
     defer allocator.free(fname);
-    try std.testing.expectEqualStrings("sony-sony-dualsense.md", fname);
+    try std.testing.expectEqualStrings("sony-dualsense.md", fname);
 }

--- a/src/wasm/wasm3_backend.zig
+++ b/src/wasm/wasm3_backend.zig
@@ -50,6 +50,7 @@ pub const Wasm3Plugin = struct {
 
     fn load(ptr: *anyopaque, wasm_bytes: []const u8, host_ctx: *HostContext) LoadError!void {
         const s = getSelf(ptr);
+        if (s.env != null or s.rt != null) unload(ptr);
         s.env = c.m3_NewEnvironment() orelse return error.PluginLoadFailed;
         errdefer {
             if (s.env) |env| c.m3_FreeEnvironment(env);
@@ -129,7 +130,6 @@ pub const Wasm3Plugin = struct {
         var ret: i32 = -1;
         if (getResultI32(f, &ret)) return .drop;
 
-        // TODO: consider adding ret=1 as passthrough variant if plugins need "skip me" semantics
         if (ret >= 0) {
             memcpyFromWasm(out, mem, output_offset) orelse return .drop;
             return .{ .override = deltaFromBytes(out) };


### PR DESCRIPTION
## What changed

- **docgen filename (MEDIUM, dead-code/correctness):** `outputFilename` computed the TOML `stem` then discarded it via `_ = stem`, slugifying the device name instead, so every generated doc filename doubled the vendor (e.g. `sony-sony-dualsense.md`). Now uses `stem` directly: `{vendor}-{stem}.md` -> `sony-dualsense.md`. Removed the dead slug alloc/loop.
- **docgen commands table:** the `...` ellipsis was a literal in the format string, so untruncated templates were falsely rendered as truncated. Now conditional on `tpl.len > 60`. Removed dead `const c` / `_ = c`.
- **docgen "wrote ..." output:** collapsed three `posix.write` syscalls into one atomic write.
- **main allocator threading:** `runSudoCopy` / `runSudoMkdir` now take the GPA allocator instead of `std.heap.page_allocator`; all 5 call sites updated.
- **main comment hygiene:** removed the forward-compat "A future version should..." comment on bare `padctl switch`.
- **render dead-code:** deleted the one-line `shortenLabel` wrapper; call site uses `shortenEventCode` directly.
- **wasm3_backend memory-safety:** `load()` now guards against leaking `env`/`rt` on a second call without a prior `unload()`.
- **wasm3_backend comment hygiene:** removed the `TODO` passthrough-variant marker.

## Skipped

- **render.zig 800-825 (performance):** rebuilding per-category `indices[]` each render. The audit itself rates it "negligible at 60fps." The suggested fix (store absolute `buttons[]` indices) changes the row-range semantics from per-category sub-list offsets to global indices, which is not behavior-identical and risks correctness for a non-measurable gain. Left as-is to honor the minimal-diff mandate.
- **docgen `std.io` writer suggestion:** the codebase convention is `std.posix.write(STDOUT_FILENO, ...)` (used throughout `main.zig`), not `std.io.getStdOut().writer()`. Kept the posix.write pattern; only the atomicity issue was real, addressed above.

## Test plan

- `./scripts/padctl-docker test` -> EXIT=0
- Updated `docgen: outputFilename` test asserts the de-duplicated name `sony-dualsense.md`. Verified the old doubled assertion (`sony-sony-dualsense.md`) **fails** against the corrected code and the new one passes (falsifiability proof).
- `zig fmt --check` (zig 0.15.2) clean on all changed files.

refs: codebase audit