### PR TITLE
fix(packaging): ship 90-padctl.rules and modules-load.d in binary packages

### DIFF
--- a/.github/workflows/install-flow.yml
+++ b/.github/workflows/install-flow.yml
@@ -373,6 +373,7 @@ jobs:
           sudo ./zig-out/bin/padctl install --destdir "$PWD/_install_stage" --prefix /usr --no-enable --no-start
           cp _install_stage/usr/lib/systemd/user/*.service "${STAGING}/install/"
           cp _install_stage/usr/lib/udev/rules.d/*.rules "${STAGING}/install/"
+          cp _install_stage/usr/lib/modules-load.d/padctl.conf "${STAGING}/install/padctl.conf"
           [ -f _install_stage/usr/bin/padctl-reconnect ] && cp _install_stage/usr/bin/padctl-reconnect "${STAGING}/install/"
           cp -r devices "${STAGING}/"
           cp LICENSE README.md "${STAGING}/"
@@ -400,8 +401,8 @@ jobs:
           sed -i "s/^Architecture:.*/Architecture: ${DEB_ARCH}/" "${DEST}/DEBIAN/control"
 
           mkdir -p "${DEST}/usr/bin" "${DEST}/usr/lib/systemd/user" \
-                   "${DEST}/usr/lib/udev/rules.d" "${DEST}/usr/share/padctl" \
-                   "${DEST}/usr/share/doc/padctl"
+                   "${DEST}/usr/lib/udev/rules.d" "${DEST}/usr/lib/modules-load.d" \
+                   "${DEST}/usr/share/padctl" "${DEST}/usr/share/doc/padctl"
 
           for bin in padctl padctl-capture padctl-debug padctl-reconnect; do
             [ -f "${SRC}/bin/${bin}" ] && install -Dm755 "${SRC}/bin/${bin}" "${DEST}/usr/bin/${bin}"
@@ -410,6 +411,7 @@ jobs:
 
           cp "${SRC}/install/"*.service "${DEST}/usr/lib/systemd/user/"
           cp "${SRC}/install/"*.rules "${DEST}/usr/lib/udev/rules.d/"
+          install -Dm644 "${SRC}/install/padctl.conf" "${DEST}/usr/lib/modules-load.d/padctl.conf"
 
           cp -r "${SRC}/devices" "${DEST}/usr/share/padctl/"
           install -Dm644 "${SRC}/LICENSE" "${DEST}/usr/share/doc/padctl/copyright"
@@ -426,6 +428,10 @@ jobs:
             || { echo "FAIL: padctl.service missing"; echo "${OUT}"; exit 1; }
           echo "${OUT}" | grep -q ' \./usr/lib/udev/rules\.d/60-padctl\.rules$' \
             || { echo "FAIL: 60-padctl.rules missing"; echo "${OUT}"; exit 1; }
+          echo "${OUT}" | grep -q ' \./usr/lib/udev/rules\.d/90-padctl\.rules$' \
+            || { echo "FAIL: 90-padctl.rules (IMU tag) missing from .deb"; echo "${OUT}"; exit 1; }
+          echo "${OUT}" | grep -q ' \./usr/lib/modules-load\.d/padctl\.conf$' \
+            || { echo "FAIL: modules-load.d/padctl.conf (uhid/uinput autoload) missing from .deb"; echo "${OUT}"; exit 1; }
           echo "${OUT}" | grep -q ' \./usr/share/padctl/devices/flydigi/vader5\.toml$' \
             || { echo "FAIL: vader5.toml not under /usr/share/padctl/devices/"; echo "${OUT}"; exit 1; }
           DEVICES=$(echo "${OUT}" | grep -c '^.* \./usr/share/padctl/devices/.\+/.\+\.toml$' || true)
@@ -457,6 +463,10 @@ jobs:
             test -x /usr/bin/padctl || { echo FAIL padctl bin not executable; exit 1; }
             test -f /usr/lib/systemd/user/padctl.service || { echo FAIL service unit missing; exit 1; }
             test -f /usr/lib/udev/rules.d/60-padctl.rules || { echo FAIL udev rules missing; exit 1; }
