### PR TITLE
test(install): assert reachable-bus crash-loop exits non-zero from the verify gate

### DIFF
--- a/src/cli/install/phase.zig
+++ b/src/cli/install/phase.zig
@@ -187,10 +187,10 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
             var sock_buf: [256]u8 = undefined;
             const sock_path = verifySocketPath(&plan, &sock_buf);
             _ = std.posix.write(std.posix.STDOUT_FILENO, "\nWaiting for the daemon to respond...\n") catch {};
-            if (!waitDaemonResponding(sock_path, 5000, 250)) {
+            runVerifyPoll(sock_path, 5000, 250, waitDaemonResponding) catch |err| {
                 printVerifyFailure(allocator, &plan);
-                return error.DaemonNotResponding;
-            }
+                return err;
+            };
         },
         .deferred_start => printDeferredStartHint(),
     }
@@ -216,6 +216,15 @@ pub fn waitDaemonResponding(path: []const u8, timeout_ms: i64, poll_interval_ms:
         if (std.time.milliTimestamp() >= deadline) return false;
         std.Thread.sleep(poll_interval_ms * std.time.ns_per_ms);
     }
+}
+
+pub const PollFn = *const fn (path: []const u8, timeout_ms: i64, poll_interval_ms: u64) bool;
+
+/// The verify branch's failure decision: poll the daemon socket and turn a
+/// no-answer into a non-zero error. `poll` is injectable so the reachable-bus
+/// crash-loop path (a never-answering socket) can be exercised end-to-end.
+pub fn runVerifyPoll(path: []const u8, timeout_ms: i64, poll_interval_ms: u64, poll: PollFn) error{DaemonNotResponding}!void {
+    if (!poll(path, timeout_ms, poll_interval_ms)) return error.DaemonNotResponding;
 }
 
 /// Resolve the socket the just-started user service will bind. Under

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -4330,11 +4330,9 @@ test "install: should-verify true but start never attempted => verify" {
     );
 }
 
-// Composed gate flow: a start ran on a reachable user bus (=> .verify), but the
-// daemon crash-loops and never answers STATUS, so the gate must surface a
-// non-zero error (error.DaemonNotResponding) — not silently exit 0. This pins
-// the end-to-end path the install-flow.yml Scenario-D exit-0 rewrite stopped
-// covering. The socket is bound (connect succeeds) but never accepted/answered.
+// Asserts the verify gate returns error.DaemonNotResponding (non-zero), not a
+// silent exit 0 when the daemon crash-loops and never answers STATUS.
+// The socket is bound (connect succeeds) but never accepted/answered.
 test "install: verify gate on reachable bus + dead daemon returns DaemonNotResponding" {
     const testing = std.testing;
     const allocator = testing.allocator;

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -4329,3 +4329,42 @@ test "install: should-verify true but start never attempted => verify" {
         phase_mod.verifyGateAction(true, .{ .start_attempted = false, .start_ran = false }),
     );
 }
+
+// Composed gate flow: a start ran on a reachable user bus (=> .verify), but the
+// daemon crash-loops and never answers STATUS, so the gate must surface a
+// non-zero error (error.DaemonNotResponding) — not silently exit 0. This pins
+// the end-to-end path the install-flow.yml Scenario-D exit-0 rewrite stopped
+// covering. The socket is bound (connect succeeds) but never accepted/answered.
+test "install: verify gate on reachable bus + dead daemon returns DaemonNotResponding" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    const reachable_start = services_mod.StartOutcome{ .start_attempted = true, .start_ran = true };
+    try testing.expectEqual(
+        phase_mod.VerifyGateAction.verify,
+        phase_mod.verifyGateAction(true, reachable_start),
+    );
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    const sock_path = try std.fmt.allocPrint(allocator, "{s}/dead.sock", .{root});
+    defer allocator.free(sock_path);
+
+    const listen_fd = bindTestSocket(sock_path) catch |err| {
+        if (err == error.AccessDenied) return error.SkipZigTest;
+        return err;
+    };
+    defer std.posix.close(listen_fd);
+
+    try testing.expectError(
+        error.DaemonNotResponding,
+        phase_mod.runVerifyPoll(sock_path, 200, 50, phase_mod.waitDaemonResponding),
+    );
+
+    // The deferred-start outcome is not .verify, so the composed gate never
+    // reaches the poll/error path even against the same dead socket.
+    const deferred = services_mod.StartOutcome{ .start_attempted = true, .start_ran = false };
+    try testing.expect(phase_mod.verifyGateAction(true, deferred) != .verify);
+}


### PR DESCRIPTION
## What

Adds the missing integration-level test for the #418 post-install
daemon-liveness gate's NON-ZERO crash-loop path (opus pre-release review Note 1).

The gate's decision logic (`verifyGateAction` returning `.verify` when a start
ran on a reachable user bus) and the socket poller (`waitDaemonResponding`
returning false on a dead socket) were each unit-tested in isolation. The
**composed** path was not asserted anywhere:

`.verify` action → poll a never-answering socket → `error.DaemonNotResponding`
(non-zero exit).

`install-flow.yml` Scenario D was rewritten to assert only the exit-0 deferred
(headless) path, so the reachable-bus-but-dead-daemon crash-loop had no coverage.

## Changes

- `src/cli/install/phase.zig`: extract the verify branch's poll/error step into
  `runVerifyPoll(path, timeout, interval, poll)` with an injectable poll fn.
  Production passes the real `waitDaemonResponding` — behavior is unchanged
  (the inline `if (!wait...) return error.DaemonNotResponding` becomes a call).
- `src/cli/install/tests.zig`: add a test that
  1. asserts `verifyGateAction(true, {start_attempted, start_ran})` == `.verify`,
  2. binds a socket that is never accepted/answered (connect succeeds, STATUS
     never replied) and asserts `runVerifyPoll(...)` returns
     `error.DaemonNotResponding`,
  3. asserts the deferred-start outcome is not `.verify` (so the same dead
     socket never reaches the poll/error path on the exit-0 path).

No existing exit-0 deferred test is weakened.

## Test plan

- `zig build test` (Docker `ghcr.io/bananasjim/padctl-build:0.15.2`): full suite green.
- Red/green proof of falsifiability:
  - Mutation A — `runVerifyPoll` treats a timeout as success: new test fails
    (`error.DaemonNotResponding` not returned).
  - Mutation B — `verifyGateAction` reverted to never return `.verify`: new test
    fails (`expected .verify, found .deferred_start`).
  - Both reverted → suite green.

Refs #418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored daemon verification flow during installation to provide clearer error diagnostics when the daemon socket is unresponsive.

* **Tests**
  * Added tests validating behavior when daemon responsiveness checks fail due to socket timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->