### PR TITLE
fix(install): udev driver-block rules check live daemon socket instead of install-time sentinel

### DIFF
--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -166,79 +166,83 @@ jobs:
                 exit 1
               fi
 
-              # ---- Scenario A: enabled install => sentinel-gated rule + predicate-true reaches unbind ----
+              # ---- Scenario A: install => socket-gated rule + guard tracks daemon socket ----
               # Sandbox install: sudo SUDO_USER=testuser ... padctl install --prefix /usr/local
               #   - is_root=true (sudo), destdir="" => staging_mode=false
-              #   - detectImmutableOs("")=.none in privileged debian:12 (writable /usr,
-              #     no /run/ostree-booted) => effective_immutable=false
               #   - resolveUdevDir(destdir="",prefix="/usr/local",imm=false)
               #     => /usr/local/lib/udev/rules.d  (plan.zig:65-70)
-              #   - installWillStartUserService(true,null,"","testuser")=true
-              #     => do_enable_systemctl = !staging && true = true  (plan.zig:383)
-              #   - shouldProactiveUnbind = do_enable_systemctl && !no_enable = true
-              #     => writeServiceSentinel runs (sentinelPath("")=/etc/padctl/service-enabled),
-              #        independent of the systemctl --user warn-fail (no user bus)
               #   - device TOMLs pre-staged at /usr/local/share/padctl/devices => vader5
-              #     block_kernel_drivers=["xpad"] => 61 rule emitted, sentinel-gated.
-              echo "=== sentinel mechanism invariants (Scenario A: enabled install) ==="
+              #     block_kernel_drivers=["xpad"] => 61 rule emitted, gated on the
+              #     runtime daemon socket (issue #406), never on an install-time file.
+              echo "=== socket-guard invariants (Scenario A: enabled install) ==="
               FAIL=0
 
               # Literal single quotes inside this docker -c argument (the whole
               # script is single-quoted by the host runner shell) would prematurely
               # close the host single-quote and corrupt parsing. Keep every check
-              # predicate single-quote-free: the sentinel-gate substring lives in a
-              # double-quoted variable and grep -F matches it verbatim.
-              SENTINEL=/etc/padctl/service-enabled
-              SENTINEL_GATE="test -e ${SENTINEL} && "
+              # predicate single-quote-free: the guard substring lives in a
+              # double-quoted variable; grep -F matches it verbatim and sh -c
+              # evaluates it (globs expand there).
+              GUARD="(ls /run/user/*/padctl.sock || ls /run/padctl/padctl.sock) >/dev/null 2>&1"
               RULE=/usr/local/lib/udev/rules.d/61-padctl-driver-block.rules
 
               check "61 driver-block rule exists" \
                 "[ -f \"\$RULE\" ]"
 
-              check "61 rule unbind is sentinel-gated" \
-                "grep -qF -- \"\$SENTINEL_GATE\" \"\$RULE\""
+              check "61 rule unbind is socket-gated" \
+                "grep -qF -- \"\$GUARD && \" \"\$RULE\""
 
-              check "sentinel present after enabled install" \
-                "[ -e \"\$SENTINEL\" ]"
+              check "61 rule remove action falls back to modprobe" \
+                "grep -qF -- \"\$GUARD || /sbin/modprobe xpad\" \"\$RULE\""
 
-              mkdir -p /tmp/fakesys && : > /tmp/fakesys/unbind
-              check "predicate-true reaches unbind" \
-                "{ [ -e \"\$SENTINEL\" ] && printf %s 1-1:1.0 > /tmp/fakesys/unbind; }; [ -s /tmp/fakesys/unbind ]"
+              check "61 rule carries no sentinel reference" \
+                "! grep -q service-enabled \"\$RULE\""
+
+              check "no sentinel file written by install" \
+                "[ ! -e /etc/padctl/service-enabled ]"
+
+              check "guard false with no daemon socket" \
+                "! sh -c \"\$GUARD\""
+
+              mkdir -p /run/user/1234 && : > /run/user/1234/padctl.sock
+              check "guard true with user-scope socket" \
+                "sh -c \"\$GUARD\""
+              rm -rf /run/user/1234
+
+              mkdir -p /run/padctl && : > /run/padctl/padctl.sock
+              check "guard true with system-scope socket" \
+                "sh -c \"\$GUARD\""
+              rm -rf /run/padctl
 
               if [ $FAIL -ne 0 ]; then
                 echo "=== SCENARIO A FAILED ==="
                 exit 1
               fi
 
-              # ---- Scenario B: --no-enable install => no sentinel => predicate-false skips unbind ----
+              # ---- Scenario B: --no-enable install => identical socket-gated rule ----
               su - testuser -c "sudo SUDO_USER=testuser SUDO_UID=$(id -u testuser) \
                 HOME=/home/testuser \
                 /usr/local/bin/padctl install --prefix /usr/local --no-enable 2>&1"
 
-              echo "=== sentinel mechanism invariants (Scenario B: --no-enable install) ==="
+              echo "=== socket-guard invariants (Scenario B: --no-enable install) ==="
               FAIL=0
 
-              check "61 rule still sentinel-gated after --no-enable" \
-                "grep -qF -- \"\$SENTINEL_GATE\" \"\$RULE\""
+              check "61 rule still socket-gated after --no-enable" \
+                "grep -qF -- \"\$GUARD && \" \"\$RULE\""
 
