### PR TITLE
feat(cli): plain interactive errors, per-subcommand help, and a guided bare invocation

### DIFF
--- a/src/cli/cli_errors.zig
+++ b/src/cli/cli_errors.zig
@@ -1,0 +1,95 @@
+const std = @import("std");
+
+/// Plain stderr error reporting for interactive CLI argument failures.
+///
+/// Daemon log lines go through padctl_log.logFn, which prepends a wall-clock
+/// timestamp and a MONO counter and renders raw Zig error names. That format is
+/// right for the journal but wrong for a person typing a command: a mistyped
+/// subcommand should read like a shell tool, not a daemon trace. These helpers
+/// write a short two-line message straight to the writer and never emit help.
+pub fn unknownArgument(writer: anytype, arg: []const u8) void {
+    writer.print("padctl: unknown argument '{s}'\n", .{arg}) catch {};
+    tryHelpHint(writer);
+}
+
+pub fn unknownSubcommand(writer: anytype, group: []const u8, sub: []const u8) void {
+    writer.print("padctl: unknown {s} subcommand '{s}'\n", .{ group, sub }) catch {};
+    tryHelpHint(writer);
+}
+
+pub fn message(writer: anytype, text: []const u8) void {
+    writer.print("padctl: {s}\n", .{text}) catch {};
+    tryHelpHint(writer);
+}
+
+fn tryHelpHint(writer: anytype) void {
+    writer.writeAll("Try 'padctl --help' for usage.\n") catch {};
+}
+
+/// Short guide shown when `padctl` is run with no subcommand on an interactive
+/// terminal. The systemd unit runs with stderr attached to the journal (not a
+/// TTY), so the daemon path stays untouched; only a human at a shell sees this.
+pub fn guide(writer: anytype, daemon_running: bool) void {
+    if (daemon_running) {
+        writer.writeAll("padctl: a daemon is already running — try 'padctl status'.\n\n") catch {};
+    }
+    writer.writeAll(
+        \\padctl — HID gamepad daemon
+        \\
+        \\Common commands:
+        \\  padctl status            Show daemon status
+        \\  padctl devices           List connected devices
+        \\  padctl scan              List HID devices and config matches
+        \\  padctl switch <name>     Switch the active mapping
+        \\  padctl doctor            Print a diagnostic report
+        \\  padctl config init       Create a mapping interactively
+        \\
+        \\Run 'padctl --help' for the full command list.
+        \\The background daemon is normally started by systemd, not by hand.
+        \\
+    ) catch {};
+}
+
+const testing = std.testing;
+
+test "cli_errors: unknownArgument prints plain two-line message, no help dump" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    unknownArgument(buf.writer(testing.allocator), "stauts");
+
+    try testing.expectEqualStrings(
+        "padctl: unknown argument 'stauts'\nTry 'padctl --help' for usage.\n",
+        buf.items,
+    );
+    // Plain output must not carry the daemon log formatter prefix.
+    try testing.expect(std.mem.indexOf(u8, buf.items, "MONO") == null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "error.") == null);
+    // A two-line message means exactly two newlines, never the full usage block.
+    try testing.expectEqual(@as(usize, 2), std.mem.count(u8, buf.items, "\n"));
+}
+
+test "cli_errors: unknownSubcommand names the group" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    unknownSubcommand(buf.writer(testing.allocator), "config", "lst");
+    try testing.expect(std.mem.indexOf(u8, buf.items, "config subcommand 'lst'") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "Try 'padctl --help'") != null);
+}
+
+test "cli_errors: guide lists discoverable commands without daemon notice" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    guide(buf.writer(testing.allocator), false);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "padctl status") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "padctl switch") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "padctl --help") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "already running") == null);
+}
+
+test "cli_errors: guide prepends a running-daemon notice" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    guide(buf.writer(testing.allocator), true);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "already running") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "padctl status") != null);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,6 +22,7 @@ pub const tools = struct {
 };
 
 pub const cli = struct {
+    pub const errors = @import("cli/cli_errors.zig");
     pub const install = @import("cli/install.zig");
     pub const scan = @import("cli/scan.zig");
     pub const reload = @import("cli/reload.zig");
@@ -314,11 +315,11 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                 } else if (std.mem.eql(u8, iarg, "--scope")) {
                     const v = args.next() orelse return error.MissingArgValue;
                     opts.scope = parseScope(v) orelse {
-                        std.log.err("invalid --scope value: {s} (expected system|user|package)", .{v});
+                        cli.errors.message(stderr_writer, "invalid --scope value (expected system|user|package)");
                         return error.UnknownArgument;
                     };
                 } else {
-                    std.log.err("unknown install argument: {s}", .{iarg});
+                    cli.errors.unknownArgument(stderr_writer, iarg);
                     return error.UnknownArgument;
                 }
             }
