### PR TITLE
fix(scan): show daemon-claimed devices missing from hidraw enumeration

### DIFF
--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -5,20 +5,9 @@ const udev = @import("install/udev.zig");
 const scan = @import("scan.zig");
 const paths = @import("../config/paths.zig");
 
-pub const StatusDevice = struct {
-    name: []const u8,
-    state: []const u8,
-    vid: u16,
-    pid: u16,
-    output_kind: []const u8,
-    output_fd_alive: bool,
-
-    pub fn deinit(self: StatusDevice, allocator: std.mem.Allocator) void {
-        allocator.free(self.name);
-        allocator.free(self.state);
-        allocator.free(self.output_kind);
-    }
-};
+pub const StatusDevice = socket_client.StatusDevice;
+pub const parseStatusLine = socket_client.parseStatusLine;
+pub const freeStatusDevices = socket_client.freeStatusDevices;
 
 pub const UsbInterface = struct {
     iface: []const u8,
@@ -116,76 +105,6 @@ pub fn probeUsbPresence(allocator: std.mem.Allocator, vid: u16, pid: u16, sys_ro
     }
 
     return UsbPresence{ .present = false, .bus_id = try allocator.dupe(u8, ""), .interfaces = &.{} };
-}
-
-/// Parse the STATUS wire line into a slice of StatusDevice.
-/// Caller owns result; call freeStatusDevices when done.
-pub fn parseStatusLine(line: []const u8, allocator: std.mem.Allocator) ![]StatusDevice {
-    const trimmed = std.mem.trim(u8, line, " \t\r\n");
-    if (!std.mem.startsWith(u8, trimmed, "STATUS")) return error.InvalidResponse;
-
-    var devices: std.ArrayList(StatusDevice) = .{};
-    errdefer {
-        for (devices.items) |d| d.deinit(allocator);
-        devices.deinit(allocator);
-    }
-
-    const rest = trimmed["STATUS".len..];
-    if (rest.len == 0 or std.mem.trim(u8, rest, " \t\r\n").len == 0) {
-        return devices.toOwnedSlice(allocator);
-    }
-
-    var chunks = std.mem.splitSequence(u8, rest, " device=");
-    _ = chunks.next(); // skip leading empty or "STATUS" prefix
-    while (chunks.next()) |chunk| {
-        const name_end = std.mem.indexOfScalar(u8, chunk, ' ') orelse chunk.len;
-        const name = try allocator.dupe(u8, chunk[0..name_end]);
-        errdefer allocator.free(name);
-
-        const state = try extractField(allocator, chunk, "state=");
-        errdefer allocator.free(state);
-        const output_kind = try extractField(allocator, chunk, "output_kind=");
-        errdefer allocator.free(output_kind);
-        const vid = parseHexField(chunk, "vid=0x") orelse 0;
-        const pid = parseHexField(chunk, "pid=0x") orelse 0;
-        const output_fd_alive = std.mem.indexOf(u8, chunk, "output_fd_alive=true") != null;
-
-        try devices.append(allocator, .{
-            .name = name,
-            .state = state,
-            .vid = vid,
-            .pid = pid,
-            .output_kind = output_kind,
-            .output_fd_alive = output_fd_alive,
-        });
-    }
-
-    return devices.toOwnedSlice(allocator);
-}
-
-fn extractField(allocator: std.mem.Allocator, chunk: []const u8, key: []const u8) ![]const u8 {
-    const start_pos = std.mem.indexOf(u8, chunk, key) orelse return allocator.dupe(u8, "");
-    const val_start = start_pos + key.len;
-    const val_end = blk: {
-        var i = val_start;
-        while (i < chunk.len and chunk[i] != ' ' and chunk[i] != '\n' and chunk[i] != '\r') i += 1;
-        break :blk i;
-    };
-    return allocator.dupe(u8, chunk[val_start..val_end]);
-}
-
-fn parseHexField(chunk: []const u8, key: []const u8) ?u16 {
-    const pos = std.mem.indexOf(u8, chunk, key) orelse return null;
-    const val_start = pos + key.len;
-    var end = val_start;
-    while (end < chunk.len and std.ascii.isHex(chunk[end])) end += 1;
-    if (end == val_start) return null;
-    return std.fmt.parseInt(u16, chunk[val_start..end], 16) catch null;
-}
-
-pub fn freeStatusDevices(allocator: std.mem.Allocator, devices: []StatusDevice) void {
-    for (devices) |d| d.deinit(allocator);
-    allocator.free(devices);
 }
 
 pub fn run(allocator: std.mem.Allocator, socket_path: []const u8, writer: anytype, _: anytype) u8 {
@@ -445,45 +364,6 @@ fn printSupportedDevices(allocator: std.mem.Allocator, status_devices: []const S
 // --- tests ---
 
 const testing = std.testing;
-
-test "doctor: parseStatusLine: bare STATUS returns empty" {
-    const devices = try parseStatusLine("STATUS\n", testing.allocator);
-    defer freeStatusDevices(testing.allocator, devices);
-    try testing.expectEqual(@as(usize, 0), devices.len);
-}
-
-test "doctor: parseStatusLine: bare STATUS no newline" {
-    const devices = try parseStatusLine("STATUS", testing.allocator);
-    defer freeStatusDevices(testing.allocator, devices);
-    try testing.expectEqual(@as(usize, 0), devices.len);
-}
-
-test "doctor: parseStatusLine: one device" {
-    const line = "STATUS device=vader5 state=active mapping=default phys_key=usb-1 vid=0x37d7 pid=0x2401 output_kind=uhid output_fd_alive=true evdev_node=/dev/input/event5 hotplug_pending=0 last_inbound_ms_ago=12 last_outbound_ms_ago=8 write_in_flight_ms=0\n";
-    const devices = try parseStatusLine(line, testing.allocator);
-    defer freeStatusDevices(testing.allocator, devices);
-    try testing.expectEqual(@as(usize, 1), devices.len);
-    try testing.expectEqualStrings("vader5", devices[0].name);
-    try testing.expectEqual(@as(u16, 0x37d7), devices[0].vid);
-    try testing.expectEqual(@as(u16, 0x2401), devices[0].pid);
-    try testing.expectEqualStrings("active", devices[0].state);
-    try testing.expectEqualStrings("uhid", devices[0].output_kind);
-    try testing.expect(devices[0].output_fd_alive);
-}
-
-test "doctor: parseStatusLine: two devices" {
-    const line = "STATUS device=vader5 state=active mapping=fps vid=0x37d7 pid=0x2401 output_kind=uhid output_fd_alive=true evdev_node=/dev/input/event5 hotplug_pending=0 last_inbound_ms_ago=1 last_outbound_ms_ago=1 write_in_flight_ms=0 device=wheel state=suspended mapping=racing vid=0x044f pid=0xb67f output_kind=uinput output_fd_alive=false evdev_node=/dev/input/event6 hotplug_pending=0 last_inbound_ms_ago=100 last_outbound_ms_ago=100 write_in_flight_ms=0\n";
-    const devices = try parseStatusLine(line, testing.allocator);
-    defer freeStatusDevices(testing.allocator, devices);
-    try testing.expectEqual(@as(usize, 2), devices.len);
-    try testing.expectEqualStrings("vader5", devices[0].name);
-    try testing.expectEqual(@as(u16, 0x37d7), devices[0].vid);
-    try testing.expectEqualStrings("wheel", devices[1].name);
-    try testing.expectEqual(@as(u16, 0x044f), devices[1].vid);
-    try testing.expectEqual(@as(u16, 0xb67f), devices[1].pid);
-    try testing.expectEqualStrings("suspended", devices[1].state);
-    try testing.expect(!devices[1].output_fd_alive);
-}
 
 test "doctor: probeUsbPresence: device present with driver" {
     const allocator = testing.allocator;

--- a/src/cli/scan.zig
+++ b/src/cli/scan.zig
@@ -6,9 +6,12 @@ const hidraw = @import("../io/hidraw.zig");
 const readPhysicalPath = hidraw.readPhysicalPath;
 const readInterfaceId = hidraw.readInterfaceId;
 const toml_extract = @import("toml_extract.zig");
+const socket_client = @import("socket_client.zig");
+const StatusDevice = socket_client.StatusDevice;
 
 const MAX_HIDRAW = 64;
 const NAME_BUF_LEN = 128;
+const DAEMON_QUERY_TIMEOUT_MS = 500;
 
 // HIDIOCGRAWNAME(128): dir=READ('H', 0x04, 128)
 const HIDIOCGRAWNAME: u32 = blk: {
@@ -298,7 +301,7 @@ fn padRight(buf: []u8, s: []const u8, width: usize) []const u8 {
     return buf[0..width];
 }
 
-pub fn run(allocator: std.mem.Allocator, config_dirs: []const []const u8, writer: anytype) !void {
+pub fn run(allocator: std.mem.Allocator, config_dirs: []const []const u8, socket_path: []const u8, writer: anytype) !void {
     var all_entries: std.ArrayList(ScanEntry) = .{};
     defer {
         for (all_entries.items) |e| freeEntry(allocator, e);
@@ -354,14 +357,34 @@ pub fn run(allocator: std.mem.Allocator, config_dirs: []const []const u8, writer
         }
     }
 
-    const entries = all_entries.items;
+    const daemon_devices = socket_client.queryStatusDevices(allocator, socket_path, DAEMON_QUERY_TIMEOUT_MS);
+    defer if (daemon_devices) |dd| socket_client.freeStatusDevices(allocator, dd);
 
-    if (entries.len == 0) {
+    try render(writer, all_entries.items, daemon_devices orelse &.{});
+}
+
+fn visibleInHidraw(d: StatusDevice, entries: []const ScanEntry) bool {
+    for (entries) |e| {
+        if (e.vid == d.vid and e.pid == d.pid) return true;
+    }
+    return false;
+}
+
+/// Render scan results. Daemon-managed devices whose hidraw nodes are gone
+/// (the libusb claim detached the kernel driver) are merged in as
+/// "(claimed by padctl)" rows, deduplicated by vid:pid.
+fn render(writer: anytype, entries: []const ScanEntry, daemon_devices: []const StatusDevice) !void {
+    var claimed: usize = 0;
+    for (daemon_devices) |d| {
+        if (!visibleInHidraw(d, entries)) claimed += 1;
+    }
+
+    if (entries.len == 0 and claimed == 0) {
         try writer.writeAll("No HID devices found.\n");
         return;
     }
 
-    const path_w = 18;
+    const path_w = 19; // fits "(claimed by padctl)"
     const vidpid_w = 9;
     const name_w = 32;
     const pad_total = path_w + vidpid_w + name_w;
@@ -392,10 +415,25 @@ pub fn run(allocator: std.mem.Allocator, config_dirs: []const []const u8, writer
         if (e.config_path == null) unmatched += 1;
     }
 
+    for (daemon_devices) |d| {
+        if (visibleInHidraw(d, entries)) continue;
+        var vidpid_buf: [9]u8 = undefined;
+        const vidpid = std.fmt.bufPrint(&vidpid_buf, "{x:0>4}:{x:0>4}", .{ d.vid, d.pid }) catch unreachable;
+
+        var row_pad: [pad_total]u8 = undefined;
+        try writer.print("{s} {s} {s} state={s} mapping={s}\n", .{
+            padRight(row_pad[0..path_w], "(claimed by padctl)", path_w),
+            padRight(row_pad[path_w .. path_w + vidpid_w], vidpid, vidpid_w),
+            padRight(row_pad[path_w + vidpid_w .. pad_total], d.name, name_w),
+            d.state,
+            d.mapping,
+        });
+    }
+
     try writer.writeByte('\n');
     try writer.print("{d} device(s) found, {d} matched, {d} unmatched.\n", .{
-        entries.len,
-        entries.len - unmatched,
+        entries.len + claimed,
+        entries.len - unmatched + claimed,
         unmatched,
     });
 
@@ -513,5 +551,74 @@ test "scan: run: explicit single missing config dir surfaces FileNotFound" {
     var buf: [256]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     const dirs = [_][]const u8{"/nonexistent/padctl/devices/path/for/test"};
-    try std.testing.expectError(error.FileNotFound, run(std.testing.allocator, &dirs, fbs.writer()));
+    try std.testing.expectError(error.FileNotFound, run(std.testing.allocator, &dirs, "/tmp/padctl-nonexistent-test.sock", fbs.writer()));
+}
+
+test "scan: run: daemon unreachable degrades to plain scan output" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    var buf: [8192]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const dirs = [_][]const u8{tmp_path};
+    try run(allocator, &dirs, "/tmp/padctl-nonexistent-test.sock", fbs.writer());
+    try std.testing.expect(std.mem.indexOf(u8, fbs.getWritten(), "(claimed by padctl)") == null);
+}
+
+test "scan: render: daemon-claimed device shown when absent from hidraw" {
+    var buf: [1024]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const daemon = [_]StatusDevice{.{
+        .name = "Flydigi Vader 5 Pro",
+        .state = "active",
+        .mapping = "Crimson Desert:Vader 5 Pro",
+        .vid = 0x37d7,
+        .pid = 0x2401,
+        .output_kind = "uinput",
+        .output_fd_alive = true,
+    }};
+    try render(fbs.writer(), &.{}, &daemon);
+    const out = fbs.getWritten();
+    try std.testing.expect(std.mem.indexOf(u8, out, "No HID devices found.") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "(claimed by padctl)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "37d7:2401") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Flydigi Vader 5 Pro") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "state=active mapping=Crimson Desert:Vader 5 Pro") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "1 device(s) found, 1 matched, 0 unmatched.") != null);
+}
+
+test "scan: render: daemon device deduped against hidraw entry with same vid:pid" {
+    var buf: [1024]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const entries = [_]ScanEntry{.{
+        .path = "/dev/hidraw3",
+        .vid = 0x37d7,
+        .pid = 0x2401,
+        .name = "Flydigi Vader 5 Pro",
+        .phys = "usb-0000:10:00.0-3/input1",
+        .config_path = "devices/vader5.toml",
+    }};
+    const daemon = [_]StatusDevice{.{
+        .name = "Flydigi Vader 5 Pro",
+        .state = "active",
+        .mapping = "fps",
+        .vid = 0x37d7,
+        .pid = 0x2401,
+        .output_kind = "uinput",
+        .output_fd_alive = true,
+    }};
+    try render(fbs.writer(), &entries, &daemon);
+    const out = fbs.getWritten();
+    try std.testing.expect(std.mem.indexOf(u8, out, "(claimed by padctl)") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "1 device(s) found, 1 matched, 0 unmatched.") != null);
+}
+
+test "scan: render: no entries and no daemon devices prints No HID devices found" {
+    var buf: [256]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try render(fbs.writer(), &.{}, &.{});
+    try std.testing.expectEqualStrings("No HID devices found.\n", fbs.getWritten());
 }

--- a/src/cli/socket_client.zig
+++ b/src/cli/socket_client.zig
@@ -96,10 +96,14 @@ pub fn connectToSocket(path: []const u8) ConnectError!posix.fd_t {
 }
 
 pub fn sendCommand(fd: posix.fd_t, cmd: []const u8, buf: []u8) ![]const u8 {
+    return sendCommandTimeout(fd, cmd, buf, 3000);
+}
+
+pub fn sendCommandTimeout(fd: posix.fd_t, cmd: []const u8, buf: []u8, timeout_ms: i32) ![]const u8 {
     _ = try posix.write(fd, cmd);
 
     var fds = [_]posix.pollfd{.{ .fd = fd, .events = posix.POLL.IN, .revents = 0 }};
-    const ready = posix.poll(&fds, 3000) catch return error.Io;
+    const ready = posix.poll(&fds, timeout_ms) catch return error.Io;
     if (ready == 0) return error.Timeout;
 
     var total: usize = 0;
@@ -123,6 +127,118 @@ pub fn formatSwitch(buf: []u8, name: []const u8, device_id: ?[]const u8) []const
     }
     const len = (std.fmt.bufPrint(buf, "SWITCH {s}\n", .{name}) catch return buf[0..0]).len;
     return buf[0..len];
+}
+
+pub const StatusDevice = struct {
+    name: []const u8,
+    state: []const u8,
+    mapping: []const u8,
+    vid: u16,
+    pid: u16,
+    output_kind: []const u8,
+    output_fd_alive: bool,
+
+    pub fn deinit(self: StatusDevice, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.state);
+        allocator.free(self.mapping);
+        allocator.free(self.output_kind);
+    }
+};
+
+/// Parse the STATUS wire line into a slice of StatusDevice.
+/// Caller owns result; call freeStatusDevices when done.
+pub fn parseStatusLine(line: []const u8, allocator: std.mem.Allocator) ![]StatusDevice {
+    const trimmed = std.mem.trim(u8, line, " \t\r\n");
+    if (!std.mem.startsWith(u8, trimmed, "STATUS")) return error.InvalidResponse;
+
+    var devices: std.ArrayList(StatusDevice) = .{};
+    errdefer {
+        for (devices.items) |d| d.deinit(allocator);
+        devices.deinit(allocator);
+    }
+
+    const rest = trimmed["STATUS".len..];
+    if (rest.len == 0 or std.mem.trim(u8, rest, " \t\r\n").len == 0) {
+        return devices.toOwnedSlice(allocator);
+    }
+
+    var chunks = std.mem.splitSequence(u8, rest, " device=");
+    _ = chunks.next(); // skip leading empty or "STATUS" prefix
+    while (chunks.next()) |chunk| {
+        // Device and mapping names may contain spaces; their values run until
+        // the next fixed key the daemon emits.
+        const name_end = std.mem.indexOf(u8, chunk, " state=") orelse
+            (std.mem.indexOfScalar(u8, chunk, ' ') orelse chunk.len);
+        const name = try allocator.dupe(u8, chunk[0..name_end]);
+        errdefer allocator.free(name);
+
+        const state = try extractField(allocator, chunk, "state=", null);
+        errdefer allocator.free(state);
+        const mapping = try extractField(allocator, chunk, "mapping=", " phys_key=");
+        errdefer allocator.free(mapping);
+        const output_kind = try extractField(allocator, chunk, "output_kind=", null);
+        errdefer allocator.free(output_kind);
+        const vid = parseHexField(chunk, "vid=0x") orelse 0;
+        const pid = parseHexField(chunk, "pid=0x") orelse 0;
+        const output_fd_alive = std.mem.indexOf(u8, chunk, "output_fd_alive=true") != null;
+
+        try devices.append(allocator, .{
+            .name = name,
+            .state = state,
+            .mapping = mapping,
+            .vid = vid,
+            .pid = pid,
+            .output_kind = output_kind,
+            .output_fd_alive = output_fd_alive,
+        });
+    }
+
+    return devices.toOwnedSlice(allocator);
+}
+
+fn extractField(allocator: std.mem.Allocator, chunk: []const u8, key: []const u8, end_key: ?[]const u8) ![]const u8 {
+    const start_pos = std.mem.indexOf(u8, chunk, key) orelse return allocator.dupe(u8, "");
+    const val_start = start_pos + key.len;
+    if (end_key) |ek| {
+        if (std.mem.indexOfPos(u8, chunk, val_start, ek)) |end| {
+            return allocator.dupe(u8, chunk[val_start..end]);
+        }
+    }
+    var i = val_start;
+    while (i < chunk.len and chunk[i] != ' ' and chunk[i] != '\n' and chunk[i] != '\r') i += 1;
+    return allocator.dupe(u8, chunk[val_start..i]);
+}
+
+fn parseHexField(chunk: []const u8, key: []const u8) ?u16 {
+    const pos = std.mem.indexOf(u8, chunk, key) orelse return null;
+    const val_start = pos + key.len;
+    var end = val_start;
+    while (end < chunk.len and std.ascii.isHex(chunk[end])) end += 1;
+    if (end == val_start) return null;
+    return std.fmt.parseInt(u16, chunk[val_start..end], 16) catch null;
+}
+
+pub fn freeStatusDevices(allocator: std.mem.Allocator, devices: []StatusDevice) void {
+    for (devices) |d| d.deinit(allocator);
+    allocator.free(devices);
+}
+
+/// Best-effort daemon STATUS query with a short timeout. Returns null when the
+/// daemon is unreachable or the response is unusable, so callers can degrade
+/// to daemon-less behavior without error output.
+pub fn queryStatusDevices(allocator: std.mem.Allocator, socket_path: []const u8, timeout_ms: i32) ?[]StatusDevice {
+    const fd = connectToSocket(socket_path) catch |err| {
+        std.log.debug("daemon status query: connect failed: {}", .{err});
+        return null;
+    };
+    defer posix.close(fd);
+    var buf: [4096]u8 = undefined;
+    const resp = sendCommandTimeout(fd, "STATUS\n", &buf, timeout_ms) catch |err| {
+        std.log.debug("daemon status query: no response: {}", .{err});
+        return null;
+    };
+    return parseStatusLine(resp, allocator) catch null;
 }
 
 // --- tests ---
