### PR TITLE
fix(shadow): re-validate unowned EBUSY shadow entries so doctor stops trusting released foreign grabs

### DIFF
--- a/src/io/shadow_grab.zig
+++ b/src/io/shadow_grab.zig
@@ -81,26 +81,82 @@ pub const GrabList = struct {
         return false;
     }
 
-    /// Evict entries whose device is gone (fd answers ENODEV). EBUSY-held
-    /// entries own no fd, so they are name-tracked and pruned only via evict().
+    /// Evict entries whose device is gone (owned fd answers ENODEV) and re-probe
+    /// entries held by a foreign reader (owned=false). A foreign EVIOCGRAB that
+    /// is later released leaves the node grabbable again with no REMOVE uevent,
+    /// so an unowned entry must be re-validated rather than trusted forever:
+    /// re-grab succeeds -> upgrade to an owned grab padctl now guards; still
+    /// EBUSY -> keep counting it; node gone -> drop it. `/dev/input` matches the
+    /// only production caller; revalidate is seam-injected for unit testing.
     pub fn pruneDead(self: *GrabList) void {
+        self.pruneDeadWith(reopenGrab, "/dev/input");
+    }
+
+    fn pruneDeadWith(
+        self: *GrabList,
+        comptime revalidate: fn ([]const u8, []const u8) Revalidation,
+        input_dir: []const u8,
+    ) void {
         var i: usize = 0;
         while (i < self.len) {
-            if (!self.grabs[i].owned) {
-                i += 1;
+            const g = &self.grabs[i];
+            if (g.owned) {
+                var id: ioctl.InputId = undefined;
+                if (linux.E.init(linux.ioctl(g.fd, ioctl.EVIOCGID, @intFromPtr(&id))) == .NODEV) {
+                    posix.close(g.fd);
+                    self.dropAt(i);
+                } else {
+                    i += 1;
+                }
                 continue;
             }
-            var id: ioctl.InputId = undefined;
-            if (linux.E.init(linux.ioctl(self.grabs[i].fd, ioctl.EVIOCGID, @intFromPtr(&id))) == .NODEV) {
-                posix.close(self.grabs[i].fd);
-                self.len -= 1;
-                self.grabs[i] = self.grabs[self.len];
-            } else {
-                i += 1;
+            switch (revalidate(input_dir, g.name())) {
+                .upgraded => |fd| {
+                    g.fd = fd;
+                    g.owned = true;
+                    i += 1;
+                },
+                .still_busy => i += 1,
+                .gone => self.dropAt(i),
             }
         }
     }
+
+    fn dropAt(self: *GrabList, i: usize) void {
+        self.len -= 1;
+        self.grabs[i] = self.grabs[self.len];
+    }
 };
+
+/// Outcome of re-probing an unowned (foreign-held) shadow entry.
+const Revalidation = union(enum) {
+    /// The foreign grab was released; padctl re-grabbed it and now owns this fd.
+    upgraded: posix.fd_t,
+    /// Another reader still holds the exclusive grab; keep the unowned entry.
+    still_busy,
+    /// The node is gone (open/ioctl failed); drop the entry.
+    gone,
+};
+
+/// Re-open `node` read-only and re-attempt EVIOCGRAB. On success padctl owns
+/// the returned fd; on EBUSY the node is still foreign-held; any open or other
+/// ioctl failure means the node disappeared.
+fn reopenGrab(input_dir: []const u8, node: []const u8) Revalidation {
+    var path_buf: [64]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ input_dir, node }) catch return .gone;
+    const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch return .gone;
+    switch (linux.E.init(linux.ioctl(fd, ioctl.EVIOCGRAB, 1))) {
+        .SUCCESS => return .{ .upgraded = fd },
+        .BUSY => {
+            posix.close(fd);
+            return .still_busy;
+        },
+        else => {
+            posix.close(fd);
+            return .gone;
+        },
+    }
+}
 
 /// Pure decision seam: grab when the node carries the managed device's
 /// physical VID/PID and is not one of padctl's own outputs — virtual-bus
