### PR TITLE
fix(config): address audit findings (double-free, test coverage, cleanup)

### DIFF
--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -102,7 +102,7 @@ pub const RemapMap = struct {
 pub const DerivedAuxCaps = struct {
     needs_rel: bool = false, // REL_X/Y/WHEEL/HWHEEL (gyro mouse, stick mouse/scroll)
     needs_keyboard: bool = false, // KEY_* remaps, dpad arrows
-    // bitmask: bit0=BTN_LEFT bit1=BTN_RIGHT bit2=BTN_MIDDLE bit3=BTN_SIDE bit4=BTN_EXTRA
+    // bitmask: bit0=BTN_LEFT bit1=BTN_RIGHT bit2=BTN_MIDDLE bit3=BTN_SIDE bit4=BTN_EXTRA bit5=BTN_FORWARD bit6=BTN_BACK
     mouse_buttons: u8 = 0,
 
     pub fn needsAux(self: DerivedAuxCaps) bool {
@@ -211,7 +211,7 @@ fn scanRemapTargets(caps: *DerivedAuxCaps, cfg: *const MappingConfig, remap: *co
 }
 
 // Maximum EV_KEY codes that buildAuxKeyCodes may produce: all key_table entries (97) + 7 mouse buttons
-pub const AUX_KEY_CODES_MAX = 106;
+pub const AUX_KEY_CODES_MAX = 104;
 
 /// Build a key_codes slice for AuxDevice.create() from derived caps.
 /// buf must be at least AUX_KEY_CODES_MAX elements.
@@ -577,36 +577,20 @@ const valid_gyro_targets = [_][]const u8{ "right_stick", "left_stick" };
 const valid_gyro_responses = [_][]const u8{ "rate", "tilt" };
 const valid_gyro_axes = [_][]const u8{ "none", "pitch", "yaw", "roll" };
 
+fn strIsOneOf(s: []const u8, opts: []const []const u8) bool {
+    for (opts) |v| if (std.mem.eql(u8, s, v)) return true;
+    return false;
+}
+
 fn validateGyroConfig(g: *const GyroConfig, trigger_threshold: ?u8) !void {
-    var mode_ok = false;
-    for (valid_gyro_modes) |v| {
-        if (std.mem.eql(u8, g.mode, v)) {
-            mode_ok = true;
-            break;
-        }
-    }
-    if (!mode_ok) return error.InvalidConfig;
+    if (!strIsOneOf(g.mode, &valid_gyro_modes)) return error.InvalidConfig;
 
     if (g.target) |t| {
-        var target_ok = false;
-        for (valid_gyro_targets) |v| {
-            if (std.mem.eql(u8, t, v)) {
-                target_ok = true;
-                break;
-            }
-        }
-        if (!target_ok) return error.InvalidConfig;
+        if (!strIsOneOf(t, &valid_gyro_targets)) return error.InvalidConfig;
     }
 
     if (g.response) |r| {
-        var response_ok = false;
-        for (valid_gyro_responses) |v| {
-            if (std.mem.eql(u8, r, v)) {
-                response_ok = true;
-                break;
-            }
-        }
-        if (!response_ok) return error.InvalidConfig;
+        if (!strIsOneOf(r, &valid_gyro_responses)) return error.InvalidConfig;
         if (std.mem.eql(u8, r, "tilt") and !std.mem.eql(u8, g.mode, "joystick")) return error.InvalidConfig;
     }
 
@@ -643,10 +627,7 @@ fn validateGyroConfig(g: *const GyroConfig, trigger_threshold: ?u8) !void {
 }
 
 fn gyroAxisValid(axis: []const u8) bool {
-    for (valid_gyro_axes) |v| {
-        if (std.mem.eql(u8, axis, v)) return true;
-    }
-    return false;
+    return strIsOneOf(axis, &valid_gyro_axes);
 }
 
 // Returns true when LT/RT appear in any remap but trigger_threshold is not set.
@@ -2286,4 +2267,14 @@ test "gesture back-compat: chord array remap still parses as chord_names" {
     try std.testing.expectEqual(@as(usize, 2), names.len);
     try std.testing.expectEqualStrings("KEY_K", names[0]);
     try std.testing.expectEqualStrings("KEY_L", names[1]);
+}
+
+test "AUX_KEY_CODES_MAX equals all key codes plus all mouse buttons" {
+    // 7 = mouse_left/right/middle/side/extra/forward/back (see scanTarget/buildAuxKeyCodes)
+    try std.testing.expectEqual(input_codes.key_table.len + 7, AUX_KEY_CODES_MAX);
+
+    var buf: [AUX_KEY_CODES_MAX]u16 = undefined;
+    const caps = DerivedAuxCaps{ .needs_keyboard = true, .mouse_buttons = 0xFF };
+    const codes = buildAuxKeyCodes(caps, &buf);
+    try std.testing.expectEqual(AUX_KEY_CODES_MAX, codes.len);
 }

--- a/src/config/mapping_discovery.zig
+++ b/src/config/mapping_discovery.zig
@@ -14,8 +14,13 @@ pub const MappingProfile = struct {
 pub fn discoverMappings(allocator: std.mem.Allocator) ![]MappingProfile {
     const dirs = try paths.resolveMappingConfigDirs(allocator);
     defer paths.freeConfigDirs(allocator, dirs);
+    return discoverMappingsFromDirs(allocator, dirs);
+}
 
-    const sources = [_]Source{ .user, .system, .package };
+/// Scan the given dirs in priority order (first wins), deduplicate by name.
+/// dirs and sources are positional: dirs[i] is tagged with sources[i].
+pub fn discoverMappingsFromDirs(allocator: std.mem.Allocator, dirs: []const []const u8) ![]MappingProfile {
+    const all_sources = [_]Source{ .user, .system, .package };
 
     var seen = std.StringHashMap(void).init(allocator);
     defer seen.deinit();
@@ -29,7 +34,8 @@ pub fn discoverMappings(allocator: std.mem.Allocator) ![]MappingProfile {
         list.deinit(allocator);
     }
 
-    for (dirs, sources) |dir_path, source| {
+    for (dirs, 0..) |dir_path, i| {
+        const source = if (i < all_sources.len) all_sources[i] else .package;
         var dir = if (std.fs.path.isAbsolute(dir_path))
             std.fs.openDirAbsolute(dir_path, .{ .iterate = true }) catch continue
         else
@@ -50,8 +56,10 @@ pub fn discoverMappings(allocator: std.mem.Allocator) ![]MappingProfile {
             const full_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir_path, entry.name });
             errdefer allocator.free(full_path);
 
-            try list.append(allocator, .{ .name = owned_name, .path = full_path, .source = source });
+            // Register in seen before list.append so only one cleanup path
+            // owns these pointers at a time (avoids double-free on OOM).
             try seen.put(owned_name, {});
+            try list.append(allocator, .{ .name = owned_name, .path = full_path, .source = source });
         }
     }
 
@@ -88,58 +96,29 @@ test "discoverMappings: empty dirs returns empty" {
 test "discoverMappings: temp dir with profiles" {
     const allocator = std.testing.allocator;
 
-    const base = "/tmp/padctl_test_mapping_discovery";
-    const user_dir = base ++ "/user/mappings";
-    const sys_dir = base ++ "/system/mappings";
-    const pkg_dir = base ++ "/package/mappings";
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(base);
 
-    // Clean up from previous runs
-    std.fs.deleteTreeAbsolute(base) catch {};
+    const user_dir = try std.fmt.allocPrint(allocator, "{s}/user", .{base});
+    defer allocator.free(user_dir);
+    const sys_dir = try std.fmt.allocPrint(allocator, "{s}/system", .{base});
+    defer allocator.free(sys_dir);
+    const pkg_dir = try std.fmt.allocPrint(allocator, "{s}/package", .{base});
+    defer allocator.free(pkg_dir);
 
-    // Create directories
-    try std.fs.makeDirAbsolute(base);
-    for ([_][]const u8{ base ++ "/user", user_dir, base ++ "/system", sys_dir, base ++ "/package", pkg_dir }) |d| {
-        try std.fs.makeDirAbsolute(d);
-    }
-    defer std.fs.deleteTreeAbsolute(base) catch {};
+    try tmp.dir.makeDir("user");
+    try tmp.dir.makeDir("system");
+    try tmp.dir.makeDir("package");
 
-    // Create mapping files
-    for ([_][]const u8{ user_dir ++ "/fps.toml", sys_dir ++ "/racing.toml", pkg_dir ++ "/fps.toml" }) |p| {
-        const f = try std.fs.createFileAbsolute(p, .{});
+    for ([_][]const u8{ "user/fps.toml", "system/racing.toml", "package/fps.toml" }) |p| {
+        const f = try tmp.dir.createFile(p, .{});
         f.close();
     }
 
-    // Override paths by calling the internal scan logic directly
-    var seen = std.StringHashMap(void).init(allocator);
-    defer seen.deinit();
-
-    var list: std.ArrayList(MappingProfile) = .{};
-
     const dirs = [_][]const u8{ user_dir, sys_dir, pkg_dir };
-    const sources = [_]Source{ .user, .system, .package };
-
-    for (dirs, sources) |dir_path, source| {
-        var dir = std.fs.openDirAbsolute(dir_path, .{ .iterate = true }) catch continue;
-        defer dir.close();
-
-        var it = dir.iterate();
-        while (try it.next()) |entry| {
-            if (entry.kind != .file and entry.kind != .sym_link) continue;
-            if (!std.mem.endsWith(u8, entry.name, ".toml")) continue;
-
-            const name = entry.name[0 .. entry.name.len - ".toml".len];
-            if (seen.contains(name)) continue;
-
-            const owned_name = try allocator.dupe(u8, name);
-            errdefer allocator.free(owned_name);
-            const full_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir_path, entry.name });
-            errdefer allocator.free(full_path);
-            try list.append(allocator, .{ .name = owned_name, .path = full_path, .source = source });
-            try seen.put(owned_name, {});
-        }
-    }
-
-    const profiles = try list.toOwnedSlice(allocator);
+    const profiles = try discoverMappingsFromDirs(allocator, &dirs);
     defer freeProfiles(allocator, profiles);
 
     // "fps" should appear once (user wins), "racing" from system
@@ -160,6 +139,30 @@ test "discoverMappings: temp dir with profiles" {
     }
     try std.testing.expect(found_fps);
     try std.testing.expect(found_racing);
+}
+
+fn discoverAndFree(allocator: std.mem.Allocator, dirs: []const []const u8) !void {
+    const profiles = try discoverMappingsFromDirs(allocator, dirs);
+    freeProfiles(allocator, profiles);
+}
+
+test "discoverMappingsFromDirs: no leak or double-free under allocation failure" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+
+    for ([_][]const u8{ "a.toml", "b.toml", "c.toml" }) |p| {
+        const f = try tmp.dir.createFile(p, .{});
+        f.close();
+    }
+
+    const dirs = [_][]const u8{base};
+    // Injects OOM at each allocation point in turn; a double-free or leak
+    // on the seen.put/list.append path fails this check.
+    try std.testing.checkAllAllocationFailures(allocator, discoverAndFree, .{&dirs});
 }
 
 test "findMapping: returns null for nonexistent" {


### PR DESCRIPTION
## Summary

Addresses 6 audit findings in `src/config/{mapping,mapping_discovery}.zig`.

- **[medium] double-free on OOM** (mapping_discovery): after `list.append` succeeded, an `seen.put` OOM let both the local errdefers and the outer list-cleanup errdefer free the same `owned_name`/`full_path`. Fixed by registering in `seen` before `list.append` so only one cleanup path owns the pointers at a time.
- **[medium] test re-implemented production logic** (mapping_discovery): the temp-dir test inlined a copy of the scan loop instead of calling the real function. Factored `discoverMappingsFromDirs(allocator, dirs)`; both production `discoverMappings` and the test now use it, so the dedup/cleanup path is actually covered.
- **[low] shared /tmp path** (mapping_discovery): temp-dir test now uses `std.testing.tmpDir` (isolated, system-managed) instead of a fixed `/tmp` path that could race across parallel runs.
- **[low] AUX_KEY_CODES_MAX off-by-2** (mapping): 106 -> 104 (97 key codes + 7 mouse buttons). Added a test pinning it to `key_table.len + 7`.
- **[low] mouse_buttons comment** (mapping): documented bits 5/6 (BTN_FORWARD/BTN_BACK).
- **[low] validateGyroConfig duplication** (mapping): extracted `strIsOneOf`, collapsed four identical manual scan loops (behavior-identical).

## New regression tests
- `discoverMappingsFromDirs: no leak or double-free under allocation failure` — `checkAllAllocationFailures` injects OOM at each alloc point; detects the double-free and leaks.
- `AUX_KEY_CODES_MAX equals all key codes plus all mouse buttons` — pins the constant and verifies a fully-enabled `buildAuxKeyCodes` fills exactly the buffer.

## Test plan
- `./scripts/padctl-docker test` => EXIT=0
- `zig fmt --check` (0.15.2) clean on both files
- Falsifiability verified for each new/changed test: reverting the fix makes the corresponding test fail (double-free => abort sig6; dedup break => count mismatch; constant 106 => `expected 104, found 106`), then restored to green.

refs: codebase audit