### PR TITLE
fix(aur): build padctl-git with musl target to avoid glibc 2.43+ link failure

### DIFF
--- a/contrib/aur/PKGBUILD
+++ b/contrib/aur/PKGBUILD
@@ -6,7 +6,7 @@ pkgdesc="HID gamepad daemon — declarative TOML device config, uinput output"
 arch=('x86_64' 'aarch64')
 url="https://github.com/BANANASJIM/padctl"
 license=('LGPL-2.1-or-later')
-depends=('systemd' 'gcc-libs' 'glibc')
+depends=('systemd')
 makedepends=('git')
 provides=('padctl')
 conflicts=('padctl' 'padctl-bin')
@@ -45,13 +45,13 @@ prepare() {
 build() {
     cd padctl
     export ZIG_GLOBAL_CACHE_DIR="${srcdir}/zig-cache"
-    local _zig_arch
+    local _zig_arch _musl_target
     case "${CARCH}" in
-        x86_64) _zig_arch="x86_64-linux" ;;
-        aarch64) _zig_arch="aarch64-linux" ;;
+        x86_64)  _zig_arch="x86_64-linux";  _musl_target="x86_64-linux-musl" ;;
+        aarch64) _zig_arch="aarch64-linux"; _musl_target="aarch64-linux-musl" ;;
         *) echo "unsupported architecture: ${CARCH}" >&2; return 1 ;;
     esac
-    "${srcdir}/zig-${_zig_arch}-${_zig_version}/zig" build -Doptimize=ReleaseSafe
+    "${srcdir}/zig-${_zig_arch}-${_zig_version}/zig" build -Doptimize=ReleaseSafe -Dtarget="${_musl_target}"
 }
 
 package() {

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -5,17 +5,16 @@
 ### Arch Linux (AUR)
 
 ```sh
-yay -S padctl-git
+yay -S padctl-bin   # prebuilt binary
+yay -S padctl-git   # build from source
 ```
-
-A prebuilt binary package (`padctl-bin`) is also available in the AUR.
 
 If you previously installed from source with `sudo padctl install`, remove that
 manual install before switching to AUR so pacman can own the files:
 
 ```sh
 sudo padctl uninstall --prefix /usr --no-immutable
-yay -S padctl-git   # or: yay -S padctl-bin
+yay -S padctl-bin   # or: yay -S padctl-git
 ```
 
 ### Debian / Ubuntu


### PR DESCRIPTION
## Changes

- `contrib/aur/PKGBUILD` `build()`: adds `-Dtarget=<arch>-linux-musl` to the `zig build` invocation, so the AUR source build produces a fully static binary using Zig's bundled musl libc instead of linking against the host's glibc 2.43+ headers and crt objects
- `contrib/aur/PKGBUILD` `depends=`: removes `gcc-libs` and `glibc` — the binary is now statically linked, no glibc runtime required
- `docs/src/getting-started.md`: reorders Arch install to show `padctl-bin` first, `padctl-git` second, matching `README.md` ordering

## Why

On Arch Linux with glibc 2.43+, `zig build` (no explicit target) picks up the host's crt1.o which contains `.sframe` sections. Zig 0.15.x's linker does not handle `R_X86_64_PC64` relocations emitted there, resulting in a hard link error. Passing `-Dtarget=x86_64-linux-musl` (or `aarch64-linux-musl`) routes through Zig's bundled musl libc, bypassing the host crt objects entirely.

## Test plan

- [ ] `docker run --rm -v "$PWD":/src -w /src ghcr.io/bananasjim/padctl-build:0.15.2 zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-musl` exits 0
- [ ] `file zig-out/bin/padctl` reports `statically linked`
- [ ] `docker run --rm -v "$PWD":/src -w /src ghcr.io/bananasjim/padctl-build:0.15.2 zig build test` exits 0

Refs #147