### PR TITLE
fix(supervisor): retry failed device opens via hotplug queue instead of blocking the supervisor thread

### DIFF
--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -92,29 +92,16 @@ fn createDeviceIO(
     return error.UnknownInterfaceClass;
 }
 
+/// Single open attempt. Transient failures are NOT retried here: a blocking
+/// sleep/retry loop on the supervisor thread stalls the control socket (issue
+/// #397). Retries are scheduled by the supervisor's event-driven hotplug queue.
 pub fn openDeviceWithRetry(
     allocator: std.mem.Allocator,
     iface: InterfaceConfig,
     vid: u16,
     pid: u16,
 ) !DeviceIO {
-    const delays = [_]u64{ 1, 2, 4 };
-    var attempt: usize = 0;
-    while (true) {
-        return createDeviceIO(allocator, iface, vid, pid) catch |err| {
-            // A missing-libusb build is a permanent condition; retrying just
-            // delays the inevitable skip. Fail fast with a single line upstream.
-            if (err == error.LibusbUnavailable) return err;
-            if (attempt >= delays.len) {
-                std.log.err("failed to open interface {d} after retries: {}", .{ iface.id, err });
-                return err;
-            }
-            std.log.warn("open interface {d} failed ({}), retrying in {}s...", .{ iface.id, err, delays[attempt] });
-            std.Thread.sleep(delays[attempt] * std.time.ns_per_s);
-            attempt += 1;
-            continue;
-        };
-    }
+    return createDeviceIO(allocator, iface, vid, pid);
 }
 
 /// Primary output ownership. T3 introduces the union so T4 can route the
@@ -134,7 +121,7 @@ pub const Owner = union(enum) {
 /// `test_devices_override` skips the interface-opening loop entirely and
 /// installs the caller-provided `DeviceIO` slice. Needed so a Layer 1 test
 /// can drive `DeviceInstance.init` end-to-end without a real `/dev/hidraw*`
-/// node — otherwise `HidrawDevice.discover` would retry for ~7s and fail in
+/// node — otherwise the legacy in-thread open retry blocked ~7s and failed in
 /// CI before the routing switch is reached. The slice is consumed (stored in
 /// `DeviceInstance.devices`) and freed by `deinit`; caller must not free it.
 /// If `init` returns an error, no instance exists and the caller still owns
@@ -1679,4 +1666,25 @@ test "DeviceInstance: rebindDeviceIO rejects device count mismatch" {
 
     var empty = [_]DeviceIO{};
     try testing.expectError(error.DeviceCountMismatch, inst.rebindDeviceIO(&empty));
+}
+
+// issue #397: openDeviceWithRetry must NOT sleep/retry on the supervisor
+// thread. A failing open must return promptly so the supervisor poll loop can
+// keep servicing the control socket (`padctl status`). The legacy loop slept
+// 1+2+4=7s before returning the error.
+test "openDeviceWithRetry returns promptly on a failing open (no in-thread sleep)" {
+    const allocator = testing.allocator;
+
+    // VID/PID 0xFFFF/0xFFFF matches no real device, so hidraw discover fails
+    // with error.NotFound. The old retry loop classified this as retryable and
+    // slept 7s; the fix returns the error on the first attempt.
+    const iface = InterfaceConfig{ .id = 0, .class = "hid" };
+
+    var timer = try std.time.Timer.start();
+    const result = openDeviceWithRetry(allocator, iface, 0xFFFF, 0xFFFF);
+    const elapsed_ns = timer.read();
+
+    try testing.expectError(error.NotFound, result);
+    // Old code: >= 7s. New code: a bare /dev scan, well under 3s.
+    try testing.expect(elapsed_ns < 3 * std.time.ns_per_s);
 }

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -2371,6 +2371,8 @@ pub const Supervisor = struct {
             error.AccessDenied,
             error.PermissionDenied,
             error.DeviceBusy,
+            error.Busy,
+            error.ClaimFailed,
             error.FileNotFound,
             error.NoDevice,
             error.NotFound,
@@ -2958,6 +2960,17 @@ test "supervisor: cold scan does not queue retry without hidraw candidates" {
     try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
     try testing.expectEqual(@as(usize, 1), sup.configs.items.len);
     try testing.expectEqual(@as(usize, 0), sup.hotplug_pending.items.len);
+}
+
+// issue #397: a libusb claim race (error.Busy) or claim failure on a
+// vendor-class wheel must be classified transient so cold scan/attach queues
+// it for an event-driven retry instead of dropping it.
+test "supervisor: libusb claim races are transient (issue #397)" {
+    try testing.expect(Supervisor.isTransientOpenError(error.Busy));
+    try testing.expect(Supervisor.isTransientOpenError(error.ClaimFailed));
+    try testing.expect(Supervisor.isTransientOpenError(error.AccessDenied));
+    try testing.expect(!Supervisor.isTransientOpenError(error.LibusbUnavailable));
+    try testing.expect(!Supervisor.isTransientOpenError(error.LibusbInit));
 }
 
 test "supervisor: hotplug rawinfo failure is transient" {


### PR DESCRIPTION
## What changed
- `openDeviceWithRetry` no longer sleeps/retries in-thread (was 1+2+4 = 7s of `std.Thread.sleep` per failing device on the supervisor poll thread); single open attempt, error returned immediately; the `std.log.err` "after retries" line removed with the loop
- Transient open/claim failures are retried through the existing event-driven `hotplug_pending` queue (300ms backoff, dedup by devname, give-up after 3 attempts with one warn) — the cold-scan and attach paths already classified and enqueued them
- `isTransientOpenError` now also covers libusb claim races (`error.Busy`, `error.ClaimFailed`) so vendor-class devices hit the queue instead of being dropped; `LibusbUnavailable`/`LibusbInit` stay permanent
- New regression tests: open promptness (fails in ~7s on old code, sub-second now) and transient classification lock-in

## Why
Issue #397: `padctl status` reports "no response from daemon" (3s client timeout) while the daemon retries a failing device open. The blocking retry ran on the poll thread during hotplug/drain attach, starving the control socket. Reproduced on real hardware with the v0.1.14 release binary: after replugging a Vader 5 Pro, a 250ms status probe recorded 5x 3017ms timeouts and 1x 6002ms over ~20s. With this fix under the same poll-thread failing-claim churn (injected ClaimFailed, 300ms retry cycles), 560 consecutive probes all responded in 1-2ms.

## Test plan
- RED: new promptness test fails on unmodified main (blocks 7s, exceeds 3s assertion); empirical falsification by reviewer (re-inserting the sleep loop fails the test)
- GREEN: full `zig build test` green in Docker (zig 0.15.2); filtered new tests pass sub-second
- Real-hardware E2E (maintainer host, Vader 5 Pro): status latency probe under poll-thread claim failures — v0.1.14 baseline 3-6s outages vs this branch max 2ms across 560 samples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device open failure handling by classifying additional error types as transient, allowing retry attempts through the supervisor's event queue rather than blocking the thread.
  * Device opening now responds promptly when encountering transient failures.

* **Tests**
  * Added regression tests to verify proper classification and handling of device open failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->