### PR TITLE
release: bump version to 0.1.15

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.14",
+    .version = "0.1.15",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
## What changed
- build.zig.zon version 0.1.14 -> 0.1.15

## Release contents since v0.1.14
- #399 config validation softening: out-of-range stick/gyro values clamp with warning instead of rejecting the whole mapping; skipped configs logged at warn
- #400 vendored static libusb 1.0.26 in all release builds (root fix for #397/#398: shipped binaries had a stub libusb_init that always failed while vader5.toml requires libusb claiming); --version feature string + release gate
- #402 non-blocking device-open retries via the hotplug queue (fixes the 'padctl status' no-response hang while a device open is failing)

## Test plan
- Release pipeline preflighted in the canonical image with fresh cache: build, (libusb) gate, install artifacts all green
- Real-hardware Vader 5 Pro verification on maintainer host: claim + virtual pad + input flow (GREEN) vs official v0.1.14 (RED, reporter-identical logs)