### PR TITLE
fix(config): fail-closed validation on load — reject out-of-range stick/gyro params and undeclared interface refs

### DIFF
--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -264,6 +264,13 @@ fn isSuppressInterface(cfg: *const DeviceConfig, iface_id: i64) bool {
     return false;
 }
 
+fn interfaceExists(cfg: *const DeviceConfig, iface_id: i64) bool {
+    for (cfg.device.interface) |iface| {
+        if (iface.id == iface_id) return true;
+    }
+    return false;
+}
+
 /// Number of interfaces opened into the devices[] array (everything except
 /// suppress-class interfaces). Suppress interfaces are claimed separately and
 /// consume no DeviceIO slot.
@@ -314,18 +321,22 @@ pub fn validate(cfg: *const DeviceConfig) !void {
     if (openedInterfaceCount(cfg) == 0) return error.InvalidConfig;
 
     // A suppress interface is claimed only to evict the kernel driver; it is
-    // never read or written, so no report/command/init may reference it.
+    // never read or written, so no report/command/init may reference it. Every
+    // referenced interface id must also exist in [[device.interface]].
     for (cfg.report) |report| {
+        if (!interfaceExists(cfg, report.interface)) return error.InvalidConfig;
         if (isSuppressInterface(cfg, report.interface)) return error.InvalidConfig;
     }
     if (cfg.commands) |cmds| {
         var it = cmds.map.iterator();
         while (it.next()) |entry| {
+            if (!interfaceExists(cfg, entry.value_ptr.interface)) return error.InvalidConfig;
             if (isSuppressInterface(cfg, entry.value_ptr.interface)) return error.InvalidConfig;
         }
     }
     if (cfg.device.init) |init_cfg| {
         if (init_cfg.interface) |iface_id| {
+            if (!interfaceExists(cfg, iface_id)) return error.InvalidConfig;
             if (isSuppressInterface(cfg, iface_id)) return error.InvalidConfig;
         }
     }
@@ -1874,4 +1885,56 @@ test "validate: clone_vid_pid=false with zero device.vid is legal" {
     const result = try parseString(allocator, toml_zero_vid_no_clone);
     defer result.deinit();
     try std.testing.expect(!result.value.output.?.force_feedback.?.clone_vid_pid);
+}
+
+test "device: report referencing nonexistent interface id is rejected" {
+    const allocator = std.testing.allocator;
+    const bad_ref_toml =
+        \\[device]
+        \\name = "Bad Ref"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\
+        \\[[report]]
+        \\name = "main"
+        \\interface = 9
+        \\size = 8
+        \\
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x00]
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad_ref_toml));
+}
+
+test "device: command referencing nonexistent interface id is rejected" {
+    const allocator = std.testing.allocator;
+    const bad_cmd_toml =
+        \\[device]
+        \\name = "Bad Cmd Ref"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\
+        \\[[report]]
+        \\name = "main"
+        \\interface = 0
+        \\size = 8
+        \\
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x00]
+        \\
+        \\[commands.rumble]
+        \\interface = 7
+        \\template = "00 {strong} {weak}"
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad_cmd_toml));
 }

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -492,7 +492,11 @@ pub fn validate(cfg: *const DeviceConfig) !void {
 
 pub const ParseResult = toml.Parsed(DeviceConfig);
 
-pub fn parseString(allocator: std.mem.Allocator, content: []const u8) !ParseResult {
+// Parse + apply presets without running validate(). The CLI lint tool needs the
+// parsed config to emit detailed diagnostics (e.g. "interface 99 not declared")
+// before validate()'s fail-closed error.InvalidConfig masks them. Daemon/CLI
+// load paths must use parseString/parseFile, which stay fail-closed.
+pub fn parseStringRaw(allocator: std.mem.Allocator, content: []const u8) !ParseResult {
     var parser = toml.Parser(DeviceConfig).init(allocator);
     defer parser.deinit();
     var result = try parser.parseString(content);
@@ -504,6 +508,11 @@ pub fn parseString(allocator: std.mem.Allocator, content: []const u8) !ParseResu
             };
         }
     }
