### PR TITLE
fix(mapper,supervisor): cancel macro timers on layer change; revert aux caps on switch rollback

### DIFF
--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -751,15 +751,20 @@ pub const Mapper = struct {
                         continue;
                     }
                     // step() didn't finish (delay after pause_for_release, etc.) — cancel.
+                    self.timer_queue.cancel(p.timer_token, now_ns);
                     p.emitPendingReleases(aux, &self.injected_buttons);
                     _ = self.active_macros.swapRemove(0);
                 } else {
+                    self.timer_queue.cancel(p.timer_token, now_ns);
                     p.emitPendingReleases(aux, &self.injected_buttons);
                     _ = self.active_macros.swapRemove(0);
                 }
             }
         } else {
-            for (self.active_macros.items) |*p| p.emitPendingReleases(aux, &self.injected_buttons);
+            for (self.active_macros.items) |*p| {
+                self.timer_queue.cancel(p.timer_token, now_ns);
+                p.emitPendingReleases(aux, &self.injected_buttons);
+            }
             self.active_macros.clearRetainingCapacity();
         }
         releasePendingAuxTapReleases(self, aux, now_ns);
@@ -1807,6 +1812,49 @@ test "mapper: pause_for_release macro drained on layer deactivation" {
         else => {},
     };
     try testing.expect(saw_release);