@@ -345,11 +346,11 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                 } else if (std.mem.eql(u8, iarg, "--scope")) {
                     const v = args.next() orelse return error.MissingArgValue;
                     opts.scope = parseScope(v) orelse {
-                        std.log.err("invalid --scope value: {s} (expected system|user|package)", .{v});
+                        cli.errors.message(stderr_writer, "invalid --scope value (expected system|user|package)");
                         return error.UnknownArgument;
                     };
                 } else {
-                    std.log.err("unknown uninstall argument: {s}", .{iarg});
+                    cli.errors.unknownArgument(stderr_writer, iarg);
                     return error.UnknownArgument;
                 }
             }
@@ -366,7 +367,7 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                 } else if (std.mem.eql(u8, sub_arg, "--config-dir")) {
                     parsed_cli.scan_config_dir = args.next() orelse return error.MissingArgValue;
                 } else {
-                    std.log.err("unknown scan argument: {s}", .{sub_arg});
+                    cli.errors.unknownArgument(stderr_writer, sub_arg);
                     return error.UnknownArgument;
                 }
             }
@@ -379,7 +380,7 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                 } else if (std.mem.eql(u8, sub_arg, "--config-dir")) {
                     parsed_cli.list_mappings_config_dir = args.next() orelse return error.MissingArgValue;
                 } else {
-                    std.log.err("unknown list-mappings argument: {s}", .{sub_arg});
+                    cli.errors.unknownArgument(stderr_writer, sub_arg);
                     return error.UnknownArgument;
                 }
             }