@@ -226,6 +342,16 @@ test "sendCommand: socketpair round-trip" {
     try testing.expectEqualStrings("OK fps\n", resp);
 }
 
+test "sendCommandTimeout: no data within short timeout returns Timeout" {
+    const fds = try testSocketpair();
+    defer posix.close(fds[0]);
+    defer posix.close(fds[1]);
+
+    var buf: [256]u8 = undefined;
+    const result = sendCommandTimeout(fds[0], "STATUS\n", &buf, 50);
+    try testing.expectError(error.Timeout, result);
+}
+
 test "sendCommand: empty response returns EndOfStream" {
     const fds = try testSocketpair();
     defer posix.close(fds[0]);
@@ -280,4 +406,62 @@ test "socket_client: connectToSocket: nonexistent absolute socket yields concret
         error.PermissionDenied => return error.SkipZigTest,
         else => return err,
     }
+}
+
+test "socket_client: parseStatusLine: bare STATUS returns empty" {
+    const devices = try parseStatusLine("STATUS\n", testing.allocator);
+    defer freeStatusDevices(testing.allocator, devices);
+    try testing.expectEqual(@as(usize, 0), devices.len);
+}
+
+test "socket_client: parseStatusLine: bare STATUS no newline" {
+    const devices = try parseStatusLine("STATUS", testing.allocator);
+    defer freeStatusDevices(testing.allocator, devices);
+    try testing.expectEqual(@as(usize, 0), devices.len);
+}
+
+test "socket_client: parseStatusLine: one device" {
+    const line = "STATUS device=vader5 state=active mapping=default phys_key=usb-1 vid=0x37d7 pid=0x2401 output_kind=uhid output_fd_alive=true evdev_node=/dev/input/event5 hotplug_pending=0 last_inbound_ms_ago=12 last_outbound_ms_ago=8 write_in_flight_ms=0\n";
+    const devices = try parseStatusLine(line, testing.allocator);
+    defer freeStatusDevices(testing.allocator, devices);
+    try testing.expectEqual(@as(usize, 1), devices.len);
+    try testing.expectEqualStrings("vader5", devices[0].name);
+    try testing.expectEqual(@as(u16, 0x37d7), devices[0].vid);
+    try testing.expectEqual(@as(u16, 0x2401), devices[0].pid);
+    try testing.expectEqualStrings("active", devices[0].state);
+    try testing.expectEqualStrings("default", devices[0].mapping);
+    try testing.expectEqualStrings("uhid", devices[0].output_kind);
+    try testing.expect(devices[0].output_fd_alive);
+}
+
+test "socket_client: parseStatusLine: two devices" {
+    const line = "STATUS device=vader5 state=active mapping=fps phys_key=usb-1 vid=0x37d7 pid=0x2401 output_kind=uhid output_fd_alive=true evdev_node=/dev/input/event5 hotplug_pending=0 last_inbound_ms_ago=1 last_outbound_ms_ago=1 write_in_flight_ms=0 device=wheel state=suspended mapping=racing phys_key=usb-2 vid=0x044f pid=0xb67f output_kind=uinput output_fd_alive=false evdev_node=/dev/input/event6 hotplug_pending=0 last_inbound_ms_ago=100 last_outbound_ms_ago=100 write_in_flight_ms=0\n";
+    const devices = try parseStatusLine(line, testing.allocator);
+    defer freeStatusDevices(testing.allocator, devices);
+    try testing.expectEqual(@as(usize, 2), devices.len);
+    try testing.expectEqualStrings("vader5", devices[0].name);
+    try testing.expectEqual(@as(u16, 0x37d7), devices[0].vid);
+    try testing.expectEqualStrings("wheel", devices[1].name);
+    try testing.expectEqual(@as(u16, 0x044f), devices[1].vid);
+    try testing.expectEqual(@as(u16, 0xb67f), devices[1].pid);
+    try testing.expectEqualStrings("suspended", devices[1].state);
+    try testing.expectEqualStrings("racing", devices[1].mapping);
+    try testing.expect(!devices[1].output_fd_alive);
+}
+
+test "socket_client: parseStatusLine: device and mapping names with spaces" {
+    // Wire line from issue #404: padctl status for Flydigi Vader 5 Pro.
+    const line = "STATUS device=Flydigi Vader 5 Pro state=active mapping=Crimson Desert:Vader 5 Pro phys_key=usb-0000:10:00.0-3 vid=0x37d7 pid=0x2401 output_kind=uinput output_fd_alive=true evdev_node=/dev/input/event2(Generic X-Box pad) hotplug_pending=0 last_inbound_ms_ago=0 last_outbound_ms_ago=0 write_in_flight_ms=0\n";
+    const devices = try parseStatusLine(line, testing.allocator);
+    defer freeStatusDevices(testing.allocator, devices);
+    try testing.expectEqual(@as(usize, 1), devices.len);
+    try testing.expectEqualStrings("Flydigi Vader 5 Pro", devices[0].name);
+    try testing.expectEqualStrings("Crimson Desert:Vader 5 Pro", devices[0].mapping);
+    try testing.expectEqual(@as(u16, 0x37d7), devices[0].vid);
+    try testing.expectEqual(@as(u16, 0x2401), devices[0].pid);
+    try testing.expectEqualStrings("active", devices[0].state);
+}
+
+test "socket_client: queryStatusDevices: unreachable socket returns null" {
+    try testing.expect(queryStatusDevices(testing.allocator, "/tmp/padctl-nonexistent-test.sock", 500) == null);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -748,7 +748,7 @@ pub fn main() !void {
     if (parsed.scan) {
         if (parsed.scan_config_dir) |dir| {
             const dirs = [_][]const u8{dir};
-            cli.scan.run(allocator, &dirs, stdout_writer) catch |err| {
+            cli.scan.run(allocator, &dirs, parsed.socket_path, stdout_writer) catch |err| {
                 std.log.err("scan failed: {}", .{err});
                 std.process.exit(1);
             };
@@ -758,7 +758,7 @@ pub fn main() !void {
                 std.process.exit(1);
             };
             defer config.paths.freeConfigDirs(allocator, dirs);
-            cli.scan.run(allocator, dirs, stdout_writer) catch |err| {
+            cli.scan.run(allocator, dirs, parsed.socket_path, stdout_writer) catch |err| {
                 std.log.err("scan failed: {}", .{err});
                 std.process.exit(1);
             };


### PR DESCRIPTION
## What changed
- `padctl scan` now queries the daemon STATUS over the control socket (500ms timeout) and merges daemon-claimed devices into the scan table as `(claimed by padctl)` rows showing name, vid:pid, state and mapping
- daemon devices still visible via hidraw are deduplicated by vid:pid
- daemon down / unreachable / unresponsive: scan output unchanged from before (debug log only, no error spam; bounded by the 500ms timeout instead of the default 3s)
- moved `StatusDevice`/`parseStatusLine` from `src/cli/doctor.zig` to `src/cli/socket_client.zig` as the single shared implementation; parser now keeps multi-word device and mapping names intact (`device=Flydigi Vader 5 Pro`, `mapping=Crimson Desert:Vader 5 Pro`)
- added `sendCommandTimeout`; `sendCommand` delegates with the previous 3s default

## Test plan
- new unit tests: render shows claimed row when device absent from hidraw; dedup by vid:pid; empty case still prints "No HID devices found."; run degrades gracefully with unreachable socket; parseStatusLine with spaces in device/mapping names (wire line from the issue); `sendCommandTimeout` returns Timeout within 50ms; `queryStatusDevices` returns null on unreachable socket
- falsifiability: with the merge neutered (`visibleInHidraw` always true), `scan: render: daemon-claimed device shown when absent from hidraw` fails with TestUnexpectedResult
- `zig build test` green in Docker (ghcr.io/bananasjim/padctl-build:0.15.2)
- host E2E: fake daemon socket serving the exact STATUS line from the issue -> scan prints the claimed row merged with real hidraw entries; no daemon -> output identical to before in 2ms; unresponsive daemon -> scan completes in 0.50s

Refs #404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `scan` command now queries the daemon to display devices claimed by padctl, including their state and mapping information.
  * Added timeout handling for daemon socket communication to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->