-              check "NO sentinel under --no-enable" \
-                "[ ! -e \"\$SENTINEL\" ]"
-
-              : > /tmp/fakesys/unbind
-              check "predicate-false skips unbind" \
-                "{ [ -e \"\$SENTINEL\" ] && printf %s X > /tmp/fakesys/unbind; }; [ ! -s /tmp/fakesys/unbind ]"
+              check "still no sentinel file under --no-enable" \
+                "[ ! -e /etc/padctl/service-enabled ]"
 
               if [ $FAIL -ne 0 ]; then
                 echo "=== SCENARIO B FAILED ==="
                 exit 1
               fi
 
-              rm -rf /tmp/fakesys
-
-              # Re-install with enabled so sentinel exists for uninstall to remove (Scenario C)
+              # Re-install enabled; plant a legacy sentinel for uninstall to clean (Scenario C)
               su - testuser -c "sudo SUDO_USER=testuser SUDO_UID=$(id -u testuser) \
                 HOME=/home/testuser \
                 /usr/local/bin/padctl install --prefix /usr/local 2>&1"
+              mkdir -p /etc/padctl && : > /etc/padctl/service-enabled
 
               # ---- uninstall ----
               su - testuser -c "sudo SUDO_USER=testuser SUDO_UID=$(id -u testuser) \
@@ -254,8 +258,8 @@ jobs:
               check "/etc/systemd/user/padctl.service removed after uninstall" \
                 "[ ! -f /etc/systemd/user/padctl.service ]"
 
-              # ---- Scenario C: uninstall removes the sentinel ----
-              check "sentinel removed after uninstall" \
+              # ---- Scenario C: uninstall removes a legacy sentinel ----
+              check "legacy sentinel removed after uninstall" \
                 "[ ! -e /etc/padctl/service-enabled ]"
 
               # ---- issue #137: uninstall removes the generated driver-block

--- a/README.md
+++ b/README.md
@@ -131,13 +131,9 @@ sudo udevadm control --reload-rules
 ```
 
 If your controller config uses `block_kernel_drivers` (currently Flydigi Vader
-5), also enable padctl's driver-block sentinel and then unplug/replug the
-controller:
-
-```sh
-sudo install -d -m 0755 /etc/padctl
-printf 'padctl service-enabled sentinel v1\nprefix=/usr\nwritten-by=package-manager setup\n' | sudo tee /etc/padctl/service-enabled >/dev/null
-```
+5), the driver-block udev rules act on their own: they unbind the kernel driver
+only while a padctl daemon is running (its control socket exists), so just
+unplug/replug the controller after starting the service.
 
 ### From Source
 

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -10,7 +10,7 @@ Device configs are TOML files in `devices/<vendor>/<model>.toml`.
 | `vid` | integer | yes | USB vendor ID (hex literal ok: `0x054c`) |
 | `pid` | integer | yes | USB product ID |
 | `mode` | string | no | Device mode identifier |
-| `block_kernel_drivers` | string[] | no | Kernel driver names to unbind via udev, e.g. `block_kernel_drivers = ["xpad"]`. The generated rule is gated by `/etc/padctl/service-enabled` so padctl only detaches the kernel driver after the service has been enabled. When `padctl install` runs as root, it writes that sentinel and also walks `/sys/bus/usb/drivers/<driver>/unbind` for matching VID:PID pairs immediately. |
+| `block_kernel_drivers` | string[] | no | Kernel driver names to unbind via udev, e.g. `block_kernel_drivers = ["xpad"]`. The generated rule only detaches the kernel driver while a padctl daemon is running (its control socket exists), so a stopped daemon leaves the device to the kernel driver. When `padctl install` runs as root, it also walks `/sys/bus/usb/drivers/<driver>/unbind` for matching VID:PID pairs immediately. |
 
 ### `[[device.interface]]`
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -43,21 +43,11 @@ sudo udevadm control --reload-rules
 ```
 
 If your controller config uses `block_kernel_drivers` (currently Flydigi Vader
-5), enable padctl's runtime driver-block sentinel before reconnecting the
-controller:
-
-```sh
-sudo install -d -m 0755 /etc/padctl
-printf 'padctl service-enabled sentinel v1\nprefix=/usr\nwritten-by=package-manager setup\n' | sudo tee /etc/padctl/service-enabled >/dev/null
-```
-
-Then unplug and replug the controller. If you later disable or remove padctl,
-remove the sentinel too:
-
-```sh
-systemctl --user disable --now padctl.service
-sudo rm -f /etc/padctl/service-enabled
-```
+5), the driver-block udev rules act on their own: they unbind the kernel driver
+only while a padctl daemon is running (its control socket exists under
+`/run/user/<uid>/` or `/run/padctl/`). Unplug and replug the controller after
+starting the service. When the service is stopped or disabled, the rules leave
+the kernel driver alone and restore it on the next unplug.
 
 ## Prerequisites
 
@@ -129,7 +119,7 @@ flag > euid > `--prefix`.
 `padctl install` also sets up the following on all systems:
 
 - **`padctl-reconnect`** — A hotplug script triggered by udev when a controller is plugged in. It re-applies the active mapping through any running padctl daemon socket. It does not start or restart the daemon; `padctl install` enables/starts `padctl.service` unless you pass `--no-enable` or `--no-start`. After suspend/resume the kernel re-emits udev events for re-enumerated devices, so the same hook handles post-wake reconnect — no separate resume unit is needed.
