### PR TITLE
fix(mapper): button remaps targeting LT/RT raise the analog axis floor

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -59,7 +59,7 @@ Without `trigger_threshold`, `LT` / `RT` emit analog axis events only and do not
 
 Top-level button remapping (active when no layer overrides). Keys are ButtonId names, values are target button names, `KEY_*` codes, `mouse_left`/`mouse_right`/`mouse_middle`/`mouse_side`/`mouse_extra`/`mouse_forward`/`mouse_back`, `disabled`, or `macro:<name>`.
 
-`LT` / `RT` as targets emit the digital trigger press plus a full analog pull (ABS_Z / ABS_RZ = 255) while the source button is held.
+`LT` / `RT` as targets emit the digital trigger press plus a full analog pull (ABS_Z / ABS_RZ = 255) while the source button is held. Tap/double gesture legs targeting `LT` / `RT` emit only the digital press; use a plain remap or a `hold` leg for an analog pull.
 
 > **Note:** `BTN_*` values (e.g. `"BTN_SOUTH"`) are routed to the virtual **mouse** device, not the gamepad. To target a gamepad button use a friendly `ButtonId` name (`"A"`, `"Select"`, etc.) instead.
 

--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -59,6 +59,8 @@ Without `trigger_threshold`, `LT` / `RT` emit analog axis events only and do not
 
 Top-level button remapping (active when no layer overrides). Keys are ButtonId names, values are target button names, `KEY_*` codes, `mouse_left`/`mouse_right`/`mouse_middle`/`mouse_side`/`mouse_extra`/`mouse_forward`/`mouse_back`, `disabled`, or `macro:<name>`.
 
