### PR TITLE
fix(supervisor): grab shadow kernel input nodes for managed devices

### DIFF
--- a/src/io/ioctl_constants.zig
+++ b/src/io/ioctl_constants.zig
@@ -29,6 +29,8 @@ pub fn HIDIOCSFEATURE(len: u14) u32 {
 
 // evdev
 pub const EVIOCGRAB = IOCTL.IOW('E', 0x90, c_int);
+pub const EVIOCGID = IOCTL.IOR('E', 0x02, c.input_id);
+pub const InputId = c.input_id;
 
 /// Dynamic-size evdev ioctl: kernel copies up to `len` bytes of the device's
 /// uniq attribute (NUL-terminated) into the user buffer. SDL reads this to

--- a/src/io/netlink.zig
+++ b/src/io/netlink.zig
@@ -57,9 +57,12 @@ pub fn parseUevent(buf: []const u8) Uevent {
     return .{ .action = action, .devname = devname, .subsystem = subsystem };
 }
 
-/// Drain all pending uevent messages from fd, calling callback for each hidraw add/remove.
+pub const Subsystem = enum { hidraw, input };
+
+/// Drain all pending uevent messages from fd, calling callback for each
+/// hidraw add/remove and each input-subsystem event-node add.
 /// Stops when recv returns WouldBlock (EAGAIN).
-pub fn drainNetlink(fd: posix.fd_t, ctx: anytype, comptime callback: fn (@TypeOf(ctx), UeventAction, []const u8) void) void {
+pub fn drainNetlink(fd: posix.fd_t, ctx: anytype, comptime callback: fn (@TypeOf(ctx), UeventAction, Subsystem, []const u8) void) void {
     var buf: [2048]u8 = undefined;
     while (true) {
         const n = posix.recv(fd, &buf, 0) catch return;
@@ -67,9 +70,14 @@ pub fn drainNetlink(fd: posix.fd_t, ctx: anytype, comptime callback: fn (@TypeOf
         const ev = parseUevent(buf[0..n]);
         if (ev.action == .other) continue;
         const sub = ev.subsystem orelse continue;
-        if (!std.mem.eql(u8, sub, "hidraw")) continue;
         const name = ev.devname orelse continue;
-        callback(ctx, ev.action, name);
+        if (std.mem.eql(u8, sub, "hidraw")) {
+            callback(ctx, ev.action, .hidraw, name);
+        } else if (ev.action == .add and std.mem.eql(u8, sub, "input") and
+            std.mem.startsWith(u8, name, "input/event"))
+        {
+            callback(ctx, ev.action, .input, name);
+        }
     }
 }
 
@@ -111,6 +119,57 @@ test "parseUevent: missing DEVNAME" {
     try testing.expectEqual(UeventAction.add, ev.action);
     try testing.expect(ev.devname == null);
     try testing.expectEqualStrings("hidraw", ev.subsystem.?);
+}
+
+const DrainRecorder = struct {
+    actions: [8]UeventAction = undefined,
+    subsystems: [8]Subsystem = undefined,
+    names: [8][32]u8 = undefined,
+    name_lens: [8]usize = undefined,
+    count: usize = 0,
+
+    fn record(self: *@This(), action: UeventAction, subsystem: Subsystem, devname: []const u8) void {
+        if (self.count >= self.actions.len) return;
+        self.actions[self.count] = action;
+        self.subsystems[self.count] = subsystem;
+        @memcpy(self.names[self.count][0..devname.len], devname);
+        self.name_lens[self.count] = devname.len;
+        self.count += 1;
+    }
+};
+
+fn drainTestPair() ![2]posix.fd_t {
+    var fds: [2]i32 = undefined;
+    if (linux.E.init(linux.socketpair(linux.AF.UNIX, linux.SOCK.DGRAM | linux.SOCK.NONBLOCK, 0, &fds)) != .SUCCESS)
+        return error.SocketPairFailed;
+    return fds;
+}
+
+test "drainNetlink: hidraw events pass with .hidraw, input event-node add passes with .input" {
+    const pair = try drainTestPair();
+    defer posix.close(pair[0]);
+    defer posix.close(pair[1]);
+
+    _ = try posix.send(pair[1], "add@/devices/x/hidraw3\x00SUBSYSTEM=hidraw\x00DEVNAME=hidraw3\x00", 0);
+    _ = try posix.send(pair[1], "add@/devices/x/input/input9/event5\x00SUBSYSTEM=input\x00DEVNAME=input/event5\x00", 0);
+    // Non-event input node (the inputN parent) must be filtered out.
+    _ = try posix.send(pair[1], "add@/devices/x/input/input9\x00SUBSYSTEM=input\x00DEVNAME=input/input9\x00", 0);
+    // Input REMOVE must be filtered out (only ADD is forwarded for input).
+    _ = try posix.send(pair[1], "remove@/devices/x/input/input9/event5\x00SUBSYSTEM=input\x00DEVNAME=input/event5\x00", 0);
+    _ = try posix.send(pair[1], "remove@/devices/x/hidraw3\x00SUBSYSTEM=hidraw\x00DEVNAME=hidraw3\x00", 0);
+
+    var rec = DrainRecorder{};
+    drainNetlink(pair[0], &rec, DrainRecorder.record);
+
+    try testing.expectEqual(@as(usize, 3), rec.count);
+    try testing.expectEqual(UeventAction.add, rec.actions[0]);
+    try testing.expectEqual(Subsystem.hidraw, rec.subsystems[0]);
+    try testing.expectEqualStrings("hidraw3", rec.names[0][0..rec.name_lens[0]]);
+    try testing.expectEqual(UeventAction.add, rec.actions[1]);
+    try testing.expectEqual(Subsystem.input, rec.subsystems[1]);
+    try testing.expectEqualStrings("input/event5", rec.names[1][0..rec.name_lens[1]]);
+    try testing.expectEqual(UeventAction.remove, rec.actions[2]);
+    try testing.expectEqual(Subsystem.hidraw, rec.subsystems[2]);
 }
 
 test "parseUevent: libudev header (defensive)" {

--- a/src/io/netlink.zig
+++ b/src/io/netlink.zig
@@ -60,7 +60,7 @@ pub fn parseUevent(buf: []const u8) Uevent {
 pub const Subsystem = enum { hidraw, input };
 
 /// Drain all pending uevent messages from fd, calling callback for each
-/// hidraw add/remove and each input-subsystem event-node add.
+/// hidraw add/remove and each input-subsystem event-node add/remove.
 /// Stops when recv returns WouldBlock (EAGAIN).
 pub fn drainNetlink(fd: posix.fd_t, ctx: anytype, comptime callback: fn (@TypeOf(ctx), UeventAction, Subsystem, []const u8) void) void {
     var buf: [2048]u8 = undefined;
@@ -73,9 +73,7 @@ pub fn drainNetlink(fd: posix.fd_t, ctx: anytype, comptime callback: fn (@TypeOf
         const name = ev.devname orelse continue;
         if (std.mem.eql(u8, sub, "hidraw")) {
             callback(ctx, ev.action, .hidraw, name);
-        } else if (ev.action == .add and std.mem.eql(u8, sub, "input") and
-            std.mem.startsWith(u8, name, "input/event"))
-        {
+        } else if (std.mem.eql(u8, sub, "input") and std.mem.startsWith(u8, name, "input/event")) {
             callback(ctx, ev.action, .input, name);
         }
     }
@@ -145,7 +143,7 @@ fn drainTestPair() ![2]posix.fd_t {
     return fds;
 }
 
-test "drainNetlink: hidraw events pass with .hidraw, input event-node add passes with .input" {
+test "drainNetlink: hidraw events pass with .hidraw, input event-node add/remove pass with .input" {
     const pair = try drainTestPair();
     defer posix.close(pair[0]);
     defer posix.close(pair[1]);
@@ -154,14 +152,14 @@ test "drainNetlink: hidraw events pass with .hidraw, input event-node add passes
     _ = try posix.send(pair[1], "add@/devices/x/input/input9/event5\x00SUBSYSTEM=input\x00DEVNAME=input/event5\x00", 0);
     // Non-event input node (the inputN parent) must be filtered out.
     _ = try posix.send(pair[1], "add@/devices/x/input/input9\x00SUBSYSTEM=input\x00DEVNAME=input/input9\x00", 0);
-    // Input REMOVE must be filtered out (only ADD is forwarded for input).
+    // Input REMOVE must pass so stale shadow grabs can be evicted.
     _ = try posix.send(pair[1], "remove@/devices/x/input/input9/event5\x00SUBSYSTEM=input\x00DEVNAME=input/event5\x00", 0);
     _ = try posix.send(pair[1], "remove@/devices/x/hidraw3\x00SUBSYSTEM=hidraw\x00DEVNAME=hidraw3\x00", 0);
 
     var rec = DrainRecorder{};
     drainNetlink(pair[0], &rec, DrainRecorder.record);
 
-    try testing.expectEqual(@as(usize, 3), rec.count);
+    try testing.expectEqual(@as(usize, 4), rec.count);
     try testing.expectEqual(UeventAction.add, rec.actions[0]);
     try testing.expectEqual(Subsystem.hidraw, rec.subsystems[0]);
     try testing.expectEqualStrings("hidraw3", rec.names[0][0..rec.name_lens[0]]);
@@ -169,7 +167,10 @@ test "drainNetlink: hidraw events pass with .hidraw, input event-node add passes
     try testing.expectEqual(Subsystem.input, rec.subsystems[1]);
     try testing.expectEqualStrings("input/event5", rec.names[1][0..rec.name_lens[1]]);
     try testing.expectEqual(UeventAction.remove, rec.actions[2]);
-    try testing.expectEqual(Subsystem.hidraw, rec.subsystems[2]);
+    try testing.expectEqual(Subsystem.input, rec.subsystems[2]);
+    try testing.expectEqualStrings("input/event5", rec.names[2][0..rec.name_lens[2]]);
+    try testing.expectEqual(UeventAction.remove, rec.actions[3]);
+    try testing.expectEqual(Subsystem.hidraw, rec.subsystems[3]);
 }
 
 test "parseUevent: libudev header (defensive)" {

--- a/src/io/shadow_grab.zig
+++ b/src/io/shadow_grab.zig
@@ -1,0 +1,224 @@
+//! Shadow input-node watchdog (issue #406).
+//!
+//! When a kernel driver (e.g. xpad) binds an unclaimed interface of a managed
+//! pad it creates a raw /dev/input/event* node carrying all buttons. SDL and
+//! games sometimes read that node instead of padctl's virtual device, so
+//! "disabled" bindings leak through. EVIOCGRAB hides a node from all other
+//! readers and needs no privileges under active-seat ACLs.
+
+const std = @import("std");
+const posix = std.posix;
+const linux = std.os.linux;
+const ioctl = @import("ioctl_constants.zig");
+const uniq_mod = @import("uniq.zig");
+
+pub const MAX_GRABS = @import("hidraw.zig").MAX_EVDEV_GRABS;
+
+const BUS_VIRTUAL: u16 = 0x06;
+const NAME_CAP = 24;
+
+pub const Params = struct {
+    phys_vendor: u16,
+    phys_product: u16,
+    output_vendor: ?u16 = null,
+    output_product: ?u16 = null,
+};
+
+const Grab = struct {
+    fd: posix.fd_t,
+    name_buf: [NAME_CAP]u8,
+    name_len: u8,
+
+    fn name(self: *const Grab) []const u8 {
+        return self.name_buf[0..self.name_len];
+    }
+};
+
+pub const GrabList = struct {
+    grabs: [MAX_GRABS]Grab = undefined,
+    len: usize = 0,
+
+    pub fn contains(self: *const GrabList, node: []const u8) bool {
+        for (self.grabs[0..self.len]) |*g| {
+            if (std.mem.eql(u8, g.name(), node)) return true;
+        }
+        return false;
+    }
+
+    /// Closing a grabbed fd implicitly releases its EVIOCGRAB.
+    pub fn releaseAll(self: *GrabList) void {
+        for (self.grabs[0..self.len]) |*g| posix.close(g.fd);
+        self.len = 0;
+    }
+};
+
+/// Pure decision seam: grab when the node carries the managed device's
+/// physical VID/PID and is not one of padctl's own outputs — virtual-bus
+/// uinput, "padctl/"-uniq UHID, or the configured [output] identity.
+pub fn shouldGrab(id: ioctl.InputId, uniq: []const u8, p: Params) bool {
+    if (id.bustype == BUS_VIRTUAL) return false;
+    if (std.mem.startsWith(u8, uniq, uniq_mod.PREFIX)) return false;
+    if (id.vendor != p.phys_vendor or id.product != p.phys_product) return false;
+    if (p.output_vendor) |ov| {
+        if (p.output_product) |op| {
+            if (id.vendor == ov and id.product == op) return false;
+        }
+    }
+    return true;
+}
+
+fn readUniq(fd: posix.fd_t, buf: *[uniq_mod.MAX_UNIQ_LEN]u8) []const u8 {
+    @memset(buf, 0);
+    const rc = linux.ioctl(fd, ioctl.EVIOCGUNIQ(buf.len), @intFromPtr(buf));
+    if (posix.errno(rc) != .SUCCESS) return "";
+    return std.mem.sliceTo(buf, 0);
+}
+
+fn driverName(node: []const u8, buf: []u8) ?[]const u8 {
+    var path_buf: [80]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "/sys/class/input/{s}/device/device/driver", .{node}) catch return null;
+    const target = posix.readlink(path, buf) catch return null;
+    return std.fs.path.basename(target);
+}
+
+/// Probe one event node and grab it when it shadows the managed device.
+/// Returns true when the node was grabbed into `list`.
+pub fn tryGrabNode(list: *GrabList, input_dir: []const u8, node: []const u8, p: Params) bool {
+    if (node.len == 0 or node.len > NAME_CAP) return false;
+    if (list.contains(node)) return false;
+    if (list.len >= list.grabs.len) return false;
+
+    var path_buf: [64]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ input_dir, node }) catch return false;
+    const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch return false;
+
+    var id: ioctl.InputId = undefined;
+    if (linux.E.init(linux.ioctl(fd, ioctl.EVIOCGID, @intFromPtr(&id))) != .SUCCESS) {
+        posix.close(fd);
+        return false;
+    }
+    var uniq_buf: [uniq_mod.MAX_UNIQ_LEN]u8 = undefined;
+    const uniq = readUniq(fd, &uniq_buf);
+    if (!shouldGrab(id, uniq, p)) {
+        posix.close(fd);
+        return false;
+    }
+
+    const grab_errno = linux.E.init(linux.ioctl(fd, ioctl.EVIOCGRAB, 1));
+    if (grab_errno != .SUCCESS) {
+        // EBUSY: someone already holds the exclusive grab (typically padctl's
+        // own hidraw-associated grab), so the node is hidden anyway.
+        if (grab_errno == .BUSY) {
+            std.log.debug("shadow grab: {s} already grabbed", .{path});
+        } else {
+            std.log.warn("shadow grab: EVIOCGRAB {s} failed: {s}", .{ path, @tagName(grab_errno) });
+        }
+        posix.close(fd);
+        return false;
+    }
+
+    list.grabs[list.len] = .{ .fd = fd, .name_buf = undefined, .name_len = @intCast(node.len) };
+    @memcpy(list.grabs[list.len].name_buf[0..node.len], node);
+    list.len += 1;
+
+    var drv_buf: [128]u8 = undefined;
+    if (driverName(node, &drv_buf)) |drv| {
+        std.log.warn("shadow input node {s} ({x:0>4}:{x:0>4}) grabbed; kernel driver {s} bound to a managed device", .{ path, id.vendor, id.product, drv });
+    } else {
+        std.log.warn("shadow input node {s} ({x:0>4}:{x:0>4}) grabbed; kernel driver bound to a managed device", .{ path, id.vendor, id.product });
+    }
+    return true;
+}
+
+/// Enumerate `input_dir` and grab every shadow node of the managed device.
+/// Catches shadows that predate the daemon (the netlink watch only sees new
+/// nodes).
+pub fn sweepDir(list: *GrabList, input_dir: []const u8, p: Params) void {
+    var dir = std.fs.openDirAbsolute(input_dir, .{ .iterate = true }) catch return;
+    defer dir.close();
+    var it = dir.iterate();
+    while (it.next() catch return) |entry| {
+        if (!std.mem.startsWith(u8, entry.name, "event")) continue;
+        _ = tryGrabNode(list, input_dir, entry.name, p);
+    }
+}
+
+// --- tests ---
+
+const testing = std.testing;
+
+fn nodeId(bustype: u16, vendor: u16, product: u16) ioctl.InputId {
+    return .{ .bustype = bustype, .vendor = vendor, .product = product, .version = 0x0110 };
+}
+
+const vader5: Params = .{
+    .phys_vendor = 0x37d7,
+    .phys_product = 0x2401,
+    .output_vendor = 0x045e,
+    .output_product = 0x0b00,
+};
+
+test "shadow_grab: shouldGrab takes xpad shadow node (BUS_USB, physical VID/PID)" {
+    try testing.expect(shouldGrab(nodeId(0x03, 0x37d7, 0x2401), "", vader5));
+}
+
+test "shadow_grab: shouldGrab skips padctl uinput outputs (BUS_VIRTUAL)" {
+    try testing.expect(!shouldGrab(nodeId(0x06, 0x045e, 0x0b00), "", vader5));
+    // Even a virtual-bus node cloning the physical VID/PID is ours, not a shadow.
+    try testing.expect(!shouldGrab(nodeId(0x06, 0x37d7, 0x2401), "", vader5));
+}
+
+test "shadow_grab: shouldGrab skips padctl UHID outputs by uniq prefix" {
+    // clone_vid_pid UHID FFB device: BUS_USB + physical VID/PID, only the
+    // uniq distinguishes it from a real xpad shadow.
+    try testing.expect(!shouldGrab(nodeId(0x03, 0x37d7, 0x2401), "padctl/vader-5-pro-1a2b", vader5));
+}
+
+test "shadow_grab: shouldGrab skips the configured output identity" {
+    var p = vader5;
+    p.phys_vendor = 0x045e;
+    p.phys_product = 0x0b00;
+    try testing.expect(!shouldGrab(nodeId(0x03, 0x045e, 0x0b00), "", p));
+}
+
+test "shadow_grab: shouldGrab skips unrelated devices" {
+    try testing.expect(!shouldGrab(nodeId(0x03, 0x046d, 0xc52b), "", vader5));
+    try testing.expect(!shouldGrab(nodeId(0x05, 0x37d7, 0x2402), "", vader5));
+}
+
+test "shadow_grab: shouldGrab without configured output ids still takes shadows" {
+    const p: Params = .{ .phys_vendor = 0x37d7, .phys_product = 0x2401 };
+    try testing.expect(shouldGrab(nodeId(0x03, 0x37d7, 0x2401), "", p));
+}
+
+test "shadow_grab: GrabList contains/releaseAll bookkeeping" {
+    var list = GrabList{};
+    try testing.expect(!list.contains("event3"));
+
+    const fd = try posix.open("/dev/null", .{ .ACCMODE = .RDONLY }, 0);
+    list.grabs[0] = .{ .fd = fd, .name_buf = undefined, .name_len = 6 };
+    @memcpy(list.grabs[0].name_buf[0..6], "event3");
+    list.len = 1;
+
+    try testing.expect(list.contains("event3"));
+    try testing.expect(!list.contains("event33"));
+    list.releaseAll();
+    try testing.expectEqual(@as(usize, 0), list.len);
+}
+
+test "shadow_grab: tryGrabNode rejects oversized, duplicate, and unopenable nodes" {
+    var list = GrabList{};
+    try testing.expect(!tryGrabNode(&list, "/dev/input", "event-name-way-too-long-to-fit", vader5));
+    try testing.expect(!tryGrabNode(&list, "/nonexistent_input_dir_xyz", "event0", vader5));
+    list.grabs[0] = .{ .fd = -1, .name_buf = undefined, .name_len = 6 };
+    @memcpy(list.grabs[0].name_buf[0..6], "event7");
+    list.len = 1;
+    try testing.expect(!tryGrabNode(&list, "/nonexistent_input_dir_xyz", "event7", vader5));
+    list.len = 0;
+}
+
+test "shadow_grab: sweepDir on nonexistent dir is a no-op" {
+    var list = GrabList{};
+    sweepDir(&list, "/nonexistent_input_dir_xyz", vader5);
+    try testing.expectEqual(@as(usize, 0), list.len);
+}

--- a/src/io/shadow_grab.zig
+++ b/src/io/shadow_grab.zig
@@ -20,9 +20,9 @@ const NAME_CAP = 24;
 pub const Params = struct {
     phys_vendor: u16,
     phys_product: u16,
-    output_vendor: ?u16 = null,
-    output_product: ?u16 = null,
 };
+
+pub const GrabResult = enum { grabbed, skipped, access_denied };
 
 const Grab = struct {
     fd: posix.fd_t,
@@ -50,21 +50,45 @@ pub const GrabList = struct {
         for (self.grabs[0..self.len]) |*g| posix.close(g.fd);
         self.len = 0;
     }
+
+    /// Drop the grab on `node` (the kernel reuses eventN names, so a stale
+    /// entry would block grabbing a new shadow with the same name).
+    pub fn evict(self: *GrabList, node: []const u8) bool {
+        for (self.grabs[0..self.len], 0..) |*g, i| {
+            if (!std.mem.eql(u8, g.name(), node)) continue;
+            posix.close(g.fd);
+            self.len -= 1;
+            self.grabs[i] = self.grabs[self.len];
+            return true;
+        }
+        return false;
+    }
+
+    /// Evict entries whose device is gone (fd answers ENODEV).
+    pub fn pruneDead(self: *GrabList) void {
+        var i: usize = 0;
+        while (i < self.len) {
+            var id: ioctl.InputId = undefined;
+            if (linux.E.init(linux.ioctl(self.grabs[i].fd, ioctl.EVIOCGID, @intFromPtr(&id))) == .NODEV) {
+                posix.close(self.grabs[i].fd);
+                self.len -= 1;
+                self.grabs[i] = self.grabs[self.len];
+            } else {
+                i += 1;
+            }
+        }
+    }
 };
 
 /// Pure decision seam: grab when the node carries the managed device's
 /// physical VID/PID and is not one of padctl's own outputs — virtual-bus
-/// uinput, "padctl/"-uniq UHID, or the configured [output] identity.
+/// uinput or "padctl/"-uniq UHID. The [output] identity is deliberately not
+/// excluded: configs often clone the physical VID/PID, and padctl's outputs
+/// are already covered by the bus/uniq checks.
 pub fn shouldGrab(id: ioctl.InputId, uniq: []const u8, p: Params) bool {
     if (id.bustype == BUS_VIRTUAL) return false;
     if (std.mem.startsWith(u8, uniq, uniq_mod.PREFIX)) return false;
-    if (id.vendor != p.phys_vendor or id.product != p.phys_product) return false;
-    if (p.output_vendor) |ov| {
-        if (p.output_product) |op| {
-            if (id.vendor == ov and id.product == op) return false;
-        }
-    }
-    return true;
+    return id.vendor == p.phys_vendor and id.product == p.phys_product;
 }
 
 fn readUniq(fd: posix.fd_t, buf: *[uniq_mod.MAX_UNIQ_LEN]u8) []const u8 {
@@ -82,26 +106,30 @@ fn driverName(node: []const u8, buf: []u8) ?[]const u8 {
 }
 
 /// Probe one event node and grab it when it shadows the managed device.
-/// Returns true when the node was grabbed into `list`.
-pub fn tryGrabNode(list: *GrabList, input_dir: []const u8, node: []const u8, p: Params) bool {
-    if (node.len == 0 or node.len > NAME_CAP) return false;
-    if (list.contains(node)) return false;
-    if (list.len >= list.grabs.len) return false;
+/// `.access_denied` flags nodes whose udev permissions are not applied yet
+/// so the caller can retry.
+pub fn tryGrabNode(list: *GrabList, input_dir: []const u8, node: []const u8, p: Params) GrabResult {
+    if (node.len == 0 or node.len > NAME_CAP) return .skipped;
+    if (list.contains(node)) return .skipped;
+    if (list.len >= list.grabs.len) return .skipped;
 
     var path_buf: [64]u8 = undefined;
-    const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ input_dir, node }) catch return false;
-    const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch return false;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ input_dir, node }) catch return .skipped;
+    const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch |err| switch (err) {
+        error.AccessDenied => return .access_denied,
+        else => return .skipped,
+    };
 
     var id: ioctl.InputId = undefined;
     if (linux.E.init(linux.ioctl(fd, ioctl.EVIOCGID, @intFromPtr(&id))) != .SUCCESS) {
         posix.close(fd);
-        return false;
+        return .skipped;
     }
     var uniq_buf: [uniq_mod.MAX_UNIQ_LEN]u8 = undefined;
     const uniq = readUniq(fd, &uniq_buf);
     if (!shouldGrab(id, uniq, p)) {
         posix.close(fd);
-        return false;
+        return .skipped;
     }
 
     const grab_errno = linux.E.init(linux.ioctl(fd, ioctl.EVIOCGRAB, 1));
@@ -114,7 +142,7 @@ pub fn tryGrabNode(list: *GrabList, input_dir: []const u8, node: []const u8, p: 
             std.log.warn("shadow grab: EVIOCGRAB {s} failed: {s}", .{ path, @tagName(grab_errno) });
         }
         posix.close(fd);
-        return false;
+        return .skipped;
     }
 
     list.grabs[list.len] = .{ .fd = fd, .name_buf = undefined, .name_len = @intCast(node.len) };
@@ -127,13 +155,14 @@ pub fn tryGrabNode(list: *GrabList, input_dir: []const u8, node: []const u8, p: 
     } else {
         std.log.warn("shadow input node {s} ({x:0>4}:{x:0>4}) grabbed; kernel driver bound to a managed device", .{ path, id.vendor, id.product });
     }
-    return true;
+    return .grabbed;
 }
 
 /// Enumerate `input_dir` and grab every shadow node of the managed device.
 /// Catches shadows that predate the daemon (the netlink watch only sees new
-/// nodes).
+/// nodes). Dead grabs are pruned first so reused eventN names stay grabbable.
 pub fn sweepDir(list: *GrabList, input_dir: []const u8, p: Params) void {
+    list.pruneDead();
     var dir = std.fs.openDirAbsolute(input_dir, .{ .iterate = true }) catch return;
     defer dir.close();
     var it = dir.iterate();
@@ -154,8 +183,6 @@ fn nodeId(bustype: u16, vendor: u16, product: u16) ioctl.InputId {
 const vader5: Params = .{
     .phys_vendor = 0x37d7,
     .phys_product = 0x2401,
-    .output_vendor = 0x045e,
-    .output_product = 0x0b00,
 };
 
 test "shadow_grab: shouldGrab takes xpad shadow node (BUS_USB, physical VID/PID)" {
@@ -174,21 +201,16 @@ test "shadow_grab: shouldGrab skips padctl UHID outputs by uniq prefix" {
     try testing.expect(!shouldGrab(nodeId(0x03, 0x37d7, 0x2401), "padctl/vader-5-pro-1a2b", vader5));
 }
 
-test "shadow_grab: shouldGrab skips the configured output identity" {
-    var p = vader5;
-    p.phys_vendor = 0x045e;
-    p.phys_product = 0x0b00;
-    try testing.expect(!shouldGrab(nodeId(0x03, 0x045e, 0x0b00), "", p));
+test "shadow_grab: shouldGrab takes shadows when [output] clones the physical identity" {
+    // xbox-elite-style config: [output] vid/pid equals the physical vid/pid,
+    // so a genuine xpad shadow carries the output identity too.
+    const p: Params = .{ .phys_vendor = 0x045e, .phys_product = 0x0b00 };
+    try testing.expect(shouldGrab(nodeId(0x03, 0x045e, 0x0b00), "", p));
 }
 
 test "shadow_grab: shouldGrab skips unrelated devices" {
     try testing.expect(!shouldGrab(nodeId(0x03, 0x046d, 0xc52b), "", vader5));
     try testing.expect(!shouldGrab(nodeId(0x05, 0x37d7, 0x2402), "", vader5));
-}
-
-test "shadow_grab: shouldGrab without configured output ids still takes shadows" {
-    const p: Params = .{ .phys_vendor = 0x37d7, .phys_product = 0x2401 };
-    try testing.expect(shouldGrab(nodeId(0x03, 0x37d7, 0x2401), "", p));
 }
 
 test "shadow_grab: GrabList contains/releaseAll bookkeeping" {
@@ -208,13 +230,57 @@ test "shadow_grab: GrabList contains/releaseAll bookkeeping" {
 
 test "shadow_grab: tryGrabNode rejects oversized, duplicate, and unopenable nodes" {
     var list = GrabList{};
-    try testing.expect(!tryGrabNode(&list, "/dev/input", "event-name-way-too-long-to-fit", vader5));
-    try testing.expect(!tryGrabNode(&list, "/nonexistent_input_dir_xyz", "event0", vader5));
+    try testing.expectEqual(GrabResult.skipped, tryGrabNode(&list, "/dev/input", "event-name-way-too-long-to-fit", vader5));
+    try testing.expectEqual(GrabResult.skipped, tryGrabNode(&list, "/nonexistent_input_dir_xyz", "event0", vader5));
     list.grabs[0] = .{ .fd = -1, .name_buf = undefined, .name_len = 6 };
     @memcpy(list.grabs[0].name_buf[0..6], "event7");
     list.len = 1;
-    try testing.expect(!tryGrabNode(&list, "/nonexistent_input_dir_xyz", "event7", vader5));
+    try testing.expectEqual(GrabResult.skipped, tryGrabNode(&list, "/nonexistent_input_dir_xyz", "event7", vader5));
     list.len = 0;
+}
+
+test "shadow_grab: tryGrabNode reports unreadable nodes as access_denied" {
+    if (linux.geteuid() == 0) return error.SkipZigTest;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    (try tmp.dir.createFile("event0", .{ .mode = 0 })).close();
+    const dir_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(dir_path);
+
+    var list = GrabList{};
+    try testing.expectEqual(GrabResult.access_denied, tryGrabNode(&list, dir_path, "event0", vader5));
+    try testing.expectEqual(@as(usize, 0), list.len);
+}
+
+test "shadow_grab: evict closes the named grab and frees the name for reuse" {
+    var list = GrabList{};
+    inline for (.{ "event3", "event4" }, 0..) |n, i| {
+        const fd = try posix.open("/dev/null", .{ .ACCMODE = .RDONLY }, 0);
+        list.grabs[i] = .{ .fd = fd, .name_buf = undefined, .name_len = n.len };
+        @memcpy(list.grabs[i].name_buf[0..n.len], n);
+    }
+    list.len = 2;
+
+    try testing.expect(!list.evict("event9"));
+    try testing.expect(list.evict("event3"));
+    try testing.expectEqual(@as(usize, 1), list.len);
+    try testing.expect(!list.contains("event3"));
+    try testing.expect(list.contains("event4"));
+
+    // A reused kernel name is grabbable again: contains() no longer blocks it.
+    try testing.expect(!list.evict("event3"));
+    list.releaseAll();
+}
+
+test "shadow_grab: pruneDead keeps live fds" {
+    var list = GrabList{};
+    const fd = try posix.open("/dev/null", .{ .ACCMODE = .RDONLY }, 0);
+    list.grabs[0] = .{ .fd = fd, .name_buf = undefined, .name_len = 6 };
+    @memcpy(list.grabs[0].name_buf[0..6], "event3");
+    list.len = 1;
+    list.pruneDead();
+    try testing.expectEqual(@as(usize, 1), list.len);
+    list.releaseAll();
 }
 
 test "shadow_grab: sweepDir on nonexistent dir is a no-op" {

--- a/src/io/shadow_grab.zig
+++ b/src/io/shadow_grab.zig
@@ -105,9 +105,16 @@ fn driverName(node: []const u8, buf: []u8) ?[]const u8 {
     return std.fs.path.basename(target);
 }
 
-/// Probe one event node and grab it when it shadows the managed device.
 /// `.access_denied` flags nodes whose udev permissions are not applied yet
-/// so the caller can retry.
+/// so the caller can retry; any other open failure is not retryable.
+fn classifyOpenError(err: posix.OpenError) GrabResult {
+    return switch (err) {
+        error.AccessDenied => .access_denied,
+        else => .skipped,
+    };
+}
+
+/// Probe one event node and grab it when it shadows the managed device.
 pub fn tryGrabNode(list: *GrabList, input_dir: []const u8, node: []const u8, p: Params) GrabResult {
     if (node.len == 0 or node.len > NAME_CAP) return .skipped;
     if (list.contains(node)) return .skipped;
@@ -115,10 +122,7 @@ pub fn tryGrabNode(list: *GrabList, input_dir: []const u8, node: []const u8, p: 
 
     var path_buf: [64]u8 = undefined;
     const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ input_dir, node }) catch return .skipped;
-    const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch |err| switch (err) {
-        error.AccessDenied => return .access_denied,
-        else => return .skipped,
-    };
+    const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch |err| return classifyOpenError(err);
 
     var id: ioctl.InputId = undefined;
     if (linux.E.init(linux.ioctl(fd, ioctl.EVIOCGID, @intFromPtr(&id))) != .SUCCESS) {
@@ -239,17 +243,10 @@ test "shadow_grab: tryGrabNode rejects oversized, duplicate, and unopenable node
     list.len = 0;
 }
 
-test "shadow_grab: tryGrabNode reports unreadable nodes as access_denied" {
-    if (linux.geteuid() == 0) return error.SkipZigTest;
-    var tmp = testing.tmpDir(.{});
-    defer tmp.cleanup();
-    (try tmp.dir.createFile("event0", .{ .mode = 0 })).close();
-    const dir_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
-    defer testing.allocator.free(dir_path);
-
-    var list = GrabList{};
-    try testing.expectEqual(GrabResult.access_denied, tryGrabNode(&list, dir_path, "event0", vader5));
-    try testing.expectEqual(@as(usize, 0), list.len);
+test "shadow_grab: classifyOpenError marks only AccessDenied retryable" {
+    try testing.expectEqual(GrabResult.access_denied, classifyOpenError(error.AccessDenied));
+    try testing.expectEqual(GrabResult.skipped, classifyOpenError(error.FileNotFound));
+    try testing.expectEqual(GrabResult.skipped, classifyOpenError(error.DeviceBusy));
 }
 
 test "shadow_grab: evict closes the named grab and frees the name for reuse" {

--- a/src/io/uniq.zig
+++ b/src/io/uniq.zig
@@ -19,6 +19,10 @@ const std = @import("std");
 
 pub const MAX_UNIQ_LEN: usize = 64;
 
+/// Shared prefix of every padctl-created UHID uniq; lets other modules
+/// recognise padctl's own virtual devices (see `src/io/shadow_grab.zig`).
+pub const PREFIX = "padctl/";
+
 /// Build the shared uniq string. Caller owns the returned NUL-terminated
 /// buffer and must free it.
 ///
@@ -42,7 +46,7 @@ pub fn buildUniq(
         break :blk std.fmt.bufPrint(&inst_buf, "ctr{x:0>4}", .{counter}) catch unreachable;
     };
 
-    const body = try std.fmt.allocPrint(allocator, "padctl/{s}-{s}", .{ device_id, instance });
+    const body = try std.fmt.allocPrint(allocator, PREFIX ++ "{s}-{s}", .{ device_id, instance });
     defer allocator.free(body);
     const out = try allocator.allocSentinel(u8, body.len, 0);
     @memcpy(out, body);

--- a/src/main.zig
+++ b/src/main.zig
@@ -78,6 +78,7 @@ pub const io = struct {
     pub const ioctl_constants = @import("io/ioctl_constants.zig");
     pub const write_exact = @import("io/write_exact.zig");
     pub const netlink = @import("io/netlink.zig");
+    pub const shadow_grab = @import("io/shadow_grab.zig");
     pub const ffb_forwarder = @import("io/ffb_forwarder.zig");
 };
 
@@ -154,6 +155,7 @@ pub const testing_support = struct {
     pub const supervisor_suspend_output_continuity_test = @import("test/supervisor_suspend_output_continuity_test.zig");
     pub const wedge_instrumentation_test = @import("test/wedge_instrumentation_test.zig");
     pub const libusb_capability_test = @import("test/libusb_capability_test.zig");
+    pub const shadow_grab_integration_test = @import("test/shadow_grab_integration_test.zig");
     // Permanent canary — proves test discovery walks into testing_support.
     // If the discovery mechanism breaks again, this test stops running and
     // we can prove the regression with a deliberate failure.

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -16,6 +16,7 @@ const HidrawDevice = @import("io/hidraw.zig").HidrawDevice;
 const readPhysicalPath = @import("io/hidraw.zig").readPhysicalPath;
 const readInterfaceId = @import("io/hidraw.zig").readInterfaceId;
 const netlink = @import("io/netlink.zig");
+const shadow_grab = @import("io/shadow_grab.zig");
 const ioctl = @import("io/ioctl_constants.zig");
 const config_paths = @import("config/paths.zig");
 const mapping_discovery = @import("config/mapping_discovery.zig");
@@ -74,6 +75,10 @@ pub const ManagedInstance = struct {
     /// `gcExpiredGrace()` tears the entry down. Set by `detach()` when
     /// `suspend_grace_sec > 0`; cleared on successful rebind.
     grace_deadline_ns: ?u64 = null,
+    /// Grabbed shadow /dev/input/event* fds of kernel drivers (e.g. xpad)
+    /// bound to this managed device (issue #406). Released on suspend and
+    /// teardown; refilled by the sweep on spawn/resume.
+    shadow_grabs: shadow_grab.GrabList = .{},
 };
 
 /// Config snapshot used for hot-reload diffing.
@@ -574,6 +579,7 @@ pub const Supervisor = struct {
             m.thread.join();
             m.instance.quiesceOutputs(.{ .reset_input_state = true, .reset_mapper_state = true });
             m.instance.closeDeviceIO();
+            m.shadow_grabs.releaseAll();
             m.suspended = true;
             // Schedule grace deadline. Saturating add keeps us safe against
             // pathological `suspend_grace_sec` values.
@@ -801,6 +807,7 @@ pub const Supervisor = struct {
             .switch_mapping = null,
             .default_mapping_pr = default_pr,
         });
+        sweepShadowNodes(&self.managed.items[self.managed.items.len - 1]);
     }
 
     fn pruneStaleSuspendedForId(self: *Supervisor, vid: u16, pid: u16, keep_phys: []const u8) void {
@@ -826,6 +833,7 @@ pub const Supervisor = struct {
     }
 
     fn teardownManaged(self: *Supervisor, m: *ManagedInstance) void {
+        m.shadow_grabs.releaseAll();
         if (m.switch_mapping) |pm| {
             pm.deinit();
             self.allocator.destroy(pm);
@@ -902,6 +910,7 @@ pub const Supervisor = struct {
         m.suspended = false;
         m.grace_deadline_ns = null;
         self.armGraceTimer();
+        sweepShadowNodes(m);
     }
 
     fn clearSwitchMapping(self: *Supervisor, m: *ManagedInstance) void {
@@ -1334,18 +1343,51 @@ pub const Supervisor = struct {
         }
     }
 
-    fn netlinkCallback(self: *Supervisor, action: netlink.UeventAction, devname: []const u8) void {
-        switch (action) {
-            .add => self.attach(devname) catch |err| {
-                if (err == error.HotplugTransient) {
-                    self.enqueueHotplugRetry(devname);
-                } else {
-                    std.log.warn("hotplug attach {s}: {}", .{ devname, err });
-                }
+    fn netlinkCallback(self: *Supervisor, action: netlink.UeventAction, subsystem: netlink.Subsystem, devname: []const u8) void {
+        switch (subsystem) {
+            .hidraw => switch (action) {
+                .add => self.attach(devname) catch |err| {
+                    if (err == error.HotplugTransient) {
+                        self.enqueueHotplugRetry(devname);
+                    } else {
+                        std.log.warn("hotplug attach {s}: {}", .{ devname, err });
+                    }
+                },
+                .remove => self.detach(devname),
+                .other => {},
             },
-            .remove => self.detach(devname),
-            .other => {},
+            .input => if (action == .add) self.handleInputNodeAdd(devname),
         }
+    }
+
+    fn shadowParams(m: *const ManagedInstance) shadow_grab.Params {
+        const cfg = m.instance.device_cfg;
+        var p: shadow_grab.Params = .{
+            .phys_vendor = @intCast(cfg.device.vid),
+            .phys_product = @intCast(cfg.device.pid),
+        };
+        if (cfg.output) |out| {
+            if (out.vid) |v| p.output_vendor = @intCast(v);
+            if (out.pid) |v| p.output_product = @intCast(v);
+        }
+        return p;
+    }
+
+    /// Netlink saw a new /dev/input/event* node: grab it if it shadows an
+    /// active managed device.
+    fn handleInputNodeAdd(self: *Supervisor, devname: []const u8) void {
+        const node = std.fs.path.basename(devname);
+        for (self.managed.items) |*m| {
+            if (m.suspended) continue;
+            if (shadow_grab.tryGrabNode(&m.shadow_grabs, "/dev/input", node, shadowParams(m))) return;
+        }
+    }
+
+    /// Grab pre-existing shadow nodes when an instance becomes active (spawn
+    /// and resume) — a shadow that predates the daemon never produces a
+    /// netlink ADD.
+    fn sweepShadowNodes(m: *ManagedInstance) void {
+        shadow_grab.sweepDir(&m.shadow_grabs, "/dev/input", shadowParams(m));
     }
 
     fn drainNetlink(self: *Supervisor) void {

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -189,7 +189,10 @@ const HotplugPending = struct {
     devname: [64]u8,
     len: u8,
     retries: u8,
+    kind: PendingKind,
 };
+
+const PendingKind = enum { hidraw, input_grab };
 
 // 8 fixed (stop, hup, netlink, inotify, debounce, hotplug_retry, grace, liveness) + 1 listen + 4 clients.
 pub const SUPERVISOR_MAX_FDS: usize = 8 + 1 + 4;
@@ -1356,30 +1359,52 @@ pub const Supervisor = struct {
                 .remove => self.detach(devname),
                 .other => {},
             },
-            .input => if (action == .add) self.handleInputNodeAdd(devname),
+            .input => switch (action) {
+                .add => self.handleInputNodeAdd(devname),
+                .remove => self.handleInputNodeRemove(devname),
+                .other => {},
+            },
         }
     }
 
     fn shadowParams(m: *const ManagedInstance) shadow_grab.Params {
         const cfg = m.instance.device_cfg;
-        var p: shadow_grab.Params = .{
+        return .{
             .phys_vendor = @intCast(cfg.device.vid),
             .phys_product = @intCast(cfg.device.pid),
         };
-        if (cfg.output) |out| {
-            if (out.vid) |v| p.output_vendor = @intCast(v);
-            if (out.pid) |v| p.output_product = @intCast(v);
+    }
+
+    /// Offer `node` to every active managed instance. `.access_denied` means
+    /// the open raced udev permission setup and a retry may succeed.
+    fn tryGrabForManaged(self: *Supervisor, node: []const u8) shadow_grab.GrabResult {
+        var denied = false;
+        for (self.managed.items) |*m| {
+            if (m.suspended) continue;
+            switch (shadow_grab.tryGrabNode(&m.shadow_grabs, "/dev/input", node, shadowParams(m))) {
+                .grabbed => return .grabbed,
+                .access_denied => denied = true,
+                .skipped => {},
+            }
         }
-        return p;
+        return if (denied) .access_denied else .skipped;
     }
 
     /// Netlink saw a new /dev/input/event* node: grab it if it shadows an
     /// active managed device.
     fn handleInputNodeAdd(self: *Supervisor, devname: []const u8) void {
         const node = std.fs.path.basename(devname);
+        if (self.tryGrabForManaged(node) == .access_denied) {
+            self.enqueueRetry(.input_grab, node);
+        }
+    }
+
+    /// Netlink saw a /dev/input/event* node disappear: drop any stale grab so
+    /// a future node reusing the same eventN name stays grabbable.
+    fn handleInputNodeRemove(self: *Supervisor, devname: []const u8) void {
+        const node = std.fs.path.basename(devname);
         for (self.managed.items) |*m| {
-            if (m.suspended) continue;
-            if (shadow_grab.tryGrabNode(&m.shadow_grabs, "/dev/input", node, shadowParams(m))) return;
+            if (m.shadow_grabs.evict(node)) return;
         }
     }
 
@@ -1405,15 +1430,20 @@ pub const Supervisor = struct {
     }
 
     fn enqueueHotplugRetry(self: *Supervisor, devname: []const u8) void {
+        self.enqueueRetry(.hidraw, devname);
+    }
+
+    fn enqueueRetry(self: *Supervisor, kind: PendingKind, devname: []const u8) void {
         if (self.hotplug_retry_fd < 0) return;
         for (self.hotplug_pending.items) |pending| {
-            if (std.mem.eql(u8, pending.devname[0..pending.len], devname)) return;
+            if (pending.kind == kind and std.mem.eql(u8, pending.devname[0..pending.len], devname)) return;
         }
         var entry: HotplugPending = undefined;
         const n = @min(devname.len, entry.devname.len);
         @memcpy(entry.devname[0..n], devname[0..n]);
         entry.len = @intCast(n);
         entry.retries = 0;
+        entry.kind = kind;
         self.hotplug_pending.append(self.allocator, entry) catch return;
         const spec = linux.itimerspec{
             .it_value = .{ .sec = 0, .nsec = 300_000_000 },
@@ -1457,6 +1487,20 @@ pub const Supervisor = struct {
         while (i < self.hotplug_pending.items.len) {
             const p = &self.hotplug_pending.items[i];
             const name = p.devname[0..p.len];
+            if (p.kind == .input_grab) {
+                if (self.tryGrabForManaged(name) == .access_denied) {
+                    p.retries += 1;
+                    if (p.retries >= 3) {
+                        std.log.debug("shadow grab: giving up on {s} after 3 retries", .{name});
+                        _ = self.hotplug_pending.swapRemove(i);
+                    } else {
+                        i += 1;
+                    }
+                } else {
+                    _ = self.hotplug_pending.swapRemove(i);
+                }
+                continue;
+            }
             self.attach(name) catch |err| {
                 if (err != error.HotplugTransient) {
                     std.log.warn("hotplug retry {s}: {}, dropping", .{ name, err });
@@ -2938,6 +2982,28 @@ test "supervisor: cold-scan retry queues hidraw basename" {
     try testing.expectEqual(@as(usize, 1), sup.hotplug_pending.items.len);
     const item = sup.hotplug_pending.items[0];
     try testing.expectEqualStrings("hidraw2", item.devname[0..item.len]);
+}
+
+test "supervisor: input grab retry dedups per kind and drains non-denied nodes" {
+    const allocator = testing.allocator;
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer sup.deinit();
+    sup.hotplug_retry_fd = try posix.timerfd_create(.MONOTONIC, .{ .CLOEXEC = true, .NONBLOCK = true });
+
+    sup.enqueueRetry(.input_grab, "event5");
+    sup.enqueueRetry(.input_grab, "event5");
+    try testing.expectEqual(@as(usize, 1), sup.hotplug_pending.items.len);
+    try testing.expectEqual(PendingKind.input_grab, sup.hotplug_pending.items[0].kind);
+
+    // Same name under a different kind is a distinct entry.
+    sup.enqueueRetry(.hidraw, "event5");
+    try testing.expectEqual(@as(usize, 2), sup.hotplug_pending.items.len);
+    _ = sup.hotplug_pending.swapRemove(1);
+
+    // Node gone (or readable but not a shadow): the retry entry is dropped.
+    sup.drainHotplugRetry();
+    try testing.expectEqual(@as(usize, 0), sup.hotplug_pending.items.len);
 }
 
 test "supervisor: cold-scan retry is inert when retry timer is unavailable" {

--- a/src/test/shadow_grab_integration_test.zig
+++ b/src/test/shadow_grab_integration_test.zig
@@ -89,12 +89,7 @@ test "shadow_grab: sweep grabs a USB-bus shadow node exclusively and releases it
     try testing.expect(!list.contains(node));
     list.releaseAll();
 
-    const params: shadow_grab.Params = .{
-        .phys_vendor = vid,
-        .phys_product = pid,
-        .output_vendor = 0x045e,
-        .output_product = 0x0b00,
-    };
+    const params: shadow_grab.Params = .{ .phys_vendor = vid, .phys_product = pid };
     shadow_grab.sweepDir(&list, "/dev/input", params);
     try testing.expect(list.contains(node));
 
@@ -114,6 +109,29 @@ test "shadow_grab: sweep grabs a USB-bus shadow node exclusively and releases it
     list.releaseAll();
     try testing.expectEqual(linux.E.SUCCESS, linux.E.init(linux.ioctl(probe, ioctl.EVIOCGRAB, 1)));
     _ = linux.ioctl(probe, ioctl.EVIOCGRAB, 0);
+}
+
+test "shadow_grab: sweep prunes a grab whose device is gone (ENODEV)" {
+    const vid: u16 = 0xFAD7;
+    const pid: u16 = 0x24FC;
+    const ufd = try createPad(BUS_USB, vid, pid);
+    var destroyed = false;
+    defer if (!destroyed) destroyPad(ufd);
+
+    var name_buf: [24]u8 = undefined;
+    const node = findEventNode(vid, pid, &name_buf) orelse return error.SkipZigTest;
+
+    var list = shadow_grab.GrabList{};
+    defer list.releaseAll();
+    const params: shadow_grab.Params = .{ .phys_vendor = vid, .phys_product = pid };
+    shadow_grab.sweepDir(&list, "/dev/input", params);
+    try testing.expect(list.contains(node));
+
+    destroyPad(ufd);
+    destroyed = true;
+
+    shadow_grab.sweepDir(&list, "/dev/input", params);
+    try testing.expect(!list.contains(node));
 }
 
 test "shadow_grab: sweep skips virtual-bus nodes (padctl's own uinput outputs)" {

--- a/src/test/shadow_grab_integration_test.zig
+++ b/src/test/shadow_grab_integration_test.zig
@@ -1,0 +1,132 @@
+//! Integration test for the shadow input-node watchdog (issue #406).
+//!
+//! Creates a uinput device that mimics a kernel-driver shadow node (BUS_USB
+//! plus the managed pad's physical VID/PID, no uniq), runs the sweep, and
+//! asserts the node is exclusively grabbed — a second EVIOCGRAB fails with
+//! EBUSY — and released again by releaseAll(). Skips when /dev/uinput or the
+//! created node is unavailable, same gating as the other uinput tests.
+
+const std = @import("std");
+const posix = std.posix;
+const linux = std.os.linux;
+const testing = std.testing;
+
+const shadow_grab = @import("../io/shadow_grab.zig");
+const ioctl = @import("../io/ioctl_constants.zig");
+
+const BUS_USB: u16 = 0x03;
+const BUS_VIRTUAL: u16 = 0x06;
+const EV_KEY: usize = 0x01;
+const BTN_SOUTH: usize = 0x130;
+
+const UinputSetup = extern struct {
+    id: ioctl.InputId,
+    name: [80]u8,
+    ff_effects_max: u32,
+};
+
+fn expectIoctlOk(rc: usize) !void {
+    if (linux.E.init(rc) != .SUCCESS) return error.IoctlFailed;
+}
+
+fn createPad(bustype: u16, vid: u16, pid: u16) !posix.fd_t {
+    const fd = posix.open("/dev/uinput", .{ .ACCMODE = .RDWR }, 0) catch |err| switch (err) {
+        error.AccessDenied, error.FileNotFound => return error.SkipZigTest,
+        else => return err,
+    };
+    errdefer posix.close(fd);
+    try expectIoctlOk(linux.ioctl(fd, ioctl.UI_SET_EVBIT, EV_KEY));
+    try expectIoctlOk(linux.ioctl(fd, ioctl.UI_SET_KEYBIT, BTN_SOUTH));
+    var setup = std.mem.zeroes(UinputSetup);
+    setup.id.bustype = bustype;
+    setup.id.vendor = vid;
+    setup.id.product = pid;
+    const name = "padctl-shadow-watchdog-test";
+    @memcpy(setup.name[0..name.len], name);
+    try expectIoctlOk(linux.ioctl(fd, ioctl.UI_DEV_SETUP, @intFromPtr(&setup)));
+    try expectIoctlOk(linux.ioctl(fd, ioctl.UI_DEV_CREATE, 0));
+    return fd;
+}
+
+fn destroyPad(fd: posix.fd_t) void {
+    _ = linux.ioctl(fd, ioctl.UI_DEV_DESTROY, 0);
+    posix.close(fd);
+}
+
+fn findEventNode(vid: u16, pid: u16, name_buf: *[24]u8) ?[]const u8 {
+    var attempt: usize = 0;
+    while (attempt < 20) : (attempt += 1) {
+        var i: u16 = 0;
+        while (i < 256) : (i += 1) {
+            var path_buf: [40]u8 = undefined;
+            const path = std.fmt.bufPrint(&path_buf, "/dev/input/event{d}", .{i}) catch continue;
+            const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch continue;
+            defer posix.close(fd);
+            var id: ioctl.InputId = undefined;
+            if (linux.E.init(linux.ioctl(fd, ioctl.EVIOCGID, @intFromPtr(&id))) != .SUCCESS) continue;
+            if (id.vendor != vid or id.product != pid) continue;
+            return std.fmt.bufPrint(name_buf, "event{d}", .{i}) catch null;
+        }
+        std.Thread.sleep(100 * std.time.ns_per_ms);
+    }
+    return null;
+}
+
+test "shadow_grab: sweep grabs a USB-bus shadow node exclusively and releases it" {
+    const vid: u16 = 0xFAD7;
+    const pid: u16 = 0x24FE;
+    const ufd = try createPad(BUS_USB, vid, pid);
+    defer destroyPad(ufd);
+
+    var name_buf: [24]u8 = undefined;
+    const node = findEventNode(vid, pid, &name_buf) orelse return error.SkipZigTest;
+
+    var list = shadow_grab.GrabList{};
+    defer list.releaseAll();
+
+    // Foreign physical VID/PID: the sweep must not touch the node.
+    shadow_grab.sweepDir(&list, "/dev/input", .{ .phys_vendor = 0xF0F0, .phys_product = 0x0F0F });
+    try testing.expect(!list.contains(node));
+    list.releaseAll();
+
+    const params: shadow_grab.Params = .{
+        .phys_vendor = vid,
+        .phys_product = pid,
+        .output_vendor = 0x045e,
+        .output_product = 0x0b00,
+    };
+    shadow_grab.sweepDir(&list, "/dev/input", params);
+    try testing.expect(list.contains(node));
+
+    // Re-sweep is idempotent: already-grabbed nodes are skipped.
+    const len_after = list.len;
+    shadow_grab.sweepDir(&list, "/dev/input", params);
+    try testing.expectEqual(len_after, list.len);
+
+    // EVIOCGRAB exclusivity is observable: a second grab fails with EBUSY.
+    var path_buf: [40]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "/dev/input/{s}", .{node});
+    const probe = try posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0);
+    defer posix.close(probe);
+    try testing.expectEqual(linux.E.BUSY, linux.E.init(linux.ioctl(probe, ioctl.EVIOCGRAB, 1)));
+
+    // releaseAll drops the grab: the probe fd can now take it.
+    list.releaseAll();
+    try testing.expectEqual(linux.E.SUCCESS, linux.E.init(linux.ioctl(probe, ioctl.EVIOCGRAB, 1)));
+    _ = linux.ioctl(probe, ioctl.EVIOCGRAB, 0);
+}
+
+test "shadow_grab: sweep skips virtual-bus nodes (padctl's own uinput outputs)" {
+    const vid: u16 = 0xFAD7;
+    const pid: u16 = 0x24FD;
+    const ufd = try createPad(BUS_VIRTUAL, vid, pid);
+    defer destroyPad(ufd);
+
+    var name_buf: [24]u8 = undefined;
+    const node = findEventNode(vid, pid, &name_buf) orelse return error.SkipZigTest;
+
+    var list = shadow_grab.GrabList{};
+    defer list.releaseAll();
+    shadow_grab.sweepDir(&list, "/dev/input", .{ .phys_vendor = vid, .phys_product = pid });
+    try testing.expect(!list.contains(node));
+}


### PR DESCRIPTION
## What changed

- `src/io/netlink.zig`: drain now also forwards input-subsystem ADD events for `input/eventN` devnames; callback gains a `Subsystem` tag param; hidraw behavior unchanged.
- `src/io/shadow_grab.zig` (new): probes `/dev/input/event*` with EVIOCGID/EVIOCGUNIQ and EVIOCGRABs nodes that shadow a managed device. Pure decision seam `shouldGrab`: trigger is a physical VID/PID match; exclusions are BUS_VIRTUAL (padctl uinput outputs), `padctl/` uniq prefix (padctl UHID outputs, incl. `clone_vid_pid`), and the configured `[output]` VID/PID identity. Per-instance `GrabList` capped at 8 fds (same bound as `MAX_EVDEV_GRABS`). Open/grab failures log once and continue; EBUSY (node already exclusively grabbed, typically by padctl's own hidraw-associated grab) logs at debug.
- `src/supervisor.zig`: on input-node ADD the first matching active instance grabs the node; when an instance becomes active (spawn and resume via `finalizeRebind`) a `/dev/input` sweep catches shadows that predate the daemon (the reporter's persistent-node case); grabs are released on suspend (`detach`) and teardown.
- `src/io/ioctl_constants.zig`: add `EVIOCGID` + `InputId`.
- `src/io/uniq.zig`: export the shared `padctl/` uniq prefix.

## Edge cases

- Node appears while the instance is suspended: the resume sweep covers it.
- Multiple shadow nodes: sweep grabs each, bounded at 8 per instance.
- Node disappears after grab: held fd just returns ENODEV; closed on teardown/suspend.
- padctl's own aux/touchpad/output devices are never grabbed: BUS_VIRTUAL, `padctl/` uniq, and output-identity exclusions (physical-VID match is the only trigger).

## Test plan

- `src/io/shadow_grab.zig` unit tests: injected device-id tuples cover the full decision matrix (xpad shadow taken; BUS_VIRTUAL / padctl-uniq / output-identity / unrelated-id skipped), GrabList bookkeeping, unopenable/oversized/duplicate node handling.
- `src/io/netlink.zig`: socketpair-driven drain test — hidraw add/remove pass with `.hidraw`, `input/eventN` ADD passes with `.input`, non-event input nodes and input REMOVE are filtered.
- `src/test/shadow_grab_integration_test.zig`: creates a uinput pad with BUS_USB + managed VID/PID, sweeps, asserts exclusive grab (second EVIOCGRAB fails EBUSY), re-sweep idempotence, and that releaseAll() frees the grab; a BUS_VIRTUAL twin is skipped. Gated on `/dev/uinput` availability like the other uinput tests.
- Full suite green in the build container; integration tests additionally verified non-skipped with `/dev/uinput` + `/dev/input` mapped in.
- Falsifiability: reverting the input-forward branch, the uniq exclusion, or the EVIOCGRAB call each turns the corresponding test red (verified).

Refs #406, docs ADR-024 (runtime-truth udev rules; this is the daemon-side second defense layer)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shadow input-node watchdog that detects and manages /dev/input/event* nodes for matching physical devices.

* **Refactor**
  * Hotplug handling generalized to route and handle both hidraw and input subsystem events.

* **Tests**
  * Added unit and integration tests covering input-node grab logic, retry behavior, pruning, and virtual-device filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->