+}
+
+test "mapper: layer change cancels macro delay timer in timer_queue" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[[layer]]
+        \\name = "fn"
+        \\trigger = "Select"
+        \\activation = "toggle"
+        \\
+        \\[remap]
+        \\M1 = "macro:hold_x"
+        \\
+        \\[[macro]]
+        \\name = "hold_x"
+        \\steps = [
+        \\  { down = "X" },
+        \\  { delay = 100000 },
+        \\  { up = "X" },
+        \\]
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const sel_mask = buttonBit("Select");
+    const m1_mask = buttonBit("M1");
+
+    // Arm the macro: the long delay step schedules the macro's timer_token in
+    // timer_queue and the macro stays active across the delay window.
+    _ = try m.apply(.{ .buttons = m1_mask }, 16, 0);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
+    try testing.expectEqual(@as(usize, 1), m.timer_queue.heap.count());
+
+    // Toggle the layer on (rising then falling edge on Select) while M1 stays
+    // held. The falling edge fires active_changed, which cancels the active
+    // macro. The macro's delay timer must be cancelled too — otherwise a stale
+    // token fires after the macro is gone.
+    _ = try m.apply(.{ .buttons = m1_mask | sel_mask }, 16, 0);
+    _ = try m.apply(.{ .buttons = m1_mask }, 16, 0);
+    try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
+    try testing.expectEqual(@as(usize, 0), m.timer_queue.heap.count());
 }
 
 test "mapper: hold_toggle pending preserves macros but sticky transition cancels them" {

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -1091,6 +1091,11 @@ pub const Supervisor = struct {
             std.log.warn("rebuildAuxIfChanged during switch: {}", .{err});
         };
         restartManagedThread(m) catch |err| {
+            if (tx.old_mapping_cfg) |old_cfg| {
+                m.instance.rebuildAuxIfChanged(old_cfg, &tx.parsed_ptr.?.value) catch |rollback_aux_err| {
+                    std.log.warn("rebuildAuxIfChanged rollback during switch: {}", .{rollback_aux_err});
+                };
+            }
             if (m.instance.mapper) |*cur| {
                 cur.deinit();
                 m.instance.mapper = null;
@@ -3550,6 +3555,85 @@ test "supervisor: switch to mapping with new aux KEY_* rebuilds aux caps" {
     const new_mcfg = sup.managed.items[0].instance.mapping_cfg.?;
     const caps = mapping_mod.deriveAuxFromMapping(new_mcfg);
     try testing.expect(caps.needs_keyboard);
+}
+
+test "supervisor: switch restart failure reverts aux caps on rollback" {
+    // Regression guard: commitSwitchTarget rebuilds aux caps for the new mapping
+    // before restarting the worker. When that restart fails, the rollback must
+    // also call rebuildAuxIfChanged to revert the aux device back to the old
+    // mapping's caps — otherwise the daemon keeps an aux device shaped for a
+    // mapping that never took effect. The reload path already does this; this
+    // mirrors it for the switch path.
+    //
+    // Like the forward-path test, this uses a device config with no [output]
+    // section so rebuildAuxIfChanged short-circuits and is observed via the
+    // rebuild_aux_calls counter. Forward call = 1, rollback revert = 2.
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+
+    // Base mapping the instance starts on, so commitSwitchTarget captures a
+    // non-null old_mapping_cfg and the rollback has something to revert to.
+    const base_map = try mapping_mod.parseString(allocator, "");
+    defer base_map.deinit();
+
+    const base_dir = "/tmp/padctl_supervisor_test_switch_rollback_aux";
+    std.fs.deleteTreeAbsolute(base_dir) catch {};
+    try std.fs.makeDirAbsolute(base_dir);
+    defer std.fs.deleteTreeAbsolute(base_dir) catch {};
+
+    const mappings_dir = try std.fmt.allocPrint(allocator, "{s}/mappings", .{base_dir});
+    defer allocator.free(mappings_dir);
+    try std.fs.makeDirAbsolute(mappings_dir);
+    const mapping_path = try std.fmt.allocPrint(allocator, "{s}/keys.toml", .{mappings_dir});
+    defer allocator.free(mapping_path);
+    {
+        const f = try std.fs.createFileAbsolute(mapping_path, .{});
+        defer f.close();
+        try f.writeAll("[remap]\nC = \"KEY_G\"\n");
+    }
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer {
+        sup.stopAll();
+        sup.ctrl_sock = null;
+        sup.deinit();
+    }
+
+    sup.ctrl_sock = .{
+        .listen_fd = -1,
+        .client_fds = .{ -1, -1, -1, -1 },
+        .client_count = 0,
+        .path = "",
+        .allocator = allocator,
+    };
+
+    const resp_fds = try testSocketpair();
+    defer posix.close(resp_fds[0]);
+    defer posix.close(resp_fds[1]);
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+
+    const inst = try makeTestInstance(allocator, &mock, &parsed_dev.value);
+    inst.mapping_cfg = &base_map.value;
+    try sup.spawnInstance("usb-1-1", inst, null);
+
+    try testing.expectEqual(@as(usize, 0), sup.managed.items[0].instance.rebuild_aux_calls);
+
+    sup.test_switch_mapping_override = try allocator.dupe(u8, mapping_path);
+
+    // Forward restart fails → commitSwitchTarget takes its rollback branch.
+    test_fail_next_restart_managed = true;
+    sup.handleSwitch(resp_fds[0], "keys", null);
+
+    var resp_buf: [64]u8 = undefined;
+    const n = try posix.read(resp_fds[1], &resp_buf);
+    try testing.expectEqualStrings("ERR switch-failed\n", resp_buf[0..n]);
+
+    // Forward rebuild (new caps) + rollback revert (old caps) = 2 calls.
+    try testing.expectEqual(@as(usize, 2), sup.managed.items[0].instance.rebuild_aux_calls);
 }
 
 test "supervisor: Supervisor: SWITCH with no devices returns no-devices" {


### PR DESCRIPTION
## What
- `mapper.zig` `handleLayerActiveChanged`: cancel each cancelled macro's `timer_queue` entry (a stale Deadline left the macro timerfd firing redundantly; long-term token wraparound risked mismatch).
- `supervisor.zig` `commitSwitchTarget`: on restart-failure rollback, also call `rebuildAuxIfChanged` to restore the prior aux capabilities, matching the reload path (mapper was reverted but aux caps drifted).

## Not included
- `DeviceInstance.init` aux_dev fd-leak errdefer: left unfixed because it is not reproducible in the unprivileged test environment (no `/dev/uinput`, no fault-injection seam). Tracked for a privileged-env repro rather than fixed without a falsifiable test.

## Test plan
- New mapper test: stale macro timer token is cleared on layer change.
- New supervisor test: aux rebuild is invoked on rollback.
- Full Docker test suite green locally; CI matrix gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed macro delays incorrectly firing after being cancelled during layer switches
  * Fixed device capabilities not properly reverting when a switch restart fails

* **Tests**
  * Added regression tests for macro cancellation during layer changes and switch failure recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->