### PR TITLE
chore(release): v0.1.16 prep — headless install gate fix, preset error guidance, version bump

### DIFF
--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -241,26 +241,31 @@ jobs:
                 exit 1
               fi
 
-              # ---- Scenario D: verify gate — a started install whose daemon never
-              # answers STATUS must exit non-zero instead of reporting blind
-              # success. No systemd runs in this sandbox, so the
-              # service is the degenerate "broken unit": start is attempted but
-              # the daemon can never come up.
-              echo "=== verify-gate invariant (Scenario D: started install, daemon cannot run) ==="
+              # ---- Scenario D: headless verify gate (issue #418) — a started
+              # install whose user session bus is NOT live (no systemd in this
+              # sandbox, exactly the headless/SSH/boot-before-login case) must
+              # NOT hard-fail. The service is enabled and starts at next login;
+              # the install exits 0 and prints the enable-linger deferred-start
+              # hint instead of a daemon-not-responding error.
+              echo "=== verify-gate invariant (Scenario D: started install, user bus not live) ==="
               RC=0
               su - testuser -c "sudo SUDO_USER=testuser SUDO_UID=$(id -u testuser) \
                 HOME=/home/testuser \
                 /usr/local/bin/padctl install --prefix /usr/local 2>&1" \
                 | tee /tmp/verify-gate.log || RC=$?
-              if [ "$RC" -eq 0 ]; then
-                echo "FAIL: install reported success though the daemon is not responding"
+              if [ "$RC" -ne 0 ]; then
+                echo "FAIL: install hard-failed on a headless start (user bus not live, rc=$RC)"
                 exit 1
               fi
-              if ! grep -q "daemon is not responding" /tmp/verify-gate.log; then
-                echo "FAIL: missing daemon-not-responding diagnostic in install output"
+              if grep -q "daemon is not responding" /tmp/verify-gate.log; then
+                echo "FAIL: headless install wrongly emitted daemon-not-responding"
                 exit 1
               fi
-              echo "  PASS: started install without responsive daemon exits non-zero (rc=$RC)"
+              if ! grep -q "loginctl enable-linger" /tmp/verify-gate.log; then
+                echo "FAIL: missing enable-linger deferred-start hint in install output"
+                exit 1
+              fi
+              echo "  PASS: headless started install exits 0 with deferred-start hint"
 
               # Re-install enabled; plant a legacy sentinel for uninstall to clean (Scenario C)
               su - testuser -c "sudo SUDO_USER=testuser SUDO_UID=$(id -u testuser) \

--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -241,7 +241,7 @@ jobs:
                 exit 1
               fi
 
-              # ---- Scenario D: headless verify gate (issue #418) — a started
+              # ---- Scenario D: headless verify gate — a started
               # install whose user session bus is NOT live (no systemd in this
               # sandbox, exactly the headless/SSH/boot-before-login case) must
               # NOT hard-fail. The service is enabled and starts at next login;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.15",
+    .version = "0.1.16",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",

--- a/src/cli/config/init.zig
+++ b/src/cli/config/init.zig
@@ -6,6 +6,16 @@ const mapping = @import("../../config/mapping.zig");
 
 const templates = [_][]const u8{ "default", "fps", "racing", "fighting" };
 
+pub const preset_removed_message =
+    "--preset was removed in v0.1.16; choose a template with --device <name> " ++
+    "(templates: default/fps/racing/fighting)";
+
+/// True when `arg` is the removed `--preset` flag, either bare (`--preset`,
+/// value follows as the next arg) or inline (`--preset=<x>`).
+pub fn isPresetArg(arg: []const u8) bool {
+    return std.mem.eql(u8, arg, "--preset") or std.mem.startsWith(u8, arg, "--preset=");
+}
+
 fn ensureMappingsDir(abs_path: []const u8) !void {
     try std.fs.cwd().makePath(abs_path);
 }