@@ -321,6 +377,21 @@ test "shadow_grab: classifyGrabErrno counts EBUSY as a handled shadow" {
     try testing.expectEqual(GrabResult.skipped, classifyGrabErrno(.INVAL));
 }
 
+fn revalidateStillBusy(_: []const u8, _: []const u8) Revalidation {
+    return .still_busy;
+}
+
+fn revalidateGone(_: []const u8, _: []const u8) Revalidation {
+    return .gone;
+}
+
+/// Upgrade fixture: opens /dev/null so the upgraded entry owns a real,
+/// closeable fd (a bare sentinel would let close() bugs go undetected).
+fn revalidateUpgrade(_: []const u8, _: []const u8) Revalidation {
+    const fd = posix.open("/dev/null", .{ .ACCMODE = .RDONLY }, 0) catch unreachable;
+    return .{ .upgraded = fd };
+}
+
 test "shadow_grab: an EBUSY-held shadow is counted but releaseAll skips its fd" {
     var list = GrabList{};
     // Simulate what tryGrabNode records on EBUSY: a counted, unowned entry
@@ -329,9 +400,10 @@ test "shadow_grab: an EBUSY-held shadow is counted but releaseAll skips its fd" 
     try testing.expectEqual(@as(usize, 1), list.len);
     try testing.expect(list.contains("event8"));
 
-    // pruneDead must not ioctl/close the unowned fd; the entry survives.
-    list.pruneDead();
+    // A still-foreign-held node stays counted and must not close the -1 fd.
+    list.pruneDeadWith(revalidateStillBusy, "/dev/input");
     try testing.expectEqual(@as(usize, 1), list.len);
+    try testing.expect(!list.grabs[0].owned);
 
     // releaseAll/evict must not posix.close(-1) on an unowned entry.
     try testing.expect(list.evict("event8"));
@@ -339,6 +411,31 @@ test "shadow_grab: an EBUSY-held shadow is counted but releaseAll skips its fd" 
 
     recordGrab(&list, "event8", -1, false);
     list.releaseAll();
+    try testing.expectEqual(@as(usize, 0), list.len);
+}
+
+test "shadow_grab: pruneDead re-grabs an unowned shadow whose foreign holder released it" {
+    var list = GrabList{};
+    recordGrab(&list, "event8", -1, false);
+
+    // The foreign reader released its grab: re-validation re-grabs the node, so
+    // the phantom entry is upgraded to an owned grab padctl genuinely guards.
+    list.pruneDeadWith(revalidateUpgrade, "/dev/input");
+    try testing.expectEqual(@as(usize, 1), list.len);
+    try testing.expect(list.grabs[0].owned);
+    try testing.expect(list.grabs[0].fd >= 0);
+
+    // The upgraded fd is owned, so releaseAll closes it (double-free would trap).
+    list.releaseAll();
+    try testing.expectEqual(@as(usize, 0), list.len);
+}
+
+test "shadow_grab: pruneDead drops an unowned shadow whose node is gone" {
+    var list = GrabList{};
+    recordGrab(&list, "event8", -1, false);
+    recordGrab(&list, "event9", -1, false);
+
+    list.pruneDeadWith(revalidateGone, "/dev/input");
     try testing.expectEqual(@as(usize, 0), list.len);
 }
 

--- a/src/test/shadow_grab_integration_test.zig
+++ b/src/test/shadow_grab_integration_test.zig
@@ -164,6 +164,45 @@ test "shadow_grab: a node already grabbed by another reader is counted (EBUSY)" 
     try testing.expectEqual(@as(usize, 0), observer.len);
 }
 
