### PR TITLE
feat(doctor): accurate permission, config-provenance, and shadow verdicts

### DIFF
--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -3,6 +3,7 @@ const posix = std.posix;
 const socket_client = @import("socket_client.zig");
 const udev = @import("install/udev.zig");
 const scan = @import("scan.zig");
+const toml_extract = @import("toml_extract.zig");
 const paths = @import("../config/paths.zig");
 
 pub const StatusDevice = socket_client.StatusDevice;
@@ -375,6 +376,123 @@ fn firstExistingDir(dirs: []const []const u8) []const u8 {
     return dirs[0];
 }
 
+/// Every device TOML matching vid:pid across `dirs`, in resolution order; the
+/// first element is the file that wins. Caller owns the slice and elements.
+pub fn collectConfigMatches(allocator: std.mem.Allocator, dirs: []const []const u8, vid: u16, pid: u16) ![][]u8 {
+    var matches: std.ArrayList([]u8) = .{};
+    errdefer {
+        for (matches.items) |m| allocator.free(m);
+        matches.deinit(allocator);
+    }
+    for (dirs) |devices_dir| {
+        var dir = std.fs.openDirAbsolute(devices_dir, .{ .iterate = true }) catch continue;
+        defer dir.close();
+        var walker = dir.walk(allocator) catch continue;
+        defer walker.deinit();
+        while (walker.next() catch null) |we| {
+            if (we.kind != .file or !std.mem.endsWith(u8, we.basename, ".toml")) continue;
+            if (std.mem.startsWith(u8, we.path, "example/")) continue;
+            const full = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ devices_dir, we.path });
+            errdefer allocator.free(full);
+            const content = std.fs.cwd().readFileAlloc(allocator, full, 1 << 20) catch {
+                allocator.free(full);
+                continue;
+            };
+            defer allocator.free(content);
+            const dev = (toml_extract.extractDeviceVidPid(allocator, content) catch null) orelse {
+                allocator.free(full);
+                continue;
+            };
+            toml_extract.freeDeviceInfo(allocator, dev);
+            if (dev.vid == vid and dev.pid == pid) {
+                try matches.append(allocator, full);
+            } else {
+                allocator.free(full);
+            }
+        }
+    }
+    return matches.toOwnedSlice(allocator);
+}
+
+pub fn freeConfigMatches(allocator: std.mem.Allocator, matches: [][]u8) void {
+    for (matches) |m| allocator.free(m);
+    allocator.free(matches);
+}
+
+/// Print which device TOML wins, flagging files it shadows.
+pub fn printProvenance(writer: anytype, matches: []const []const u8) !void {
+    if (matches.len == 0) return;
+    try writer.print("  config: {s}", .{matches[0]});
+    if (matches.len > 1) {
+        try writer.writeAll(" (OVERRIDES");
+        for (matches[1..]) |m| try writer.print(" {s}", .{m});
+        try writer.writeByte(')');
+    }
+    try writer.writeByte('\n');
+}
+
+pub fn printHidrawDiagnosis(writer: anytype, path: ?[]const u8, access_denied: bool) !void {
+    const p = path orelse {
+        try writer.writeAll("  hidraw: none\n");
+        return;
+    };
+    if (access_denied) {
+        try writer.print("  hidraw: {s} exists but permission denied (mode/owner; you are not in the input group)\n", .{p});
+        try writer.writeAll("  hint: sudo usermod -aG input $USER && re-login (or replug to apply udev rules)\n");
+    } else {
+        try writer.print("  hidraw: {s}\n", .{p});
+    }
+}
+
+/// First interface bound to a known gamepad driver (xpad or the device's
+/// block_kernel_drivers list). usbhid is never flagged: hidraw-backed devices
+/// legitimately keep it bound.
+pub fn findFlaggedShadow(interfaces: []const UsbInterface, block_drivers: []const []const u8) ?UsbInterface {
+    for (interfaces) |iface| {
+        const d = iface.driver orelse continue;
+        if (std.mem.eql(u8, d, "usbhid")) continue;
+        if (std.mem.eql(u8, d, "xpad")) return iface;
+        for (block_drivers) |b| {
+            if (std.mem.eql(u8, d, b)) return iface;
+        }
+    }
+    return null;
+}
+
+pub const HidrawState = enum { missing, ok, denied };
+
+pub const VerdictInput = struct {
+    usb_present: bool,
+    claimed: bool,
+    hidraw: HidrawState,
+    kernel_driver: bool,
+    flagged_driver: bool,
+    shadow_grabs: usize,
+};
+
+pub const Verdict = enum {
+    not_detected,
+    ok_managed,
+    managed_unguarded_shadow,
+    permission_denied,
+    shadowed_no_hidraw,
+    no_hidraw,
+    present_not_claimed,
+};
+
+pub fn decideVerdict(in: VerdictInput) Verdict {
+    if (!in.usb_present) return .not_detected;
+    if (in.claimed) {
+        if (in.flagged_driver and in.shadow_grabs == 0) return .managed_unguarded_shadow;
+        return .ok_managed;
+    }
+    if (in.hidraw == .denied) return .permission_denied;
+    if (in.hidraw == .missing) {
+        return if (in.kernel_driver) .shadowed_no_hidraw else .no_hidraw;
+    }
+    return .present_not_claimed;
+}
+
 fn printSupportedDevices(allocator: std.mem.Allocator, status_devices: []const StatusDevice, exec_start: ?[]const u8, writer: anytype) !void {
     try writer.writeAll("[supported devices]\n");
 
@@ -405,6 +523,10 @@ fn printSupportedDevices(allocator: std.mem.Allocator, status_devices: []const S
     for (entries.items) |entry| {
         try writer.print("{s} (0x{x:0>4}:0x{x:0>4})\n", .{ entry.name, entry.vid, entry.pid });
 
+        const matches = collectConfigMatches(allocator, dirs, entry.vid, entry.pid) catch null;
+        defer if (matches) |ms| freeConfigMatches(allocator, ms);
+        if (matches) |ms| try printProvenance(writer, ms);
+
         const presence = probeUsbPresence(allocator, entry.vid, entry.pid, "") catch null;
         defer if (presence) |p| p.deinit(allocator);
 
@@ -425,50 +547,65 @@ fn printSupportedDevices(allocator: std.mem.Allocator, status_devices: []const S
             try writer.writeAll("  usb: (sysfs unavailable)\n");
         }
 
-        const hidraw_path: ?[]const u8 = blk: {
+        const hid_entry: ?scan.ScanEntry = blk: {
             if (scan_entries) |se| {
                 for (se) |se_entry| {
                     if (se_entry.vid == entry.vid and se_entry.pid == entry.pid) {
-                        break :blk se_entry.path;
+                        break :blk se_entry;
                     }
                 }
             }
             break :blk null;
         };
-        if (hidraw_path) |p| {
-            try writer.print("  hidraw: {s}\n", .{p});
-        } else {
-            try writer.writeAll("  hidraw: none\n");
+        const hidraw_state: HidrawState = if (hid_entry) |he|
+            (if (he.access_denied) .denied else .ok)
+        else
+            .missing;
+        try printHidrawDiagnosis(writer, if (hid_entry) |he| he.path else null, hidraw_state == .denied);
+
+        const claimed_sd: ?StatusDevice = blk: {
+            for (status_devices) |sd| {
+                if (sd.vid == entry.vid and sd.pid == entry.pid) break :blk sd;
+            }
+            break :blk null;
+        };
+        const claimed = claimed_sd != null;
+        try writer.print("  padctl: {s}\n", .{if (claimed) "CLAIMED" else "not claimed"});
+        if (claimed_sd) |sd| {
+            if (sd.shadow_grabs > 0) {
+                if (sd.shadow_nodes.len > 0) {
+                    try writer.print("  shadow nodes grabbed: {d} ({s})\n", .{ sd.shadow_grabs, sd.shadow_nodes });
+                } else {
+                    try writer.print("  shadow nodes grabbed: {d}\n", .{sd.shadow_grabs});
+                }
+            }
         }
 
-        const claimed = blk: {
-            for (status_devices) |sd| {
-                if (sd.vid == entry.vid and sd.pid == entry.pid) break :blk true;
-            }
-            break :blk false;
-        };
-        try writer.print("  padctl: {s}\n", .{if (claimed) "CLAIMED" else "not claimed"});
-
         if (presence) |p| {
-            if (!p.present) {
-                try writer.writeAll("  verdict: device not detected on USB\n");
-            } else if (claimed) {
-                try writer.writeAll("  verdict: OK — managed by padctl\n");
-            } else {
-                var any_driver: ?[]const u8 = null;
-                for (p.interfaces) |iface| {
-                    if (iface.driver != null) {
-                        any_driver = iface.driver;
-                        break;
-                    }
+            var any_driver: ?[]const u8 = null;
+            for (p.interfaces) |iface| {
+                if (iface.driver != null) {
+                    any_driver = iface.driver;
+                    break;
                 }
-                if (any_driver != null and hidraw_path == null) {
-                    try writer.print("  verdict: device present but shadowed by '{s}' and no hidraw node\n", .{any_driver.?});
-                } else if (hidraw_path == null) {
-                    try writer.writeAll("  verdict: USB present but no hidraw node — check udev rules or group membership\n");
-                } else {
-                    try writer.writeAll("  verdict: hidraw present but not claimed — daemon down or device not in active mapping\n");
-                }
+            }
+            const flagged = findFlaggedShadow(p.interfaces, entry.block_kernel_drivers);
+            const verdict = decideVerdict(.{
+                .usb_present = p.present,
+                .claimed = claimed,
+                .hidraw = hidraw_state,
+                .kernel_driver = any_driver != null,
+                .flagged_driver = flagged != null,
+                .shadow_grabs = if (claimed_sd) |sd| sd.shadow_grabs else 0,
+            });
+            switch (verdict) {
+                .not_detected => try writer.writeAll("  verdict: device not detected on USB\n"),
+                .ok_managed => try writer.writeAll("  verdict: OK — managed by padctl\n"),
+                .managed_unguarded_shadow => try writer.print("  verdict: WARNING — kernel driver '{s}' bound on {s} but no shadow grab held\n", .{ flagged.?.driver.?, flagged.?.iface }),
+                .permission_denied => try writer.writeAll("  verdict: hidraw node exists but permission denied — fix group membership (see hint above)\n"),
+                .shadowed_no_hidraw => try writer.print("  verdict: device present but shadowed by '{s}' and no hidraw node\n", .{any_driver.?}),
+                .no_hidraw => try writer.writeAll("  verdict: USB present but no hidraw node — check udev rules or group membership\n"),
+                .present_not_claimed => try writer.writeAll("  verdict: hidraw present but not claimed — daemon down or device not in active mapping\n"),
             }
         }
 

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -353,6 +353,22 @@ pub fn resolveDoctorDeviceDirs(allocator: std.mem.Allocator, exec_start: ?[]cons
     return dirs.toOwnedSlice(allocator);
 }
 
+/// Directories in the order the daemon actually resolves device configs: the
+/// unit's --config-dir alone when set (the daemon ignores all other dirs),
+/// otherwise the default user-first search path the bare daemon walks.
+/// Caller owns the returned slice and each element.
+pub fn resolveDaemonConfigDirs(allocator: std.mem.Allocator, exec_start: ?[]const u8) ![][]const u8 {
+    if (exec_start) |es| {
+        if (configDirFromExecStart(es)) |cfg| {
+            const dirs = try allocator.alloc([]const u8, 1);
+            errdefer allocator.free(dirs);
+            dirs[0] = try allocator.dupe(u8, cfg);
+            return dirs;
+        }
+    }
+    return paths.resolveDeviceConfigDirs(allocator);
+}
+
 /// Query the live padctl.service ExecStart so doctor scans the same device dir
 /// the daemon was launched with. Best-effort: returns null on any failure.
 fn queryServiceExecStart(allocator: std.mem.Allocator) ?[]u8 {
@@ -376,12 +392,17 @@ fn firstExistingDir(dirs: []const []const u8) []const u8 {
     return dirs[0];
 }
 
+pub const ConfigMatch = struct {
+    path: []const u8,
+    iface_mask: ?u64,
+};
+
 /// Every device TOML matching vid:pid across `dirs`, in resolution order; the
-/// first element is the file that wins. Caller owns the slice and elements.
-pub fn collectConfigMatches(allocator: std.mem.Allocator, dirs: []const []const u8, vid: u16, pid: u16) ![][]u8 {
-    var matches: std.ArrayList([]u8) = .{};
+/// first element is the file that wins. Caller owns the slice and the paths.
+pub fn collectConfigMatches(allocator: std.mem.Allocator, dirs: []const []const u8, vid: u16, pid: u16) ![]ConfigMatch {
+    var matches: std.ArrayList(ConfigMatch) = .{};
     errdefer {
-        for (matches.items) |m| allocator.free(m);
+        for (matches.items) |m| allocator.free(m.path);
         matches.deinit(allocator);
     }
     for (dirs) |devices_dir| {
@@ -405,7 +426,7 @@ pub fn collectConfigMatches(allocator: std.mem.Allocator, dirs: []const []const 
             };
             toml_extract.freeDeviceInfo(allocator, dev);
             if (dev.vid == vid and dev.pid == pid) {
-                try matches.append(allocator, full);
+                try matches.append(allocator, .{ .path = full, .iface_mask = scan.interfaceIdMask(content) });
             } else {
                 allocator.free(full);
             }
@@ -414,21 +435,41 @@ pub fn collectConfigMatches(allocator: std.mem.Allocator, dirs: []const []const 
     return matches.toOwnedSlice(allocator);
 }
 
-pub fn freeConfigMatches(allocator: std.mem.Allocator, matches: [][]u8) void {
-    for (matches) |m| allocator.free(m);
+pub fn freeConfigMatches(allocator: std.mem.Allocator, matches: []ConfigMatch) void {
+    for (matches) |m| allocator.free(m.path);
     allocator.free(matches);
 }
 
-/// Print which device TOML wins, flagging files it shadows.
-pub fn printProvenance(writer: anytype, matches: []const []const u8) !void {
-    if (matches.len == 0) return;
-    try writer.print("  config: {s}", .{matches[0]});
-    if (matches.len > 1) {
-        try writer.writeAll(" (OVERRIDES");
-        for (matches[1..]) |m| try writer.print(" {s}", .{m});
-        try writer.writeByte(')');
+fn ifaceOverlap(a: ?u64, b: ?u64) bool {
+    const am = a orelse return true;
+    const bm = b orelse return true;
+    return (am & bm) != 0;
+}
+
+fn firstOverlapping(matches: []const ConfigMatch, idx: usize) ?usize {
+    for (matches[0..idx], 0..) |prev, k| {
+        if (ifaceOverlap(prev.iface_mask, matches[idx].iface_mask)) return k;
     }
-    try writer.writeByte('\n');
+    return null;
+}
+
+/// Print which device TOML wins, flagging files it shadows. Files constrained
+/// to disjoint interfaces are co-active and each get their own line.
+pub fn printProvenance(writer: anytype, matches: []const ConfigMatch) !void {
+    for (matches, 0..) |m, i| {
+        if (firstOverlapping(matches, i) != null) continue;
+        try writer.print("  config: {s}", .{m.path});
+        var open = false;
+        for (matches[i + 1 ..], i + 1..) |later, j| {
+            const winner = firstOverlapping(matches, j) orelse continue;
+            if (winner != i) continue;
+            try writer.writeAll(if (open) " " else " (OVERRIDES ");
+            try writer.print("{s}", .{later.path});
+            open = true;
+        }
+        if (open) try writer.writeByte(')');
+        try writer.writeByte('\n');
+    }
 }
 
 pub fn printHidrawDiagnosis(writer: anytype, path: ?[]const u8, access_denied: bool) !void {
@@ -493,6 +534,18 @@ pub fn decideVerdict(in: VerdictInput) Verdict {
     return .present_not_claimed;
 }
 
+/// Entry for vid:pid, preferring a readable node over an access-denied one
+/// when the device exposes several hidraw nodes with mixed permissions.
+pub fn pickScanEntry(entries: []const scan.ScanEntry, vid: u16, pid: u16) ?scan.ScanEntry {
+    var denied: ?scan.ScanEntry = null;
+    for (entries) |e| {
+        if (e.vid != vid or e.pid != pid) continue;
+        if (!e.access_denied) return e;
+        if (denied == null) denied = e;
+    }
+    return denied;
+}
+
 fn printSupportedDevices(allocator: std.mem.Allocator, status_devices: []const StatusDevice, exec_start: ?[]const u8, writer: anytype) !void {
     try writer.writeAll("[supported devices]\n");
 
@@ -520,10 +573,16 @@ fn printSupportedDevices(allocator: std.mem.Allocator, status_devices: []const S
     const scan_entries = scan.scan(allocator, scan_dir) catch null;
     defer if (scan_entries) |se| scan.freeEntries(allocator, se);
 
+    const daemon_dirs = resolveDaemonConfigDirs(allocator, exec_start) catch null;
+    defer if (daemon_dirs) |dd| paths.freeConfigDirs(allocator, dd);
+
     for (entries.items) |entry| {
         try writer.print("{s} (0x{x:0>4}:0x{x:0>4})\n", .{ entry.name, entry.vid, entry.pid });
 
-        const matches = collectConfigMatches(allocator, dirs, entry.vid, entry.pid) catch null;
+        const matches = if (daemon_dirs) |dd|
+            collectConfigMatches(allocator, dd, entry.vid, entry.pid) catch null
+        else
+            null;
         defer if (matches) |ms| freeConfigMatches(allocator, ms);
         if (matches) |ms| try printProvenance(writer, ms);
 
@@ -547,16 +606,10 @@ fn printSupportedDevices(allocator: std.mem.Allocator, status_devices: []const S
             try writer.writeAll("  usb: (sysfs unavailable)\n");
         }
 
-        const hid_entry: ?scan.ScanEntry = blk: {
-            if (scan_entries) |se| {
-                for (se) |se_entry| {
-                    if (se_entry.vid == entry.vid and se_entry.pid == entry.pid) {
-                        break :blk se_entry;
-                    }
-                }
-            }
-            break :blk null;
-        };
+        const hid_entry: ?scan.ScanEntry = if (scan_entries) |se|
+            pickScanEntry(se, entry.vid, entry.pid)
+        else
+            null;
         const hidraw_state: HidrawState = if (hid_entry) |he|
             (if (he.access_denied) .denied else .ok)
         else

--- a/src/cli/scan.zig
+++ b/src/cli/scan.zig
@@ -32,7 +32,69 @@ pub const ScanEntry = struct {
     phys: []const u8,
     config_path: ?[]const u8,
     interface_id: ?u8 = null,
+    access_denied: bool = false,
 };
+
+pub const UeventInfo = struct {
+    vid: u16,
+    pid: u16,
+    name: []const u8,
+};
+
+/// Parse HID_ID/HID_NAME from a hidraw device uevent, so a node's identity is
+/// readable without opening it. `name` aliases `content`.
+pub fn parseHidrawUevent(content: []const u8) ?UeventInfo {
+    var info: UeventInfo = .{ .vid = 0, .pid = 0, .name = "" };
+    var have_id = false;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |raw| {
+        const line = std.mem.trimRight(u8, raw, "\r");
+        if (std.mem.startsWith(u8, line, "HID_ID=")) {
+            var parts = std.mem.splitScalar(u8, line["HID_ID=".len..], ':');
+            _ = parts.next();
+            const vid_s = parts.next() orelse continue;
+            const pid_s = parts.next() orelse continue;
+            const vid = std.fmt.parseInt(u32, vid_s, 16) catch continue;
+            const pid = std.fmt.parseInt(u32, pid_s, 16) catch continue;
+            info.vid = @truncate(vid);
+            info.pid = @truncate(pid);
+            have_id = true;
+        } else if (std.mem.startsWith(u8, line, "HID_NAME=")) {
+            info.name = line["HID_NAME=".len..];
+        }
+    }
+    return if (have_id) info else null;
+}
+
+/// Build an entry for a node that exists but cannot be opened, using the
+/// world-readable sysfs uevent for identity.
+fn accessDeniedEntry(allocator: std.mem.Allocator, config_dir: []const u8, path: []const u8) !?ScanEntry {
+    var uevent_path_buf: [256]u8 = undefined;
+    const uevent_path = std.fmt.bufPrint(&uevent_path_buf, "/sys/class/hidraw/{s}/device/uevent", .{std.fs.path.basename(path)}) catch return null;
+    var f = std.fs.openFileAbsolute(uevent_path, .{}) catch return null;
+    defer f.close();
+    var content: [1024]u8 = undefined;
+    const n = f.read(&content) catch return null;
+    const info = parseHidrawUevent(content[0..n]) orelse return null;
+
+    const owned_path = try allocator.dupe(u8, path);
+    errdefer allocator.free(owned_path);
+    const name = try allocator.dupe(u8, info.name);
+    errdefer allocator.free(name);
+    const phys = readPhysicalPath(allocator, path) catch try allocator.dupe(u8, "");
+    errdefer allocator.free(phys);
+    const iface_id = readInterfaceId(path);
+    return .{
+        .path = owned_path,
+        .vid = info.vid,
+        .pid = info.pid,
+        .name = name,
+        .phys = phys,
+        .config_path = findConfig(allocator, config_dir, info.vid, info.pid, iface_id) catch null,
+        .interface_id = iface_id,
+        .access_denied = true,
+    };
+}
 
 /// Enumerate /dev/hidrawN, match against *.toml with interface filtering.
 /// Caller owns result; call freeEntries() when done.
@@ -43,7 +105,6 @@ pub fn scan(allocator: std.mem.Allocator, config_dir: []const u8) ![]ScanEntry {
         entries.deinit(allocator);
     }
 
-    var access_denied_hint_shown = false;
     var i: u8 = 0;
     while (i < MAX_HIDRAW) : (i += 1) {
         var path_buf: [32]u8 = undefined;
@@ -52,9 +113,11 @@ pub fn scan(allocator: std.mem.Allocator, config_dir: []const u8) ![]ScanEntry {
         const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch |err| switch (err) {
             error.FileNotFound => continue,
             error.AccessDenied => {
-                if (!access_denied_hint_shown) {
-                    std.log.warn("scan: permission denied on {s} — run with sudo or add yourself to the 'input' group", .{path});
-                    access_denied_hint_shown = true;
+                if (accessDeniedEntry(allocator, config_dir, path) catch null) |e| {
+                    entries.append(allocator, e) catch |aerr| {
+                        freeEntry(allocator, e);
+                        return aerr;
+                    };
                 }
                 continue;
             },
@@ -372,8 +435,10 @@ fn visibleInHidraw(d: StatusDevice, entries: []const ScanEntry) bool {
 
 /// Render scan results. Daemon-managed devices whose hidraw nodes are gone
 /// (the libusb claim detached the kernel driver) are merged in as
-/// "(claimed by padctl)" rows, deduplicated by vid:pid.
-fn render(writer: anytype, entries: []const ScanEntry, daemon_devices: []const StatusDevice) !void {
+/// "(claimed by padctl)" rows, deduplicated by vid:pid. A single permission
+/// warning covers all access-denied nodes regardless of how many config dirs
+/// were scanned.
+pub fn render(writer: anytype, entries: []const ScanEntry, daemon_devices: []const StatusDevice) !void {
     var claimed: usize = 0;
     for (daemon_devices) |d| {
         if (!visibleInHidraw(d, entries)) claimed += 1;
@@ -436,6 +501,15 @@ fn render(writer: anytype, entries: []const ScanEntry, daemon_devices: []const S
         entries.len - unmatched + claimed,
         unmatched,
     });
+
+    var denied: usize = 0;
+    for (entries) |e| {
+        if (e.access_denied) denied += 1;
+    }
+    if (denied > 0) {
+        try writer.print("\nwarning: permission denied opening {d} hidraw node(s)\n", .{denied});
+        try writer.writeAll("hint: sudo usermod -aG input $USER && re-login (or replug to apply udev rules)\n");
+    }
 
     if (unmatched > 0) {
         try writer.writeByte('\n');

--- a/src/cli/scan.zig
+++ b/src/cli/scan.zig
@@ -71,11 +71,15 @@ pub fn parseHidrawUevent(content: []const u8) ?UeventInfo {
 fn accessDeniedEntry(allocator: std.mem.Allocator, config_dir: []const u8, path: []const u8) !?ScanEntry {
     var uevent_path_buf: [256]u8 = undefined;
     const uevent_path = std.fmt.bufPrint(&uevent_path_buf, "/sys/class/hidraw/{s}/device/uevent", .{std.fs.path.basename(path)}) catch return null;
-    var f = std.fs.openFileAbsolute(uevent_path, .{}) catch return null;
-    defer f.close();
-    var content: [1024]u8 = undefined;
-    const n = f.read(&content) catch return null;
-    const info = parseHidrawUevent(content[0..n]) orelse return null;
+    const content = std.fs.cwd().readFileAlloc(allocator, uevent_path, 8192) catch |err| {
+        std.log.warn("scan: cannot identify denied node {s}: {}", .{ path, err });
+        return null;
+    };
+    defer allocator.free(content);
+    const info = parseHidrawUevent(content) orelse {
+        std.log.warn("scan: cannot identify denied node {s}: no HID_ID in uevent", .{path});
+        return null;
+    };
 
     const owned_path = try allocator.dupe(u8, path);
     errdefer allocator.free(owned_path);
@@ -166,20 +170,26 @@ pub fn scan(allocator: std.mem.Allocator, config_dir: []const u8) ![]ScanEntry {
         });
     }
 
-    // Suppress unmatched sibling interfaces of matched physical devices.
-    // If any hidraw node for a physical device matched a config, hide the
-    // unmatched siblings sharing the same physical path.
+    suppressUnmatchedSiblings(allocator, &entries);
+
+    return entries.toOwnedSlice(allocator);
+}
+
+/// Suppress unmatched sibling interfaces of matched physical devices: if any
+/// hidraw node for a physical device matched a config, hide the unmatched
+/// siblings sharing the same physical path. Access-denied siblings stay
+/// visible so denied-node counts remain accurate.
+fn suppressUnmatchedSiblings(allocator: std.mem.Allocator, entries: *std.ArrayList(ScanEntry)) void {
     for (entries.items) |e| {
         if (e.config_path != null and e.phys.len > 0) {
             for (entries.items) |*other| {
-                if (other.config_path == null and std.mem.eql(u8, other.phys, e.phys)) {
+                if (other.config_path == null and !other.access_denied and std.mem.eql(u8, other.phys, e.phys)) {
                     other.config_path = ""; // sentinel: suppress but don't show
                 }
             }
         }
     }
 
-    // Remove suppressed entries (sentinel config_path == "")
     var keep: usize = 0;
     for (entries.items) |e| {
         if (e.config_path) |cp| {
@@ -195,8 +205,6 @@ pub fn scan(allocator: std.mem.Allocator, config_dir: []const u8) ![]ScanEntry {
         keep += 1;
     }
     entries.shrinkRetainingCapacity(keep);
-
-    return entries.toOwnedSlice(allocator);
 }
 
 pub fn findConfig(allocator: std.mem.Allocator, config_dir: []const u8, vid: u16, pid: u16, iface_id: ?u8) ![]const u8 {
@@ -265,6 +273,26 @@ fn tomlMatchesVidPid(allocator: std.mem.Allocator, path: []const u8, vid: u16, p
     return matchInterfaceId(content, iface_id);
 }
 
+/// First `id = <n>` value in one [[device.interface]] section body.
+fn sectionInterfaceId(after: []const u8) ?u8 {
+    var lines = std.mem.splitScalar(u8, after, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trimLeft(u8, line, " \t");
+        if (trimmed.len == 0) continue;
+        if (trimmed[0] == '[') break; // next section
+        if (trimmed[0] == '#') continue;
+        if (!std.mem.startsWith(u8, trimmed, "id")) continue;
+        const rest = std.mem.trimLeft(u8, trimmed["id".len..], " \t");
+        if (rest.len == 0 or rest[0] != '=') continue;
+        const val_str = std.mem.trimLeft(u8, rest[1..], " \t");
+        var end: usize = 0;
+        while (end < val_str.len and std.ascii.isDigit(val_str[end])) end += 1;
+        if (end == 0) continue;
+        return std.fmt.parseInt(u8, val_str[0..end], 10) catch continue;
+    }
+    return null;
+}
+
 /// Check whether TOML content has a [[device.interface]] section whose id matches target.
 /// Returns null if no [[device.interface]] sections exist (no constraint),
 /// true if any section's id matches target, false otherwise.
@@ -274,28 +302,30 @@ fn configHasInterfaceId(content: []const u8, target: u8) ?bool {
     var pos: usize = 0;
     while (std.mem.indexOfPos(u8, content, pos, marker)) |idx| {
         found_any = true;
-        const after = content[idx + marker.len ..];
-        var lines = std.mem.splitScalar(u8, after, '\n');
-        while (lines.next()) |line| {
-            const trimmed = std.mem.trimLeft(u8, line, " \t");
-            if (trimmed.len == 0) continue;
-            if (trimmed[0] == '[') break; // next section
-            if (trimmed[0] == '#') continue;
-            if (!std.mem.startsWith(u8, trimmed, "id")) continue;
-            const rest = std.mem.trimLeft(u8, trimmed["id".len..], " \t");
-            if (rest.len == 0 or rest[0] != '=') continue;
-            const val_str = std.mem.trimLeft(u8, rest[1..], " \t");
-            var end: usize = 0;
-            while (end < val_str.len and std.ascii.isDigit(val_str[end])) end += 1;
-            if (end == 0) continue;
-            const parsed = std.fmt.parseInt(u8, val_str[0..end], 10) catch continue;
-            if (parsed == target) return true;
-            break; // found id for this section, move to next
+        if (sectionInterfaceId(content[idx + marker.len ..])) |id| {
+            if (id == target) return true;
         }
         pos = idx + marker.len;
     }
     if (!found_any) return null;
     return false;
+}
+
+/// Bitmask of [[device.interface]] ids declared in TOML content (ids above 63
+/// share the top bit). Null when no interface sections exist (matches any).
+pub fn interfaceIdMask(content: []const u8) ?u64 {
+    const marker = "[[device.interface]]";
+    var mask: u64 = 0;
+    var found_any = false;
+    var pos: usize = 0;
+    while (std.mem.indexOfPos(u8, content, pos, marker)) |idx| {
+        found_any = true;
+        if (sectionInterfaceId(content[idx + marker.len ..])) |id| {
+            mask |= @as(u64, 1) << @intCast(@min(id, 63));
+        }
+        pos = idx + marker.len;
+    }
+    return if (found_any) mask else null;
 }
 
 /// Match device interface id against config's [[device.interface]] sections.
@@ -614,6 +644,57 @@ test "scan: matchInterfaceId: with constraint and known iface" {
 test "scan: matchInterfaceId: with constraint and null iface returns false" {
     const toml = "[[device.interface]]\nid = 2\n";
     try std.testing.expectEqual(@as(?bool, false), matchInterfaceId(toml, null));
+}
+
+test "scan: interfaceIdMask: no sections is null, ids become bits" {
+    try std.testing.expectEqual(@as(?u64, null), interfaceIdMask("[device]\nvid = 0x1234\n"));
+    try std.testing.expectEqual(@as(?u64, 1 << 2), interfaceIdMask("[[device.interface]]\nid = 2\n"));
+    try std.testing.expectEqual(
+        @as(?u64, (1 << 0) | (1 << 2)),
+        interfaceIdMask("[[device.interface]]\nid = 0\n\n[[device.interface]]\nid = 2\n"),
+    );
+}
+
+test "scan: suppressUnmatchedSiblings keeps access-denied siblings visible" {
+    const allocator = std.testing.allocator;
+    var entries: std.ArrayList(ScanEntry) = .{};
+    defer {
+        for (entries.items) |e| freeEntry(allocator, e);
+        entries.deinit(allocator);
+    }
+    const phys = "usb-0000:10:00.0-3";
+    try entries.append(allocator, .{
+        .path = try allocator.dupe(u8, "/dev/hidraw0"),
+        .vid = 0x37d7,
+        .pid = 0x2401,
+        .name = try allocator.dupe(u8, "pad"),
+        .phys = try allocator.dupe(u8, phys),
+        .config_path = try allocator.dupe(u8, "devices/pad.toml"),
+    });
+    try entries.append(allocator, .{
+        .path = try allocator.dupe(u8, "/dev/hidraw1"),
+        .vid = 0x37d7,
+        .pid = 0x2401,
+        .name = try allocator.dupe(u8, "pad"),
+        .phys = try allocator.dupe(u8, phys),
+        .config_path = null,
+    });
+    try entries.append(allocator, .{
+        .path = try allocator.dupe(u8, "/dev/hidraw2"),
+        .vid = 0x37d7,
+        .pid = 0x2401,
+        .name = try allocator.dupe(u8, "pad"),
+        .phys = try allocator.dupe(u8, phys),
+        .config_path = null,
+        .access_denied = true,
+    });
+
+    suppressUnmatchedSiblings(allocator, &entries);
+
+    try std.testing.expectEqual(@as(usize, 2), entries.items.len);
+    try std.testing.expectEqualStrings("/dev/hidraw0", entries.items[0].path);
+    try std.testing.expectEqualStrings("/dev/hidraw2", entries.items[1].path);
+    try std.testing.expect(entries.items[1].access_denied);
 }
 
 test "scan: freeEntries: empty slice is a no-op" {

--- a/src/cli/socket_client.zig
+++ b/src/cli/socket_client.zig
@@ -144,12 +144,15 @@ pub const StatusDevice = struct {
     pid: u16,
     output_kind: []const u8,
     output_fd_alive: bool,
+    shadow_grabs: usize = 0,
+    shadow_nodes: []const u8 = "",
 
     pub fn deinit(self: StatusDevice, allocator: std.mem.Allocator) void {
         allocator.free(self.name);
         allocator.free(self.state);
         allocator.free(self.mapping);
         allocator.free(self.output_kind);
+        allocator.free(self.shadow_nodes);
     }
 };
 
@@ -186,9 +189,12 @@ pub fn parseStatusLine(line: []const u8, allocator: std.mem.Allocator) ![]Status
         errdefer allocator.free(mapping);
         const output_kind = try extractField(allocator, chunk, "output_kind=", null);
         errdefer allocator.free(output_kind);
+        const shadow_nodes = try extractField(allocator, chunk, "shadow_nodes=", null);
+        errdefer allocator.free(shadow_nodes);
         const vid = parseHexField(chunk, "vid=0x") orelse 0;
         const pid = parseHexField(chunk, "pid=0x") orelse 0;
         const output_fd_alive = std.mem.indexOf(u8, chunk, "output_fd_alive=true") != null;
+        const shadow_grabs = parseDecField(chunk, "shadow_grabs=") orelse 0;
 
         try devices.append(allocator, .{
             .name = name,
@@ -198,6 +204,8 @@ pub fn parseStatusLine(line: []const u8, allocator: std.mem.Allocator) ![]Status
             .pid = pid,
             .output_kind = output_kind,
             .output_fd_alive = output_fd_alive,
+            .shadow_grabs = shadow_grabs,
+            .shadow_nodes = shadow_nodes,
         });
     }
 
@@ -215,6 +223,15 @@ fn extractField(allocator: std.mem.Allocator, chunk: []const u8, key: []const u8
     var i = val_start;
     while (i < chunk.len and chunk[i] != ' ' and chunk[i] != '\n' and chunk[i] != '\r') i += 1;
     return allocator.dupe(u8, chunk[val_start..i]);
+}
+
+fn parseDecField(chunk: []const u8, key: []const u8) ?usize {
+    const pos = std.mem.indexOf(u8, chunk, key) orelse return null;
+    const val_start = pos + key.len;
+    var end = val_start;
+    while (end < chunk.len and std.ascii.isDigit(chunk[end])) end += 1;
+    if (end == val_start) return null;
+    return std.fmt.parseInt(usize, chunk[val_start..end], 10) catch null;
 }
 
 fn parseHexField(chunk: []const u8, key: []const u8) ?u16 {

--- a/src/io/shadow_grab.zig
+++ b/src/io/shadow_grab.zig
@@ -45,6 +45,18 @@ pub const GrabList = struct {
         return false;
     }
 
+    /// Append this list's STATUS wire fields: ` shadow_grabs=<n>` plus a
+    /// comma-joined ` shadow_nodes=` list when any grab is held.
+    pub fn appendStatusFields(self: *const GrabList, w: anytype) !void {
+        try w.print(" shadow_grabs={d}", .{self.len});
+        if (self.len == 0) return;
+        try w.writeAll(" shadow_nodes=");
+        for (self.grabs[0..self.len], 0..) |*g, i| {
+            if (i > 0) try w.writeByte(',');
+            try w.writeAll(g.name());
+        }
+    }
+
     /// Closing a grabbed fd implicitly releases its EVIOCGRAB.
     pub fn releaseAll(self: *GrabList) void {
         for (self.grabs[0..self.len]) |*g| posix.close(g.fd);

--- a/src/main.zig
+++ b/src/main.zig
@@ -117,6 +117,7 @@ pub const testing_support = struct {
     pub const auto_device_test = @import("test/auto_device_test.zig");
     pub const transform_boundary_test = @import("test/transform_boundary_test.zig");
     pub const bugfix_regression_test = @import("test/bugfix_regression_test.zig");
+    pub const doctor_accuracy_test = @import("test/doctor_accuracy_test.zig");
     pub const event_loop_rumble_test = @import("test/event_loop_rumble_test.zig");
     pub const uhid_output_dispatch_test = @import("test/uhid_output_dispatch_test.zig");
     pub const pidff_e2e_test = @import("test/pidff_e2e_test.zig");

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -2101,6 +2101,8 @@ pub const Supervisor = struct {
             w.print(" last_inbound_ms_ago={d} last_outbound_ms_ago={d} write_in_flight_ms={d}", .{
                 inb_ago_ms, outb_ago_ms, inflight_ms,
             }) catch {};
+
+            m.shadow_grabs.appendStatusFields(w) catch {};
         }
         w.writeByte('\n') catch return;
         cs.sendResponse(fd, stream.getWritten());

--- a/src/test/doctor_accuracy_test.zig
+++ b/src/test/doctor_accuracy_test.zig
@@ -1,0 +1,277 @@
+const std = @import("std");
+const testing = std.testing;
+const scan = @import("../cli/scan.zig");
+const doctor = @import("../cli/doctor.zig");
+const socket_client = @import("../cli/socket_client.zig");
+const shadow_grab = @import("../io/shadow_grab.zig");
+
+// --- hidraw uevent parsing (permission-denied identity without open()) ---
+
+test "doctor_accuracy: parseHidrawUevent extracts vid/pid/name from HID_ID and HID_NAME" {
+    const uevent =
+        "DRIVER=flydigi\n" ++
+        "HID_ID=0003:000037D7:00002401\n" ++
+        "HID_NAME=Flydigi VADER5\n" ++
+        "HID_PHYS=usb-0000:10:00.0-3/input1\n" ++
+        "MODALIAS=hid:b0003g0001v000037D7p00002401\n";
+    const info = scan.parseHidrawUevent(uevent).?;
+    try testing.expectEqual(@as(u16, 0x37d7), info.vid);
+    try testing.expectEqual(@as(u16, 0x2401), info.pid);
+    try testing.expectEqualStrings("Flydigi VADER5", info.name);
+}
+
+test "doctor_accuracy: parseHidrawUevent without HID_ID returns null" {
+    try testing.expect(scan.parseHidrawUevent("DRIVER=hid-generic\nHID_NAME=foo\n") == null);
+    try testing.expect(scan.parseHidrawUevent("") == null);
+}
+
+test "doctor_accuracy: parseHidrawUevent tolerates CRLF and missing HID_NAME" {
+    const info = scan.parseHidrawUevent("HID_ID=0003:0000045E:00000B00\r\n").?;
+    try testing.expectEqual(@as(u16, 0x045e), info.vid);
+    try testing.expectEqual(@as(u16, 0x0b00), info.pid);
+    try testing.expectEqualStrings("", info.name);
+}
+
+// --- scan: permission warning printed once per run, not per config dir ---
+
+test "doctor_accuracy: render prints one permission warning for multiple denied nodes" {
+    var buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const entries = [_]scan.ScanEntry{
+        .{ .path = "/dev/hidraw1", .vid = 0x37d7, .pid = 0x2401, .name = "Vader 5", .phys = "usb-1", .config_path = null, .access_denied = true },
+        .{ .path = "/dev/hidraw2", .vid = 0x045e, .pid = 0x0b00, .name = "Elite 2", .phys = "usb-2", .config_path = null, .access_denied = true },
+    };
+    try scan.render(fbs.writer(), &entries, &.{});
+    const out = fbs.getWritten();
+
+    try testing.expect(std.mem.indexOf(u8, out, "permission denied opening 2 hidraw node(s)") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "usermod -aG input") != null);
+    const first = std.mem.indexOf(u8, out, "permission denied").?;
+    try testing.expect(std.mem.indexOfPos(u8, out, first + 1, "permission denied") == null);
+}
+
+test "doctor_accuracy: render prints no permission warning when nothing denied" {
+    var buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const entries = [_]scan.ScanEntry{
+        .{ .path = "/dev/hidraw0", .vid = 0x37d7, .pid = 0x2401, .name = "Vader 5", .phys = "usb-1", .config_path = "devices/vader5.toml" },
+    };
+    try scan.render(fbs.writer(), &entries, &.{});
+    try testing.expect(std.mem.indexOf(u8, fbs.getWritten(), "permission denied") == null);
+}
+
+// --- doctor: hidraw line tells the truth for access-denied nodes ---
+
+test "doctor_accuracy: printHidrawDiagnosis denied node names the node and remedy" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    try doctor.printHidrawDiagnosis(buf.writer(testing.allocator), "/dev/hidraw3", true);
+    try testing.expectEqualStrings(
+        "  hidraw: /dev/hidraw3 exists but permission denied (mode/owner; you are not in the input group)\n" ++
+            "  hint: sudo usermod -aG input $USER && re-login (or replug to apply udev rules)\n",
+        buf.items,
+    );
+}
+
+test "doctor_accuracy: printHidrawDiagnosis readable node and missing node" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    try doctor.printHidrawDiagnosis(buf.writer(testing.allocator), "/dev/hidraw3", false);
+    try testing.expectEqualStrings("  hidraw: /dev/hidraw3\n", buf.items);
+    buf.clearRetainingCapacity();
+    try doctor.printHidrawDiagnosis(buf.writer(testing.allocator), null, false);
+    try testing.expectEqualStrings("  hidraw: none\n", buf.items);
+}
+
+// --- doctor: verdict decision ---
+
+test "doctor_accuracy: decideVerdict denied node is permission_denied, not shadowed or no-node" {
+    const base: doctor.VerdictInput = .{
+        .usb_present = true,
+        .claimed = false,
+        .hidraw = .denied,
+        .kernel_driver = false,
+        .flagged_driver = false,
+        .shadow_grabs = 0,
+    };
+    try testing.expectEqual(doctor.Verdict.permission_denied, doctor.decideVerdict(base));
+
+    var with_driver = base;
+    with_driver.kernel_driver = true;
+    with_driver.flagged_driver = true;
+    try testing.expectEqual(doctor.Verdict.permission_denied, doctor.decideVerdict(with_driver));
+}
+
+test "doctor_accuracy: decideVerdict unclaimed missing-node branches" {
+    var in: doctor.VerdictInput = .{
+        .usb_present = true,
+        .claimed = false,
+        .hidraw = .missing,
+        .kernel_driver = true,
+        .flagged_driver = false,
+        .shadow_grabs = 0,
+    };
+    try testing.expectEqual(doctor.Verdict.shadowed_no_hidraw, doctor.decideVerdict(in));
+    in.kernel_driver = false;
+    try testing.expectEqual(doctor.Verdict.no_hidraw, doctor.decideVerdict(in));
+    in.hidraw = .ok;
+    try testing.expectEqual(doctor.Verdict.present_not_claimed, doctor.decideVerdict(in));
+    in.usb_present = false;
+    try testing.expectEqual(doctor.Verdict.not_detected, doctor.decideVerdict(in));
+}
+
+test "doctor_accuracy: decideVerdict managed device downgraded only when flagged driver has no grab" {
+    var in: doctor.VerdictInput = .{
+        .usb_present = true,
+        .claimed = true,
+        .hidraw = .ok,
+        .kernel_driver = true,
+        .flagged_driver = true,
+        .shadow_grabs = 0,
+    };
+    try testing.expectEqual(doctor.Verdict.managed_unguarded_shadow, doctor.decideVerdict(in));
+    in.shadow_grabs = 2;
+    try testing.expectEqual(doctor.Verdict.ok_managed, doctor.decideVerdict(in));
+    in.shadow_grabs = 0;
+    in.flagged_driver = false;
+    try testing.expectEqual(doctor.Verdict.ok_managed, doctor.decideVerdict(in));
+}
+
+test "doctor_accuracy: findFlaggedShadow flags xpad and block-listed drivers, never usbhid" {
+    const ifaces = [_]doctor.UsbInterface{
+        .{ .iface = "1-2:1.0", .driver = "usbhid" },
+        .{ .iface = "1-2:1.1", .driver = null },
+        .{ .iface = "1-2:1.2", .driver = "xpad" },
+    };
+    const hit = doctor.findFlaggedShadow(&ifaces, &.{}).?;
+    try testing.expectEqualStrings("1-2:1.2", hit.iface);
+    try testing.expectEqualStrings("xpad", hit.driver.?);
+
+    const usbhid_only = [_]doctor.UsbInterface{
+        .{ .iface = "1-2:1.0", .driver = "usbhid" },
+    };
+    try testing.expect(doctor.findFlaggedShadow(&usbhid_only, &.{}) == null);
+    try testing.expect(doctor.findFlaggedShadow(&usbhid_only, &.{"usbhid"}) == null);
+
+    const custom = [_]doctor.UsbInterface{
+        .{ .iface = "3-1:1.0", .driver = "hid-tmff2" },
+    };
+    try testing.expect(doctor.findFlaggedShadow(&custom, &.{}) == null);
+    const flagged = doctor.findFlaggedShadow(&custom, &.{"hid-tmff2"}).?;
+    try testing.expectEqualStrings("hid-tmff2", flagged.driver.?);
+}
+
+// --- doctor: config provenance (#397 stale-override trap) ---
+
+test "doctor_accuracy: printProvenance single match has no OVERRIDES" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    try doctor.printProvenance(buf.writer(testing.allocator), &.{"/usr/share/padctl/devices/flydigi/vader5.toml"});
+    try testing.expectEqualStrings("  config: /usr/share/padctl/devices/flydigi/vader5.toml\n", buf.items);
+}
+
+test "doctor_accuracy: printProvenance shadowed files listed after OVERRIDES" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    try doctor.printProvenance(buf.writer(testing.allocator), &.{
+        "/home/u/.config/padctl/devices/vader5.toml",
+        "/usr/share/padctl/devices/flydigi/vader5.toml",
+    });
+    try testing.expectEqualStrings(
+        "  config: /home/u/.config/padctl/devices/vader5.toml (OVERRIDES /usr/share/padctl/devices/flydigi/vader5.toml)\n",
+        buf.items,
+    );
+}
+
+test "doctor_accuracy: printProvenance empty match prints nothing" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    try doctor.printProvenance(buf.writer(testing.allocator), &.{});
+    try testing.expectEqual(@as(usize, 0), buf.items.len);
+}
+
+test "doctor_accuracy: collectConfigMatches walks dirs in resolution order" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    try tmp.dir.makePath("user/devices");
+    try tmp.dir.makePath("system/devices/flydigi");
+    inline for (.{ "user/devices/vader5.toml", "system/devices/flydigi/vader5.toml" }) |rel| {
+        var f = try tmp.dir.createFile(rel, .{});
+        defer f.close();
+        try f.writeAll("[device]\nname = \"vader5\"\nvid = 0x37d7\npid = 0x2401\n");
+    }
+    {
+        var f = try tmp.dir.createFile("system/devices/other.toml", .{});
+        defer f.close();
+        try f.writeAll("[device]\nname = \"other\"\nvid = 0x1111\npid = 0x2222\n");
+    }
+
+    const user_dir = try std.fmt.allocPrint(allocator, "{s}/user/devices", .{root});
+    defer allocator.free(user_dir);
+    const sys_dir = try std.fmt.allocPrint(allocator, "{s}/system/devices", .{root});
+    defer allocator.free(sys_dir);
+
+    const matches = try doctor.collectConfigMatches(allocator, &.{ user_dir, sys_dir }, 0x37d7, 0x2401);
+    defer doctor.freeConfigMatches(allocator, matches);
+    try testing.expectEqual(@as(usize, 2), matches.len);
+    try testing.expect(std.mem.endsWith(u8, matches[0], "user/devices/vader5.toml"));
+    try testing.expect(std.mem.endsWith(u8, matches[1], "system/devices/flydigi/vader5.toml"));
+
+    const none = try doctor.collectConfigMatches(allocator, &.{ user_dir, sys_dir }, 0xffff, 0xffff);
+    defer doctor.freeConfigMatches(allocator, none);
+    try testing.expectEqual(@as(usize, 0), none.len);
+}
+
+// --- STATUS wire: shadow_grabs fields, additive ---
+
+test "doctor_accuracy: GrabList.appendStatusFields emits count and node list" {
+    var list = shadow_grab.GrabList{};
+    var buf: [256]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try list.appendStatusFields(fbs.writer());
+    try testing.expectEqualStrings(" shadow_grabs=0", fbs.getWritten());
+
+    inline for (.{ "event5", "event17" }, 0..) |n, i| {
+        list.grabs[i] = .{ .fd = -1, .name_buf = undefined, .name_len = n.len };
+        @memcpy(list.grabs[i].name_buf[0..n.len], n);
+    }
+    list.len = 2;
+    fbs.reset();
+    try list.appendStatusFields(fbs.writer());
+    try testing.expectEqualStrings(" shadow_grabs=2 shadow_nodes=event5,event17", fbs.getWritten());
+}
+
+test "doctor_accuracy: parseStatusLine reads shadow_grabs and shadow_nodes" {
+    const line = "STATUS device=vader5 state=active mapping=default phys_key=usb-1 vid=0x37d7 pid=0x2401 output_kind=uhid output_fd_alive=true evdev_node=/dev/input/event5 hotplug_pending=0 last_inbound_ms_ago=12 last_outbound_ms_ago=8 write_in_flight_ms=0 shadow_grabs=2 shadow_nodes=event5,event17\n";
+    const devices = try socket_client.parseStatusLine(line, testing.allocator);
+    defer socket_client.freeStatusDevices(testing.allocator, devices);
+    try testing.expectEqual(@as(usize, 1), devices.len);
+    try testing.expectEqual(@as(usize, 2), devices[0].shadow_grabs);
+    try testing.expectEqualStrings("event5,event17", devices[0].shadow_nodes);
+    try testing.expectEqualStrings("vader5", devices[0].name);
+    try testing.expectEqual(@as(u16, 0x37d7), devices[0].vid);
+}
+
+test "doctor_accuracy: parseStatusLine without shadow fields defaults to zero" {
+    const line = "STATUS device=vader5 state=active mapping=default phys_key=usb-1 vid=0x37d7 pid=0x2401 output_kind=uhid output_fd_alive=true\n";
+    const devices = try socket_client.parseStatusLine(line, testing.allocator);
+    defer socket_client.freeStatusDevices(testing.allocator, devices);
+    try testing.expectEqual(@as(usize, 1), devices.len);
+    try testing.expectEqual(@as(usize, 0), devices[0].shadow_grabs);
+    try testing.expectEqualStrings("", devices[0].shadow_nodes);
+}
+
+test "doctor_accuracy: parseStatusLine two devices with distinct shadow fields" {
+    const line = "STATUS device=vader5 state=active mapping=fps phys_key=usb-1 vid=0x37d7 pid=0x2401 output_kind=uhid output_fd_alive=true shadow_grabs=1 shadow_nodes=event9 device=wheel state=active mapping=racing phys_key=usb-2 vid=0x044f pid=0xb67f output_kind=uinput output_fd_alive=true shadow_grabs=0\n";
+    const devices = try socket_client.parseStatusLine(line, testing.allocator);
+    defer socket_client.freeStatusDevices(testing.allocator, devices);
+    try testing.expectEqual(@as(usize, 2), devices.len);
+    try testing.expectEqual(@as(usize, 1), devices[0].shadow_grabs);
+    try testing.expectEqualStrings("event9", devices[0].shadow_nodes);
+    try testing.expectEqual(@as(usize, 0), devices[1].shadow_grabs);
+    try testing.expectEqualStrings("", devices[1].shadow_nodes);
+}

--- a/src/test/doctor_accuracy_test.zig
+++ b/src/test/doctor_accuracy_test.zig
@@ -4,6 +4,7 @@ const scan = @import("../cli/scan.zig");
 const doctor = @import("../cli/doctor.zig");
 const socket_client = @import("../cli/socket_client.zig");
 const shadow_grab = @import("../io/shadow_grab.zig");
+const paths = @import("../config/paths.zig");
 
 // --- hidraw uevent parsing (permission-denied identity without open()) ---
 
@@ -166,7 +167,9 @@ test "doctor_accuracy: findFlaggedShadow flags xpad and block-listed drivers, ne
 test "doctor_accuracy: printProvenance single match has no OVERRIDES" {
     var buf: std.ArrayList(u8) = .{};
     defer buf.deinit(testing.allocator);
-    try doctor.printProvenance(buf.writer(testing.allocator), &.{"/usr/share/padctl/devices/flydigi/vader5.toml"});
+    try doctor.printProvenance(buf.writer(testing.allocator), &.{
+        .{ .path = "/usr/share/padctl/devices/flydigi/vader5.toml", .iface_mask = null },
+    });
     try testing.expectEqualStrings("  config: /usr/share/padctl/devices/flydigi/vader5.toml\n", buf.items);
 }
 
@@ -174,11 +177,38 @@ test "doctor_accuracy: printProvenance shadowed files listed after OVERRIDES" {
     var buf: std.ArrayList(u8) = .{};
     defer buf.deinit(testing.allocator);
     try doctor.printProvenance(buf.writer(testing.allocator), &.{
-        "/home/u/.config/padctl/devices/vader5.toml",
-        "/usr/share/padctl/devices/flydigi/vader5.toml",
+        .{ .path = "/home/u/.config/padctl/devices/vader5.toml", .iface_mask = null },
+        .{ .path = "/usr/share/padctl/devices/flydigi/vader5.toml", .iface_mask = null },
     });
     try testing.expectEqualStrings(
         "  config: /home/u/.config/padctl/devices/vader5.toml (OVERRIDES /usr/share/padctl/devices/flydigi/vader5.toml)\n",
+        buf.items,
+    );
+}
+
+test "doctor_accuracy: printProvenance disjoint interface constraints are co-active" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    try doctor.printProvenance(buf.writer(testing.allocator), &.{
+        .{ .path = "/etc/padctl/devices/pad-iface1.toml", .iface_mask = 1 << 1 },
+        .{ .path = "/etc/padctl/devices/pad-iface2.toml", .iface_mask = 1 << 2 },
+    });
+    try testing.expectEqualStrings(
+        "  config: /etc/padctl/devices/pad-iface1.toml\n" ++
+            "  config: /etc/padctl/devices/pad-iface2.toml\n",
+        buf.items,
+    );
+}
+
+test "doctor_accuracy: printProvenance unconstrained file overrides any constraint" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    try doctor.printProvenance(buf.writer(testing.allocator), &.{
+        .{ .path = "/home/u/.config/padctl/devices/pad.toml", .iface_mask = null },
+        .{ .path = "/usr/share/padctl/devices/pad-iface2.toml", .iface_mask = 1 << 2 },
+    });
+    try testing.expectEqualStrings(
+        "  config: /home/u/.config/padctl/devices/pad.toml (OVERRIDES /usr/share/padctl/devices/pad-iface2.toml)\n",
         buf.items,
     );
 }
@@ -199,10 +229,15 @@ test "doctor_accuracy: collectConfigMatches walks dirs in resolution order" {
 
     try tmp.dir.makePath("user/devices");
     try tmp.dir.makePath("system/devices/flydigi");
-    inline for (.{ "user/devices/vader5.toml", "system/devices/flydigi/vader5.toml" }) |rel| {
-        var f = try tmp.dir.createFile(rel, .{});
+    {
+        var f = try tmp.dir.createFile("user/devices/vader5.toml", .{});
         defer f.close();
         try f.writeAll("[device]\nname = \"vader5\"\nvid = 0x37d7\npid = 0x2401\n");
+    }
+    {
+        var f = try tmp.dir.createFile("system/devices/flydigi/vader5.toml", .{});
+        defer f.close();
+        try f.writeAll("[device]\nname = \"vader5\"\nvid = 0x37d7\npid = 0x2401\n\n[[device.interface]]\nid = 1\n");
     }
     {
         var f = try tmp.dir.createFile("system/devices/other.toml", .{});
@@ -218,12 +253,55 @@ test "doctor_accuracy: collectConfigMatches walks dirs in resolution order" {
     const matches = try doctor.collectConfigMatches(allocator, &.{ user_dir, sys_dir }, 0x37d7, 0x2401);
     defer doctor.freeConfigMatches(allocator, matches);
     try testing.expectEqual(@as(usize, 2), matches.len);
-    try testing.expect(std.mem.endsWith(u8, matches[0], "user/devices/vader5.toml"));
-    try testing.expect(std.mem.endsWith(u8, matches[1], "system/devices/flydigi/vader5.toml"));
+    try testing.expect(std.mem.endsWith(u8, matches[0].path, "user/devices/vader5.toml"));
+    try testing.expectEqual(@as(?u64, null), matches[0].iface_mask);
+    try testing.expect(std.mem.endsWith(u8, matches[1].path, "system/devices/flydigi/vader5.toml"));
+    try testing.expectEqual(@as(?u64, 1 << 1), matches[1].iface_mask);
 
     const none = try doctor.collectConfigMatches(allocator, &.{ user_dir, sys_dir }, 0xffff, 0xffff);
     defer doctor.freeConfigMatches(allocator, none);
     try testing.expectEqual(@as(usize, 0), none.len);
+}
+
+test "doctor_accuracy: resolveDaemonConfigDirs with --config-dir returns only that dir" {
+    const allocator = testing.allocator;
+    const dirs = try doctor.resolveDaemonConfigDirs(
+        allocator,
+        "/usr/local/bin/padctl --config-dir /usr/local/share/padctl/devices",
+    );
+    defer paths.freeConfigDirs(allocator, dirs);
+    try testing.expectEqual(@as(usize, 1), dirs.len);
+    try testing.expectEqualStrings("/usr/local/share/padctl/devices", dirs[0]);
+}
+
+test "doctor_accuracy: resolveDaemonConfigDirs default install uses daemon user-first order" {
+    const allocator = testing.allocator;
+    const got = try doctor.resolveDaemonConfigDirs(allocator, "/usr/bin/padctl");
+    defer paths.freeConfigDirs(allocator, got);
+    const want = try paths.resolveDeviceConfigDirs(allocator);
+    defer paths.freeConfigDirs(allocator, want);
+    try testing.expectEqual(want.len, got.len);
+    for (want, got) |w, g| try testing.expectEqualStrings(w, g);
+    // Daemon resolution order differs from doctor's scan/listing order, which
+    // leads with the install prefixes.
+    const scan_dirs = try doctor.resolveDoctorDeviceDirs(allocator, null);
+    defer paths.freeConfigDirs(allocator, scan_dirs);
+    try testing.expectEqualStrings("/usr/local/share/padctl/devices", scan_dirs[0]);
+    try testing.expect(!std.mem.eql(u8, got[0], scan_dirs[0]));
+}
+
+test "doctor_accuracy: pickScanEntry prefers readable node over denied sibling" {
+    const entries = [_]scan.ScanEntry{
+        .{ .path = "/dev/hidraw0", .vid = 0x37d7, .pid = 0x2401, .name = "v", .phys = "usb-1", .config_path = null, .access_denied = true },
+        .{ .path = "/dev/hidraw1", .vid = 0x37d7, .pid = 0x2401, .name = "v", .phys = "usb-1", .config_path = null },
+    };
+    const picked = doctor.pickScanEntry(&entries, 0x37d7, 0x2401).?;
+    try testing.expectEqualStrings("/dev/hidraw1", picked.path);
+    try testing.expect(!picked.access_denied);
+
+    const denied_only = entries[0..1];
+    try testing.expect(doctor.pickScanEntry(denied_only, 0x37d7, 0x2401).?.access_denied);
+    try testing.expect(doctor.pickScanEntry(&entries, 0x1111, 0x2222) == null);
 }
 
 // --- STATUS wire: shadow_grabs fields, additive ---


### PR DESCRIPTION
## Changes

- scan: hidraw nodes that exist but open with EACCES are returned as entries with an `access_denied` flag; identity (vid/pid/name) read from the world-readable sysfs uevent (`HID_ID`/`HID_NAME`) without opening the node
- scan: the permission warning prints once per run (previously once per config dir, up to 3x), now on the command output with the input-group remedy
- doctor: access-denied nodes print `hidraw: /dev/hidrawN exists but permission denied` plus `sudo usermod -aG input $USER` hint, instead of falling into the shadowed-by-driver or no-hidraw-node verdicts
- doctor: each supported device prints config provenance: `config: <winner> (OVERRIDES <shadowed>...)`; resolution order unchanged (#355 ostree ExecStart-derived dir order kept as-is, display only)
- daemon: STATUS reply gains `shadow_grabs=<n>` and `shadow_nodes=<list>` per managed device from the supervisor's GrabList; `parseStatusLine` extended additively, old lines keep parsing
- doctor: managed devices with held shadow grabs print `shadow nodes grabbed: N (...)`; a known gamepad driver (xpad or the device's `block_kernel_drivers`) bound on a USB interface with no grab held downgrades the verdict to a warning naming interface and driver; usbhid never flagged

## Test plan

- new `src/test/doctor_accuracy_test.zig`: uevent parser, warn-once render, hidraw diagnosis formatting, verdict decision table, flagged-driver selection, provenance formatting + dir-order collection, GrabList STATUS field emission, STATUS parsing (extended, legacy, multi-device)
- RED: with impl files restored to origin/main and tests kept, `zig build test` fails (new symbols absent); GREEN: full Docker `zig build test` exits 0
- `zig fmt --check` clean on changed files

Refs #406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features & Improvements**
  * Permission-denied USB devices now remain visible in device scans with helpful diagnostic messages
  * Enhanced device diagnostics with improved hidraw access status detection and reporting
  * Added shadow grab state information to device status output

* **Bug Fixes**
  * Improved detection and visibility of devices inaccessible due to permission constraints

* **Tests**
  * Added comprehensive test coverage for device diagnostic accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->