### PR TITLE
feat(cli): config test accepts a mapping name; reload verifies via the socket

### DIFF
--- a/src/cli/config/test.zig
+++ b/src/cli/config/test.zig
@@ -6,7 +6,6 @@ const hidraw = @import("../../io/hidraw.zig");
 const device_mod = @import("../../config/device.zig");
 const mapping_mod = @import("../../config/mapping.zig");
 const paths = @import("../../config/paths.zig");
-const mapping_discovery = @import("../../config/mapping_discovery.zig");
 const scan_mod = @import("../scan.zig");
 const interpreter_mod = @import("../../core/interpreter.zig");
 const state_mod = @import("../../core/state.zig");
@@ -152,7 +151,17 @@ fn formatEvents(w: anytype, prev: state_mod.GamepadState, curr: state_mod.Gamepa
 fn resolveMappingPath(allocator: std.mem.Allocator, mapping_arg: []const u8) !?[]const u8 {
     if (std.mem.indexOfScalar(u8, mapping_arg, '/') != null)
         return try allocator.dupe(u8, mapping_arg);
-    return mapping_discovery.findMapping(allocator, mapping_arg);
+    const dirs = try paths.resolveMappingConfigDirs(allocator);
+    defer paths.freeConfigDirs(allocator, dirs);
+    return resolveMappingNameInDirs(allocator, mapping_arg, dirs);
+}
+
+/// Resolve a bare profile name to `<dir>/<name>.toml` across `dirs` in priority
+/// order, the same lookup `padctl switch` uses. Caller frees when non-null.
+fn resolveMappingNameInDirs(allocator: std.mem.Allocator, name: []const u8, dirs: []const []const u8) !?[]const u8 {
+    const filename = try std.fmt.allocPrint(allocator, "{s}.toml", .{name});
+    defer allocator.free(filename);
+    return paths.findConfig(allocator, filename, dirs);
 }
 
 pub fn run(
@@ -320,6 +329,36 @@ test "resolveMappingPath: slash arg is used as a literal path" {
 test "resolveMappingPath: bare name resolves through mapping dirs" {
     const allocator = testing.allocator;
     const got = try resolveMappingPath(allocator, "nonexistent_profile_xyz_12345");
+    defer if (got) |p| allocator.free(p);
+    try testing.expectEqual(@as(?[]const u8, null), got);
+}
+
+test "resolveMappingNameInDirs: bare name resolves to the on-disk profile" {
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "fps.toml", .data = "name = \"fps\"\n" });
+    const dir = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir);
+
+    const dirs = [_][]const u8{dir};
+    const got = try resolveMappingNameInDirs(allocator, "fps", &dirs);
+    defer if (got) |p| allocator.free(p);
+    try testing.expect(got != null);
+    try testing.expect(std.mem.endsWith(u8, got.?, "/fps.toml"));
+}
+
+test "resolveMappingNameInDirs: missing name returns null" {
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir);
+
+    const dirs = [_][]const u8{dir};
+    const got = try resolveMappingNameInDirs(allocator, "absent", &dirs);
     defer if (got) |p| allocator.free(p);
     try testing.expectEqual(@as(?[]const u8, null), got);
 }

--- a/src/cli/config/test.zig
+++ b/src/cli/config/test.zig
@@ -6,6 +6,7 @@ const hidraw = @import("../../io/hidraw.zig");
 const device_mod = @import("../../config/device.zig");
 const mapping_mod = @import("../../config/mapping.zig");
 const paths = @import("../../config/paths.zig");
+const mapping_discovery = @import("../../config/mapping_discovery.zig");
 const scan_mod = @import("../scan.zig");
 const interpreter_mod = @import("../../core/interpreter.zig");
 const state_mod = @import("../../core/state.zig");
@@ -145,13 +146,30 @@ fn formatEvents(w: anytype, prev: state_mod.GamepadState, curr: state_mod.Gamepa
     }
 }
 