+    return result;
+}
+
+pub fn parseString(allocator: std.mem.Allocator, content: []const u8) !ParseResult {
+    var result = try parseStringRaw(allocator, content);
     validate(&result.value) catch |err| {
         result.deinit();
         return err;
@@ -1937,4 +1946,32 @@ test "device: command referencing nonexistent interface id is rejected" {
         \\template = "00 {strong} {weak}"
     ;
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad_cmd_toml));
+}
+
+test "device: init referencing nonexistent interface id is rejected" {
+    const allocator = std.testing.allocator;
+    const bad_init_toml =
+        \\[device]
+        \\name = "Bad Init Ref"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\
+        \\[[report]]
+        \\name = "main"
+        \\interface = 0
+        \\size = 8
+        \\
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x00]
+        \\
+        \\[device.init]
+        \\interface = 5
+        \\commands = ["5aa5"]
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad_init_toml));
 }

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -462,7 +462,10 @@ fn expandMacroStepDelays(result: *ParseResult) !void {
 pub fn parseFile(allocator: std.mem.Allocator, path: []const u8) !ParseResult {
     const content = try std.fs.cwd().readFileAlloc(allocator, path, 1024 * 1024);
     defer allocator.free(content);
-    return parseString(allocator, content);
+    var result = try parseString(allocator, content);
+    errdefer result.deinit();
+    try validate(&result.value);
+    return result;
 }
 
 fn macroExists(cfg: *const MappingConfig, name: []const u8) bool {
@@ -882,6 +885,21 @@ fn warnLintFindings(findings: []const LintFinding) void {
     }
 }
 
+// Stick deadzone is cast to i16 at runtime (mapper.resolveStickConfig); accept
+// only the non-negative i16 range. sensitivity feeds an f32 accumulator that
+// integrates per-frame; cap it so the accumulator cannot overflow into the
+// @intFromFloat used in stick mouse/scroll modes.
+const stick_sensitivity_max: f64 = 1000.0;
+
+fn validateStick(s: *const StickConfig) !void {
+    if (s.deadzone) |dz| {
+        if (dz < 0 or dz > std.math.maxInt(i16)) return error.InvalidConfig;
+    }
+    if (s.sensitivity) |sens| {
+        if (!(sens >= 0.0) or sens > stick_sensitivity_max) return error.InvalidConfig;
+    }
+}
+
 pub fn validate(cfg: *const MappingConfig) !void {
     if (cfg.remap) |*m| {
         try checkRemapMacros(cfg, m);
@@ -890,6 +908,11 @@ pub fn validate(cfg: *const MappingConfig) !void {
     }
     if (cfg.adaptive_trigger) |*at| try validateAdaptiveTrigger(at);
     if (cfg.gyro) |*g| try validateGyroConfig(g, cfg.trigger_threshold);
+
+    if (cfg.stick) |*pair| {
+        if (pair.left) |*s| try validateStick(s);
+        if (pair.right) |*s| try validateStick(s);
+    }
 
     if (needsTriggerThresholdWarn(cfg)) {
         std.log.warn("config: LT/RT used in [remap] or [layer.remap] without trigger_threshold — analog triggers are not synthesized into button events; add trigger_threshold = 128 (or your preferred 0-255 value) to enable", .{});
@@ -936,6 +959,8 @@ pub fn validate(cfg: *const MappingConfig) !void {
         }
         if (layer.adaptive_trigger) |*at| try validateAdaptiveTrigger(at);
         if (layer.gyro) |*g| try validateGyroConfig(g, cfg.trigger_threshold);
+        if (layer.stick_left) |*s| try validateStick(s);
+        if (layer.stick_right) |*s| try validateStick(s);
     }
 }
 
@@ -2277,4 +2302,52 @@ test "AUX_KEY_CODES_MAX equals all key codes plus all mouse buttons" {
     const caps = DerivedAuxCaps{ .needs_keyboard = true, .mouse_buttons = 0xFF };
     const codes = buildAuxKeyCodes(caps, &buf);
     try std.testing.expectEqual(AUX_KEY_CODES_MAX, codes.len);
+}
+
+test "validate: stick deadzone out of i16 range is rejected" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[stick.left]
+        \\deadzone = 100000
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "validate: stick sensitivity above bound is rejected" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[stick.right]
+        \\mode = "mouse"
+        \\sensitivity = 1.0e12
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "validate: in-range stick deadzone and sensitivity accepted" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[stick.left]
+        \\deadzone = 128
+        \\sensitivity = 2.0
+    );
+    defer result.deinit();
+    try validate(&result.value);
+}
+
+test "parseFile: invalid mapping is rejected fail-closed" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{
+        .sub_path = "bad.toml",
+        .data =
+        \\[stick.left]
+        \\deadzone = 100000
+        ,
+    });
+    const path = try tmp.dir.realpathAlloc(allocator, "bad.toml");
+    defer allocator.free(path);
+    try std.testing.expectError(error.InvalidConfig, parseFile(allocator, path));
 }

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -608,6 +608,12 @@ fn validateGyroConfig(g: *const GyroConfig, trigger_threshold: ?u8) !void {
         if (v <= 0.0 or v > 180.0) return error.InvalidConfig;
     }
 
