### PR TITLE
release: bump version to 0.1.14

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.13",
+    .version = "0.1.14",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
Bumps `build.zig.zon` version 0.1.13 -> 0.1.14. Tagging `v0.1.14` after merge triggers the release workflow.

## Notable changes since v0.1.13 (30 commits)

- feat(cli): `padctl doctor` diagnostic subcommand (#355)
- feat(layer): `hold` passthrough output emitted while a layer is active (#332)
- feat(gyro): `minimum_output` snap for in-game deadzone compensation
- fix(vader5): back-paddle evdev codes + block only xpad so the pad stays discoverable (#362, #389)
- fix(rumble): arm auto-stop deadline on throttled play frames (#65)
- fix(usbraw): release claimed interface on open() error paths (#369)
- fix(install): grant raw USB node access for libusb-claimed devices; reload udev before re-probe (#361, #368)
- Broad audit follow-up sweep across cli/config/io/install/supervisor/control-socket (errno handling, OOM leaks, double-free, dead-code, comment hygiene)

## Test plan

- CI full matrix on this branch must be green before merge
- `zig fmt --check src/ tools/` passes under canonical Zig 0.15.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.1.14

<!-- end of auto-generated comment: release notes by coderabbit.ai -->