@@ -264,6 +274,21 @@ test "init: formatGuidance contains expected substrings" {
     try std.testing.expect(std.mem.indexOf(u8, guidance, "padctl switch vader-5-pro") != null);
     try std.testing.expect(std.mem.indexOf(u8, guidance, "name = \"Vader 5 Pro\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, guidance, "default_mapping = \"vader-5-pro\"") != null);
+}
+
+test "init: isPresetArg recognizes bare and inline --preset" {
+    try std.testing.expect(isPresetArg("--preset"));
+    try std.testing.expect(isPresetArg("--preset=fps"));
+    try std.testing.expect(!isPresetArg("--device"));
+    try std.testing.expect(!isPresetArg("--presets"));
+    try std.testing.expect(!isPresetArg("preset"));
+}
+
+test "init: preset-removed message names the removal version and the replacement" {
+    const m = preset_removed_message;
+    try std.testing.expect(std.mem.indexOf(u8, m, "--preset was removed in v0.1.16") != null);
+    try std.testing.expect(std.mem.indexOf(u8, m, "--device") != null);
+    try std.testing.expect(std.mem.indexOf(u8, m, "default/fps/racing/fighting") != null);
 }
 
 // Validate generated TOML content in memory; returns error if invalid.

--- a/src/cli/install/phase.zig
+++ b/src/cli/install/phase.zig
@@ -171,8 +171,9 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         runCmd(&.{ "udevadm", "trigger" });
         udev.applyDriverState(allocator, &plan, device_entries.items);
     }
+    var start_outcome = services.StartOutcome{};
     if (plan.do_enable_systemctl) {
-        services.runSystemctlUnits(&plan);
+        start_outcome = services.runSystemctlUnits(&plan);
     }
 
     if (mapping_failed) {
@@ -180,14 +181,18 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         return error.MappingInstallFailed;
     }
 