@@ -408,53 +409,72 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                 } else if (std.mem.eql(u8, sub_arg, "--pid")) {
                     parsed_cli.reload_pid = args.next() orelse return error.MissingArgValue;
                 } else {
-                    std.log.err("unknown reload argument: {s}", .{sub_arg});
+                    cli.errors.unknownArgument(stderr_writer, sub_arg);
                     return error.UnknownArgument;
                 }
             }
         } else if (std.mem.eql(u8, arg, "config")) {
             const sub = args.next() orelse {
-                std.log.err("config: missing subcommand (list|init|edit|test)", .{});
-                return error.MissingArgValue;
+                cli.errors.message(stderr_writer, "config: missing subcommand (list|init|edit|test)");
+                return error.UnknownArgument;
             };
-            if (std.mem.eql(u8, sub, "list")) {
+            if (isHelpFlag(sub)) {
+                printConfigHelp(null);
+                std.process.exit(0);
+            } else if (std.mem.eql(u8, sub, "list")) {
                 parsed_cli.config_cmd = .list;
             } else if (std.mem.eql(u8, sub, "init")) {
                 var device: ?[]const u8 = null;
                 while (args.next()) |iarg| {
-                    if (std.mem.eql(u8, iarg, "--device")) {
+                    if (isHelpFlag(iarg)) {
+                        printConfigHelp("init");
+                        std.process.exit(0);
+                    } else if (std.mem.eql(u8, iarg, "--device")) {
                         device = args.next() orelse return error.MissingArgValue;
                     } else if (cli.config.init.isPresetArg(iarg)) {
-                        std.log.err("{s}", .{cli.config.init.preset_removed_message});
+                        cli.errors.message(stderr_writer, cli.config.init.preset_removed_message);
                         return error.UnknownArgument;
                     } else {
-                        std.log.err("unknown config init argument: {s}", .{iarg});
+                        cli.errors.unknownArgument(stderr_writer, iarg);
                         return error.UnknownArgument;
                     }
                 }
                 parsed_cli.config_cmd = .{ .init = .{ .device = device } };
             } else if (std.mem.eql(u8, sub, "edit")) {
-                const mapping_name = args.next();
-                parsed_cli.config_cmd = .{ .edit = mapping_name };
+                const next = args.next();
+                if (next) |n| {
+                    if (isHelpFlag(n)) {
+                        printConfigHelp("edit");
+                        std.process.exit(0);
+                    }
+                    if (n.len > 0 and n[0] == '-') {
+                        cli.errors.unknownArgument(stderr_writer, n);
+                        return error.UnknownArgument;
+                    }
+                }
+                parsed_cli.config_cmd = .{ .edit = next };
             } else if (std.mem.eql(u8, sub, "test")) {
                 var test_config: ?[]const u8 = null;
                 var test_mapping: ?[]const u8 = null;
                 var test_raw = false;
                 while (args.next()) |targ| {
-                    if (std.mem.eql(u8, targ, "--config")) {
+                    if (isHelpFlag(targ)) {
+                        printConfigHelp("test");
+                        std.process.exit(0);
+                    } else if (std.mem.eql(u8, targ, "--config")) {
                         test_config = args.next() orelse return error.MissingArgValue;
                     } else if (std.mem.eql(u8, targ, "--mapping")) {
                         test_mapping = args.next() orelse return error.MissingArgValue;
                     } else if (std.mem.eql(u8, targ, "--raw")) {
                         test_raw = true;
                     } else {
-                        std.log.err("unknown config test argument: {s}", .{targ});
+                        cli.errors.unknownArgument(stderr_writer, targ);
                         return error.UnknownArgument;
                     }
                 }
                 parsed_cli.config_cmd = .{ .@"test" = .{ .config = test_config, .mapping = test_mapping, .raw = test_raw } };
             } else {
-                std.log.err("unknown config subcommand: {s}", .{sub});
+                cli.errors.unknownSubcommand(stderr_writer, "config", sub);
                 return error.UnknownArgument;
             }
         } else if (std.mem.eql(u8, arg, "switch")) {
@@ -473,11 +493,11 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                 } else if (std.mem.eql(u8, sub_arg, "--persist")) {
                     persist = true;
                 } else if (sub_arg[0] == '-') {
-                    std.log.err("unknown switch argument: {s}", .{sub_arg});
+                    cli.errors.unknownArgument(stderr_writer, sub_arg);
                     return error.UnknownArgument;
                 } else {
                     if (name != null) {
-                        std.log.err("switch accepts at most one mapping name", .{});
+                        cli.errors.message(stderr_writer, "switch accepts at most one mapping name");
                         return error.UnknownArgument;
                     }
                     name = sub_arg;
@@ -494,7 +514,7 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                     parsed_cli.socket_path = args.next() orelse return error.MissingArgValue;
                     parsed_cli.socket_explicit = true;
                 } else {
-                    std.log.err("unknown status argument: {s}", .{sub_arg});
+                    cli.errors.unknownArgument(stderr_writer, sub_arg);
                     return error.UnknownArgument;
                 }
             }
@@ -508,7 +528,7 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                     parsed_cli.socket_path = args.next() orelse return error.MissingArgValue;
                     parsed_cli.socket_explicit = true;
                 } else {
-                    std.log.err("unknown doctor argument: {s}", .{sub_arg});
+                    cli.errors.unknownArgument(stderr_writer, sub_arg);
                     return error.UnknownArgument;
                 }
             }
@@ -522,7 +542,7 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                     parsed_cli.socket_path = args.next() orelse return error.MissingArgValue;
                     parsed_cli.socket_explicit = true;
                 } else {
-                    std.log.err("unknown devices argument: {s}", .{sub_arg});
+                    cli.errors.unknownArgument(stderr_writer, sub_arg);
                     return error.UnknownArgument;
                 }
             }
@@ -536,7 +556,7 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                     std.process.exit(0);
                 }
                 if (dump_argc >= dump_args.len) {
-                    std.log.err("too many dump arguments", .{});
+                    cli.errors.message(stderr_writer, "too many dump arguments");
                     return error.UnknownArgument;
                 }
                 dump_args[dump_argc] = da;
