### PR TITLE
docs(mapping): worked example for remapping buttons to LT/RT triggers

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -61,6 +61,12 @@ Top-level button remapping (active when no layer overrides). Keys are ButtonId n
 
 `LT` / `RT` as targets emit the digital trigger press plus a full analog pull (ABS_Z / ABS_RZ = 255) while the source button is held. Tap/double gesture legs targeting `LT` / `RT` emit only the digital press; use a plain remap or a `hold` leg for an analog pull.
 
+```toml
+[remap]
+M1 = "RT"   # full analog pull (255) while M1 is held
+M2 = "LT"
+```
+
 > **Note:** `BTN_*` values (e.g. `"BTN_SOUTH"`) are routed to the virtual **mouse** device, not the gamepad. To target a gamepad button use a friendly `ButtonId` name (`"A"`, `"Select"`, etc.) instead.
 
 ```toml

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -137,6 +137,14 @@ Available target types:
 | `"disabled"` | Suppress the button entirely |
 | `"macro:<name>"` | Run a named macro sequence |
 
+For example, to fire the triggers from back buttons:
+
+```toml
+[remap]
+M1 = "RT"   # full analog pull (255) while M1 is held
+M2 = "LT"
+```
+
 > **Note:** `BTN_*` values (e.g. `"BTN_SOUTH"`) are routed to the virtual **mouse** device, not the gamepad. To remap to a gamepad button use a friendly `ButtonId` name (`"A"`, `"Select"`, etc.) instead.
 
 Available button names: `A`, `B`, `X`, `Y`, `LB`, `RB`, `LT`, `RT`, `Start`, `Select`, `Home`, `Capture`, `LS`, `RS`, `DPadUp`, `DPadDown`, `DPadLeft`, `DPadRight`, `M1`, `M2`, `M3`, `M4`, `Paddle1`, `Paddle2`, `Paddle3`, `Paddle4`, `TouchPad`, `Mic`, `C`, `Z`, `LM`, `RM`, `O`


### PR DESCRIPTION
- Add a copyable `[remap]` TOML example mapping back buttons to triggers (`M1 = "RT"`, `M2 = "LT"`) in `docs/src/mapping-config.md`, directly under the existing LT/RT-as-targets paragraph in the `[remap]` section
- Add the same worked example to `docs/src/mapping-guide.md` under the Button Remapping target-type table
- No semantic changes; PR #408 added the prose, this adds the missing concrete example

Refs #405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added TOML configuration examples in mapping documentation demonstrating how to map back buttons to analog trigger outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->