### PR TITLE
fix(control-socket): tighten socket perms to 0o660 and whitelist SWITCH absolute paths

### DIFF
--- a/src/io/control_socket.zig
+++ b/src/io/control_socket.zig
@@ -63,7 +63,7 @@ pub const ControlSocket = struct {
         try posix.bind(fd, @ptrCast(&addr), @sizeOf(linux.sockaddr.un));
         errdefer std.fs.deleteFileAbsolute(path) catch {};
 
-        const rc = linux.chmod(path_z.ptr, 0o666);
+        const rc = linux.chmod(path_z.ptr, 0o660);
         if (linux.E.init(rc) != .SUCCESS) return error.ChmodFailed;
 
         try posix.listen(fd, 4);
@@ -560,6 +560,30 @@ test "control_socket: ControlSocket: init writes advertised file with socket pat
     var buf: [256]u8 = undefined;
     const n = try file.readAll(&buf);
     try testing.expectEqualStrings(socket_path, buf[0..n]);
+}
+
+// Falsifiability: restore the chmod argument to 0o666 in ControlSocket.init and
+// this test FAILS — the world-write bit (0o002) is set on the bound socket,
+// which is the local-privilege-escalation surface this hardening removes.
+test "control_socket: ControlSocket: init binds socket without world-write" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    const socket_path = try std.fs.path.join(allocator, &.{ root, "perm.sock" });
+    defer allocator.free(socket_path);
+
+    var cs = ControlSocket.init(allocator, socket_path) catch |err| {
+        if (err == error.AccessDenied) return;
+        return err;
+    };
+    defer cs.deinit();
+
+    const st = try posix.fstatat(posix.AT.FDCWD, socket_path, 0);
+    try testing.expectEqual(@as(u32, 0), st.mode & 0o002);
 }
 
 // Falsifiability: drop the deleteFileAbsolute(self.advertised_path) branch in

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -45,6 +45,19 @@ fn openDeviceWithRetryForRebind(
     return openDeviceWithRetry(allocator, iface, vid, pid);
 }
 