@@ -544,15 +564,15 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
             }
             const result = parseDumpFromSlice(dump_args[0..dump_argc]) catch |err| switch (err) {
                 error.MissingSubcommand => {
-                    std.log.err("dump requires a subcommand: enable, disable, status, export, clear", .{});
-                    return error.MissingArgValue;
+                    cli.errors.message(stderr_writer, "dump requires a subcommand: enable, disable, status, export, clear");
+                    return error.UnknownArgument;
                 },
                 error.MissingArgValue => {
-                    std.log.err("dump: missing value for option (expected an argument after --period, --socket, or -o)", .{});
-                    return error.MissingArgValue;
+                    cli.errors.message(stderr_writer, "dump: missing value for option (expected an argument after --period, --socket, or -o)");
+                    return error.UnknownArgument;
                 },
                 error.UnknownArgument => {
-                    std.log.err("unknown dump argument", .{});
+                    cli.errors.message(stderr_writer, "unknown dump argument");
                     return error.UnknownArgument;
                 },
             };
@@ -564,91 +584,143 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                 parsed_cli.socket_explicit = true;
             }
         } else {
-            std.log.err("unknown argument: {s}", .{arg});
+            cli.errors.unknownArgument(stderr_writer, arg);
             return error.UnknownArgument;
         }
     }
     return parsed_cli;
 }
 