-- **Driver conflict rules** — Auto-generated udev rules that unbind conflicting kernel drivers (e.g., `xpad`) from devices that padctl manages. Configured per-device via `block_kernel_drivers` in device TOML configs. The udev rule is gated by `/etc/padctl/service-enabled` so package installs do not detach a controller before the user service is enabled. When `padctl install` runs as root, it writes that sentinel and also walks `/sys/bus/usb/drivers/<driver>/unbind` for matching VID:PID pairs immediately, so already-bound devices are evicted without waiting for replug (issue #162).
+- **Driver conflict rules** — Auto-generated udev rules that unbind conflicting kernel drivers (e.g., `xpad`) from devices that padctl manages. Configured per-device via `block_kernel_drivers` in device TOML configs. The udev rule only detaches a kernel driver while a padctl daemon is running (its control socket exists), so a plain package install never strips a controller before the service starts. When `padctl install` runs as root, it also walks `/sys/bus/usb/drivers/<driver>/unbind` for matching VID:PID pairs immediately, so already-bound devices are evicted without waiting for replug (issue #162).
 
 ### Install a Mapping
 
@@ -168,7 +158,7 @@ zig build
 sudo ./zig-out/bin/padctl install    # installs binary, service, device configs, and udev rules
 ```
 
-`padctl install` automatically runs `daemon-reload`, enables, and starts `padctl.service` via `sudo -u $SUDO_USER systemctl --user`. It also writes `/etc/padctl/service-enabled` when the service was actually enabled, activating driver-block udev rules for devices that need them. The `systemctl --user enable --now padctl.service` line is only needed if you used `--no-enable` or `--no-start`.
+`padctl install` automatically runs `daemon-reload`, enables, and starts `padctl.service` via `sudo -u $SUDO_USER systemctl --user`. Driver-block udev rules activate on their own once the daemon is running. The `systemctl --user enable --now padctl.service` line is only needed if you used `--no-enable` or `--no-start`.
 
 To auto-start at boot without an active login session (headless setups, Steam Deck game mode):
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -101,18 +101,12 @@ If your device is not listed, capture it and open a device-config contribution.
 systemctl --user daemon-reload
 systemctl --user enable --now padctl.service
 sudo udevadm control --reload-rules
-sudo install -d -m 0755 /etc/padctl
-printf 'padctl service-enabled sentinel v1\nprefix=/usr\nwritten-by=package-manager setup\n' | sudo tee /etc/padctl/service-enabled >/dev/null
 ```
 
-Then unplug and replug the controller. The sentinel activates the
-driver-block udev rule for devices whose TOML sets `block_kernel_drivers`.
-Remove it if you later disable or remove padctl:
-
-```sh
-systemctl --user disable --now padctl.service
-sudo rm -f /etc/padctl/service-enabled
-```
+Then unplug and replug the controller. The driver-block udev rule unbinds the
+kernel driver only while a padctl daemon is running (its control socket exists),
+so no extra setup step is needed — and a stopped daemon means the kernel driver
+keeps the device.
 
 **Source install fix:**
 
@@ -122,10 +116,10 @@ systemctl --user restart padctl.service
 ```
 
 Then unplug and replug the controller. For devices with `block_kernel_drivers`,
-the source installer writes the driver-block sentinel when it enables the user
-service, installs udev rules, and also tries to unbind already attached matching
-devices during install. Do not use `sudo padctl install` as the normal fix for
-AUR or `.deb` installs because it rewrites files that the package manager owns.
+the source installer installs the udev rules and also tries to unbind already
+attached matching devices during install. Do not use `sudo padctl install` as
+the normal fix for AUR or `.deb` installs because it rewrites files that the
+package manager owns.
 
 ---
 

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -139,14 +139,14 @@ fn runInner(allocator: std.mem.Allocator, socket_path: []const u8, writer: anyty
     const connect_fd = socket_client.connectToSocket(socket_path) catch |err| switch (err) {
         error.FileNotFound, error.ConnectionRefused => {
             try writer.writeAll("daemon: DOWN (no socket / not running)\n");
-            try printSentinel(writer);
+            try printDriverBlock(writer);
             try writer.writeByte('\n');
             try printSupportedDevices(allocator, status_devices, exec_start, writer);
             return;
         },
         else => {
             try writer.print("daemon: DOWN (connect error: {})\n", .{err});
-            try printSentinel(writer);
+            try printDriverBlock(writer);
             try writer.writeByte('\n');
             try printSupportedDevices(allocator, status_devices, exec_start, writer);
             return;
@@ -157,7 +157,7 @@ fn runInner(allocator: std.mem.Allocator, socket_path: []const u8, writer: anyty
     var resp_buf: [4096]u8 = undefined;
     const resp = socket_client.sendCommand(connect_fd, "STATUS\n", &resp_buf) catch {
         try writer.writeAll("daemon: UP (no status response)\n");
-        try printSentinel(writer);
+        try printDriverBlock(writer);
         try writer.writeByte('\n');
         try printSupportedDevices(allocator, status_devices, exec_start, writer);
         return;
@@ -171,17 +171,31 @@ fn runInner(allocator: std.mem.Allocator, socket_path: []const u8, writer: anyty
         });
     }
 
-    try printSentinel(writer);
+    try printDriverBlock(writer);
     try writer.writeByte('\n');
     try printSupportedDevices(allocator, status_devices, exec_start, writer);
 }
 
-fn printSentinel(writer: anytype) !void {
-    std.fs.accessAbsolute(udev.runtime_sentinel_path, .{}) catch {
-        try writer.print("sentinel: ABSENT ({s}) — driver-block rules fail-safe disabled\n", .{udev.runtime_sentinel_path});
-        return;
-    };
-    try writer.print("sentinel: present ({s})\n", .{udev.runtime_sentinel_path});
+// Mirrors the daemon_socket_guard glob in the generated driver-block rules.
+fn daemonSocketPresent() bool {
+    if (std.fs.accessAbsolute("/run/padctl/padctl.sock", .{})) |_| return true else |_| {}
+    var dir = std.fs.openDirAbsolute("/run/user", .{ .iterate = true }) catch return false;
+    defer dir.close();
+    var it = dir.iterate();
+    while (it.next() catch null) |entry| {
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const path = std.fmt.bufPrint(&buf, "/run/user/{s}/padctl.sock", .{entry.name}) catch continue;
+        if (std.fs.accessAbsolute(path, .{})) |_| return true else |_| {}
+    }
+    return false;
+}
+
+fn printDriverBlock(writer: anytype) !void {
+    if (daemonSocketPresent()) {
+        try writer.writeAll("driver-block: armed (daemon socket present)\n");
+    } else {
+        try writer.writeAll("driver-block: idle (no daemon socket — kernel drivers keep devices)\n");
+    }
 }
 
 /// Extract the `--config-dir <path>` argument from a unit ExecStart line.

--- a/src/cli/install/phase.zig
+++ b/src/cli/install/phase.zig
@@ -159,17 +159,6 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         mapping_failed = mapping_failed or binding_failed;
     }
 
-    // Sentinel gates the conditional driver-block udev rule:
-    // present ⇒ unbind fires; absent ⇒ xpad keeps the device so a
-    // non-enabled install never leaves the controller ownerless. Always
-    // clear it on the non-enable path so a re-install with --no-enable over
-    // a previously-enabled install does not leave a stale sentinel.
-    if (udev.shouldProactiveUnbind(&plan)) {
-        udev.writeServiceSentinel(allocator, &plan) catch {};
-    } else {
-        udev.removeServiceSentinel(allocator, plan.opts.destdir);
-    }
-
     // Order is load-bearing: reload the udev ruleset, THEN mutate live driver
     // state, THEN start the service. applyDriverState re-probes driverless
     // interfaces, which generates bind uevents udevd evaluates against its
@@ -387,14 +376,17 @@ pub fn uninstall(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
     }
 
-    // Drop the service-enabled sentinel so a future replug of a
-    // block_kernel_drivers device is not unbound by a stale udev rule.
-    udev.removeServiceSentinel(allocator, destdir);
+    // Remove the legacy service-enabled sentinel left by older installs.
+    {
+        const legacy_sentinel = try std.fmt.allocPrint(allocator, "{s}/etc/padctl/service-enabled", .{destdir});
+        defer allocator.free(legacy_sentinel);
+        std.fs.deleteFileAbsolute(legacy_sentinel) catch {};
+    }
 
-    // The 61-padctl-driver-block rule + sentinel are now gone, so a
-    // controller still plugged in and currently unbound from xpad would
-    // otherwise stay unbound until a physical replug (the REMOVE-side modprobe
-    // only fires on a real `remove` uevent). Actively rebind it to the kernel
+    // The 61-padctl-driver-block rule is now gone, so a controller still
+    // plugged in and currently unbound from xpad would otherwise stay
+    // unbound until a physical replug (the REMOVE-side modprobe only fires
+    // on a real `remove` uevent). Actively rebind it to the kernel
     // driver. Only on a live root uninstall (a destdir staging uninstall has no
     // real sysfs to act on). The share dir is read here before it is removed
     // below; collectDeviceEntriesForUninstall also reads /etc/padctl/devices.

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -61,10 +61,7 @@ const parseHexOrDec = _udev.parseHexOrDec;
 const generateUdevRules = _udev.generateUdevRules;
 const generateDriverBlockRules = _udev.generateDriverBlockRules;
 const generateDriverBlockRulesFromEntries = _udev.generateDriverBlockRulesFromEntries;
-const sentinelPath = udev_mod.sentinelPath;
-const runtime_sentinel_path = udev_mod.runtime_sentinel_path;
-const writeServiceSentinel = udev_mod.writeServiceSentinel;
-const removeServiceSentinel = udev_mod.removeServiceSentinel;
+const daemon_socket_guard = udev_mod.daemon_socket_guard;
 const shouldProactiveUnbind = udev_mod.shouldProactiveUnbind;
 
 // migration.zig
@@ -1865,11 +1862,11 @@ test "install: generateDriverBlockRules skips when no drivers configured" {
     return error.TestUnexpectedResult;
 }
 
-// --- conditional driver-block + service-enabled sentinel ---
+// --- conditional driver-block + daemon socket guard ---
 
-// Builds a single-driver entry list and generates the driver-block rules with
-// an explicit sentinel path. Caller owns nothing extra; entries are stack-lived.
-fn genIssue137Rules(allocator: std.mem.Allocator, rules_path: []const u8, sentinel: []const u8) !void {
+// Builds a single-driver entry list and generates the driver-block rules.
+// Caller owns nothing extra; entries are stack-lived.
+fn genIssue137Rules(allocator: std.mem.Allocator, rules_path: []const u8) !void {
     const drivers = [_][]const u8{"xpad"};
     const entries = [_]UdevEntry{.{
         .name = "Test Pad",
@@ -1877,7 +1874,7 @@ fn genIssue137Rules(allocator: std.mem.Allocator, rules_path: []const u8, sentin
         .pid = 0x00c1,
         .block_kernel_drivers = &drivers,
     }};
-    try generateDriverBlockRulesFromEntries(allocator, &entries, rules_path, sentinel);
+    try generateDriverBlockRulesFromEntries(allocator, &entries, rules_path);
 }
 
 fn readRulesFile(allocator: std.mem.Allocator, rules_path: []const u8) ![]u8 {
@@ -1887,10 +1884,10 @@ fn readRulesFile(allocator: std.mem.Allocator, rules_path: []const u8) ![]u8 {
 }
 
 // (1) MUTATION-CI-PROOF: every line that performs an `unbind` must be guarded
-// by a `test -e <sentinel> &&` predicate. FAILS if the sentinel predicate is
-// removed from the unbind RUN+= line in generateDriverBlockRulesFromEntries
-// (reverting to the unconditional `echo %k > .../unbind` shape).
-test "install: #137 every unbind line is sentinel-gated" {
+// by the daemon-socket predicate. FAILS if the guard is removed from the
+// unbind RUN+= line in generateDriverBlockRulesFromEntries (reverting to the
+// unconditional `echo %k > .../unbind` shape).
+test "install: #406 every unbind line is daemon-socket-gated" {
     const testing = std.testing;
     const allocator = testing.allocator;
 
@@ -1901,27 +1898,27 @@ test "install: #137 every unbind line is sentinel-gated" {
 
     const rules_path = try std.fmt.allocPrint(allocator, "{s}/61.rules", .{tmp_path});
     defer allocator.free(rules_path);
-    const sentinel = "/etc/padctl/service-enabled";
-    try genIssue137Rules(allocator, rules_path, sentinel);
+    try genIssue137Rules(allocator, rules_path);
 
     const content = try readRulesFile(allocator, rules_path);
     defer allocator.free(content);
 
-    const guard = try std.fmt.allocPrint(allocator, "test -e {s} &&", .{sentinel});
+    const guard = try std.fmt.allocPrint(allocator, "{s} &&", .{daemon_socket_guard});
     defer allocator.free(guard);
     try testing.expect(std.mem.indexOf(u8, content, guard) != null);
 
     var it = std.mem.splitScalar(u8, content, '\n');
     while (it.next()) |line| {
         if (std.mem.indexOf(u8, line, "unbind") == null) continue;
-        try testing.expect(std.mem.indexOf(u8, line, "test -e ") != null);
-        try testing.expect(std.mem.indexOf(u8, line, sentinel) != null);
+        try testing.expect(std.mem.indexOf(u8, line, daemon_socket_guard) != null);
     }
 }
 
-// (2) FAILS if the ACTION=="remove" rebind loop is deleted from
-// generateDriverBlockRulesFromEntries.
-test "install: #137 generates ACTION==remove rebind line" {
+// (2) FAILS if the ACTION=="remove" rule regresses to the sentinel-era shape:
+// it must modprobe only when no daemon socket exists, and must never echo into
+// the driver's `bind` attribute (always a no-op for a removed device, and the
+// failing echo used to chain into modprobe on every unplug).
+test "install: #406 remove rule modprobes only without daemon socket" {
     const testing = std.testing;
     const allocator = testing.allocator;
 
@@ -1932,16 +1929,50 @@ test "install: #137 generates ACTION==remove rebind line" {
 
     const rules_path = try std.fmt.allocPrint(allocator, "{s}/61.rules", .{tmp_path});
     defer allocator.free(rules_path);
-    try genIssue137Rules(allocator, rules_path, "/etc/padctl/service-enabled");
+    try genIssue137Rules(allocator, rules_path);
 
     const content = try readRulesFile(allocator, rules_path);
     defer allocator.free(content);
 
-    try testing.expect(std.mem.indexOf(u8, content, "ACTION==\"remove\"") != null);
-    try testing.expect(std.mem.indexOf(u8, content, "/bind") != null);
+    const fallback = try std.fmt.allocPrint(allocator, "{s} || /sbin/modprobe xpad", .{daemon_socket_guard});
+    defer allocator.free(fallback);
+
+    var seen_remove = false;
+    var it = std.mem.splitScalar(u8, content, '\n');
+    while (it.next()) |line| {
+        if (std.mem.indexOf(u8, line, "ACTION==\"remove\"") == null) continue;
+        seen_remove = true;
+        try testing.expect(std.mem.indexOf(u8, line, fallback) != null);
+        try testing.expect(std.mem.indexOf(u8, line, "echo") == null);
+        try testing.expect(std.mem.indexOf(u8, line, "/bind") == null);
+    }
+    try testing.expect(seen_remove);
 }
 
-test "install: staged driver-block udev rule uses runtime sentinel path" {
+// (3) FAILS if any install-time sentinel reference creeps back into the rules.
+test "install: #406 rules carry socket globs and no sentinel" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    const rules_path = try std.fmt.allocPrint(allocator, "{s}/61.rules", .{tmp_path});
+    defer allocator.free(rules_path);
+    try genIssue137Rules(allocator, rules_path);
+
+    const content = try readRulesFile(allocator, rules_path);
+    defer allocator.free(content);
+
+    try testing.expect(std.mem.indexOf(u8, content, "/run/user/*/padctl.sock") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "/run/padctl/padctl.sock") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "service-enabled") == null);
+    try testing.expect(std.mem.indexOf(u8, content, "test -e") == null);
+}
+
+test "install: staged driver-block udev rule uses runtime socket paths" {
     const testing = std.testing;
     const allocator = testing.allocator;
 
@@ -1974,38 +2005,13 @@ test "install: staged driver-block udev rule uses runtime sentinel path" {
     const content = try readRulesFile(allocator, rules_path);
     defer allocator.free(content);
 
-    try testing.expect(std.mem.indexOf(u8, content, runtime_sentinel_path) != null);
+    try testing.expect(std.mem.indexOf(u8, content, "/run/user/*/padctl.sock") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "/run/padctl/padctl.sock") != null);
     try testing.expect(std.mem.indexOf(u8, content, destdir) == null);
 }
 
-// (3) FAILS if writeServiceSentinel stops writing or sentinelPath diverges
-// from the file actually written when the plan is enabling & not --no-enable.
-test "install: #137 writeServiceSentinel creates the gating file" {
-    const testing = std.testing;
-    const allocator = testing.allocator;
-
-    var tmp = testing.tmpDir(.{});
-    defer tmp.cleanup();
-    const destdir = try tmp.dir.realpathAlloc(allocator, ".");
-    defer allocator.free(destdir);
-
-    const opts = InstallOptions{ .destdir = destdir };
-    const env = EnvSnapshot{ .uid = 1000, .home = "/home/alice", .sudo_user = null, .sudo_uid = null };
-    const plan = try InstallPlan.compute(allocator, opts, env);
-    defer plan.deinit(allocator);
-    // destdir set → staging → do_enable_systemctl=false; force the enabling
-    // shape this test is about by checking shouldProactiveUnbind precondition
-    // directly is covered by test (7); here we exercise the writer/path pair.
-    try writeServiceSentinel(allocator, &plan);
-
-    const path = try sentinelPath(allocator, destdir);
-    defer allocator.free(path);
-    try std.fs.accessAbsolute(path, .{});
-}
-
-// (4) FAILS if the install path writes a sentinel under --no-enable. Drives
-// the predicate that gates writeServiceSentinel in phase.zig.
-test "install: #137 no sentinel under --no-enable" {
+// (4) FAILS if the install path proactively unbinds under --no-enable.
+test "install: #137 no proactive unbind under --no-enable" {
     const testing = std.testing;
     const opts = InstallOptions{ .no_enable = true, .prefix = "/home/alice/.local" };
     const env = EnvSnapshot{ .uid = 1000, .home = "/home/alice", .sudo_user = null, .sudo_uid = null };
@@ -2015,8 +2021,8 @@ test "install: #137 no sentinel under --no-enable" {
 }
 
 // (5) FAILS if shouldProactiveUnbind returns true when do_enable_systemctl is
-// false (staged build), which would write a sentinel for a non-running install.
-test "install: #137 no sentinel when do_enable_systemctl false" {
+// false (staged build), which would unbind for a non-running install.
+test "install: #137 no proactive unbind when do_enable_systemctl false" {
     const testing = std.testing;
     const opts = InstallOptions{ .destdir = "/tmp/staging137" };
     const env = EnvSnapshot{ .uid = 0, .home = "/root", .sudo_user = null, .sudo_uid = null };
@@ -2024,33 +2030,6 @@ test "install: #137 no sentinel when do_enable_systemctl false" {
     defer plan.deinit(testing.allocator);
     try testing.expect(!plan.do_enable_systemctl);
     try testing.expect(!shouldProactiveUnbind(&plan));
-}
-
-// (6) FAILS if removeServiceSentinel does not delete the file, or is not
-// idempotent (panics / errors on the second call when already absent).
-test "install: #137 removeServiceSentinel deletes and is idempotent" {
-    const testing = std.testing;
-    const allocator = testing.allocator;
-
-    var tmp = testing.tmpDir(.{});
-    defer tmp.cleanup();
-    const destdir = try tmp.dir.realpathAlloc(allocator, ".");
-    defer allocator.free(destdir);
-
-    const opts = InstallOptions{ .destdir = destdir };
-    const env = EnvSnapshot{ .uid = 1000, .home = "/home/alice", .sudo_user = null, .sudo_uid = null };
-    const plan = try InstallPlan.compute(allocator, opts, env);
-    defer plan.deinit(allocator);
-    try writeServiceSentinel(allocator, &plan);
-
-    const path = try sentinelPath(allocator, destdir);
-    defer allocator.free(path);
-    try std.fs.accessAbsolute(path, .{});
-
-    removeServiceSentinel(allocator, destdir);
-    try testing.expectError(error.FileNotFound, std.fs.accessAbsolute(path, .{}));
-    removeServiceSentinel(allocator, destdir); // idempotent: must not error/panic
-    try testing.expectError(error.FileNotFound, std.fs.accessAbsolute(path, .{}));
 }
 
 // (7) FAILS if shouldProactiveUnbind is not exactly

--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -48,70 +48,19 @@ pub const UdevEntry = struct {
     needs_libusb: bool = false,
 };
 
-/// Runtime path checked by installed udev rules. This must never include
-/// `destdir`: package managers stage files under DESTDIR, but udev executes the
-/// rule on the target system after installation.
-pub const runtime_sentinel_path = "/etc/padctl/service-enabled";
+/// POSIX sh guard used inside generated udev RUN+= commands: exits 0 iff a
+/// padctl daemon control socket exists — user-scope /run/user/<uid>/padctl.sock
+/// or system-scope /run/padctl/padctl.sock (socket_client.zig). One glob per ls
+/// invocation: an unmatched glob stays a literal argument and the missing
+/// operand makes ls fail, while a match means every operand exists. A single
+/// `ls glob1 glob2` would fail whenever either glob is unmatched.
+pub const daemon_socket_guard = "(ls /run/user/*/padctl.sock || ls /run/padctl/padctl.sock) >/dev/null 2>&1";
 
-/// Filesystem path to the service-enabled sentinel. `/etc/padctl` is the fixed
-/// FHS sysconfdir (consistent with the reconnect-script `/etc/padctl/mappings`
-/// path in services.zig), so only `destdir` is prefixed — never `prefix`.
-pub fn sentinelPath(allocator: std.mem.Allocator, destdir: []const u8) ![]u8 {
-    return std.fmt.allocPrint(allocator, "{s}/etc/padctl/service-enabled", .{destdir});
-}
-
-/// Proactive unbind / sentinel write is performed only when this install
-/// actually enables and starts a runnable user service. Pure predicate so
-/// tests can table-drive it; the absence of the sentinel is what makes the
-/// generated udev rule fail-safe: absent sentinel ⇒ xpad keeps the device.
+/// Proactive unbind is performed only when this install actually enables and
+/// starts a runnable user service; otherwise an unbound device would be left
+/// ownerless. Pure predicate so tests can table-drive it.
 pub fn shouldProactiveUnbind(plan: *const InstallPlan) bool {
     return plan.do_enable_systemctl and !plan.opts.no_enable;
-}
-
-/// Write the service-enabled sentinel. Only its existence is load-bearing for
-/// the udev `test -e` predicate; the body is provenance for debugging.
-pub fn writeServiceSentinel(allocator: std.mem.Allocator, plan: *const InstallPlan) !void {
-    const dir_path = try std.fmt.allocPrint(allocator, "{s}/etc/padctl", .{plan.opts.destdir});
-    defer allocator.free(dir_path);
-    try ensureDirAll(allocator, dir_path);
-
-    const path = try sentinelPath(allocator, plan.opts.destdir);
-    defer allocator.free(path);
-
-    var buf: [64]u8 = undefined;
-    const now = std.time.timestamp();
-    const es = std.time.epoch.EpochSeconds{ .secs = @intCast(@max(now, 0)) };
-    const yd = es.getEpochDay().calculateYearDay();
-    const md = yd.calculateMonthDay();
-    const ds = es.getDaySeconds();
-    const iso = std.fmt.bufPrint(&buf, "{d:0>4}-{d:0>2}-{d:0>2}T{d:0>2}:{d:0>2}:{d:0>2}Z", .{
-        yd.year,
-        @as(u32, @intFromEnum(md.month)),
-        @as(u32, md.day_index) + 1,
-        ds.getHoursIntoDay(),
-        ds.getMinutesIntoHour(),
-        ds.getSecondsIntoMinute(),
-    }) catch "unknown";
-
-    const content = try std.fmt.allocPrint(
-        allocator,
-        "padctl service-enabled sentinel v1\nprefix={s}\nwritten-by=padctl install\ndate={s}\n",
-        .{ plan.prefix, iso },
-    );
-    defer allocator.free(content);
-
-    var f = try std.fs.createFileAbsolute(path, .{ .truncate = true });
-    defer f.close();
-    try f.writeAll(content);
-}
-
-/// Remove the service-enabled sentinel. Idempotent: a missing file is success
-/// so `--no-enable` re-install over a previously-enabled install and uninstall
-/// can both call this unconditionally.
-pub fn removeServiceSentinel(allocator: std.mem.Allocator, destdir: []const u8) void {
-    const path = sentinelPath(allocator, destdir) catch return;
-    defer allocator.free(path);
-    std.fs.deleteFileAbsolute(path) catch {};
 }
 
 pub fn writeImuUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan) !void {
@@ -285,7 +234,7 @@ pub fn installUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan, 
 
     const driver_rules_path = try std.fmt.allocPrint(allocator, "{s}/61-padctl-driver-block.rules", .{plan.udev_dir});
     defer allocator.free(driver_rules_path);
-    generateDriverBlockRulesFromEntries(allocator, entries, driver_rules_path, runtime_sentinel_path) catch |err| {
+    generateDriverBlockRulesFromEntries(allocator, entries, driver_rules_path) catch |err| {
         var errbuf: [256]u8 = undefined;
         const msg = std.fmt.bufPrint(&errbuf, "warning: driver block rules not generated: {}\n", .{err}) catch "warning: driver block rules error\n";
         _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch {};
@@ -505,7 +454,7 @@ fn generateUdevRulesFromDirs(allocator: std.mem.Allocator, dirs: []const []const
     try generateUdevRulesFromEntries(allocator, entries.items, rules_path, prefix);
 }
 
-pub fn generateDriverBlockRulesFromEntries(allocator: std.mem.Allocator, entries: []const UdevEntry, rules_path: []const u8, sentinel_path: []const u8) !void {
+pub fn generateDriverBlockRulesFromEntries(allocator: std.mem.Allocator, entries: []const UdevEntry, rules_path: []const u8) !void {
     var has_blocks = false;
     for (entries) |e| {
         if (e.block_kernel_drivers.len > 0) {
@@ -525,28 +474,27 @@ pub fn generateDriverBlockRulesFromEntries(allocator: std.mem.Allocator, entries
 
     for (entries) |e| {
         for (e.block_kernel_drivers) |driver| {
-            // Unbind only when the service-enabled sentinel exists. If padctl
-            // is not deployed/enabled the sentinel is absent, `test -e` fails,
-            // `&&` short-circuits, and xpad keeps the device so the controller
-            // still works as a plain kernel gamepad (fail-safe: absent sentinel → skip unbind).
+            // Unbind only when a padctl daemon is actually running (control
+            // socket present). No daemon ⇒ the kernel driver keeps the device
+            // so the controller still works as a plain kernel gamepad.
             const line = try std.fmt.allocPrint(
                 allocator,
-                "ACTION==\"add|bind\", SUBSYSTEM==\"usb\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", DRIVER==\"{s}\", RUN+=\"/bin/sh -c 'test -e {s} && echo %k > /sys/bus/usb/drivers/{s}/unbind'\"\n# {s}\n",
-                .{ e.vid, e.pid, driver, sentinel_path, driver, e.name },
+                "ACTION==\"add|bind\", SUBSYSTEM==\"usb\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", DRIVER==\"{s}\", RUN+=\"/bin/sh -c '{s} && echo %k > /sys/bus/usb/drivers/{s}/unbind'\"\n# {s}\n",
+                .{ e.vid, e.pid, driver, daemon_socket_guard, driver, e.name },
             );
             defer allocator.free(line);
             try buf.appendSlice(allocator, line);
         }
     }
 
-    // On device removal, rebind the kernel driver (or modprobe it) so a stale
-    // unbind never persists across replug when padctl is no longer enabled.
+    // On device removal, restore the kernel driver only when no daemon is
+    // running; a running padctl keeps owning the VID:PID across replug.
     for (entries) |e| {
         for (e.block_kernel_drivers) |driver| {
             const line = try std.fmt.allocPrint(
                 allocator,
-                "ACTION==\"remove\", SUBSYSTEM==\"usb\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", RUN+=\"/bin/sh -c 'test -e {s} && echo %k > /sys/bus/usb/drivers/{s}/bind || /sbin/modprobe {s}'\"\n",
-                .{ e.vid, e.pid, sentinel_path, driver, driver },
+                "ACTION==\"remove\", SUBSYSTEM==\"usb\", ATTRS{{idVendor}}==\"{x:0>4}\", ATTRS{{idProduct}}==\"{x:0>4}\", RUN+=\"/bin/sh -c '{s} || /sbin/modprobe {s}'\"\n",
+                .{ e.vid, e.pid, daemon_socket_guard, driver },
             );
             defer allocator.free(line);
             try buf.appendSlice(allocator, line);
@@ -562,7 +510,7 @@ pub fn generateDriverBlockRulesFromEntries(allocator: std.mem.Allocator, entries
 fn generateDriverBlockRules(allocator: std.mem.Allocator, dirs: []const []const u8, rules_path: []const u8) !void {
     var entries = try collectDeviceEntries(allocator, dirs);
     defer freeDeviceEntries(allocator, &entries);
-    try generateDriverBlockRulesFromEntries(allocator, entries.items, rules_path, "/etc/padctl/service-enabled");
+    try generateDriverBlockRulesFromEntries(allocator, entries.items, rules_path);
 }
 
 /// Walk <sys_root>/sys/bus/usb/drivers/<driver>/ and synchronously unbind any
@@ -638,7 +586,7 @@ pub fn probeAndUnbindDrivers(allocator: std.mem.Allocator, entries: []const Udev
 /// Inverse of probeAndUnbindDrivers: walk <sys_root>/sys/bus/usb/devices/ and,
 /// for any USB device whose idVendor:idProduct matches an entry, rebind every
 /// interface that currently has no driver back to a blocked driver. Called by
-/// uninstall after the sentinel + driver-block rule are removed so a controller
+/// uninstall after the driver-block rule is removed so a controller
 /// that is still plugged in and currently unbound is restored to the kernel
 /// driver without requiring a physical replug.
 /// Requires root; skips silently / warn-logs on permission errors. A best-effort


### PR DESCRIPTION
## What changed

- `61-padctl-driver-block.rules` add|bind rule now unbinds the conflicting kernel driver only while a padctl daemon is actually running, detected via control socket presence: `(ls /run/user/*/padctl.sock || ls /run/padctl/padctl.sock) >/dev/null 2>&1` (paths from `src/cli/socket_client.zig`)
- remove rule is now `<socket guard> || /sbin/modprobe <driver>`: restores the kernel driver only when no daemon runs; the old `echo %k > .../bind` was always a no-op for a removed device and its failure chained into `modprobe` on every unplug, loading xpad each time the dongle was pulled
- deleted the `/etc/padctl/service-enabled` sentinel concept (`writeServiceSentinel` / `removeServiceSentinel` / `sentinelPath` / `runtime_sentinel_path`); package-manager installs (AUR/deb) never had the sentinel, so their driver-block rules were permanently inert
- uninstall still deletes a legacy sentinel file if present (one-line cleanup)
- `padctl doctor` now prints `driver-block: armed/idle` from daemon socket presence instead of sentinel presence
- `install-flow.yml` sandbox scenarios rewritten: assert socket-gated rule text, no sentinel file written, guard true/false behavior with user-scope and system-scope sockets, legacy sentinel removal on uninstall
- docs (README, getting-started, troubleshooting, device-config) updated: no manual sentinel step for package installs

## Shell semantics note

The single `ls glob1 glob2` form suggested in the design was verified broken: ls exits non-zero if any operand is missing, so a user-scope-only daemon would fail the guard. The chained `(ls G1 || ls G2)` form was verified in sh for all four cases (user-only, system-only, both absent, multi-user).

## Edge cases

- Daemon starting after device plug: the rule will not unbind retroactively; the companion daemon input-shadow watchdog covers that window
- Multiple users: any user-scope socket arms the guard (glob matches all of /run/user/*/)
- System-scope daemon: covered by the /run/padctl/padctl.sock branch
- Stale socket file after daemon crash: guard stays armed until runtime-dir cleanup; remove-side modprobe is then skipped once, restored on next replug

## Test plan

- `zig build test` green in Docker (ghcr.io/bananasjim/padctl-build:0.15.2)
- Red/green proof: reverting the rule-text hunks (keeping new tests) fails exactly the 4 new/rewritten tests (`#406 every unbind line is daemon-socket-gated`, `#406 remove rule modprobes only without daemon socket`, `#406 rules carry socket globs and no sentinel`, `staged driver-block udev rule uses runtime socket paths`); restoring the fix returns the suite to green
- install-flow.yml exercises the guard against real socket files in the debian:12 sandbox

Refs #406, #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Driver-block udev rules now automatically gate based on daemon presence, eliminating the need for manual sentinel file configuration.
  * Installation and uninstallation processes updated to align with daemon-socket-based control.

* **Documentation**
  * Updated installation, troubleshooting, and configuration guides to reflect how driver unbinding activates when the padctl daemon is running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->