-    if (plan.shouldVerifyDaemon()) {
-        var sock_buf: [256]u8 = undefined;
-        const sock_path = verifySocketPath(&plan, &sock_buf);
-        _ = std.posix.write(std.posix.STDOUT_FILENO, "\nWaiting for the daemon to respond...\n") catch {};
-        if (!waitDaemonResponding(sock_path, 5000, 250)) {
-            printVerifyFailure(allocator, &plan);
-            return error.DaemonNotResponding;
-        }
+    switch (verifyGateAction(plan.shouldVerifyDaemon(), start_outcome)) {
+        .skip => {},
+        .verify => {
+            var sock_buf: [256]u8 = undefined;
+            const sock_path = verifySocketPath(&plan, &sock_buf);
+            _ = std.posix.write(std.posix.STDOUT_FILENO, "\nWaiting for the daemon to respond...\n") catch {};
+            if (!waitDaemonResponding(sock_path, 5000, 250)) {
+                printVerifyFailure(allocator, &plan);
+                return error.DaemonNotResponding;
+            }
+        },
+        .deferred_start => printDeferredStartHint(),
     }
 
     printCompletionHint(&plan);
@@ -223,6 +228,41 @@ fn verifySocketPath(plan: *const InstallPlan, buf: []u8) []const u8 {
         return socket_client.resolveSocketPathFor(buf, null, xrd, socket_client.SYSTEM_RUNTIME_DIR, false);
     }
     return socket_client.resolveSocketPath(buf);
+}
+
+pub const VerifyGateAction = enum {
+    /// No start was requested for this install (staging, --no-start, etc.).
+    skip,
+    /// A start ran on a reachable user bus — poll the socket; non-zero on no answer.
+    verify,
+    /// A start was requested but the user bus was not live (headless / SSH /
+    /// boot-before-login / linger not enabled). The unit is enabled and starts
+    /// at next login — print a hint, do not fail the install (issue #418).
+    deferred_start,
+};
+
+/// Decide what the post-install gate should do, given whether a start was
+/// requested for this install (`should_verify`) and the runtime outcome of the
+/// `systemctl --user start` (`outcome`). Pure for testability.
+pub fn verifyGateAction(should_verify: bool, outcome: services.StartOutcome) VerifyGateAction {
+    if (!should_verify) return .skip;
+    if (outcome.start_attempted and !outcome.start_ran) return .deferred_start;
+    return .verify;
+}
+
+fn printDeferredStartHint() void {
+    _ = std.posix.write(std.posix.STDOUT_FILENO,
+        \\
+        \\Note: the user service is enabled but could not be started now — your
+        \\user session bus is not active (headless/SSH/boot-before-login). It will
+        \\start automatically at your next graphical login. No action is required.
+        \\
+        \\To start it now without logging in, or to run it on a headless/server
+        \\box with no login session:
+        \\  sudo loginctl enable-linger $USER
+        \\  systemctl --user start padctl.service
+        \\
+    ) catch {};
 }
 
 fn printVerifyFailure(allocator: std.mem.Allocator, plan: *const InstallPlan) void {

--- a/src/cli/install/phase.zig
+++ b/src/cli/install/phase.zig
@@ -237,7 +237,7 @@ pub const VerifyGateAction = enum {
     verify,
     /// A start was requested but the user bus was not live (headless / SSH /
     /// boot-before-login / linger not enabled). The unit is enabled and starts
-    /// at next login — print a hint, do not fail the install (issue #418).
+    /// at next login — print a hint, do not fail the install.
     deferred_start,
 };
 

--- a/src/cli/install/plan.zig
+++ b/src/cli/install/plan.zig
@@ -139,7 +139,8 @@ pub fn runCmd(argv: []const []const u8) void {
 }
 
 /// Like runCmd but warns on non-zero exit. Used for critical steps (enable/start).
-pub fn runCmdWarn(argv: []const []const u8) void {
+/// Returns true when the command exited 0, false on spawn failure or non-zero exit.
+pub fn runCmdWarn(argv: []const []const u8) bool {
     var child = std.process.Child.init(argv, std.heap.page_allocator);
     child.stdin_behavior = .Ignore;
     child.stdout_behavior = .Inherit;
@@ -148,7 +149,7 @@ pub fn runCmdWarn(argv: []const []const u8) void {
         _ = std.posix.write(std.posix.STDERR_FILENO, "warning: failed to spawn: ") catch {};
         _ = std.posix.write(std.posix.STDERR_FILENO, argv[0]) catch {};
         _ = std.posix.write(std.posix.STDERR_FILENO, "\n") catch {};
-        return;
+        return false;
     };
     const failed = switch (term) {
         .Exited => |code| code != 0,
@@ -163,6 +164,7 @@ pub fn runCmdWarn(argv: []const []const u8) void {
         }
         _ = std.posix.write(std.posix.STDERR_FILENO, "\n") catch {};
     }
+    return !failed;
 }
 
 /// Ask a y/n question on stderr and read the answer from stdin.
@@ -342,10 +344,12 @@ pub const InstallPlan = struct {
         return self.scope == .package;
     }
 
-    /// True when this install actually starts the user service, so a
+    /// True when this install attempts to start the user service, so a
     /// post-install daemon liveness check is meaningful. Mirrors
-    /// runSystemctlUnits: start only runs on live installs without
-    /// --no-start when a user bus is reachable.
+    /// runSystemctlUnits: start is requested on live installs without
+    /// --no-start when a user bus plan is not .skip. Whether the bus was
+    /// actually reachable is only known after the start runs — see
+    /// `verifyGateAction`.
     pub fn shouldVerifyDaemon(self: *const InstallPlan) bool {
         return self.do_enable_systemctl and !self.opts.no_start and self.systemctl_plan.mode != .skip;
     }

--- a/src/cli/install/services.zig
+++ b/src/cli/install/services.zig
@@ -332,24 +332,27 @@ pub fn runSystemctlUser(verbs: []const []const u8) void {
 }
 
 /// Same as runSystemctlUser but warns on non-zero exit (mirrors runCmdWarn).
-pub fn runSystemctlUserWarn(verbs: []const []const u8) void {
+/// Returns true when systemctl ran and exited 0 (the user bus was reachable and
+/// the verb succeeded), false when it was skipped, could not be built, or the
+/// user manager rejected the command (bus not live — headless/boot-before-login).
+pub fn runSystemctlUserWarn(verbs: []const []const u8) bool {
     const plan = currentPlanFromEnv();
     if (plan.mode == .skip) {
         printSkipSystemctlNote();
-        return;
+        return false;
     }
     const allocator = std.heap.page_allocator;
     const argv = buildSystemctlUserArgv(allocator, plan, verbs) catch |err| {
         var errbuf: [128]u8 = undefined;
         const msg = std.fmt.bufPrint(&errbuf, "warning: could not build systemctl argv: {}\n", .{err}) catch "warning: systemctl argv build failed\n";
         writeAll(std.posix.STDERR_FILENO, msg);
-        return;
+        return false;
     } orelse {
         printSkipSystemctlNote();
-        return;
+        return false;
     };
     defer freeArgv(allocator, argv);
-    runCmdWarn(argv);
+    return runCmdWarn(argv);
 }
 
 /// System-scope counterpart to runSystemctlUser. Used by the legacy-unit
@@ -488,10 +491,23 @@ pub fn installReconnectScript(allocator: std.mem.Allocator, plan: *const Install
     _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
 }
 
+/// Outcome of the start phase, fed back to the post-install verify gate so it
+/// can tell a genuine crash-loop (start ran on a live bus, daemon never
+/// answered) from a headless/boot-before-login install (the user bus is not
+/// live yet, the service is enabled and will start at next login).
+pub const StartOutcome = struct {
+    /// True when a `systemctl --user start` was requested (not --no-start and
+    /// the bus plan was not .skip).
+    start_attempted: bool = false,
+    /// True only when `systemctl --user start` actually ran and exited 0,
+    /// i.e. the user bus was reachable and the unit was launched.
+    start_ran: bool = false,
+};
+
 // Manage the systemd units. The caller reloads the udev ruleset and applies
 // driver state first, so the service starts against a device already in its
 // final driver state.
-pub fn runSystemctlUnits(plan: *const InstallPlan) void {
+pub fn runSystemctlUnits(plan: *const InstallPlan) StartOutcome {
     if (plan.systemctl_plan.mode == .skip) {
         var groups: [3][]const []const u8 = undefined;
         var n: usize = 0;
@@ -506,13 +522,13 @@ pub fn runSystemctlUnits(plan: *const InstallPlan) void {
             n += 1;
         }
         printSkipSystemctlNoteFor(groups[0..n]);
-        return;
+        return .{};
     }
     runSystemctlUser(&.{"daemon-reload"});
     if (!plan.opts.no_enable) {
-        runSystemctlUserWarn(&.{ "enable", "padctl.service" });
+        _ = runSystemctlUserWarn(&.{ "enable", "padctl.service" });
     }
-    if (!plan.opts.no_start) {
-        runSystemctlUserWarn(&.{ "start", "padctl.service" });
-    }
+    if (plan.opts.no_start) return .{};
+    const ran = runSystemctlUserWarn(&.{ "start", "padctl.service" });
+    return .{ .start_attempted = true, .start_ran = ran };
 }

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -4295,3 +4295,37 @@ test "install: waitDaemonResponding false when daemon answers garbage" {
 
     try testing.expect(!phase_mod.waitDaemonResponding(sock_path, 300, 50));
 }
+
+// --- verify gate decision: reachable-bus crash-loop vs deferred headless start (#418) ---
+
+test "install: verify gate skips when no start was requested" {
+    const testing = std.testing;
+    try testing.expectEqual(
+        phase_mod.VerifyGateAction.skip,
+        phase_mod.verifyGateAction(false, .{ .start_attempted = false, .start_ran = false }),
+    );
+}
+
+test "install: reachable bus + start ran => verify (genuine crash-loop is non-zero)" {
+    const testing = std.testing;
+    try testing.expectEqual(
+        phase_mod.VerifyGateAction.verify,
+        phase_mod.verifyGateAction(true, .{ .start_attempted = true, .start_ran = true }),
+    );
+}
+
+test "install: start attempted but bus not reachable => deferred start (exit 0 + linger hint)" {
+    const testing = std.testing;
+    try testing.expectEqual(
+        phase_mod.VerifyGateAction.deferred_start,
+        phase_mod.verifyGateAction(true, .{ .start_attempted = true, .start_ran = false }),
+    );
+}
+
+test "install: should-verify true but start never attempted => verify" {
+    const testing = std.testing;
+    try testing.expectEqual(
+        phase_mod.VerifyGateAction.verify,
+        phase_mod.verifyGateAction(true, .{ .start_attempted = false, .start_ran = false }),
+    );
+}

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -4296,7 +4296,7 @@ test "install: waitDaemonResponding false when daemon answers garbage" {
     try testing.expect(!phase_mod.waitDaemonResponding(sock_path, 300, 50));
 }
 
-// --- verify gate decision: reachable-bus crash-loop vs deferred headless start (#418) ---
+// --- verify gate decision: reachable-bus crash-loop vs deferred headless start ---
 
 test "install: verify gate skips when no start was requested" {
     const testing = std.testing;

--- a/src/main.zig
+++ b/src/main.zig
@@ -424,6 +424,9 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                 while (args.next()) |iarg| {
                     if (std.mem.eql(u8, iarg, "--device")) {
                         device = args.next() orelse return error.MissingArgValue;
+                    } else if (cli.config.init.isPresetArg(iarg)) {
+                        std.log.err("{s}", .{cli.config.init.preset_removed_message});
+                        return error.UnknownArgument;
                     } else {
                         std.log.err("unknown config init argument: {s}", .{iarg});
                         return error.UnknownArgument;


### PR DESCRIPTION
## Changes

### fix(install): headless post-install gate false-positive (Refs #418)
- On a live-service install where the user session bus is not reachable (headless / SSH / boot-before-login / linger not enabled), `systemctl --user start` legitimately fails and the daemon starts only at next login. The previous gate polled the socket, timed out, and exited non-zero with "daemon is not responding" — a false failure on documented supported paths.
- The start outcome is now threaded back from `runSystemctlUnits` via a `StartOutcome` struct. A new pure `verifyGateAction(should_verify, outcome)` classifies:
  - `deferred_start` — start requested but the user bus was not live → print "service enabled, starts at next login" + `loginctl enable-linger` hint, **exit 0**.
  - `verify` — start ran on a reachable bus → poll the socket; on no answer keep the existing non-zero exit + journalctl excerpt + `padctl doctor` hint (genuine crash-loop).
  - `skip` — staging / `--no-start` / no start requested.
- `runCmdWarn` / `runSystemctlUserWarn` now return whether the command exited 0.

### fix(cli): `config init --preset` error guidance (Refs #414)
- `--preset <x>` and `--preset=<x>` now produce a specific message — `--preset was removed in v0.1.16; choose a template with --device <name> (templates: default/fps/racing/fighting)` — instead of the generic unknown-argument error.

### chore: version bump
- `build.zig.zon` `.version` 0.1.15 → 0.1.16 (single-sourced into the binary by `build.zig`).

## Test plan
- `zig build test` green in the canonical Docker build image (Zig 0.15.2).
- New unit tests:
  - `verifyGateAction`: skip / verify (reachable-bus crash-loop) / deferred_start (bus not reachable) / start-never-attempted.
  - `config init`: `isPresetArg` recognizer + preset-removed message content.
- RED/GREEN proven: reverting the `deferred_start` branch fails the headless gate test; reverting to the generic preset message fails the message test.
- `install-flow.yml` Scenario D rewritten — a started install whose user bus is not live now asserts exit 0 with the `loginctl enable-linger` deferred-start hint.
- Functional check in Docker: `padctl --version` → `0.1.16`; `padctl config init --preset fps` prints the new error and exits non-zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deprecation notice for the removed --preset flag with migration guidance.

* **Bug Fixes**
  * Improved post-install verification for headless/SSH/boot-before-login scenarios: installs that defer service start are treated as success and show a deferred-start hint instead of failing.

* **Chores**
  * Bumped package version to 0.1.16.

* **Tests**
  * Added tests covering the install verification decision logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->