-fn printHelp() void {
-    const help =
-        \\Usage: padctl [options]
-        \\       padctl install [--prefix /usr] [--immutable] [--mapping <name>...]
-        \\       padctl uninstall [--prefix /usr] [--immutable] [--mapping <name>...]
-        \\       padctl scan [--config-dir <dir>]
-        \\       padctl list-mappings [--config-dir <dir>]
-        \\       padctl reload [--pid <pid>]
-        \\       padctl switch <name> [--device <id>] [--socket <path>]
-        \\       padctl status [--socket <path>]
-        \\       padctl devices [--socket <path>]
-        \\       padctl dump <enable|disable|status|export|clear>
-        \\
-        \\Subcommands:
-        \\  install               Install binary, service, udev rules, and device configs
-        \\    --prefix <dir>      Installation prefix (default: /usr)
-        \\    --destdir <dir>     Staging root for package builds (default: "")
-        \\    --immutable         Use immutable OS file placement (/etc/ for systemd+udev)
-        \\    --no-immutable      Force standard install even on detected immutable OS
-        \\    --mapping <name>    Install a mapping config to /etc/padctl/mappings/ (repeatable)
-        \\    --force-mapping     Overwrite existing mapping files
-        \\    --force-binding     Overwrite device bindings in /etc/padctl/config.toml
-        \\    --user-service      Force user-scope install (~/.config/systemd/user/)
-        \\    --no-user-service   Skip user-service enable/start (even under sudo)
-        \\    --no-enable         Skip systemctl enable
-        \\    --no-start          Skip systemctl start
-        \\  uninstall             Remove installed files, stop and disable service
-        \\    --prefix <dir>      Installation prefix (default: /usr)
-        \\    --destdir <dir>     Staging root for package builds (default: "")
-        \\    --no-immutable      Force standard uninstall even on detected immutable OS
-        \\    --immutable         Also remove immutable-specific files from /etc/
-        \\    --mapping <name>    Remove a specific mapping from /etc/padctl/mappings/ (repeatable)
-        \\  scan                  List connected HID devices and config match status
-        \\    --config-dir <dir>  Search for device configs here (default: XDG paths)
-        \\  list-mappings         List discovered mapping profiles from XDG paths
-        \\    --config-dir <dir>  Also show device-specific mappings from this directory
-        \\  reload [--pid <pid>]  Send SIGHUP to running padctl daemon
-        \\  switch [name]         Switch mapping (omit name to re-apply from user config)
-        \\    --persist           Copy mapping + config to /etc/padctl/ (survives reboot, uses sudo)
-        \\    --device <id>       Apply only to specific device
-        \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
-        \\  status                Show daemon status (current mapping, devices)
-        \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
-        \\  doctor                Print self-contained diagnostic (daemon/device/hidraw/scope)
-        \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
-        \\  devices               List connected devices via daemon
-        \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
-        \\  dump enable           Turn on diagnostic logging (persists across reboots)
-        \\  dump disable          Turn off diagnostic logging (default)
-        \\  dump status           Show dump state, log path, size, and time span
-        \\  dump export           Export filtered logs to stdout or file
-        \\    --period <duration> Time window: Nm, Nh, or Nd (default: 1d)
-        \\    -o <path>           Write to file instead of stdout
-        \\  dump clear            Delete all log files (interactive confirmation)
-        \\  config list           List XDG-layer device and mapping configs
-        \\  config init           Interactively create a mapping in ~/.config/padctl/mappings/
-        \\    --device <name>     Skip device selection prompt
-        \\  config edit [name]    Open mapping in $VISUAL/$EDITOR; validate on exit
-        \\  config test           Live input preview decoded into named button/axis events (Ctrl-C to exit)
-        \\                        Decoding supports hidraw devices only; vendor-class (libusb) devices show raw bytes
-        \\    --config <path>     Device config to decode input (default: auto-detect from XDG device dirs)
-        \\    --mapping <path>    Mapping to apply for display
-        \\    --raw               Show raw report bytes instead of decoded events
-        \\
-        \\Options:
-        \\  --config <path>     Device config TOML file (required to run)
-        \\  --config-dir <dir>  Glob *.toml in dir; discover all matching devices
-        \\  --mapping <path>    Mapping config TOML file (optional)
-        \\  --validate <path>   Validate device or mapping config and exit (returns 0/1)
-        \\  --pid-file <path>   Write PID to file on start, remove on exit
-        \\  --doc-gen           Generate Markdown device reference from --config path(s)
-        \\  --output <dir>      Output directory for --doc-gen (default: docs/src/devices)
-        \\  --help, -h          Show this help
-        \\  --version, -V       Show version
-        \\
-    ;
-    _ = std.posix.write(std.posix.STDOUT_FILENO, help) catch 0;
+fn isHelpFlag(arg: []const u8) bool {
+    return std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h");
 }
+
+fn printConfigHelp(sub: ?[]const u8) void {
+    const text = if (sub) |s| blk: {
+        if (std.mem.eql(u8, s, "init"))
+            break :blk 
+            \\Usage: padctl config init [--device <name>]
+            \\
+            \\Interactively create a mapping in ~/.config/padctl/mappings/.
+            \\  --device <name>   Skip the device selection prompt
+            \\
+        ;
+        if (std.mem.eql(u8, s, "edit"))
+            break :blk 
+            \\Usage: padctl config edit [name]
+            \\
+            \\Open a mapping in $VISUAL/$EDITOR; validate on exit.
+            \\Omit the name to pick from discovered mappings.
+            \\
+        ;
+        if (std.mem.eql(u8, s, "test"))
+            break :blk 
+            \\Usage: padctl config test [--config <path>] [--mapping <path>] [--raw]
+            \\
+            \\Live input preview decoded into named button/axis events (Ctrl-C to exit).
+            \\  --config <path>    Device config to decode input (default: auto-detect)
+            \\  --mapping <path>   Mapping to apply for display
+            \\  --raw              Show raw report bytes instead of decoded events
+            \\
+        ;
+        break :blk config_group_help;
+    } else config_group_help;
+    _ = std.posix.write(std.posix.STDOUT_FILENO, text) catch 0;
+}
+
+const config_group_help =
+    \\Usage: padctl config <list|init|edit|test>
+    \\
+    \\  list           List XDG-layer device and mapping configs
+    \\  init           Interactively create a mapping
+    \\  edit [name]    Open a mapping in $VISUAL/$EDITOR
+    \\  test           Live input preview decoded into named events
+    \\
+    \\Run 'padctl config <subcommand> --help' for details.
+    \\
+;
+
+fn printHelp() void {
+    _ = std.posix.write(std.posix.STDOUT_FILENO, help_text) catch 0;
+}
+
+pub const help_text =
+    \\Usage: padctl [options]
+    \\       padctl install [--prefix /usr] [--immutable] [--mapping <name>...]
+    \\       padctl uninstall [--prefix /usr] [--immutable] [--mapping <name>...]
+    \\       padctl scan [--config-dir <dir>]
+    \\       padctl list-mappings [--config-dir <dir>]
+    \\       padctl reload [--pid <pid>]
+    \\       padctl switch <name> [--device <id>] [--socket <path>]
+    \\       padctl status [--socket <path>]
+    \\       padctl devices [--socket <path>]
+    \\       padctl doctor [--socket <path>]
+    \\       padctl dump <enable|disable|status|export|clear>
+    \\       padctl config <list|init|edit|test>
+    \\
+    \\Subcommands:
+    \\  install               Install binary, service, udev rules, and device configs
+    \\    --prefix <dir>      Installation prefix (default: /usr)
+    \\    --destdir <dir>     Staging root for package builds (default: "")
+    \\    --immutable         Use immutable OS file placement (/etc/ for systemd+udev)
+    \\    --no-immutable      Force standard install even on detected immutable OS
+    \\    --mapping <name>    Install a mapping config to /etc/padctl/mappings/ (repeatable)
+    \\    --force-mapping     Overwrite existing mapping files
+    \\    --force-binding     Overwrite device bindings in /etc/padctl/config.toml
+    \\    --user-service      Force user-scope install (~/.config/systemd/user/)
+    \\    --no-user-service   Skip user-service enable/start (even under sudo)
+    \\    --no-enable         Skip systemctl enable
+    \\    --no-start          Skip systemctl start
+    \\  uninstall             Remove installed files, stop and disable service
+    \\    --prefix <dir>      Installation prefix (default: /usr)
+    \\    --destdir <dir>     Staging root for package builds (default: "")
+    \\    --no-immutable      Force standard uninstall even on detected immutable OS
+    \\    --immutable         Also remove immutable-specific files from /etc/
+    \\    --mapping <name>    Remove a specific mapping from /etc/padctl/mappings/ (repeatable)
+    \\  scan                  List connected HID devices and config match status
+    \\    --config-dir <dir>  Search for device configs here (default: XDG paths)
+    \\  list-mappings         List discovered mapping profiles from XDG paths
+    \\    --config-dir <dir>  Also show device-specific mappings from this directory
+    \\  reload [--pid <pid>]  Send SIGHUP to running padctl daemon
+    \\  switch [name]         Switch mapping (omit name to re-apply from user config)
+    \\    --persist           Copy mapping + config to /etc/padctl/ (survives reboot, uses sudo)
+    \\    --device <id>       Apply only to specific device
+    \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
+    \\  status                Show daemon status (current mapping, devices)
+    \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
+    \\  doctor                Print self-contained diagnostic (daemon/device/hidraw/scope)
+    \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
+    \\  devices               List connected devices via daemon
+    \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
+    \\  dump enable           Turn on diagnostic logging (persists across reboots)
+    \\  dump disable          Turn off diagnostic logging (default)
+    \\  dump status           Show dump state, log path, size, and time span
+    \\  dump export           Export filtered logs to stdout or file
+    \\    --period <duration> Time window: Nm, Nh, or Nd (default: 1d)
+    \\    -o <path>           Write to file instead of stdout
+    \\  dump clear            Delete all log files (interactive confirmation)
+    \\  config list           List XDG-layer device and mapping configs
+    \\  config init           Interactively create a mapping in ~/.config/padctl/mappings/
+    \\    --device <name>     Skip device selection prompt
+    \\  config edit [name]    Open mapping in $VISUAL/$EDITOR; validate on exit
+    \\  config test           Live input preview decoded into named button/axis events (Ctrl-C to exit)
+    \\                        Decoding supports hidraw devices only; vendor-class (libusb) devices show raw bytes
+    \\    --config <path>     Device config to decode input (default: auto-detect from XDG device dirs)
+    \\    --mapping <path>    Mapping to apply for display
+    \\    --raw               Show raw report bytes instead of decoded events
+    \\
+    \\Options:
+    \\  --config <path>     Device config TOML file (required to run)
+    \\  --config-dir <dir>  Glob *.toml in dir; discover all matching devices
+    \\  --mapping <path>    Mapping config TOML file (optional)
+    \\  --validate <path>   Validate device or mapping config and exit (returns 0/1)
+    \\  --pid-file <path>   Write PID to file on start, remove on exit
+    \\  --doc-gen           Generate Markdown device reference from --config path(s)
+    \\  --output <dir>      Output directory for --doc-gen (default: docs/src/devices)
+    \\  --help, -h          Show this help
+    \\  --version, -V       Show version
+    \\
+;
 
 fn writePidFile(path: []const u8) void {
     var buf: [32]u8 = undefined;
@@ -717,8 +789,11 @@ pub fn main() !void {
     const allocator = gpa.allocator();
 
     var parsed = parseArgs(allocator) catch |err| {
-        std.log.err("argument error: {}", .{err});
-        printHelp();
+        // parseArgs already printed a plain message for named errors. The bare
+        // `orelse return MissingArgValue` sites carry no context, so print a
+        // generic hint here rather than dumping help via the log formatter.
+        if (err == error.MissingArgValue)
+            cli.errors.message(stderr_writer, "missing value for an option");
         std.process.exit(1);
     };
     defer parsed.deinit();
@@ -1068,6 +1143,22 @@ pub fn main() !void {
             std.log.err("doc-gen failed: {}", .{err});
             std.process.exit(1);
         };
+        std.process.exit(0);
+    }
+
+    // Bare invocation with no subcommand on an interactive terminal: show a
+    // guide instead of silently forking a daemon. systemd starts the daemon
+    // with stderr on the journal (not a TTY), so the unit keeps its behavior;
+    // any explicit daemon flag (--config-dir/--config/--pid-file) does too.
+    if (parsed.config_path == null and parsed.config_dir == null and
+        parsed.pid_file == null and parsed.mapping_path == null and
+        std.posix.isatty(std.posix.STDERR_FILENO))
+    {
+        const running = if (cli.socket_client.connectToSocket(parsed.socket_path)) |fd| blk: {
+            std.posix.close(fd);
+            break :blk true;
+        } else |_| false;
+        cli.errors.guide(stderr_writer, running);
         std.process.exit(0);
     }
 

--- a/src/test/cli_e2e_test.zig
+++ b/src/test/cli_e2e_test.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const testing = std.testing;
 
+const main_mod = @import("../main.zig");
 const paths_mod = @import("../config/paths.zig");
 const scan_mod = @import("../cli/scan.zig");
 const device_mod = @import("../config/device.zig");
@@ -10,6 +11,16 @@ const config_edit = @import("../cli/config/edit.zig");
 const config_test_mod = @import("../cli/config/test.zig");
 const helpers = @import("helpers.zig");
 const collectTomlPaths = helpers.collectTomlPaths;
+
+// --- 0. Help/usage block coverage ---
+
+test "help: usage block lists doctor, config, and dump" {
+    const usage_end = std.mem.indexOf(u8, main_mod.help_text, "Subcommands:").?;
+    const usage = main_mod.help_text[0..usage_end];
+    try testing.expect(std.mem.indexOf(u8, usage, "padctl doctor") != null);
+    try testing.expect(std.mem.indexOf(u8, usage, "padctl config") != null);
+    try testing.expect(std.mem.indexOf(u8, usage, "padctl dump") != null);
+}
 
 // --- 1. Install: directory structure paths ---
 


### PR DESCRIPTION
## What changed

- **Plain interactive argument errors.** A bad CLI argument no longer goes through the daemon log formatter. Instead of a timestamped `[MONO:...]` line with a raw Zig error name plus the full ~70-line usage dump, the user gets two plain lines:
  ```
  padctl: unknown argument 'stauts'
  Try 'padctl --help' for usage.
  ```
  All argument-shape errors in `parseArgs` (top-level, install/uninstall, scan, list-mappings, reload, switch, status, doctor, devices, dump, config) now route through a small `src/cli/cli_errors.zig` helper. `main()` no longer dumps help on a parse error.
- **Usage block + per-subcommand help.** Added `padctl doctor` and `padctl config <list|init|edit|test>` to the top usage block (`dump` was already listed). `config init`, `config edit`, and `config test` now accept `--help`/`-h` and print a focused usage blurb. A leading-dash token is rejected as an `edit`/`test` name instead of being silently treated as a mapping name.
- **Guided bare invocation.** Running `padctl` with no subcommand on an interactive terminal now prints a short command guide and exits 0 (with a "daemon already running -- try padctl status" notice when a daemon is reachable) rather than silently starting the daemon. The systemd unit is unchanged: its stderr is the journal (not a TTY), so the daemon path is unaffected, and explicit daemon flags (`--config-dir`/`--config`/`--pid-file`) still daemonize.

## Test plan

- New unit tests in `src/cli/cli_errors.zig`: plain two-line output asserts no `MONO`/`error.` prefix and exactly two newlines; subcommand-error and guide variants (with/without daemon-running notice).
- New test in `src/test/cli_e2e_test.zig`: the usage block lists `padctl doctor`, `padctl config`, and `padctl dump`.
- `zig build test` green in the pinned `padctl-build:0.15.2` container.
- Manual binary checks: `padctl stauts` -> 2 plain lines, exit 1; `padctl config init/edit/test --help` -> per-subcommand usage; `padctl config edit --bogus` -> rejected; bare `padctl` over a PTY -> guide + exit 0; bare `padctl` over a pipe (non-TTY) -> daemon path intact.