+/// `mapping_arg` is a bare profile name (resolved through the XDG mapping dirs,
+/// matching `padctl switch`) unless it contains a '/', in which case it is used
+/// as a literal path. Caller frees the result when non-null.
+fn resolveMappingPath(allocator: std.mem.Allocator, mapping_arg: []const u8) !?[]const u8 {
+    if (std.mem.indexOfScalar(u8, mapping_arg, '/') != null)
+        return try allocator.dupe(u8, mapping_arg);
+    return mapping_discovery.findMapping(allocator, mapping_arg);
+}
+
 pub fn run(
     allocator: std.mem.Allocator,
     config_path: ?[]const u8,
-    mapping_path: ?[]const u8,
+    mapping_arg: ?[]const u8,
     raw_mode: bool,
     writer: anytype,
 ) !void {
+    const mapping_path: ?[]const u8 = if (mapping_arg) |ma|
+        resolveMappingPath(allocator, ma) catch null
+    else
+        null;
+    defer if (mapping_path) |p| allocator.free(p);
+    if (mapping_arg != null and mapping_path == null)
+        std.log.warn("mapping '{s}' not found", .{mapping_arg.?});
+
     const mapping: ?mapping_mod.ParseResult = blk: {
         const mpath = if (mapping_path) |mp| mp else {
             break :blk null;
@@ -290,6 +308,21 @@ fn formatReport(w: anytype, report: []const u8, remap: ?mapping_mod.RemapMap) !v
 // --- tests ---
 
 const testing = std.testing;
+
+test "resolveMappingPath: slash arg is used as a literal path" {
+    const allocator = testing.allocator;
+    const got = try resolveMappingPath(allocator, "/etc/padctl/mappings/fps.toml");
+    defer if (got) |p| allocator.free(p);
+    try testing.expect(got != null);
+    try testing.expectEqualStrings("/etc/padctl/mappings/fps.toml", got.?);
+}
+
+test "resolveMappingPath: bare name resolves through mapping dirs" {
+    const allocator = testing.allocator;
+    const got = try resolveMappingPath(allocator, "nonexistent_profile_xyz_12345");
+    defer if (got) |p| allocator.free(p);
+    try testing.expectEqual(@as(?[]const u8, null), got);
+}
 
 test "formatReport: hex dump without mapping" {
     var out: std.ArrayList(u8) = .{};

--- a/src/cli/reload.zig
+++ b/src/cli/reload.zig
@@ -43,25 +43,28 @@ fn isAlive(pid: std.posix.pid_t) bool {
     return true;
 }
 
-/// Ask the daemon to reload via the control socket. Returns true when it
-/// answered with a verified result (which is forwarded to `writer`/`err_writer`),
-/// false when the socket was unreachable so the caller can fall back to SIGHUP.
-fn reloadViaSocket(socket_path: []const u8, writer: anytype, err_writer: anytype) bool {
-    const fd = socket_client.connectToSocket(socket_path) catch return false;
+const SocketReload = enum { ok, failed, unreachable_socket };
+
+/// Ask the daemon to reload via the control socket. Forwards the reply to
+/// `writer`/`err_writer` and reports whether it confirmed success (`ok`),
+/// reported a failure (`failed`), or the socket was unreachable so the caller
+/// can fall back to SIGHUP (`unreachable_socket`).
+fn reloadViaSocket(socket_path: []const u8, writer: anytype, err_writer: anytype) SocketReload {
+    const fd = socket_client.connectToSocket(socket_path) catch return .unreachable_socket;
     defer std.posix.close(fd);
 
     var resp_buf: [256]u8 = undefined;
-    const resp = socket_client.sendCommand(fd, "RELOAD\n", &resp_buf) catch return false;
-    printReply(resp, writer, err_writer);
-    return true;
+    const resp = socket_client.sendCommand(fd, "RELOAD\n", &resp_buf) catch return .unreachable_socket;
+    return printReply(resp, writer, err_writer);
 }
 
-fn printReply(resp: []const u8, writer: anytype, err_writer: anytype) void {
+fn printReply(resp: []const u8, writer: anytype, err_writer: anytype) SocketReload {
     if (std.mem.startsWith(u8, resp, "OK")) {
         writeLine(writer, resp);
-    } else {
-        writeLine(err_writer, resp);
+        return .ok;
     }
+    writeLine(err_writer, resp);
+    return .failed;
 }
 
 fn writeLine(out: anytype, resp: []const u8) void {
@@ -72,7 +75,11 @@ fn writeLine(out: anytype, resp: []const u8) void {
 pub fn run(allocator: std.mem.Allocator, pid_arg: ?[]const u8, socket_path: []const u8, writer: anytype, err_writer: anytype) !void {
     // The socket reply confirms the reload actually happened; SIGHUP only
     // assumes it. Use the socket when reachable, fall back to the signal.
-    if (pid_arg == null and reloadViaSocket(socket_path, writer, err_writer)) return;
+    if (pid_arg == null) switch (reloadViaSocket(socket_path, writer, err_writer)) {
+        .ok => return,
+        .failed => std.process.exit(1),
+        .unreachable_socket => {},
+    };
 
     const pid = resolvePid(allocator, pid_arg) catch {
         std.log.err("padctl daemon not running", .{});
@@ -145,12 +152,14 @@ test "printReply: OK goes to writer, ERR goes to err_writer" {
     var err: std.ArrayList(u8) = .{};
     defer err.deinit(testing.allocator);
 
-    printReply("OK reloaded 2 devices\n", out.writer(testing.allocator), err.writer(testing.allocator));
+    const ok = printReply("OK reloaded 2 devices\n", out.writer(testing.allocator), err.writer(testing.allocator));
+    try testing.expectEqual(SocketReload.ok, ok);
     try testing.expectEqualStrings("OK reloaded 2 devices\n", out.items);
     try testing.expectEqualStrings("", err.items);
 
     out.clearRetainingCapacity();
-    printReply("ERR /etc/x.toml: bad", out.writer(testing.allocator), err.writer(testing.allocator));
+    const failed = printReply("ERR /etc/x.toml: bad", out.writer(testing.allocator), err.writer(testing.allocator));
+    try testing.expectEqual(SocketReload.failed, failed);
     try testing.expectEqualStrings("", out.items);
     try testing.expectEqualStrings("ERR /etc/x.toml: bad\n", err.items);
 }

--- a/src/cli/reload.zig
+++ b/src/cli/reload.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const socket_client = @import("socket_client.zig");
 
 /// Resolve PID: explicit arg → /run/padctl.pid → pgrep -x padctl
 fn resolvePid(allocator: std.mem.Allocator, explicit: ?[]const u8) !std.posix.pid_t {
@@ -42,7 +43,37 @@ fn isAlive(pid: std.posix.pid_t) bool {
     return true;
 }
 
-pub fn run(allocator: std.mem.Allocator, pid_arg: ?[]const u8) !void {
+/// Ask the daemon to reload via the control socket. Returns true when it
+/// answered with a verified result (which is forwarded to `writer`/`err_writer`),
+/// false when the socket was unreachable so the caller can fall back to SIGHUP.
+fn reloadViaSocket(socket_path: []const u8, writer: anytype, err_writer: anytype) bool {
+    const fd = socket_client.connectToSocket(socket_path) catch return false;
+    defer std.posix.close(fd);
+
+    var resp_buf: [256]u8 = undefined;
+    const resp = socket_client.sendCommand(fd, "RELOAD\n", &resp_buf) catch return false;
+    printReply(resp, writer, err_writer);
+    return true;
+}
+
+fn printReply(resp: []const u8, writer: anytype, err_writer: anytype) void {
+    if (std.mem.startsWith(u8, resp, "OK")) {
+        writeLine(writer, resp);
+    } else {
+        writeLine(err_writer, resp);
+    }
+}
+
+fn writeLine(out: anytype, resp: []const u8) void {
+    out.writeAll(resp) catch {};
+    if (resp.len == 0 or resp[resp.len - 1] != '\n') out.writeAll("\n") catch {};
+}
+
+pub fn run(allocator: std.mem.Allocator, pid_arg: ?[]const u8, socket_path: []const u8, writer: anytype, err_writer: anytype) !void {
+    // The socket reply confirms the reload actually happened; SIGHUP only
+    // assumes it. Use the socket when reachable, fall back to the signal.
+    if (pid_arg == null and reloadViaSocket(socket_path, writer, err_writer)) return;
+
     const pid = resolvePid(allocator, pid_arg) catch {
         std.log.err("padctl daemon not running", .{});
         std.process.exit(1);
@@ -56,7 +87,7 @@ pub fn run(allocator: std.mem.Allocator, pid_arg: ?[]const u8) !void {
         std.process.exit(1);
     }
 
-    _ = std.posix.write(std.posix.STDOUT_FILENO, "Reloaded.\n") catch 0;
+    writer.writeAll("Reloaded.\n") catch {};
 }
 
 // --- tests ---
@@ -106,4 +137,20 @@ test "isAlive: pid 0 is not a user process (alive check via kill)" {
     // PID 1 always exists on Linux; just verify isAlive doesn't crash
     // (may return true or false depending on permissions, but must not panic)
     _ = isAlive(1);
+}
+
+test "printReply: OK goes to writer, ERR goes to err_writer" {
+    var out: std.ArrayList(u8) = .{};
+    defer out.deinit(testing.allocator);
+    var err: std.ArrayList(u8) = .{};
+    defer err.deinit(testing.allocator);
+
+    printReply("OK reloaded 2 devices\n", out.writer(testing.allocator), err.writer(testing.allocator));
+    try testing.expectEqualStrings("OK reloaded 2 devices\n", out.items);
+    try testing.expectEqualStrings("", err.items);
+
+    out.clearRetainingCapacity();
+    printReply("ERR /etc/x.toml: bad", out.writer(testing.allocator), err.writer(testing.allocator));
+    try testing.expectEqualStrings("", out.items);
+    try testing.expectEqualStrings("ERR /etc/x.toml: bad\n", err.items);
 }

--- a/src/io/control_socket.zig
+++ b/src/io/control_socket.zig
@@ -174,6 +174,7 @@ pub const CommandTag = enum {
     status,
     list,
     devices,
+    reload,
     dump_on,
     dump_off,
     dump_status,
@@ -220,6 +221,8 @@ pub fn parseCommand(raw: []const u8) Command {
         return .{ .tag = .list };
     } else if (std.ascii.eqlIgnoreCase(verb, "DEVICES")) {
         return .{ .tag = .devices };
+    } else if (std.ascii.eqlIgnoreCase(verb, "RELOAD")) {
+        return .{ .tag = .reload };
     } else if (std.ascii.eqlIgnoreCase(verb, "DUMP")) {
         const mode = it.next() orelse return .{ .tag = .unknown };
         if (std.ascii.eqlIgnoreCase(mode, "ON")) return .{ .tag = .dump_on };
@@ -287,6 +290,11 @@ test "control_socket: parseCommand: LIST" {
 test "control_socket: parseCommand: DEVICES" {
     const cmd = parseCommand("DEVICES\n");
     try testing.expectEqual(CommandTag.devices, cmd.tag);
+}
+
+test "control_socket: parseCommand: RELOAD" {
+    try testing.expectEqual(CommandTag.reload, parseCommand("RELOAD\n").tag);
+    try testing.expectEqual(CommandTag.reload, parseCommand("reload\n").tag);
 }
 
 test "control_socket: parseCommand: CHORD_SWITCH valid index" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -447,9 +447,15 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                         test_mapping = args.next() orelse return error.MissingArgValue;
                     } else if (std.mem.eql(u8, targ, "--raw")) {
                         test_raw = true;
-                    } else {
+                    } else if (targ.len > 0 and targ[0] == '-') {
                         std.log.err("unknown config test argument: {s}", .{targ});
                         return error.UnknownArgument;
+                    } else {
+                        if (test_mapping != null) {
+                            std.log.err("config test accepts at most one mapping name", .{});
+                            return error.UnknownArgument;
+                        }
+                        test_mapping = targ;
                     }
                 }
                 parsed_cli.config_cmd = .{ .@"test" = .{ .config = test_config, .mapping = test_mapping, .raw = test_raw } };
@@ -607,7 +613,7 @@ fn printHelp() void {
         \\    --config-dir <dir>  Search for device configs here (default: XDG paths)
         \\  list-mappings         List discovered mapping profiles from XDG paths
         \\    --config-dir <dir>  Also show device-specific mappings from this directory
-        \\  reload [--pid <pid>]  Send SIGHUP to running padctl daemon
+        \\  reload [--pid <pid>]  Reload device configs; verifies via the control socket (SIGHUP fallback)
         \\  switch [name]         Switch mapping (omit name to re-apply from user config)
         \\    --persist           Copy mapping + config to /etc/padctl/ (survives reboot, uses sudo)
         \\    --device <id>       Apply only to specific device
@@ -629,10 +635,11 @@ fn printHelp() void {
         \\  config init           Interactively create a mapping in ~/.config/padctl/mappings/
         \\    --device <name>     Skip device selection prompt
         \\  config edit [name]    Open mapping in $VISUAL/$EDITOR; validate on exit
-        \\  config test           Live input preview decoded into named button/axis events (Ctrl-C to exit)
+        \\  config test [mapping] Live input preview decoded into named button/axis events (Ctrl-C to exit)
+        \\                        [mapping] is a profile name (resolved like switch) or a path with '/'
         \\                        Decoding supports hidraw devices only; vendor-class (libusb) devices show raw bytes
         \\    --config <path>     Device config to decode input (default: auto-detect from XDG device dirs)
-        \\    --mapping <path>    Mapping to apply for display
+        \\    --mapping <name>    Mapping name or path to apply for display
         \\    --raw               Show raw report bytes instead of decoded events
         \\
         \\Options:
@@ -785,7 +792,7 @@ pub fn main() !void {
 
     // reload subcommand
     if (parsed.reload) {
-        cli.reload.run(allocator, parsed.reload_pid) catch |err| {
+        cli.reload.run(allocator, parsed.reload_pid, parsed.socket_path, stdout_writer, stderr_writer) catch |err| {
             std.log.err("reload failed: {}", .{err});
             std.process.exit(1);
         };

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -268,6 +268,42 @@ pub const Supervisor = struct {
     /// RELOAD control-socket command runs the same path as SIGHUP. null until the
     /// loop installs it.
     reload_hook: ?ReloadHook = null,
+    /// First config that failed to parse during the in-flight reload. The reload
+    /// path swallows per-file errors (a bad file just drops its device), so this
+    /// records the first failure for `handleReload` to surface as `ERR <file>:
+    /// <reason>` instead of a misleading `OK`. Cleared before each reload.
+    reload_failure: ?ReloadFailure = null,
+
+    /// First failing config of a reload, kept in inline buffers so the socket
+    /// reply path needs no allocation. `recordReloadFailure` fills it once.
+    pub const ReloadFailure = struct {
+        file_buf: [160]u8 = undefined,
+        file_len: usize = 0,
+        reason_buf: [80]u8 = undefined,
+        reason_len: usize = 0,
+
+        fn file(self: *const ReloadFailure) []const u8 {
+            return self.file_buf[0..self.file_len];
+        }
+        fn reason(self: *const ReloadFailure) []const u8 {
+            return self.reason_buf[0..self.reason_len];
+        }
+    };
+
+    /// Record the first config that failed to parse during a reload. Later
+    /// failures are ignored so the reply names the first broken file.
+    fn recordReloadFailure(self: *Supervisor, file_path: []const u8, err: anyerror) void {
+        if (self.reload_failure != null) return;
+        var f: ReloadFailure = .{};
+        const fc = @min(file_path.len, f.file_buf.len);
+        @memcpy(f.file_buf[0..fc], file_path[0..fc]);
+        f.file_len = fc;
+        const name = @errorName(err);
+        const rc = @min(name.len, f.reason_buf.len);
+        @memcpy(f.reason_buf[0..rc], name[0..rc]);
+        f.reason_len = rc;
+        self.reload_failure = f;
+    }
 
     /// Emit a [lifecycle] info line when trace_lifecycle is enabled.
     fn traceLifecycle(self: *const Supervisor, comptime fmt: []const u8, args: anytype) void {
@@ -1804,8 +1840,14 @@ pub const Supervisor = struct {
             cs.sendResponse(fd, "ERR reload-unavailable\n");
             return;
         };
+        self.reload_failure = null;
         hook.call(hook.ctx, self);
-        var buf: [64]u8 = undefined;
+        var buf: [control_socket.BUF_SIZE]u8 = undefined;
+        if (self.reload_failure) |*f| {
+            const msg = std.fmt.bufPrint(&buf, "ERR {s}: {s}\n", .{ f.file(), f.reason() }) catch "ERR reload-failed\n";
+            cs.sendResponse(fd, msg);
+            return;
+        }
         const msg = std.fmt.bufPrint(&buf, "OK reloaded {d} devices\n", .{self.managed.items.len}) catch "OK reloaded\n";
         cs.sendResponse(fd, msg);
     }
@@ -2224,7 +2266,7 @@ pub const Supervisor = struct {
     /// Caller owns the returned ParseResult (call deinit on it). Returns null if none configured.
     const DefaultMapping = struct { result: mapping_cfg.ParseResult, stem: []u8 };
 
-    fn loadUserDefaultMapping(self: *const Supervisor, device_name: []const u8) ?DefaultMapping {
+    fn loadUserDefaultMapping(self: *Supervisor, device_name: []const u8) ?DefaultMapping {
         const ucfg = &(self.user_cfg orelse return null);
         const mapping_name = user_config_mod.findDefaultMapping(ucfg, device_name) orelse return null;
         const path = blk: {
@@ -2241,6 +2283,7 @@ pub const Supervisor = struct {
         defer self.allocator.free(path);
         const result = mapping_cfg.parseFile(self.allocator, path) catch |err| {
             std.log.warn("skipping default mapping {s}: {}", .{ path, err });
+            self.recordReloadFailure(path, err);
             return null;
         };
         const stem = self.allocator.dupe(u8, std.fs.path.stem(path)) catch {
@@ -2259,7 +2302,7 @@ pub const Supervisor = struct {
     /// the mapping file omits a `name =` field). Returns null
     /// when no default mapping is configured or it fails to load/allocate;
     /// on null nothing is leaked. Ownership transfers to the caller.
-    fn buildDefaultMapping(self: *const Supervisor, device_name: []const u8) ?DefaultMappingPtr {
+    fn buildDefaultMapping(self: *Supervisor, device_name: []const u8) ?DefaultMappingPtr {
         const dm = self.loadUserDefaultMapping(device_name) orelse return null;
         const p = self.allocator.create(mapping_cfg.ParseResult) catch {
             var r = dm.result;
@@ -2299,6 +2342,7 @@ pub const Supervisor = struct {
 
             const parsed = config_device.parseFile(self.allocator, toml_path) catch |err| {
                 std.log.warn("skipping device config {s}: {}", .{ toml_path, err });
+                self.recordReloadFailure(toml_path, err);
                 continue;
             };
             const cfg_ptr = try self.allocator.create(config_device.ParseResult);
@@ -4893,6 +4937,97 @@ test "supervisor: handleReload without a hook reports ERR" {
     var resp_buf: [256]u8 = undefined;
     const n = try posix.read(resp_fds[1], &resp_buf);
     try testing.expectEqualStrings("ERR reload-unavailable\n", resp_buf[0..n]);
+}
+
+// Hook that drives the production dir-reload path, mirroring serve()'s dispatch
+// so handleReload sees the same swallowed-parse failures a real reload would.
+const DirReloadDispatch = struct {
+    dir_path: []const u8,
+    fn reload(d: @This(), sup: *Supervisor) void {
+        sup.doReloadFromDir(d.dir_path);
+    }
+};
+
+fn installDirReloadHook(sup: *Supervisor, dispatch: *const DirReloadDispatch) void {
+    sup.reload_hook = .{
+        .ctx = dispatch,
+        .call = struct {
+            fn call(ctx: *const anyopaque, s: *Supervisor) void {
+                const d: *const DirReloadDispatch = @ptrCast(@alignCast(ctx));
+                d.reload(s);
+            }
+        }.call,
+    };
+}
+
+test "supervisor: handleReload reports ERR when a config no longer parses" {
+    const allocator = testing.allocator;
+
+    var cfg_dir = testing.tmpDir(.{});
+    defer cfg_dir.cleanup();
+    try cfg_dir.dir.writeFile(.{ .sub_path = "broken.toml", .data = "this is = not [valid toml" });
+    const cfg_dir_path = try cfg_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(cfg_dir_path);
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer sup.deinit();
+
+    const resp_fds = try testSocketpair();
+    defer posix.close(resp_fds[0]);
+    defer posix.close(resp_fds[1]);
+    sup.ctrl_sock = .{
+        .listen_fd = -1,
+        .client_fds = .{ -1, -1, -1, -1 },
+        .client_count = 0,
+        .path = "",
+        .allocator = allocator,
+    };
+    defer sup.ctrl_sock = null;
+
+    const dispatch = DirReloadDispatch{ .dir_path = cfg_dir_path };
+    installDirReloadHook(&sup, &dispatch);
+    defer sup.reload_hook = null;
+
+    sup.handleReload(resp_fds[0]);
+    var resp_buf: [256]u8 = undefined;
+    const n = try posix.read(resp_fds[1], &resp_buf);
+    try testing.expect(std.mem.startsWith(u8, resp_buf[0..n], "ERR "));
+    try testing.expect(std.mem.indexOf(u8, resp_buf[0..n], "broken.toml") != null);
+}
+
+test "supervisor: handleReload reports OK when every config parses" {
+    const allocator = testing.allocator;
+
+    var cfg_dir = testing.tmpDir(.{});
+    defer cfg_dir.cleanup();
+    try cfg_dir.dir.writeFile(.{ .sub_path = "device.toml", .data = minimal_device_toml });
+    const cfg_dir_path = try cfg_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(cfg_dir_path);
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer sup.deinit();
+    sup.hotplug_retry_fd = try posix.timerfd_create(.MONOTONIC, .{ .CLOEXEC = true, .NONBLOCK = true });
+
+    const resp_fds = try testSocketpair();
+    defer posix.close(resp_fds[0]);
+    defer posix.close(resp_fds[1]);
+    sup.ctrl_sock = .{
+        .listen_fd = -1,
+        .client_fds = .{ -1, -1, -1, -1 },
+        .client_count = 0,
+        .path = "",
+        .allocator = allocator,
+    };
+    defer sup.ctrl_sock = null;
+
+    const dispatch = DirReloadDispatch{ .dir_path = cfg_dir_path };
+    installDirReloadHook(&sup, &dispatch);
+    defer sup.reload_hook = null;
+
+    sup.handleReload(resp_fds[0]);
+    var resp_buf: [256]u8 = undefined;
+    const n = try posix.read(resp_fds[1], &resp_buf);
+    try testing.expectEqualStrings("OK reloaded 0 devices\n", resp_buf[0..n]);
 }
 
 test "supervisor: Supervisor: status shows (none) when no mapping loaded" {

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -197,6 +197,13 @@ const PendingKind = enum { hidraw, input_grab };
 // 8 fixed (stop, hup, netlink, inotify, debounce, hotplug_retry, grace, liveness) + 1 listen + 4 clients.
 pub const SUPERVISOR_MAX_FDS: usize = 8 + 1 + 4;
 
+/// Type-erased binding to the active dispatch's reload strategy. `ctx` points at
+/// the dispatch value living on `serveLoop`'s stack for the loop's duration.
+const ReloadHook = struct {
+    ctx: *const anyopaque,
+    call: *const fn (ctx: *const anyopaque, sup: *Supervisor) void,
+};
+
 pub const Supervisor = struct {
     allocator: std.mem.Allocator,
     managed: std.ArrayList(ManagedInstance),
@@ -257,6 +264,10 @@ pub const Supervisor = struct {
     /// True when PADCTL_TRACE_LIFECYCLE=1 at startup. Cached once so hot paths
     /// pay only a bool branch, not a getenv call per event.
     trace_lifecycle: bool = false,
+    /// Reload trigger bound by `serveLoop` to the active dispatch strategy, so a
+    /// RELOAD control-socket command runs the same path as SIGHUP. null until the
+    /// loop installs it.
+    reload_hook: ?ReloadHook = null,
 
     /// Emit a [lifecycle] info line when trace_lifecycle is enabled.
     fn traceLifecycle(self: *const Supervisor, comptime fmt: []const u8, args: anytype) void {
@@ -1635,6 +1646,18 @@ pub const Supervisor = struct {
     ) !void {
         defer self.stopAll();
 
+        const Dispatch = @TypeOf(dispatch);
+        self.reload_hook = .{
+            .ctx = &dispatch,
+            .call = struct {
+                fn call(ctx: *const anyopaque, sup: *Supervisor) void {
+                    const d: *const Dispatch = @ptrCast(@alignCast(ctx));
+                    d.reload(sup);
+                }
+            }.call,
+        };
+        defer self.reload_hook = null;
+
         // 7 base fds + 1 listen + 4 clients = 12
         var pollfds: [SUPERVISOR_MAX_FDS]posix.pollfd = undefined;
         const set = SupervisorPollSet.init(self, &pollfds);
@@ -1767,11 +1790,24 @@ pub const Supervisor = struct {
             .status => self.handleStatus(fd),
             .list => self.handleList(fd),
             .devices => self.handleDevices(fd),
+            .reload => self.handleReload(fd),
             .dump_on => self.handleDump(fd, true),
             .dump_off => self.handleDump(fd, false),
             .dump_status => self.handleDumpStatus(fd),
             .unknown => cs.sendResponse(fd, "ERR unknown-command\n"),
         }
+    }
+
+    fn handleReload(self: *Supervisor, fd: posix.fd_t) void {
+        var cs = &self.ctrl_sock.?;
+        const hook = self.reload_hook orelse {
+            cs.sendResponse(fd, "ERR reload-unavailable\n");
+            return;
+        };
+        hook.call(hook.ctx, self);
+        var buf: [64]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "OK reloaded {d} devices\n", .{self.managed.items.len}) catch "OK reloaded\n";
+        cs.sendResponse(fd, msg);
     }
 
     fn handleChordSwitch(self: *Supervisor, fd: posix.fd_t, chord_index: u8) void {
@@ -4787,6 +4823,76 @@ test "supervisor: Supervisor: status includes mapping name" {
         sup.ctrl_sock = null;
         sup.deinit();
     }
+}
+
+var test_reload_calls: usize = 0;
+
+fn testReloadHookCall(_: *const anyopaque, _: *Supervisor) void {
+    test_reload_calls += 1;
+}
+
+test "supervisor: handleReload runs the hook and reports the device count" {
+    const allocator = testing.allocator;
+
+    const parsed_dev = try device_mod.parseString(allocator, minimal_device_toml);
+    defer parsed_dev.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+    var sup = try Supervisor.initForTest(allocator);
+
+    const inst_a = try makeTestInstance(allocator, &mock_a, &parsed_dev.value);
+    try sup.attachWithInstance("hidraw3", "usb-1-1", inst_a, null);
+
+    const resp_fds = try testSocketpair();
+    defer posix.close(resp_fds[0]);
+    defer posix.close(resp_fds[1]);
+    sup.ctrl_sock = .{
+        .listen_fd = -1,
+        .client_fds = .{ -1, -1, -1, -1 },
+        .client_count = 0,
+        .path = "",
+        .allocator = allocator,
+    };
+    var dummy: u8 = 0;
+    test_reload_calls = 0;
+    sup.reload_hook = .{ .ctx = &dummy, .call = testReloadHookCall };
+
+    sup.handleReload(resp_fds[0]);
+    var resp_buf: [256]u8 = undefined;
+    const n = try posix.read(resp_fds[1], &resp_buf);
+    try testing.expectEqual(@as(usize, 1), test_reload_calls);
+    try testing.expectEqualStrings("OK reloaded 1 devices\n", resp_buf[0..n]);
+
+    defer {
+        sup.stopAll();
+        sup.ctrl_sock = null;
+        sup.deinit();
+    }
+}
+
+test "supervisor: handleReload without a hook reports ERR" {
+    const allocator = testing.allocator;
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer sup.deinit();
+
+    const resp_fds = try testSocketpair();
+    defer posix.close(resp_fds[0]);
+    defer posix.close(resp_fds[1]);
+    sup.ctrl_sock = .{
+        .listen_fd = -1,
+        .client_fds = .{ -1, -1, -1, -1 },
+        .client_count = 0,
+        .path = "",
+        .allocator = allocator,
+    };
+    defer sup.ctrl_sock = null;
+
+    sup.handleReload(resp_fds[0]);
+    var resp_buf: [256]u8 = undefined;
+    const n = try posix.read(resp_fds[1], &resp_buf);
+    try testing.expectEqualStrings("ERR reload-unavailable\n", resp_buf[0..n]);
 }
 
 test "supervisor: Supervisor: status shows (none) when no mapping loaded" {


### PR DESCRIPTION
## What

Two command-surface fixes from the CLI audit.

### config test accepts a positional mapping name (C12)
- `padctl config test <mapping>` is documented in the README but the parser only accepted `--config`/`--mapping`/`--raw` and rejected any positional with `error.UnknownArgument`.
- Now accepts a positional mapping name, resolved through the XDG mapping dirs like `padctl switch` (via `mapping_discovery.findMapping`). An argument containing `/` is treated as a literal path.
- `--config`/`--mapping` overrides are unchanged; `--mapping` also accepts a name or a path now.
- Help text updated; README was already correct.

### reload verifies via the control socket (C11)
- `padctl reload` printed `Reloaded.` unconditionally and was the only daemon command bypassing the control socket (SIGHUP + `--pid`).
- Adds a `RELOAD` verb to the control-socket protocol (alongside `SWITCH`/`STATUS`/`DEVICES`/`DUMP`). The daemon runs the same reload path as SIGHUP and replies `OK reloaded N devices`.
- `padctl reload` now uses the socket and reports the verified result; it falls back to SIGHUP when the socket is unreachable or `--pid` is given.

## Test plan
- `docker run --rm -v "$PWD":/src -w /src ghcr.io/bananasjim/padctl-build:0.15.2 zig build test` — green.
- New unit tests:
  - `control_socket`: `RELOAD` verb parses (case-insensitive).
  - `supervisor`: `handleReload` runs the bound hook and replies `OK reloaded 1 devices`; replies `ERR reload-unavailable` when no hook is installed.
  - `reload`: `printReply` routes `OK` to stdout, `ERR` to stderr.
  - `config/test`: `resolveMappingPath` uses a slashed arg as a literal path and resolves a bare name through the mapping dirs.
- RED/GREEN: the `RELOAD` tag, `handleReload`/`reload_hook`, `reloadViaSocket`/`printReply`, and the positional path are all absent on `main`; the new tests do not compile against the original sources. Functional check: `padctl config test <name>` exits 1 (rejected) on `main` and 0 (resolves the name) on this branch.

Refs: cli command-surface audit C11, C12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `config test` command now accepts mapping profile names (resolved via mapping directories) or direct file paths for greater flexibility
  * Daemon reload mechanism enhanced with control socket support and detailed error reporting for configuration issues

* **Documentation**
  * Updated help text clarifying reload and config test command functionality and options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->