+`LT` / `RT` as targets emit the digital trigger press plus a full analog pull (ABS_Z / ABS_RZ = 255) while the source button is held.
+
 > **Note:** `BTN_*` values (e.g. `"BTN_SOUTH"`) are routed to the virtual **mouse** device, not the gamepad. To target a gamepad button use a friendly `ButtonId` name (`"A"`, `"Select"`, etc.) instead.
 
 ```toml

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -130,6 +130,7 @@ Available target types:
 | Value | Effect |
 |-------|--------|
 | `"A"`, `"B"`, `"LB"`, … | Remap to another gamepad button |
+| `"LT"` / `"RT"` | Remap to a trigger — emits the digital press plus a full analog pull (axis 255) while held |
 | `"KEY_*"` | Emit a Linux keyboard key (e.g. `"KEY_F13"`, `"KEY_LEFTSHIFT"`) |
 | `"mouse_left"` / `"mouse_right"` / `"mouse_middle"` / `"mouse_side"` / `"mouse_extra"` | Emit a mouse button |
 | `"mouse_forward"` / `"mouse_back"` | Emit mouse forward/back (button 4/5) |

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -130,7 +130,7 @@ Available target types:
 | Value | Effect |
 |-------|--------|
 | `"A"`, `"B"`, `"LB"`, … | Remap to another gamepad button |
-| `"LT"` / `"RT"` | Remap to a trigger — emits the digital press plus a full analog pull (axis 255) while held |
+| `"LT"` / `"RT"` | Remap to a trigger — emits the digital press plus a full analog pull (axis 255) while held; tap/double gesture legs emit only the digital press, so use a plain remap or a `hold` leg for an analog pull |
 | `"KEY_*"` | Emit a Linux keyboard key (e.g. `"KEY_F13"`, `"KEY_LEFTSHIFT"`) |
 | `"mouse_left"` / `"mouse_right"` / `"mouse_middle"` / `"mouse_side"` / `"mouse_extra"` | Emit a mouse button |
 | `"mouse_forward"` / `"mouse_back"` | Emit mouse forward/back (button 4/5) |

--- a/src/core/macro_player.zig
+++ b/src/core/macro_player.zig
@@ -15,21 +15,7 @@ const ButtonId = state_mod.ButtonId;
 /// Analog floor contributed by macros for LT/RT. Mapper merges this into
 /// emit_state.lt/rt via @max so a physical press always wins over the macro
 /// when stronger (digital BTN_TL2 alone is not seen by SDL/games).
-pub const AxisInjection = struct {
-    lt: u8 = 0,
-    rt: u8 = 0,
-};
-
-fn axisFloorOf(target: RemapTargetResolved) ?struct { lt: u8, rt: u8 } {
-    return switch (target) {
-        .gamepad_button => |b| switch (b) {
-            .LT => .{ .lt = 255, .rt = 0 },
-            .RT => .{ .lt = 0, .rt = 255 },
-            else => null,
-        },
-        else => null,
-    };
-}
+pub const AxisInjection = remap.AxisFloor;
 
 fn raiseAxis(dst: *u8, value: u8) void {
     if (value > dst.*) dst.* = value;
@@ -125,7 +111,7 @@ pub const MacroPlayer = struct {
                 .tap => |name| {
                     const target = resolveTargetSafe(name) orelse continue;
                     remap.applyTarget(target, .tap, aux, injected_buttons, pending_tap_release, null);
-                    if (axisFloorOf(target)) |f| {
+                    if (remap.axisFloorOf(target)) |f| {
                         raiseAxis(&axes.lt, f.lt);
                         raiseAxis(&axes.rt, f.rt);
                     }
@@ -133,7 +119,7 @@ pub const MacroPlayer = struct {
                 .down => |name| {
                     const target = resolveTargetSafe(name) orelse continue;
                     remap.applyTarget(target, .press, aux, injected_buttons, null, &self.held_gamepad_buttons);
-                    if (axisFloorOf(target)) |f| {
+                    if (remap.axisFloorOf(target)) |f| {
                         raiseAxis(&self.held_axis_lt, f.lt);
                         raiseAxis(&self.held_axis_rt, f.rt);
                     }
@@ -141,7 +127,7 @@ pub const MacroPlayer = struct {
                 .up => |name| {
                     const target = resolveTargetSafe(name) orelse continue;
                     remap.applyTarget(target, .release, aux, injected_buttons, null, &self.held_gamepad_buttons);
-                    if (axisFloorOf(target)) |f| {
+                    if (remap.axisFloorOf(target)) |f| {
                         if (f.lt != 0) self.held_axis_lt = 0;
                         if (f.rt != 0) self.held_axis_rt = 0;
                     }

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -538,6 +538,8 @@ pub const Mapper = struct {
             }
         }
 
+        var inject_axes: remap_mod.AxisFloor = .{};
+
         for (0..BUTTON_COUNT) |i| {
             const src_mask: u64 = @as(u64, 1) << @as(u6, @intCast(i));
             const pressed = (self.state.buttons & src_mask) != 0;
@@ -571,7 +573,13 @@ pub const Mapper = struct {
                 .gamepad_button => {
                     // Level-triggered: OR bit each frame while held;
                     // `injected_buttons` is reset at frame start so release is implicit.
-                    if (pressed) remap_mod.applyTarget(target, .press, &aux, &self.injected_buttons, null, null);
+                    if (pressed) {
+                        remap_mod.applyTarget(target, .press, &aux, &self.injected_buttons, null, null);
+                        if (remap_mod.axisFloorOf(target)) |f| {
+                            if (f.lt > inject_axes.lt) inject_axes.lt = f.lt;
+                            if (f.rt > inject_axes.rt) inject_axes.rt = f.rt;
+                        }
+                    }
                 },
                 .key, .mouse_button => {
                     if (pressed and !prev_pressed) {
@@ -598,6 +606,12 @@ pub const Mapper = struct {
 
         // Re-assert the active layer's `hold` passthrough gamepad bit each frame.
         self.injected_buttons |= self.layer_held_gamepad;
+
+        // Gesture hold legs and layer hold passthrough drive LT/RT via these
+        // masks rather than per_src_inject; give them the same analog floor.
+        const held_gamepad = self.gesture_held_gamepad | self.layer_held_gamepad;
+        if (held_gamepad & buttonBit("LT") != 0) inject_axes.lt = 255;
+        if (held_gamepad & buttonBit("RT") != 0) inject_axes.rt = 255;
 
         if (action.tap_event) |tap| {
             emitTapEvent(self, tap, &aux, now_ns);
@@ -640,10 +654,12 @@ pub const Mapper = struct {
         // assemble emit state
         var emit_state = self.state;
         emit_state.buttons = (self.state.buttons & ~self.suppressed_buttons) | self.injected_buttons;
-        // macros driving LT/RT raise the analog axis floor; physical input
-        // still wins when the user presses harder than the macro.
+        // macros and remaps driving LT/RT raise the analog axis floor; physical
+        // input still wins when the user presses harder.
         if (macro_axes.lt > emit_state.lt) emit_state.lt = macro_axes.lt;
         if (macro_axes.rt > emit_state.rt) emit_state.rt = macro_axes.rt;
+        if (inject_axes.lt > emit_state.lt) emit_state.lt = inject_axes.lt;
+        if (inject_axes.rt > emit_state.rt) emit_state.rt = inject_axes.rt;
         emit_state.synthesizeDpadAxes();
         if (suppress_dpad_hat) {
             emit_state.dpad_x = 0;
@@ -1587,6 +1603,117 @@ test "mapper: inject last-write wins: layer inject overrides base inject for sam
 
     try testing.expectEqual(@as(u64, 0), events.gamepad.buttons & (@as(u64, 1) << x_idx));
     try testing.expect((events.gamepad.buttons & (@as(u64, 1) << y_idx)) != 0);
+}
+
+test "mapper: remap to RT raises analog axis while held, drops on release" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[remap]
+        \\M1 = "RT"
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const held = try m.apply(.{ .buttons = buttonBit("M1") }, 16, 0);
+    try testing.expect((held.gamepad.buttons & buttonBit("RT")) != 0);
+    try testing.expectEqual(@as(u8, 255), held.gamepad.rt);
+
+    const released = try m.apply(.{ .buttons = 0 }, 16, 0);
+    try testing.expectEqual(@as(u8, 0), released.gamepad.rt);
+}
+
+test "mapper: remap to LT raises analog axis while held" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[remap]
+        \\M2 = "LT"
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const held = try m.apply(.{ .buttons = buttonBit("M2") }, 16, 0);
+    try testing.expect((held.gamepad.buttons & buttonBit("LT")) != 0);
+    try testing.expectEqual(@as(u8, 255), held.gamepad.lt);
+    try testing.expectEqual(@as(u8, 0), held.gamepad.rt);
+}
+
+test "mapper: remap axis floor max-merges with physical trigger" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[remap]
+        \\A = "RT"
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const events = try m.apply(.{ .buttons = buttonBit("A"), .rt = 200 }, 16, 0);
+    try testing.expectEqual(@as(u8, 255), events.gamepad.rt);
+}
+
+test "mapper: physical trigger unchanged without remap" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping("", allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const events = try m.apply(.{ .rt = 200 }, 16, 0);
+    try testing.expectEqual(@as(u8, 200), events.gamepad.rt);
+}
+
+test "mapper: layer remap to RT raises analog axis" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[[layer]]
+        \\name = "aim"
+        \\trigger = "LB"
+        \\activation = "hold"
+        \\
+        \\[layer.remap]
+        \\A = "RT"
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const configs = parsed.value.layer.?;
+    _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
+    _ = m.layer.onTimerExpired();
+
+    const events = try m.apply(.{ .buttons = buttonBit("A") }, 16, 0);
+    try testing.expect((events.gamepad.buttons & buttonBit("RT")) != 0);
+    try testing.expectEqual(@as(u8, 255), events.gamepad.rt);
+}
+
+test "mapper: gesture hold to RT raises analog axis while held" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[remap]
+        \\A = { tap = "X", hold = "RT", hold_ms = 100 }
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const a_mask = buttonBit("A");
+    _ = try m.apply(.{ .buttons = a_mask }, 16, 0);
+    _ = m.onMacroTimerExpired(100 * std.time.ns_per_ms + 1);
+
+    const held = try m.apply(.{ .buttons = a_mask }, 16, 110 * std.time.ns_per_ms);
+    try testing.expect((held.gamepad.buttons & buttonBit("RT")) != 0);
+    try testing.expectEqual(@as(u8, 255), held.gamepad.rt);
+
+    const released = try m.apply(.{ .buttons = 0 }, 16, 120 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(u8, 0), released.gamepad.rt);
 }
 
 test "mapper: prev frame masking: suppress produces correct diff" {

--- a/src/core/remap.zig
+++ b/src/core/remap.zig
@@ -96,6 +96,22 @@ pub fn applyTarget(
     }
 }
 
+pub const AxisFloor = struct { lt: u8 = 0, rt: u8 = 0 };
+
+/// Digital LT/RT targets imply a full analog pull — games read ABS_Z/ABS_RZ,
+/// not BTN_TL2/BTN_TR2. Callers max-merge the floor into emitted lt/rt so
+/// physical input still wins when stronger.
+pub fn axisFloorOf(target: RemapTargetResolved) ?AxisFloor {
+    return switch (target) {
+        .gamepad_button => |b| switch (b) {
+            .LT => .{ .lt = 255 },
+            .RT => .{ .rt = 255 },
+            else => null,
+        },
+        else => null,
+    };
+}
+
 pub const CHORD_MIN_KEYS: usize = 2;
 pub const CHORD_MAX_KEYS: usize = 4;
 


### PR DESCRIPTION
## What changed

- `src/core/remap.zig`: new pub `AxisFloor` + `axisFloorOf` — digital LT/RT targets imply a full analog pull (games read ABS_Z/ABS_RZ, not BTN_TL2/BTN_TR2)
- `src/core/macro_player.zig`: use the shared `remap.axisFloorOf` instead of its private copy; `AxisInjection` is now an alias of `remap.AxisFloor`
- `src/core/mapper.zig`: frame-local `inject_axes` floor raised in the `.gamepad_button` remap-inject arm (covers base `[remap]` and `[layer.remap]` — both flow through `per_src_inject`) and from the gesture-hold / layer-hold passthrough masks; max-merged into `emit_state.lt/rt` next to the existing macro axis merge, so physical input still wins when pressed harder
- Gesture `tap`/`double` legs targeting LT/RT remain digital-only one-frame events (staged through the shared pending-tap-release machinery; flooring them would require threading axis state through the timer-context gesture path) — plain `[remap]` is the documented way to hold a trigger
- Docs: `mapping-guide.md` target-types table + `mapping-config.md` `[remap]` section now document LT/RT as valid targets emitting a full analog press

## Test plan

- 6 new mapper tests: remap M1→RT raises rt to 255 while held / 0 on release; LT variant; physical rt=200 + floor max-merges to 255; physical rt=200 with no remap unchanged; `[layer.remap]` A→RT; gesture `hold = "RT"`
- Red proof against unfixed mapper: 1667/1683 passed, 5 failed (the 5 fix-dependent tests, e.g. `expected 255, found 0`)
- Green: `zig build test` in `ghcr.io/bananasjim/padctl-build:0.15.2` exits 0

Refs #405, #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified trigger remapping behavior and analog value emission.

* **Bug Fixes**
  * Remapping buttons to triggers now properly emits full analog values while held.
  * Layer and gesture hold-to-trigger now correctly raises analog output.
  * Improved consistency in trigger analog handling across remap targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->