+test "shadow_grab: sweep re-grabs an unowned EBUSY node once the foreign holder releases it" {
+    const vid: u16 = 0xFAD7;
+    const pid: u16 = 0x24FA;
+    const ufd = try createPad(BUS_USB, vid, pid);
+    defer destroyPad(ufd);
+
+    var name_buf: [24]u8 = undefined;
+    const node = findEventNode(vid, pid, &name_buf) orelse return error.SkipZigTest;
+    const params: shadow_grab.Params = .{ .phys_vendor = vid, .phys_product = pid };
+
+    var path_buf: [40]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "/dev/input/{s}", .{node});
+
+    // A foreign reader holds the exclusive grab.
+    const foreign = try posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0);
+    var foreign_open = true;
+    defer if (foreign_open) posix.close(foreign);
+    try testing.expectEqual(linux.E.SUCCESS, linux.E.init(linux.ioctl(foreign, ioctl.EVIOCGRAB, 1)));
+
+    // padctl can only count it (EBUSY): an unowned, fd-less entry.
+    var list = shadow_grab.GrabList{};
+    defer list.releaseAll();
+    shadow_grab.sweepDir(&list, "/dev/input", params, {}, null);
+    try testing.expect(list.contains(node));
+
+    // The foreign reader releases the node with no REMOVE uevent.
+    posix.close(foreign);
+    foreign_open = false;
+
+    // The next sweep re-validates the unowned entry and re-grabs it: padctl now
+    // genuinely guards the node, observable as a second EVIOCGRAB hitting EBUSY.
+    shadow_grab.sweepDir(&list, "/dev/input", params, {}, null);
+    try testing.expect(list.contains(node));
+
+    const probe = try posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0);
+    defer posix.close(probe);
+    try testing.expectEqual(linux.E.BUSY, linux.E.init(linux.ioctl(probe, ioctl.EVIOCGRAB, 1)));
+}
+
 test "shadow_grab: sweep skips virtual-bus nodes (padctl's own uinput outputs)" {
     const vid: u16 = 0xFAD7;
     const pid: u16 = 0x24FD;


### PR DESCRIPTION
## What changed

- `GrabList.pruneDead` now re-validates unowned (foreign-held, `owned=false`, `fd=-1`) shadow entries instead of skipping them. For each unowned entry it re-opens the node and re-attempts `EVIOCGRAB`:
  - SUCCESS -> upgrade to an owned grab (store the fd, set `owned=true`); padctl now genuinely guards the node.
  - EBUSY -> keep the unowned entry (still externally held).
  - open/ioctl failure -> drop the entry (node gone).
- Revalidation is factored into a `pruneDeadWith(revalidate, input_dir)` seam so the upgrade/still-busy/gone branches are unit-testable without a real device; production `pruneDead()` injects `reopenGrab` against `/dev/input`.
- fd math guarded: the `-1` unowned sentinel is never `close()`d; an upgraded entry's fd is owned and closed by `releaseAll`/`evict`.

## Why

PR #424 made an EBUSY `EVIOCGRAB` record an unowned entry that counts toward `shadow_grabs` / STATUS. But `pruneDead` skipped `owned=false` entries and `tryGrabNode`'s `contains()`-dedup matched them, so an unowned "phantom" was only ever reaped by a netlink REMOVE of that exact node. If a non-padctl reader briefly grabs a shadow node and then releases it while the node persists (no REMOVE uevent), padctl kept counting it as a held shadow forever and `doctor` reported `ok_managed` even though the node was open to SDL again — a diagnostic false-negative. The EBUSY-counting #424 added stays intact; this only stops the count from being permanently sticky. Runtime input defense via owned grabs is unaffected.

## Tests

- `pruneDead re-grabs an unowned shadow whose foreign holder released it` — unowned entry whose re-grab succeeds is upgraded to owned; the upgraded fd is closed by `releaseAll`.
- `pruneDead drops an unowned shadow whose node is gone` — unowned entries are dropped on ENODEV/open failure.
- `an EBUSY-held shadow is counted but releaseAll skips its fd` (updated) — a still-foreign-held node stays counted, `-1` fd never closed.
- Integration (`/dev/uinput`-gated): `sweep re-grabs an unowned EBUSY node once the foreign holder releases it` — real uinput node, foreign grab then release, next sweep re-grabs (observable as a second `EVIOCGRAB` hitting EBUSY).

Falsifiability (RED/GREEN) verified: the unowned-revalidate assertions fail against the pre-fix skip-unowned `pruneDead` logic and pass with this change. Full `zig build test` green in the CI build image.

Refs #406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of input device management when external applications hold exclusive access and then release it.
  * Enhanced device revalidation to properly detect and reclaim control of devices that become available after being held by external sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->