### PR TITLE
fix(uhid,wasm): align touchpad report width to max_slots; fail-safe wasm passthrough

### DIFF
--- a/src/io/uhid_descriptor.zig
+++ b/src/io/uhid_descriptor.zig
@@ -1281,12 +1281,15 @@ pub fn encodeReport(
     }
 
     // --- Touchpad (per-finger tip + X + Y) ---
-    if (cfg.touchpad) |_| {
-        const finger0 = [_]struct { active: bool, x: i16, y: i16 }{
+    if (cfg.touchpad) |tp| {
+        const fingers = [_]struct { active: bool, x: i16, y: i16 }{
             .{ .active = gs.touch0_active, .x = gs.touch0_x, .y = gs.touch0_y },
             .{ .active = gs.touch1_active, .x = gs.touch1_x, .y = gs.touch1_y },
         };
-        for (finger0) |f| {
+        // Finger count must match the descriptor, which clamps max_slots to
+        // [1, MAX_TOUCH_CONTACTS]; a mismatch desyncs the wire length.
+        const slots: usize = if (tp.max_slots) |s| @intCast(@min(@max(s, 1), MAX_TOUCH_CONTACTS)) else MAX_TOUCH_CONTACTS;
+        for (fingers[0..slots]) |f| {
             if (pos + 5 > buf.len) return error.ReportTooLong;
             buf[pos] = if (f.active) 1 else 0;
             pos += 1;
@@ -2212,6 +2215,42 @@ test "encodeReport: Steam Deck TOML produces a non-empty report with correct ID"
     // sticks(4×2=8) + triggers(2) + touchpad(2 fingers × 5=10) = 25.
     try testing.expect(r.len > 1);
     try testing.expect(r.len <= MAX_REPORT_BYTES);
+}
+
+test "encodeReport: touchpad finger count matches descriptor max_slots" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const axes = try makeAxesMap(a, &.{
+        .{ .name = "left_x", .cfg = .{ .code = "ABS_X", .min = -32768, .max = 32767 } },
+    });
+
+    const cases = [_]struct { max_slots: ?i64, fingers: usize }{
+        .{ .max_slots = 1, .fingers = 1 },
+        .{ .max_slots = 2, .fingers = 2 },
+        .{ .max_slots = null, .fingers = MAX_TOUCH_CONTACTS },
+    };
+
+    for (cases) |tc| {
+        const out = device.OutputConfig{
+            .name = "touch",
+            .axes = axes,
+            .touchpad = .{
+                .x_min = -32768,
+                .x_max = 32767,
+                .y_min = -32768,
+                .y_max = 32767,
+                .max_slots = tc.max_slots,
+            },
+        };
+
+        var buf: [MAX_REPORT_BYTES]u8 = undefined;
+        const r = try encodeReport(out, .{}, &buf);
+        // Non-touchpad region: ID(1) + sticks(ABS_X → 2). Touchpad finger = 5 bytes.
+        const expected_len: usize = 1 + 2 + tc.fingers * 5;
+        try testing.expectEqual(expected_len, r.len);
+    }
 }
 
 test "encodeReport: empty config is rejected by descriptor builder, encoder never sees it" {

--- a/src/wasm/wasm3_backend.zig
+++ b/src/wasm/wasm3_backend.zig
@@ -7,7 +7,6 @@ const runtime_mod = @import("runtime.zig");
 const WasmPlugin = runtime_mod.WasmPlugin;
 const LoadError = runtime_mod.LoadError;
 const ProcessResult = runtime_mod.ProcessResult;
-const GamepadStateDelta = @import("../core/state.zig").GamepadStateDelta;
 
 const wasm_log = std.log.scoped(.wasm3);
 
@@ -132,7 +131,10 @@ pub const Wasm3Plugin = struct {
 
         if (ret >= 0) {
             memcpyFromWasm(out, mem, output_offset) orelse return .drop;
-            return .{ .override = deltaFromBytes(out) };
+            // No structured wasm-to-delta ABI yet, so an override here would carry
+            // an empty delta that freezes the pad. Fall back to passthrough until
+            // the ABI lands; the raw report still drives the interpreter.
+            return .passthrough;
         } else {
             return .drop;
         }
@@ -340,18 +342,6 @@ pub const Wasm3Plugin = struct {
             unload(@ptrCast(s));
         }
     }
-
-    // -- helpers --
-
-    fn deltaFromBytes(buf: []const u8) GamepadStateDelta {
-        // GamepadStateDelta has Zig-private layout (optionals), so we cannot @bitCast
-        // raw plugin output bytes into it. Current plugins (IMU calibration, echo)
-        // write the modified raw HID report into `out`; downstream parses that buffer
-        // directly via the device protocol path. The override delta payload is unused
-        // until a structured wasm-to-delta ABI is defined.
-        _ = buf;
-        return .{};
-    }
 };
 
 // --- tests ---
@@ -385,7 +375,7 @@ test "wasm3: initDevice returns true" {
     try testing.expect(plugin.initDevice());
 }
 
-test "wasm3: processReport echo round-trip returns override" {
+test "wasm3: processReport echo round-trip writes out buffer and passes through" {
     const t = try testCreate();
     const plugin = t.plugin;
     defer plugin.destroy(testing.allocator);
@@ -394,12 +384,25 @@ test "wasm3: processReport echo round-trip returns override" {
     try plugin.load(@embedFile("../../tests/wasm/echo_plugin.wasm"), &ctx);
     const input = [_]u8{ 0xAA, 0xBB, 0xCC, 0xDD };
     var out: [4]u8 = undefined;
-    const result = plugin.processReport(&input, &out);
-    switch (result) {
-        .override => {},
-        else => return error.ExpectedOverride,
-    }
+    try testing.expectEqual(ProcessResult.passthrough, plugin.processReport(&input, &out));
     try testing.expectEqualSlices(u8, &input, &out);
+}
+
+test "wasm3: processReport never returns an empty-delta override (fail-safe passthrough)" {
+    // deltaFromBytes has no structured wasm-to-delta ABI, so it always yields an
+    // empty delta. Returning that as `.override` makes the event loop apply a
+    // no-op delta and skip interpreter parsing, freezing the pad. Until the ABI
+    // lands, a successful plugin call must fall back to passthrough so the raw
+    // report still drives the interpreter.
+    const t = try testCreate();
+    const plugin = t.plugin;
+    defer plugin.destroy(testing.allocator);
+    var ctx = HostContext.init(testing.allocator);
+    defer ctx.deinit();
+    try plugin.load(@embedFile("../../tests/wasm/echo_plugin.wasm"), &ctx);
+    const input = [_]u8{ 0xAA, 0xBB, 0xCC, 0xDD };
+    var out: [4]u8 = undefined;
+    try testing.expectEqual(ProcessResult.passthrough, plugin.processReport(&input, &out));
 }
 
 test "wasm3: no exports returns false/passthrough" {
@@ -604,11 +607,7 @@ test "imu_cal: init_device reads calibration via device_read" {
     writeI16le(&raw, 22, 1000); // accel_x
 
     var out: [64]u8 = undefined;
-    const result = plugin.processReport(&raw, &out);
-    switch (result) {
-        .override => {},
-        else => return error.ExpectedOverride,
-    }
+    try testing.expectEqual(ProcessResult.passthrough, plugin.processReport(&raw, &out));
 
     // Gyro: 10 * 1024000 / 2000 = 5120
     try testing.expectEqual(@as(i16, 5120), readI16le(&out, 16));
@@ -643,11 +642,7 @@ test "imu_cal: process_calibration path and calibrated output" {
     raw[1] = 0xAB;
 
     var out: [64]u8 = undefined;
-    const result = plugin.processReport(&raw, &out);
-    switch (result) {
-        .override => {},
-        else => return error.ExpectedOverride,
-    }
+    try testing.expectEqual(ProcessResult.passthrough, plugin.processReport(&raw, &out));
 
     // Gyro: calibrated = raw * 1024000 / 2000 = raw * 512
     try testing.expectEqual(@as(i16, 10 * 512), readI16le(&out, 16)); // 5120
@@ -688,11 +683,7 @@ test "imu_cal: zero denominator fallback" {
     writeI16le(&raw, 22, 100); // accel_x
 
     var out: [64]u8 = undefined;
-    const result = plugin.processReport(&raw, &out);
-    switch (result) {
-        .override => {},
-        else => return error.ExpectedOverride,
-    }
+    try testing.expectEqual(ProcessResult.passthrough, plugin.processReport(&raw, &out));
 
     // Gyro fallback: 100 * 2097152 / 32767 = 6400 (truncated integer division)
     const gyro_expected: i16 = @intCast(@divTrunc(@as(i64, 100) * 2097152, 32767));


### PR DESCRIPTION
## What
- `uhid_descriptor.zig` `encodeReport`: derive the touchpad finger count from `cfg.touchpad.max_slots` (was unconditionally 2) so the encoded report width matches the emitted descriptor. With `max_slots=1` the kernel previously parsed a 5-byte-too-long report.
- `wasm3_backend.zig`: on plugin success, return `.passthrough` (route the raw report through the interpreter) instead of an empty-delta `.override`, which froze the gamepad when `process_report=true` because `event_loop` short-circuits the interpreter on `.override`.

## Test plan
- New test: `max_slots=1` encoded report length equals descriptor width.
- New test: wasm override path falls back to passthrough; calibration bytes still asserted.
- Full Docker test suite green locally; CI matrix gates.