### PR TITLE
fix(interpreter): saturate lt/rt/battery to u8 instead of wrapping with & 0xff

### DIFF
--- a/src/core/interpreter.zig
+++ b/src/core/interpreter.zig
@@ -126,8 +126,8 @@ fn applyFieldTag(delta: *GamepadStateDelta, tag: FieldTag, val: i64) void {
         .ay => delta.ay = saturateCast(i16, val),
         .rx => delta.rx = saturateCast(i16, val),
         .ry => delta.ry = saturateCast(i16, val),
-        .lt => delta.lt = @intCast(val & 0xff),
-        .rt => delta.rt = @intCast(val & 0xff),
+        .lt => delta.lt = saturateCast(u8, val),
+        .rt => delta.rt = saturateCast(u8, val),
         .gyro_x => delta.gyro_x = saturateCast(i16, val),
         .gyro_y => delta.gyro_y = saturateCast(i16, val),
         .gyro_z => delta.gyro_z = saturateCast(i16, val),
@@ -140,7 +140,7 @@ fn applyFieldTag(delta: *GamepadStateDelta, tag: FieldTag, val: i64) void {
         .touch1_y => delta.touch1_y = saturateCast(i16, val),
         .touch0_active => delta.touch0_active = val != 0,
         .touch1_active => delta.touch1_active = val != 0,
-        .battery_level => delta.battery_level = @intCast(val & 0xff),
+        .battery_level => delta.battery_level = saturateCast(u8, val),
         .dpad => {
             const decoded = decodeDpadHat(val);
             delta.dpad_x = decoded.x;

--- a/src/test/transform_boundary_test.zig
+++ b/src/test/transform_boundary_test.zig
@@ -164,3 +164,50 @@ test "negate/abs single-point saturation matches Lean oracle" {
         try testing.expectEqual(@as(i64, 2147483647), interpreter.runTransformChain(-2147483648, &abs_));
     }
 }
+
+fn makeTriggerToml(comptime field: []const u8, comptime transform: []const u8) []const u8 {
+    return "[device]\nname = \"T\"\nvid = 1\npid = 2\n" ++
+        "[[device.interface]]\nid = 0\nclass = \"hid\"\n" ++
+        "[[report]]\nname = \"r\"\ninterface = 0\nsize = 4\n" ++
+        "[report.match]\noffset = 0\nexpect = [0x01]\n" ++
+        "[report.fields]\n" ++ field ++ " = { offset = 2, type = \"u8\", transform = \"" ++ transform ++ "\" }\n";
+}
+
+// lt/rt/battery_level overshoot past 255 after a transform must saturate to
+// the u8 max, not silently wrap via `& 0xff`. scale(0, 300) maps raw 255 to
+// 300; `300 & 0xff == 44` is the wrong wrapped value, saturate gives 255.
+test "boundary: lt saturates instead of wrapping after overshoot" {
+    const allocator = testing.allocator;
+    const parsed = try device.parseString(allocator, makeTriggerToml("lt", "scale(0, 300)"));
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+    var raw = [_]u8{0} ** 4;
+    raw[0] = 0x01;
+    raw[2] = 255;
+    const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+    try testing.expectEqual(@as(?u8, 255), delta.lt);
+}
+
+test "boundary: rt saturates instead of wrapping after overshoot" {
+    const allocator = testing.allocator;
+    const parsed = try device.parseString(allocator, makeTriggerToml("rt", "scale(0, 300)"));
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+    var raw = [_]u8{0} ** 4;
+    raw[0] = 0x01;
+    raw[2] = 255;
+    const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+    try testing.expectEqual(@as(?u8, 255), delta.rt);
+}
+
+test "boundary: battery_level saturates instead of wrapping after overshoot" {
+    const allocator = testing.allocator;
+    const parsed = try device.parseString(allocator, makeTriggerToml("battery_level", "scale(0, 300)"));
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+    var raw = [_]u8{0} ** 4;
+    raw[0] = 0x01;
+    raw[2] = 255;
+    const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+    try testing.expectEqual(@as(?u8, 255), delta.battery_level);
+}


### PR DESCRIPTION
## What
- `interpreter.zig`: `lt` / `rt` / `battery_level` now use `saturateCast(u8, val)` instead of `val & 0xff`. A transform that amplifies a trigger past 255 now clamps to 255 instead of wrapping (e.g. scaled 300 → 255, previously 44), matching the saturation used for the i16 axis fields.

## Not included (deferred — not reproducible at Layer 0)
This batch's other findings were left unfixed because no falsifiable Layer-0 reproduction is possible without new test infrastructure: usbraw persistent-error busy-wait (needs libusb fake), `detach_kernel_driver`/`applyChecksum` warn-only changes (no observable behavior to assert), install XDG pre-seed hard-fail (needs full install harness). Tracked for follow-up.

## Test plan
- New `transform_boundary_test` cases assert saturation, not wrap; RED→GREEN verified in Docker.