+            test -f /usr/lib/udev/rules.d/90-padctl.rules || { echo FAIL 90-padctl.rules IMU tag missing; exit 1; }
+            test -f /usr/lib/modules-load.d/padctl.conf || { echo FAIL modules-load.d/padctl.conf missing; exit 1; }
+            grep -qx uhid /usr/lib/modules-load.d/padctl.conf || { echo FAIL uhid not autoloaded; exit 1; }
+            grep -qx uinput /usr/lib/modules-load.d/padctl.conf || { echo FAIL uinput not autoloaded; exit 1; }
             echo "::endgroup::"
 
             echo "::group::version sync (zon=${ZON_VER})"
@@ -508,6 +518,8 @@ jobs:
             test ! -f /usr/bin/padctl || { echo FAIL bin still present; exit 1; }
             test ! -f /usr/lib/systemd/user/padctl.service || { echo FAIL service still present; exit 1; }
             test ! -f /usr/lib/udev/rules.d/60-padctl.rules || { echo FAIL udev still present; exit 1; }
+            test ! -f /usr/lib/udev/rules.d/90-padctl.rules || { echo FAIL 90-padctl.rules still present; exit 1; }
+            test ! -f /usr/lib/modules-load.d/padctl.conf || { echo FAIL modules-load.d/padctl.conf still present; exit 1; }
             echo "::endgroup::"
 
             echo "::group::purge cleans residual share dir"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,7 @@ jobs:
           done
           cp staging/usr/lib/systemd/user/*.service "${STAGING}/install/"
           cp staging/usr/lib/udev/rules.d/*.rules "${STAGING}/install/"
+          cp staging/usr/lib/modules-load.d/padctl.conf "${STAGING}/install/padctl.conf"
           [ -f staging/usr/bin/padctl-reconnect ] && cp staging/usr/bin/padctl-reconnect "${STAGING}/install/"
           cp -r devices "${STAGING}/"
           cp LICENSE README.md "${STAGING}/"
@@ -220,8 +221,8 @@ jobs:
           sed -i "s/^Architecture:.*/Architecture: ${DEB_ARCH}/" "${DEST}/DEBIAN/control"
 
           mkdir -p "${DEST}/usr/bin" "${DEST}/usr/lib/systemd/user" \
-                   "${DEST}/usr/lib/udev/rules.d" "${DEST}/usr/share/padctl" \
-                   "${DEST}/usr/share/doc/padctl"
+                   "${DEST}/usr/lib/udev/rules.d" "${DEST}/usr/lib/modules-load.d" \
+                   "${DEST}/usr/share/padctl" "${DEST}/usr/share/doc/padctl"
 
           for bin in padctl padctl-capture padctl-debug padctl-reconnect; do
             [ -f "${SRC}/bin/${bin}" ] && install -Dm755 "${SRC}/bin/${bin}" "${DEST}/usr/bin/${bin}"
@@ -230,6 +231,7 @@ jobs:
 
           cp "${SRC}/install/"*.service "${DEST}/usr/lib/systemd/user/"
           cp "${SRC}/install/"*.rules "${DEST}/usr/lib/udev/rules.d/"
+          install -Dm644 "${SRC}/install/padctl.conf" "${DEST}/usr/lib/modules-load.d/padctl.conf"
 
           cp -r "${SRC}/devices" "${DEST}/usr/share/padctl/"
           install -Dm644 "${SRC}/LICENSE" "${DEST}/usr/share/doc/padctl/copyright"
@@ -280,6 +282,10 @@ jobs:
             padctl list-mappings
             padctl --validate /usr/share/padctl/devices/sony/dualsense.toml
             test -d /usr/share/padctl/devices/
+            test -f /usr/lib/udev/rules.d/90-padctl.rules
+            test -f /usr/lib/modules-load.d/padctl.conf
+            grep -qx uhid /usr/lib/modules-load.d/padctl.conf
+            grep -qx uinput /usr/lib/modules-load.d/padctl.conf
           "
 
   checksums:

--- a/contrib/aur/padctl-bin/PKGBUILD
+++ b/contrib/aur/padctl-bin/PKGBUILD
@@ -48,6 +48,11 @@ package() {
         "${pkgdir}/usr/lib/udev/rules.d/60-padctl.rules"
     [[ -f install/61-padctl-driver-block.rules ]] && install -Dm644 install/61-padctl-driver-block.rules \
         "${pkgdir}/usr/lib/udev/rules.d/61-padctl-driver-block.rules"
+    install -Dm644 install/90-padctl.rules \
+        "${pkgdir}/usr/lib/udev/rules.d/90-padctl.rules"
+
+    install -Dm644 install/padctl.conf \
+        "${pkgdir}/usr/lib/modules-load.d/padctl.conf"
 
     while IFS= read -r -d '' toml; do
         install -Dm644 "${toml}" "${pkgdir}/usr/share/padctl/${toml}"

--- a/contrib/copr/padctl.spec
+++ b/contrib/copr/padctl.spec
@@ -47,6 +47,8 @@ systemd socket activation and udev integration.
 %{_unitdir}/padctl.service
 %{_udevrulesdir}/60-padctl.rules
 %{_udevrulesdir}/61-padctl-driver-block.rules
+%{_udevrulesdir}/90-padctl.rules
+%{_modulesloaddir}/padctl.conf
 %{_datadir}/padctl/
 
 %post


### PR DESCRIPTION
## What

Binary packages omitted two install files that source installs get from `padctl install`, so binary-package users miss IMU tagging and kernel-module autoload.

- **`90-padctl.rules`** (IMU/sensor udev tag): tags padctl UHID IMU nodes as accelerometers so SDL / Steam treat them as sensors instead of joysticks (`ID_INPUT_ACCELEROMETER=1`, clears `ID_INPUT_JOYSTICK`). It was shipped in the tarball and `.deb` via the `*.rules` glob, but `contrib/aur/padctl-bin/PKGBUILD` hardcoded only `60`/`61`, and the COPR `%files` manifest listed only `60`/`61` — so AUR `padctl-bin` and COPR users lost it.
- **`modules-load.d/padctl.conf`** (uhid/uinput autoload): never copied into the release tarball, so **no** binary package (tarball, `.deb`, AUR, COPR) shipped it. Source installs autoload `uhid` + `uinput` at boot; binary users didn't.

The release `gen-install-artifacts` step already generates both files into the staging tree (verified). The gap is purely in the packaging copy steps that downstream-derive the tarball/.deb/AUR/COPR.

## Changes

- `release.yml`: copy `modules-load.d/padctl.conf` into the tarball `install/`; place it and (explicitly) the modules-load dir into the `.deb`; assert both files land in the release `.deb` smoke test.
- `install-flow.yml` (`pkg-deb-smoke`): mirror the tarball + `.deb` copy changes; assert `90-padctl.rules` and `modules-load.d/padctl.conf` are present in `dpkg-deb -c`, parse correctly at runtime (`uhid`/`uinput` lines), and are removed on uninstall.
- `contrib/aur/padctl-bin/PKGBUILD`: install `90-padctl.rules` and `modules-load.d/padctl.conf`.
- `contrib/copr/padctl.spec`: add `90-padctl.rules` and `modules-load.d/padctl.conf` to `%files` (RPM fails on unpackaged generated files).

No `.zig` source changed.

## Test plan

Reproduced and verified locally in Docker (canonical build image + `debian:12` + `archlinux:latest`):

- RED on `main` (89647c6): simulated release Package step → `modules-load.d/padctl.conf` absent from tarball staging.
- GREEN with fix: built a real `.deb` → `dpkg-deb -c` shows `90-padctl.rules` and `modules-load.d/padctl.conf`; installed in `debian:12` → both present, `uhid`/`uinput` autoload lines present, IMU accelerometer tag present; `apt-get remove` → both removed.
- GREEN AUR: ran `makepkg` on `padctl-bin` against a release-shaped tarball → built package contains `usr/lib/udev/rules.d/90-padctl.rules` and `usr/lib/modules-load.d/padctl.conf`.
- `zig build test` passes (EXIT=0).

Refs #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package build workflows across multiple platforms to include kernel module autoload configuration (`padctl.conf`) and updated udev rules (`90-padctl.rules`) in distributed packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->