+/// True when a client-supplied absolute mapping path resides directly in one of
+/// the trusted mapping config dirs. Rejects arbitrary absolute paths so a local
+/// caller on the world-reachable control socket cannot make the daemon parse
+/// (and leak parse diagnostics from) files outside the mapping search path.
+fn absolutePathInMappingDirs(path: []const u8, dirs: []const []const u8) bool {
+    const parent = std.fs.path.dirname(path) orelse return false;
+    for (dirs) |dir| {
+        const trimmed = std.mem.trimRight(u8, dir, "/");
+        if (std.mem.eql(u8, parent, trimmed)) return true;
+    }
+    return false;
+}
+
 /// One running device under Supervisor management.
 pub const ManagedInstance = struct {
     phys_key: []const u8,
@@ -1728,18 +1741,26 @@ pub const Supervisor = struct {
             return;
         }
 
-        // If the name is an absolute path, use it directly (client-resolved).
-        // Otherwise, do server-side lookup from config dirs.
-        const path: ?[]const u8 = if (name.len > 0 and name[0] == '/')
-            (self.allocator.dupe(u8, name) catch {
-                cs.sendResponse(fd, "ERR oom\n");
-                return;
-            })
-        else
-            self.lookupSwitchMappingPath(name) catch {
+        // If the name is an absolute path, accept it only when it resides in a
+        // trusted mapping config dir; otherwise do server-side name lookup.
+        const path: ?[]const u8 = if (name.len > 0 and name[0] == '/') blk: {
+            const dirs = config_paths.resolveMappingConfigDirs(self.allocator) catch {
                 cs.sendResponse(fd, "ERR mapping-lookup-failed\n");
                 return;
             };
+            defer config_paths.freeConfigDirs(self.allocator, dirs);
+            if (!absolutePathInMappingDirs(name, dirs)) {
+                cs.sendResponse(fd, "ERR mapping-not-allowed\n");
+                return;
+            }
+            break :blk (self.allocator.dupe(u8, name) catch {
+                cs.sendResponse(fd, "ERR oom\n");
+                return;
+            });
+        } else self.lookupSwitchMappingPath(name) catch {
+            cs.sendResponse(fd, "ERR mapping-lookup-failed\n");
+            return;
+        };
         if (path == null) {
             cs.sendResponse(fd, "ERR mapping-not-found\n");
             return;
@@ -5349,4 +5370,62 @@ test "supervisor: resolveEvdevNodesAt returns all matching nodes with device nam
     try testing.expect(std.mem.indexOf(u8, s, "/dev/input/event5") != null);
     try testing.expect(std.mem.indexOf(u8, s, "/dev/input/event7") != null);
     try testing.expect(std.mem.indexOf(u8, s, "Vader 5 Pro IMU") != null);
+}
+
+// Falsifiability: drop the absolutePathInMappingDirs guard (or invert it) and the
+// negative cases below accept arbitrary absolute paths, failing these asserts.
+test "supervisor: absolutePathInMappingDirs accepts only files in trusted dirs" {
+    const dirs = [_][]const u8{
+        "/home/u/.config/padctl/mappings",
+        "/etc/padctl/mappings/",
+        "/usr/share/padctl/mappings",
+    };
+    try testing.expect(absolutePathInMappingDirs("/home/u/.config/padctl/mappings/fps.toml", &dirs));
+    try testing.expect(absolutePathInMappingDirs("/etc/padctl/mappings/racing.toml", &dirs));
+    try testing.expect(absolutePathInMappingDirs("/usr/share/padctl/mappings/x.toml", &dirs));
+    try testing.expect(!absolutePathInMappingDirs("/etc/passwd", &dirs));
+    try testing.expect(!absolutePathInMappingDirs("/home/u/.config/padctl/mappings/sub/fps.toml", &dirs));
+    try testing.expect(!absolutePathInMappingDirs("/home/u/.ssh/id_rsa", &dirs));
+    try testing.expect(!absolutePathInMappingDirs("/usr/share/padctl/devices/x.toml", &dirs));
+}
+
+// Falsifiability: revert handleSwitch to dupe any absolute path unconditionally
+// and this test FAILS — the daemon would attempt parseFile("/etc/passwd") and
+// reply "ERR mapping-parse-failed" instead of refusing the path outright.
+test "supervisor: SWITCH rejects absolute path outside mapping dirs" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.ctrl_sock = null;
+        sup.deinit();
+    }
+
+    sup.ctrl_sock = .{
+        .listen_fd = -1,
+        .client_fds = .{ -1, -1, -1, -1 },
+        .client_count = 0,
+        .path = "",
+        .allocator = allocator,
+    };
+
+    const resp_fds = try testSocketpair();
+    defer posix.close(resp_fds[0]);
+    defer posix.close(resp_fds[1]);
+
+    const inst = try makeTestInstance(allocator, &mock, &parsed_dev.value);
+    try sup.spawnInstance("usb-1-1", inst, null);
+
+    sup.handleSwitch(resp_fds[0], "/etc/passwd", null);
+
+    var resp_buf: [64]u8 = undefined;
+    const n = try posix.read(resp_fds[1], &resp_buf);
+    try testing.expectEqualStrings("ERR mapping-not-allowed\n", resp_buf[0..n]);
 }


### PR DESCRIPTION
## What
- `control_socket.zig`: chmod the control socket `0o666` → `0o660` (was world-writable; any local user could send commands to the root daemon).
- `supervisor.zig` `handleSwitch`: reject client-supplied absolute paths that are not inside a trusted mapping config dir (dirname whitelist) before calling `parseFile`, closing an arbitrary-file-read path (`containsPathTraversal` previously allowed `/`-rooted paths).

Interim hardening ahead of the ADR-020 D-Bus/polkit migration.

## Test plan
- New `control_socket` test: bound socket mode has no world-write bit (`st.mode & 0o002 == 0`).
- New SWITCH test: a non-trusted absolute path (`/etc/passwd`) returns `mapping-not-allowed` before any parse.
- Full Docker test suite green locally; CI matrix gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted control socket file permissions to prevent unauthorized access.
  * Added validation to reject absolute mapping paths outside trusted configuration directories.

* **Tests**
  * Added tests to verify socket permission restrictions and mapping path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->