### PR TITLE
fix(config): clamp out-of-range stick/gyro values instead of rejecting

### DIFF
--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -464,6 +464,7 @@ pub fn parseFile(allocator: std.mem.Allocator, path: []const u8) !ParseResult {
     defer allocator.free(content);
     var result = try parseString(allocator, content);
     errdefer result.deinit();
+    clampNumericRanges(&result.value);
     try validate(&result.value);
     return result;
 }
@@ -606,12 +607,6 @@ fn validateGyroConfig(g: *const GyroConfig, trigger_threshold: ?u8) !void {
 
     if (g.degrees_full) |v| {
         if (v <= 0.0 or v > 180.0) return error.InvalidConfig;
-    }
-
-    // deadzone is cast to i16 at runtime (mapper.resolveGyroConfig); accept
-    // only the non-negative i16 range to avoid @intCast panic in Safe builds.
-    if (g.deadzone) |dz| {
-        if (dz < 0 or dz > std.math.maxInt(i16)) return error.InvalidConfig;
     }
 
     if (g.activate) |spec| {
@@ -891,18 +886,50 @@ fn warnLintFindings(findings: []const LintFinding) void {
     }
 }
 
-// Stick deadzone is cast to i16 at runtime (mapper.resolveStickConfig); accept
-// only the non-negative i16 range. sensitivity feeds an f32 accumulator that
-// integrates per-frame; cap it so the accumulator cannot overflow into the
-// @intFromFloat used in stick mouse/scroll modes.
-const stick_sensitivity_max: f64 = 1000.0;
+// Deadzone is cast to i16 at runtime (mapper resolve paths); sensitivity feeds
+// an f32 per-frame accumulator that must not overflow @intFromFloat in stick
+// mouse/scroll modes. Out-of-range values are clamped with a warning so
+// existing user configs keep loading.
+const deadzone_max: i64 = std.math.maxInt(i16);
+const sensitivity_max: f64 = 1000.0;
 
-fn validateStick(s: *const StickConfig) !void {
-    if (s.deadzone) |dz| {
-        if (dz < 0 or dz > std.math.maxInt(i16)) return error.InvalidConfig;
+fn clampDeadzone(field: []const u8, dz: *?i64) void {
+    const v = dz.* orelse return;
+    const c = std.math.clamp(v, 0, deadzone_max);
+    if (c != v) {
+        std.log.warn("config: {s}.deadzone {d} out of range [0, {d}], clamped to {d}", .{ field, v, deadzone_max, c });
+        dz.* = c;
     }
-    if (s.sensitivity) |sens| {
-        if (!(sens >= 0.0) or sens > stick_sensitivity_max) return error.InvalidConfig;
+}
+
+fn clampSensitivity(field: []const u8, sens: *?f64) void {
+    const v = sens.* orelse return;
+    if (!(v >= 0.0)) {
+        std.log.warn("config: {s}.sensitivity {d} invalid, clamped to 0", .{ field, v });
+        sens.* = 0.0;
+    } else if (v > sensitivity_max) {
+        std.log.warn("config: {s}.sensitivity {d} out of range [0, {d}], clamped to {d}", .{ field, v, sensitivity_max, sensitivity_max });
+        sens.* = sensitivity_max;
+    }
+}
+
+fn clampStick(field: []const u8, s: *StickConfig) void {
+    clampDeadzone(field, &s.deadzone);
+    clampSensitivity(field, &s.sensitivity);
+}
+
+fn clampNumericRanges(cfg: *MappingConfig) void {
+    if (cfg.gyro) |*g| clampDeadzone("gyro", &g.deadzone);
+    if (cfg.stick) |*pair| {
+        if (pair.left) |*s| clampStick("stick.left", s);
+        if (pair.right) |*s| clampStick("stick.right", s);
+    }
+    const layers = cfg.layer orelse return;
+    // Arena-owned parse output; mutation through the const slice is safe.
+    for (@constCast(layers)) |*layer| {
+        if (layer.gyro) |*g| clampDeadzone("layer.gyro", &g.deadzone);
+        if (layer.stick_left) |*s| clampStick("layer.stick_left", s);
+        if (layer.stick_right) |*s| clampStick("layer.stick_right", s);
     }
 }
 
@@ -914,11 +941,6 @@ pub fn validate(cfg: *const MappingConfig) !void {
     }
     if (cfg.adaptive_trigger) |*at| try validateAdaptiveTrigger(at);
     if (cfg.gyro) |*g| try validateGyroConfig(g, cfg.trigger_threshold);
-
-    if (cfg.stick) |*pair| {
-        if (pair.left) |*s| try validateStick(s);
-        if (pair.right) |*s| try validateStick(s);
-    }
 
     if (needsTriggerThresholdWarn(cfg)) {
         std.log.warn("config: LT/RT used in [remap] or [layer.remap] without trigger_threshold — analog triggers are not synthesized into button events; add trigger_threshold = 128 (or your preferred 0-255 value) to enable", .{});
@@ -965,8 +987,6 @@ pub fn validate(cfg: *const MappingConfig) !void {
         }
         if (layer.adaptive_trigger) |*at| try validateAdaptiveTrigger(at);
         if (layer.gyro) |*g| try validateGyroConfig(g, cfg.trigger_threshold);
-        if (layer.stick_left) |*s| try validateStick(s);
-        if (layer.stick_right) |*s| try validateStick(s);
     }
 }
 
@@ -2144,37 +2164,17 @@ test "validate: layer gyro valid mode passes" {
     try validate(&result.value);
 }
 
-test "validate: gyro deadzone out of i16 range returns error" {
+test "clamp: gyro deadzone at i16 max is kept as-is" {
     const allocator = std.testing.allocator;
-    const result = try parseString(allocator,
-        \\[gyro]
-        \\mode = "joystick"
-        \\deadzone = 100000
-    );
-    defer result.deinit();
-    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
-}
-
-test "validate: gyro deadzone negative returns error" {
-    const allocator = std.testing.allocator;
-    const result = try parseString(allocator,
-        \\[gyro]
-        \\mode = "joystick"
-        \\deadzone = -1
-    );
-    defer result.deinit();
-    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
-}
-
-test "validate: gyro deadzone at i16 max is valid" {
-    const allocator = std.testing.allocator;
-    const result = try parseString(allocator,
+    var result = try parseString(allocator,
         \\[gyro]
         \\mode = "joystick"
         \\deadzone = 32767
     );
     defer result.deinit();
+    clampNumericRanges(&result.value);
     try validate(&result.value);
+    try std.testing.expectEqual(@as(?i64, 32767), result.value.gyro.?.deadzone);
 }
 
 test "chord remap: layer-level chord too long is rejected by validate" {
@@ -2343,50 +2343,141 @@ test "AUX_KEY_CODES_MAX equals all key codes plus all mouse buttons" {
     try std.testing.expectEqual(AUX_KEY_CODES_MAX, codes.len);
 }
 
-test "validate: stick deadzone out of i16 range is rejected" {
+test "clamp: in-range stick deadzone and sensitivity kept as-is" {
     const allocator = std.testing.allocator;
-    const result = try parseString(allocator,
-        \\[stick.left]
-        \\deadzone = 100000
-    );
-    defer result.deinit();
-    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
-}
-
-test "validate: stick sensitivity above bound is rejected" {
-    const allocator = std.testing.allocator;
-    const result = try parseString(allocator,
-        \\[stick.right]
-        \\mode = "mouse"
-        \\sensitivity = 1.0e12
-    );
-    defer result.deinit();
-    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
-}
-
-test "validate: in-range stick deadzone and sensitivity accepted" {
-    const allocator = std.testing.allocator;
-    const result = try parseString(allocator,
+    var result = try parseString(allocator,
         \\[stick.left]
         \\deadzone = 128
         \\sensitivity = 2.0
     );
     defer result.deinit();
+    clampNumericRanges(&result.value);
     try validate(&result.value);
+    try std.testing.expectEqual(@as(?i64, 128), result.value.stick.?.left.?.deadzone);
+    try std.testing.expectEqual(@as(?f64, 2.0), result.value.stick.?.left.?.sensitivity);
 }
 
-test "parseFile: invalid mapping is rejected fail-closed" {
+test "parseFile: structurally invalid mapping is rejected fail-closed" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try tmp.dir.writeFile(.{
         .sub_path = "bad.toml",
         .data =
-        \\[stick.left]
-        \\deadzone = 100000
+        \\[gyro]
+        \\mode = "bogus"
         ,
     });
     const path = try tmp.dir.realpathAlloc(allocator, "bad.toml");
     defer allocator.free(path);
     try std.testing.expectError(error.InvalidConfig, parseFile(allocator, path));
+}
+
+fn parseTmpFile(tmp: *std.testing.TmpDir, allocator: std.mem.Allocator, data: []const u8) !ParseResult {
+    try tmp.dir.writeFile(.{ .sub_path = "m.toml", .data = data });
+    const path = try tmp.dir.realpathAlloc(allocator, "m.toml");
+    defer allocator.free(path);
+    return parseFile(allocator, path);
+}
+
+test "parseFile: oversized stick deadzone is clamped and loads" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const result = try parseTmpFile(&tmp, allocator,
+        \\[stick.left]
+        \\deadzone = 50000
+    );
+    defer result.deinit();
+    try std.testing.expectEqual(@as(?i64, 32767), result.value.stick.?.left.?.deadzone);
+}
+
+test "parseFile: oversized stick sensitivity is clamped and loads" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const result = try parseTmpFile(&tmp, allocator,
+        \\[stick.right]
+        \\mode = "mouse"
+        \\sensitivity = 1.0e12
+    );
+    defer result.deinit();
+    try std.testing.expectEqual(@as(?f64, 1000.0), result.value.stick.?.right.?.sensitivity);
+}
+
+test "parseFile: negative stick sensitivity is clamped and loads" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const result = try parseTmpFile(&tmp, allocator,
+        \\[stick.left]
+        \\sensitivity = -2.0
+    );
+    defer result.deinit();
+    try std.testing.expectEqual(@as(?f64, 0.0), result.value.stick.?.left.?.sensitivity);
+}
+
+test "parseFile: oversized gyro deadzone is clamped and loads" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const result = try parseTmpFile(&tmp, allocator,
+        \\[gyro]
+        \\mode = "joystick"
+        \\deadzone = 100000
+    );
+    defer result.deinit();
+    try std.testing.expectEqual(@as(?i64, 32767), result.value.gyro.?.deadzone);
+}
+
+test "parseFile: negative gyro deadzone is clamped and loads" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const result = try parseTmpFile(&tmp, allocator,
+        \\[gyro]
+        \\mode = "joystick"
+        \\deadzone = -1
+    );
+    defer result.deinit();
+    try std.testing.expectEqual(@as(?i64, 0), result.value.gyro.?.deadzone);
+}
+
+test "parseFile: per-layer stick and gyro values are clamped and loads" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const result = try parseTmpFile(&tmp, allocator,
+        \\[[layer]]
+        \\name = "aim"
+        \\trigger = "LM"
+        \\[layer.gyro]
+        \\mode = "joystick"
+        \\deadzone = 40000
+        \\[layer.stick_left]
+        \\deadzone = -5
+        \\sensitivity = 2000.0
+    );
+    defer result.deinit();
+    const layer = result.value.layer.?[0];
+    try std.testing.expectEqual(@as(?i64, 32767), layer.gyro.?.deadzone);
+    try std.testing.expectEqual(@as(?i64, 0), layer.stick_left.?.deadzone);
+    try std.testing.expectEqual(@as(?f64, 1000.0), layer.stick_left.?.sensitivity);
+}
+
+test "shipped mappings parse, clamp, and validate" {
+    const allocator = std.testing.allocator;
+    const shipped = [_][]const u8{
+        @embedFile("../../examples/mappings/chord-output.toml"),
+        @embedFile("../../examples/mappings/chord-switch-mapping-a.toml"),
+        @embedFile("../../examples/mappings/comprehensive.toml"),
+        @embedFile("../../mappings/vader5.toml"),
+        @embedFile("../../mappings/vader5-test-mapping.toml"),
+    };
+    for (shipped) |content| {
+        var result = try parseString(allocator, content);
+        defer result.deinit();
+        clampNumericRanges(&result.value);
+        try validate(&result.value);
+    }
 }

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -892,6 +892,8 @@ fn warnLintFindings(findings: []const LintFinding) void {
 // existing user configs keep loading.
 const deadzone_max: i64 = std.math.maxInt(i16);
 const sensitivity_max: f64 = 1000.0;
+// Anti-overflow guard only; gyro users legitimately need very high values (#359).
+const gyro_sensitivity_max: f64 = 1.0e6;
 
 fn clampDeadzone(field: []const u8, dz: *?i64) void {
     const v = dz.* orelse return;
@@ -918,8 +920,28 @@ fn clampStick(field: []const u8, s: *StickConfig) void {
     clampSensitivity(field, &s.sensitivity);
 }
 
-fn clampNumericRanges(cfg: *MappingConfig) void {
-    if (cfg.gyro) |*g| clampDeadzone("gyro", &g.deadzone);
+fn clampGyroSensField(field: []const u8, sens: *?f64) void {
+    const v = sens.* orelse return;
+    if (!(v >= 0.0)) {
+        std.log.warn("config: {s}.sensitivity {d} invalid, clamped to 0", .{ field, v });
+        sens.* = 0.0;
+    } else if (v > gyro_sensitivity_max) {
+        std.log.warn("config: {s}.sensitivity {d} out of range [0, {d}], clamped to {d}", .{ field, v, gyro_sensitivity_max, gyro_sensitivity_max });
+        sens.* = gyro_sensitivity_max;
+    }
+}
+
+fn clampGyroSensitivities(field: []const u8, g: *GyroConfig) void {
+    clampGyroSensField(field, &g.sensitivity);
+    clampGyroSensField(field, &g.sensitivity_x);
+    clampGyroSensField(field, &g.sensitivity_y);
+}
+
+pub fn clampNumericRanges(cfg: *MappingConfig) void {
+    if (cfg.gyro) |*g| {
+        clampDeadzone("gyro", &g.deadzone);
+        clampGyroSensitivities("gyro", g);
+    }
     if (cfg.stick) |*pair| {
         if (pair.left) |*s| clampStick("stick.left", s);
         if (pair.right) |*s| clampStick("stick.right", s);
@@ -927,7 +949,10 @@ fn clampNumericRanges(cfg: *MappingConfig) void {
     const layers = cfg.layer orelse return;
     // Arena-owned parse output; mutation through the const slice is safe.
     for (@constCast(layers)) |*layer| {
-        if (layer.gyro) |*g| clampDeadzone("layer.gyro", &g.deadzone);
+        if (layer.gyro) |*g| {
+            clampDeadzone("layer.gyro", &g.deadzone);
+            clampGyroSensitivities("layer.gyro", g);
+        }
         if (layer.stick_left) |*s| clampStick("layer.stick_left", s);
         if (layer.stick_right) |*s| clampStick("layer.stick_right", s);
     }
@@ -2463,6 +2488,38 @@ test "parseFile: per-layer stick and gyro values are clamped and loads" {
     try std.testing.expectEqual(@as(?i64, 32767), layer.gyro.?.deadzone);
     try std.testing.expectEqual(@as(?i64, 0), layer.stick_left.?.deadzone);
     try std.testing.expectEqual(@as(?f64, 1000.0), layer.stick_left.?.sensitivity);
+}
+
+test "parseFile: gyro sensitivity overflow is clamped and loads" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const result = try parseTmpFile(&tmp, allocator,
+        \\[gyro]
+        \\mode = "joystick"
+        \\sensitivity = 1.0e40
+        \\sensitivity_x = -5.0
+    );
+    defer result.deinit();
+    try std.testing.expectEqual(@as(?f64, 1.0e6), result.value.gyro.?.sensitivity);
+    try std.testing.expectEqual(@as(?f64, 0.0), result.value.gyro.?.sensitivity_x);
+}
+
+test "parseFile: per-layer gyro sensitivity overflow is clamped and loads" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const result = try parseTmpFile(&tmp, allocator,
+        \\[[layer]]
+        \\name = "aim"
+        \\trigger = "LM"
+        \\[layer.gyro]
+        \\mode = "joystick"
+        \\sensitivity_y = 1.0e40
+    );
+    defer result.deinit();
+    const layer = result.value.layer.?[0];
+    try std.testing.expectEqual(@as(?f64, 1.0e6), layer.gyro.?.sensitivity_y);
 }
 
 test "shipped mappings parse, clamp, and validate" {

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -2109,7 +2109,10 @@ pub const Supervisor = struct {
             };
         };
         defer self.allocator.free(path);
-        const result = mapping_cfg.parseFile(self.allocator, path) catch return null;
+        const result = mapping_cfg.parseFile(self.allocator, path) catch |err| {
+            std.log.warn("skipping default mapping {s}: {}", .{ path, err });
+            return null;
+        };
         const stem = self.allocator.dupe(u8, std.fs.path.stem(path)) catch {
             var r = result;
             r.deinit();
@@ -2165,7 +2168,7 @@ pub const Supervisor = struct {
             const toml_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ dir_path, entry.path });
 
             const parsed = config_device.parseFile(self.allocator, toml_path) catch |err| {
-                std.log.debug("skip {s}: {}", .{ entry.path, err });
+                std.log.warn("skipping device config {s}: {}", .{ toml_path, err });
                 continue;
             };
             const cfg_ptr = try self.allocator.create(config_device.ParseResult);

--- a/src/tools/validate.zig
+++ b/src/tools/validate.zig
@@ -176,6 +176,7 @@ pub fn validateFile(
                 return errors.toOwnedSlice(allocator);
             };
             defer parsed.deinit();
+            mapping.clampNumericRanges(@constCast(&parsed.value));
             mapping.validate(&parsed.value) catch |err| {
                 const msg = try std.fmt.allocPrint(allocator, "mapping validation error: {}", .{err});
                 const file_copy = try allocator.dupe(u8, path);
@@ -554,4 +555,17 @@ test "validate: mapping with bad layer activation fails" {
     const errors = try validateString(allocator, bad);
     defer freeErrors(errors, allocator);
     try testing.expect(errors.len > 0);
+}
+
+test "validate: mapping with overflow gyro sensitivity passes (clamped before validate)" {
+    const allocator = testing.allocator;
+    const toml_content =
+        \\[gyro]
+        \\mode = "joystick"
+        \\sensitivity = 1.0e40
+        \\
+    ;
+    const errors = try validateString(allocator, toml_content);
+    defer freeErrors(errors, allocator);
+    try testing.expectEqual(@as(usize, 0), errors.len);
 }


### PR DESCRIPTION
## What changed
- `clampNumericRanges` in `mapping.parseFile`: stick/gyro `deadzone` clamped to `[0, 32767]`, stick `sensitivity` to `[0, 1000]`, gyro `sensitivity`/`sensitivity_x`/`sensitivity_y` to `[0, 1e6]` (anti-overflow guard only — gyro users legitimately need very high values, see #359); NaN/negative -> 0; each clamp emits one `std.log.warn` naming field, original and clamped value; config still loads
- Removed the numeric reject checks from `validateStick`/`validateGyroConfig` (unreachable after clamping); all structural `validate()` checks (macro refs, gyro mode strings, adaptive trigger, chords, layer rules) stay fail-closed
- `tools/validate.zig` lint path now runs `clampNumericRanges` before `validate`, so `padctl config test` emits the same warnings as the daemon instead of silently accepting out-of-range values
- Supervisor: device-config skip log upgraded debug -> warn with full path + error; rejected default mapping logged at warn with path + error
- Applies to top-level `[stick.*]`/`[gyro]` and per-layer `stick_left`/`stick_right`/`gyro`

## Why
The fail-closed validation added in #394 (unreleased) rejects whole mapping files for out-of-range numerics that earlier releases loaded fine; shipping it as-is would silently disable existing user configs. Clamping preserves the `@intCast`/`@intFromFloat` panic protection while keeping configs loading.

## Test plan
- 8 new parseFile clamp regression tests (verified RED before each implementation step, GREEN after)
- Shipped mappings under `mappings/` and `examples/mappings/` covered by an embed-based load test
- Reviewer falsification check: no-op'ing `clampNumericRanges` makes exactly the clamp tests fail
- Full `zig build test` green in Docker (debian:bookworm, zig 0.15.2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration numeric values that exceed defined limits are now automatically clamped to valid ranges instead of causing the configuration to fail.

* **Bug Fixes**
  * Improved logging when configuration files fail to parse, including detailed error information and file paths.
  * Validation tool now gracefully handles out-of-range numeric configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->