+    // deadzone is cast to i16 at runtime (mapper.resolveGyroConfig); accept
+    // only the non-negative i16 range to avoid @intCast panic in Safe builds.
+    if (g.deadzone) |dz| {
+        if (dz < 0 or dz > std.math.maxInt(i16)) return error.InvalidConfig;
+    }
+
     if (g.activate) |spec| {
         const btn_name = if (std.mem.startsWith(u8, spec, "hold_"))
             spec["hold_".len..]
@@ -2133,6 +2139,39 @@ test "validate: layer gyro valid mode passes" {
         \\
         \\[layer.gyro]
         \\mode = "mouse"
+    );
+    defer result.deinit();
+    try validate(&result.value);
+}
+
+test "validate: gyro deadzone out of i16 range returns error" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[gyro]
+        \\mode = "joystick"
+        \\deadzone = 100000
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "validate: gyro deadzone negative returns error" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[gyro]
+        \\mode = "joystick"
+        \\deadzone = -1
+    );
+    defer result.deinit();
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
+}
+
+test "validate: gyro deadzone at i16 max is valid" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator,
+        \\[gyro]
+        \\mode = "joystick"
+        \\deadzone = 32767
     );
     defer result.deinit();
     try validate(&result.value);

--- a/src/tools/validate.zig
+++ b/src/tools/validate.zig
@@ -423,11 +423,6 @@ test "validate: undeclared interface in report: error reported" {
     const errors = try validateString(allocator, bad);
     defer freeErrors(errors, allocator);
     try testing.expect(errors.len > 0);
-    var found = false;
-    for (errors) |e| {
-        if (std.mem.indexOf(u8, e.message, "interface 99") != null) found = true;
-    }
-    try testing.expect(found);
 }
 
 test "validate: validate devices/flydigi/vader5.toml: 0 errors" {

--- a/src/tools/validate.zig
+++ b/src/tools/validate.zig
@@ -148,7 +148,11 @@ pub fn validateFile(
 
     switch (detectFileKind(content)) {
         .device => {
-            const parsed = device.parseString(allocator, content) catch |err| {
+            // Parse without validate() so validateExtended can emit detailed
+            // diagnostics (e.g. "interface 99 not declared") that validate()'s
+            // fail-closed error.InvalidConfig would otherwise mask. Then run
+            // validate() to surface any remaining fail-closed checks.
+            const parsed = device.parseStringRaw(allocator, content) catch |err| {
                 const msg = try std.fmt.allocPrint(allocator, "parse/schema error: {}", .{err});
                 const file_copy = try allocator.dupe(u8, path);
                 try errors.append(allocator, .{ .file = file_copy, .message = msg });
@@ -156,6 +160,13 @@ pub fn validateFile(
             };
             defer parsed.deinit();
             try validateExtended(&parsed.value, path, &errors, allocator);
+            if (errors.items.len == 0) {
+                device.validate(&parsed.value) catch |err| {
+                    const msg = try std.fmt.allocPrint(allocator, "schema error: {}", .{err});
+                    const file_copy = try allocator.dupe(u8, path);
+                    try errors.append(allocator, .{ .file = file_copy, .message = msg });
+                };
+            }
         },
         .mapping => {
             const parsed = mapping.parseString(allocator, content) catch |err| {
@@ -423,6 +434,11 @@ test "validate: undeclared interface in report: error reported" {
     const errors = try validateString(allocator, bad);
     defer freeErrors(errors, allocator);
     try testing.expect(errors.len > 0);
+    var found = false;
+    for (errors) |e| {
+        if (std.mem.indexOf(u8, e.message, "interface 99") != null) found = true;
+    }
+    try testing.expect(found);
 }
 
 test "validate: validate devices/flydigi/vader5.toml: 0 errors" {


### PR DESCRIPTION
## What
- `mapping.validate()` now runs on every production load path (`parseFile` + daemon switch/reload/discovery), fail-closed: an illegal mapping is rejected instead of silently entering the running daemon (it was previously dead code outside tests/`--validate`).
- Range checks added in validate (all were `@intCast` i64→i16 panic vectors in Safe builds): stick `deadzone` 0..32767, stick/mouse `sensitivity` upper bound, gyro `deadzone` 0..32767.
- `device.validate`: `report`/`command`/`init` interface references must exist in `[[device.interface]]`.
- CLI lint (`validate` tool) keeps its detailed `interface N not declared` diagnostic via a parse-without-validate seam (`parseStringRaw`), then runs `device.validate` for fail-closed coverage.

## Test plan
- Regression tests: `deadzone = 100000` (stick and gyro) rejected with `error.InvalidConfig` instead of panicking; negative deadzone rejected; undeclared interface ref rejected; CLI lint message preserved.
- RED→GREEN verified in Docker (tests fail without the production hunks, pass with them); full suite green (0 failed).