### PR TITLE
fix(supervisor): count EBUSY shadows and retry access-denied shadow grabs

### DIFF
--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -670,6 +670,34 @@ fn printSupportedDevices(allocator: std.mem.Allocator, status_devices: []const S
 
 const testing = std.testing;
 
+test "doctor: decideVerdict: a held shadow grab clears the unguarded warning" {
+    const base: VerdictInput = .{
+        .usb_present = true,
+        .claimed = true,
+        .hidraw = .ok,
+        .kernel_driver = true,
+        .flagged_driver = true,
+        .shadow_grabs = 0,
+    };
+    // No grab counted (e.g. the old EBUSY-drops-to-skipped path): false warning.
+    try testing.expectEqual(Verdict.managed_unguarded_shadow, decideVerdict(base));
+    // Counting an EBUSY-held shadow (shadow_grabs > 0) is the healthy state.
+    var guarded = base;
+    guarded.shadow_grabs = 1;
+    try testing.expectEqual(Verdict.ok_managed, decideVerdict(guarded));
+}
+
+test "doctor: decideVerdict: normal device stays OK with no flagged driver" {
+    try testing.expectEqual(Verdict.ok_managed, decideVerdict(.{
+        .usb_present = true,
+        .claimed = true,
+        .hidraw = .ok,
+        .kernel_driver = false,
+        .flagged_driver = false,
+        .shadow_grabs = 0,
+    }));
+}
+
 test "doctor: probeUsbPresence: device present with driver" {
     const allocator = testing.allocator;
 

--- a/src/io/shadow_grab.zig
+++ b/src/io/shadow_grab.zig
@@ -22,12 +22,15 @@ pub const Params = struct {
     phys_product: u16,
 };
 
-pub const GrabResult = enum { grabbed, skipped, access_denied };
+pub const GrabResult = enum { grabbed, already_grabbed, skipped, access_denied };
 
 const Grab = struct {
     fd: posix.fd_t,
     name_buf: [NAME_CAP]u8,
     name_len: u8,
+    // false when another reader holds the exclusive EVIOCGRAB (EBUSY): the node
+    // is hidden so it counts as a handled shadow, but we own no fd to release.
+    owned: bool = true,
 
     fn name(self: *const Grab) []const u8 {
         return self.name_buf[0..self.name_len];
@@ -59,7 +62,9 @@ pub const GrabList = struct {
 
     /// Closing a grabbed fd implicitly releases its EVIOCGRAB.
     pub fn releaseAll(self: *GrabList) void {
-        for (self.grabs[0..self.len]) |*g| posix.close(g.fd);
+        for (self.grabs[0..self.len]) |*g| {
+            if (g.owned) posix.close(g.fd);
+        }
         self.len = 0;
     }
 
@@ -68,7 +73,7 @@ pub const GrabList = struct {
     pub fn evict(self: *GrabList, node: []const u8) bool {
         for (self.grabs[0..self.len], 0..) |*g, i| {
             if (!std.mem.eql(u8, g.name(), node)) continue;
-            posix.close(g.fd);
+            if (g.owned) posix.close(g.fd);
             self.len -= 1;
             self.grabs[i] = self.grabs[self.len];
             return true;
@@ -76,10 +81,15 @@ pub const GrabList = struct {
         return false;
     }
 
-    /// Evict entries whose device is gone (fd answers ENODEV).
+    /// Evict entries whose device is gone (fd answers ENODEV). EBUSY-held
+    /// entries own no fd, so they are name-tracked and pruned only via evict().
     pub fn pruneDead(self: *GrabList) void {
         var i: usize = 0;
         while (i < self.len) {
+            if (!self.grabs[i].owned) {
+                i += 1;
+                continue;
+            }
             var id: ioctl.InputId = undefined;
             if (linux.E.init(linux.ioctl(self.grabs[i].fd, ioctl.EVIOCGID, @intFromPtr(&id))) == .NODEV) {
                 posix.close(self.grabs[i].fd);
@@ -126,6 +136,23 @@ fn classifyOpenError(err: posix.OpenError) GrabResult {
     };
 }
 
+/// EBUSY means another reader already holds the exclusive grab, so the shadow
+/// is hidden either way and counts as handled; any other ioctl failure leaves
+/// the node ungrabbed and uncounted.
+fn classifyGrabErrno(e: linux.E) GrabResult {
+    return switch (e) {
+        .SUCCESS => .grabbed,
+        .BUSY => .already_grabbed,
+        else => .skipped,
+    };
+}
+
+fn recordGrab(list: *GrabList, node: []const u8, fd: posix.fd_t, owned: bool) void {
+    list.grabs[list.len] = .{ .fd = fd, .name_buf = undefined, .name_len = @intCast(node.len), .owned = owned };
+    @memcpy(list.grabs[list.len].name_buf[0..node.len], node);
+    list.len += 1;
+}
+
 /// Probe one event node and grab it when it shadows the managed device.
 pub fn tryGrabNode(list: *GrabList, input_dir: []const u8, node: []const u8, p: Params) GrabResult {
     if (node.len == 0 or node.len > NAME_CAP) return .skipped;
@@ -148,43 +175,68 @@ pub fn tryGrabNode(list: *GrabList, input_dir: []const u8, node: []const u8, p: 
         return .skipped;
     }
 
-    const grab_errno = linux.E.init(linux.ioctl(fd, ioctl.EVIOCGRAB, 1));
-    if (grab_errno != .SUCCESS) {
-        // EBUSY: someone already holds the exclusive grab (typically padctl's
-        // own hidraw-associated grab), so the node is hidden anyway.
-        if (grab_errno == .BUSY) {
-            std.log.debug("shadow grab: {s} already grabbed", .{path});
-        } else {
-            std.log.warn("shadow grab: EVIOCGRAB {s} failed: {s}", .{ path, @tagName(grab_errno) });
-        }
-        posix.close(fd);
-        return .skipped;
+    const result = classifyGrabErrno(linux.E.init(linux.ioctl(fd, ioctl.EVIOCGRAB, 1)));
+    switch (result) {
+        .grabbed => {
+            recordGrab(list, node, fd, true);
+            var drv_buf: [128]u8 = undefined;
+            if (driverName(node, &drv_buf)) |drv| {
+                std.log.warn("shadow input node {s} ({x:0>4}:{x:0>4}) grabbed; kernel driver {s} bound to a managed device", .{ path, id.vendor, id.product, drv });
+            } else {
+                std.log.warn("shadow input node {s} ({x:0>4}:{x:0>4}) grabbed; kernel driver bound to a managed device", .{ path, id.vendor, id.product });
+            }
+        },
+        .already_grabbed => {
+            // Hidden by another reader's grab; count it but own no fd to hold.
+            std.log.debug("shadow grab: {s} already grabbed by another reader", .{path});
+            posix.close(fd);
+            recordGrab(list, node, -1, false);
+        },
+        else => {
+            std.log.warn("shadow grab: EVIOCGRAB {s} failed", .{path});
+            posix.close(fd);
+        },
     }
-
-    list.grabs[list.len] = .{ .fd = fd, .name_buf = undefined, .name_len = @intCast(node.len) };
-    @memcpy(list.grabs[list.len].name_buf[0..node.len], node);
-    list.len += 1;
-
-    var drv_buf: [128]u8 = undefined;
-    if (driverName(node, &drv_buf)) |drv| {
-        std.log.warn("shadow input node {s} ({x:0>4}:{x:0>4}) grabbed; kernel driver {s} bound to a managed device", .{ path, id.vendor, id.product, drv });
-    } else {
-        std.log.warn("shadow input node {s} ({x:0>4}:{x:0>4}) grabbed; kernel driver bound to a managed device", .{ path, id.vendor, id.product });
-    }
-    return .grabbed;
+    return result;
 }
 
 /// Enumerate `input_dir` and grab every shadow node of the managed device.
 /// Catches shadows that predate the daemon (the netlink watch only sees new
 /// nodes). Dead grabs are pruned first so reused eventN names stay grabbable.
-pub fn sweepDir(list: *GrabList, input_dir: []const u8, p: Params) void {
+/// `on_denied` (when non-null) is invoked with the node name for every node
+/// that returns `.access_denied`, mirroring the netlink ADD retry path so a
+/// pre-existing shadow whose udev ACL has not landed yet is not lost.
+pub fn sweepDir(
+    list: *GrabList,
+    input_dir: []const u8,
+    p: Params,
+    ctx: anytype,
+    comptime on_denied: ?fn (@TypeOf(ctx), []const u8) void,
+) void {
+    sweepDirWith(tryGrabNode, list, input_dir, p, ctx, on_denied);
+}
+
+/// `sweepDir` with the per-node grab function injectable so the denied-node
+/// callback dispatch is testable without a real access-denied open (root, the
+/// CI uid, bypasses file permissions).
+fn sweepDirWith(
+    comptime grab_fn: fn (*GrabList, []const u8, []const u8, Params) GrabResult,
+    list: *GrabList,
+    input_dir: []const u8,
+    p: Params,
+    ctx: anytype,
+    comptime on_denied: ?fn (@TypeOf(ctx), []const u8) void,
+) void {
     list.pruneDead();
     var dir = std.fs.openDirAbsolute(input_dir, .{ .iterate = true }) catch return;
     defer dir.close();
     var it = dir.iterate();
     while (it.next() catch return) |entry| {
         if (!std.mem.startsWith(u8, entry.name, "event")) continue;
-        _ = tryGrabNode(list, input_dir, entry.name, p);
+        const r = grab_fn(list, input_dir, entry.name, p);
+        if (r == .access_denied) {
+            if (on_denied) |cb| cb(ctx, entry.name);
+        }
     }
 }
 
@@ -261,6 +313,35 @@ test "shadow_grab: classifyOpenError marks only AccessDenied retryable" {
     try testing.expectEqual(GrabResult.skipped, classifyOpenError(error.DeviceBusy));
 }
 
+test "shadow_grab: classifyGrabErrno counts EBUSY as a handled shadow" {
+    try testing.expectEqual(GrabResult.grabbed, classifyGrabErrno(.SUCCESS));
+    try testing.expectEqual(GrabResult.already_grabbed, classifyGrabErrno(.BUSY));
+    // Any other ioctl failure leaves the node ungrabbed and uncounted.
+    try testing.expectEqual(GrabResult.skipped, classifyGrabErrno(.NODEV));
+    try testing.expectEqual(GrabResult.skipped, classifyGrabErrno(.INVAL));
+}
+
+test "shadow_grab: an EBUSY-held shadow is counted but releaseAll skips its fd" {
+    var list = GrabList{};
+    // Simulate what tryGrabNode records on EBUSY: a counted, unowned entry
+    // whose fd was already closed (-1 would crash close() if treated as owned).
+    recordGrab(&list, "event8", -1, false);
+    try testing.expectEqual(@as(usize, 1), list.len);
+    try testing.expect(list.contains("event8"));
+
+    // pruneDead must not ioctl/close the unowned fd; the entry survives.
+    list.pruneDead();
+    try testing.expectEqual(@as(usize, 1), list.len);
+
+    // releaseAll/evict must not posix.close(-1) on an unowned entry.
+    try testing.expect(list.evict("event8"));
+    try testing.expectEqual(@as(usize, 0), list.len);
+
+    recordGrab(&list, "event8", -1, false);
+    list.releaseAll();
+    try testing.expectEqual(@as(usize, 0), list.len);
+}
+
 test "shadow_grab: evict closes the named grab and frees the name for reuse" {
     var list = GrabList{};
     inline for (.{ "event3", "event4" }, 0..) |n, i| {
@@ -294,6 +375,55 @@ test "shadow_grab: pruneDead keeps live fds" {
 
 test "shadow_grab: sweepDir on nonexistent dir is a no-op" {
     var list = GrabList{};
-    sweepDir(&list, "/nonexistent_input_dir_xyz", vader5);
+    sweepDir(&list, "/nonexistent_input_dir_xyz", vader5, {}, null);
     try testing.expectEqual(@as(usize, 0), list.len);
+}
+
+const DeniedSink = struct {
+    nodes: std.ArrayList([]const u8) = .{},
+    allocator: std.mem.Allocator,
+
+    fn cb(self: *DeniedSink, node: []const u8) void {
+        const owned = self.allocator.dupe(u8, node) catch return;
+        self.nodes.append(self.allocator, owned) catch {};
+    }
+    fn deinit(self: *DeniedSink) void {
+        for (self.nodes.items) |n| self.allocator.free(n);
+        self.nodes.deinit(self.allocator);
+    }
+};
+
+fn stubAlwaysDenied(_: *GrabList, _: []const u8, node: []const u8, _: Params) GrabResult {
+    return if (std.mem.eql(u8, node, "event9")) .access_denied else .skipped;
+}
+
+test "shadow_grab: sweepDir reports access_denied nodes to the retry callback" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    // The grab function is stubbed to report event9 as access_denied — the exact
+    // race the netlink ADD path retries; the sweep must surface it to the
+    // callback so a pre-existing shadow is not lost (uid-independent: root
+    // bypasses real file permissions, so a 0000-mode file would not suffice).
+    {
+        var f = try tmp.dir.createFile("event9", .{});
+        f.close();
+    }
+    {
+        var f = try tmp.dir.createFile("event8", .{});
+        f.close();
+    }
+    try tmp.dir.makePath("not-an-event"); // ignored: wrong prefix
+
+    var sink = DeniedSink{ .allocator = allocator };
+    defer sink.deinit();
+    var list = GrabList{};
+    sweepDirWith(stubAlwaysDenied, &list, tmp_path, vader5, &sink, DeniedSink.cb);
+
+    try testing.expectEqual(@as(usize, 0), list.len);
+    try testing.expectEqual(@as(usize, 1), sink.nodes.items.len);
+    try testing.expectEqualStrings("event9", sink.nodes.items[0]);
 }

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -810,7 +810,7 @@ pub const Supervisor = struct {
             .switch_mapping = null,
             .default_mapping_pr = default_pr,
         });
-        sweepShadowNodes(&self.managed.items[self.managed.items.len - 1]);
+        self.sweepShadowNodes(&self.managed.items[self.managed.items.len - 1]);
     }
 
     fn pruneStaleSuspendedForId(self: *Supervisor, vid: u16, pid: u16, keep_phys: []const u8) void {
@@ -913,7 +913,7 @@ pub const Supervisor = struct {
         m.suspended = false;
         m.grace_deadline_ns = null;
         self.armGraceTimer();
-        sweepShadowNodes(m);
+        self.sweepShadowNodes(m);
     }
 
     fn clearSwitchMapping(self: *Supervisor, m: *ManagedInstance) void {
@@ -1383,6 +1383,7 @@ pub const Supervisor = struct {
             if (m.suspended) continue;
             switch (shadow_grab.tryGrabNode(&m.shadow_grabs, "/dev/input", node, shadowParams(m))) {
                 .grabbed => return .grabbed,
+                .already_grabbed => return .already_grabbed,
                 .access_denied => denied = true,
                 .skipped => {},
             }
@@ -1410,9 +1411,14 @@ pub const Supervisor = struct {
 
     /// Grab pre-existing shadow nodes when an instance becomes active (spawn
     /// and resume) — a shadow that predates the daemon never produces a
-    /// netlink ADD.
-    fn sweepShadowNodes(m: *ManagedInstance) void {
-        shadow_grab.sweepDir(&m.shadow_grabs, "/dev/input", shadowParams(m));
+    /// netlink ADD. Nodes that race udev permission setup are queued for retry,
+    /// mirroring the netlink ADD path so a pre-existing shadow is never lost.
+    fn sweepShadowNodes(self: *Supervisor, m: *ManagedInstance) void {
+        shadow_grab.sweepDir(&m.shadow_grabs, "/dev/input", shadowParams(m), self, enqueueShadowRetry);
+    }
+
+    fn enqueueShadowRetry(self: *Supervisor, node: []const u8) void {
+        self.enqueueRetry(.input_grab, node);
     }
 
     fn drainNetlink(self: *Supervisor) void {
@@ -3006,6 +3012,23 @@ test "supervisor: input grab retry dedups per kind and drains non-denied nodes" 
     // Node gone (or readable but not a shadow): the retry entry is dropped.
     sup.drainHotplugRetry();
     try testing.expectEqual(@as(usize, 0), sup.hotplug_pending.items.len);
+}
+
+test "supervisor: sweep denied callback enqueues an input_grab retry" {
+    const allocator = testing.allocator;
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer sup.deinit();
+    sup.hotplug_retry_fd = try posix.timerfd_create(.MONOTONIC, .{ .CLOEXEC = true, .NONBLOCK = true });
+
+    // The sweep wires this callback for every node it found but could not yet
+    // open (access_denied), mirroring the netlink ADD retry path.
+    sup.enqueueShadowRetry("event9");
+    sup.enqueueShadowRetry("event9");
+    try testing.expectEqual(@as(usize, 1), sup.hotplug_pending.items.len);
+    try testing.expectEqual(PendingKind.input_grab, sup.hotplug_pending.items[0].kind);
+    const item = sup.hotplug_pending.items[0];
+    try testing.expectEqualStrings("event9", item.devname[0..item.len]);
 }
 
 test "supervisor: cold-scan retry is inert when retry timer is unavailable" {

--- a/src/test/shadow_grab_integration_test.zig
+++ b/src/test/shadow_grab_integration_test.zig
@@ -85,17 +85,17 @@ test "shadow_grab: sweep grabs a USB-bus shadow node exclusively and releases it
     defer list.releaseAll();
 
     // Foreign physical VID/PID: the sweep must not touch the node.
-    shadow_grab.sweepDir(&list, "/dev/input", .{ .phys_vendor = 0xF0F0, .phys_product = 0x0F0F });
+    shadow_grab.sweepDir(&list, "/dev/input", .{ .phys_vendor = 0xF0F0, .phys_product = 0x0F0F }, {}, null);
     try testing.expect(!list.contains(node));
     list.releaseAll();
 
     const params: shadow_grab.Params = .{ .phys_vendor = vid, .phys_product = pid };
-    shadow_grab.sweepDir(&list, "/dev/input", params);
+    shadow_grab.sweepDir(&list, "/dev/input", params, {}, null);
     try testing.expect(list.contains(node));
 
     // Re-sweep is idempotent: already-grabbed nodes are skipped.
     const len_after = list.len;
-    shadow_grab.sweepDir(&list, "/dev/input", params);
+    shadow_grab.sweepDir(&list, "/dev/input", params, {}, null);
     try testing.expectEqual(len_after, list.len);
 
     // EVIOCGRAB exclusivity is observable: a second grab fails with EBUSY.
@@ -124,14 +124,44 @@ test "shadow_grab: sweep prunes a grab whose device is gone (ENODEV)" {
     var list = shadow_grab.GrabList{};
     defer list.releaseAll();
     const params: shadow_grab.Params = .{ .phys_vendor = vid, .phys_product = pid };
-    shadow_grab.sweepDir(&list, "/dev/input", params);
+    shadow_grab.sweepDir(&list, "/dev/input", params, {}, null);
     try testing.expect(list.contains(node));
 
     destroyPad(ufd);
     destroyed = true;
 
-    shadow_grab.sweepDir(&list, "/dev/input", params);
+    shadow_grab.sweepDir(&list, "/dev/input", params, {}, null);
     try testing.expect(!list.contains(node));
+}
+
+test "shadow_grab: a node already grabbed by another reader is counted (EBUSY)" {
+    const vid: u16 = 0xFAD7;
+    const pid: u16 = 0x24FB;
+    const ufd = try createPad(BUS_USB, vid, pid);
+    defer destroyPad(ufd);
+
+    var name_buf: [24]u8 = undefined;
+    const node = findEventNode(vid, pid, &name_buf) orelse return error.SkipZigTest;
+    const params: shadow_grab.Params = .{ .phys_vendor = vid, .phys_product = pid };
+
+    // First reader takes the exclusive grab.
+    var holder = shadow_grab.GrabList{};
+    defer holder.releaseAll();
+    try testing.expectEqual(shadow_grab.GrabResult.grabbed, shadow_grab.tryGrabNode(&holder, "/dev/input", node, params));
+
+    // Second reader hits EBUSY: the node is hidden, so it must be counted as a
+    // handled shadow (shadow_grabs > 0) rather than silently dropped — otherwise
+    // doctor would falsely report 'managed_unguarded_shadow'.
+    var observer = shadow_grab.GrabList{};
+    defer observer.releaseAll();
+    try testing.expectEqual(shadow_grab.GrabResult.already_grabbed, shadow_grab.tryGrabNode(&observer, "/dev/input", node, params));
+    try testing.expectEqual(@as(usize, 1), observer.len);
+    try testing.expect(observer.contains(node));
+
+    // The EBUSY entry owns no fd; releaseAll/evict must not double-close, and
+    // the real holder still owns the kernel grab.
+    try testing.expect(observer.evict(node));
+    try testing.expectEqual(@as(usize, 0), observer.len);
 }
 
 test "shadow_grab: sweep skips virtual-bus nodes (padctl's own uinput outputs)" {
@@ -145,6 +175,6 @@ test "shadow_grab: sweep skips virtual-bus nodes (padctl's own uinput outputs)" 
 
     var list = shadow_grab.GrabList{};
     defer list.releaseAll();
-    shadow_grab.sweepDir(&list, "/dev/input", .{ .phys_vendor = vid, .phys_product = pid });
+    shadow_grab.sweepDir(&list, "/dev/input", .{ .phys_vendor = vid, .phys_product = pid }, {}, null);
     try testing.expect(!list.contains(node));
 }


### PR DESCRIPTION
Hardens two observability gaps in the #406 input-shadow defense. Both findings were independently verified to reproduce on main (78f27fa) before fixing.

## Changes

- **Count EBUSY-held shadows.** `EVIOCGRAB` returning `EBUSY` means another reader already holds the exclusive grab, so the evdev node is hidden either way. The old code dropped this to `GrabResult.skipped` and never counted it, so `doctor` read `shadow_grabs == 0` with a flagged kernel driver bound and falsely reported `managed_unguarded_shadow` for a present-and-grabbed shadow. EBUSY is now classified as a distinct `.already_grabbed` result and recorded as an unowned (fd-less) `GrabList` entry, so it counts toward `shadow_grabs` without holding an fd. `releaseAll` / `evict` / `pruneDead` skip unowned entries (they own no fd to close).

- **Retry access-denied shadows from the sweep.** The spawn/resume `sweepDir` discarded each `tryGrabNode` result, so a pre-existing shadow whose udev ACL had not landed yet (`access_denied`) was silently dropped — asymmetric with the netlink ADD path, which retries via the hotplug queue. `sweepDir` now reports `access_denied` nodes to a callback; `sweepShadowNodes` enqueues an `input_grab` retry, mirroring the ADD path.

`shouldGrab` matching and the normal-device healthy path (`shadow_grabs == 0`, no flagged driver) are unchanged.

## Test plan

- `docker run --rm -v "$PWD":/src -w /src ghcr.io/bananasjim/padctl-build:0.15.2 zig build test` — green.
- `shadow_grab: classifyGrabErrno counts EBUSY as a handled shadow` + `an EBUSY-held shadow is counted but releaseAll skips its fd` — RED on main's EBUSY→skipped behavior, GREEN on fix (Docker).
- `shadow_grab: sweepDir reports access_denied nodes to the retry callback` (deterministic via injected grab fn) — RED with the sweep discarding results, GREEN on fix (Docker, root-safe).
- `supervisor: sweep denied callback enqueues an input_grab retry` and `doctor: decideVerdict` verdict-contract tests added.
- `shadow_grab: a node already grabbed by another reader is counted (EBUSY)` — real-uinput integration test (gates on `/dev/uinput`, skips in CI like the other uinput tests).

Refs #406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests for verdict decision logic and managed device scenarios
  * Extended integration tests for already-grabbed device handling
  * Added tests for denied-access callback behavior

* **Bug Fixes**
  * Improved handling of already-grabbed input devices to prevent resource leaks
  * Implemented automatic retry mechanism for devices denied on open

* **Refactor**
  * Extended device sweep API with callback context support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->