### PR TITLE
fix(ipc): STATUS line must not truncate additive shadow fields under many devices

### DIFF
--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -157,14 +157,14 @@ fn runInner(allocator: std.mem.Allocator, socket_path: []const u8, writer: anyty
     };
     defer posix.close(connect_fd);
 
-    var resp_buf: [4096]u8 = undefined;
-    const resp = socket_client.sendCommand(connect_fd, "STATUS\n", &resp_buf) catch {
+    const resp = socket_client.sendCommandAlloc(allocator, connect_fd, "STATUS\n", 3000) catch {
         try writer.writeAll("daemon: UP (no status response)\n");
         try printDriverBlock(writer);
         try writer.writeByte('\n');
         try printSupportedDevices(allocator, status_devices, exec_start, writer);
         return;
     };
+    defer allocator.free(resp);
 
     status_devices = parseStatusLine(resp, allocator) catch &.{};
     try writer.print("daemon: up, {d} managed device(s)\n", .{status_devices.len});

--- a/src/cli/socket_client.zig
+++ b/src/cli/socket_client.zig
@@ -127,6 +127,42 @@ pub fn sendCommandTimeout(fd: posix.fd_t, cmd: []const u8, buf: []u8, timeout_ms
     return buf[0..total];
 }
 
+/// Like sendCommandTimeout but reads the full newline-terminated reply into a
+/// heap buffer that grows as needed. STATUS replies scale with the managed
+/// device count and name lengths, so a fixed read buffer can truncate the tail
+/// fields. Caller owns the returned slice.
+pub fn sendCommandAlloc(
+    allocator: std.mem.Allocator,
+    fd: posix.fd_t,
+    cmd: []const u8,
+    timeout_ms: i32,
+) ![]u8 {
+    _ = try posix.write(fd, cmd);
+
+    var fds = [_]posix.pollfd{.{ .fd = fd, .events = posix.POLL.IN, .revents = 0 }};
+
+    var out: std.ArrayList(u8) = .{};
+    errdefer out.deinit(allocator);
+    var chunk: [4096]u8 = undefined;
+
+    while (true) {
+        const ready = posix.poll(&fds, timeout_ms) catch return error.Io;
+        if (ready == 0) {
+            if (out.items.len == 0) return error.Timeout;
+            break;
+        }
+        const n = posix.read(fd, &chunk) catch |err| switch (err) {
+            error.WouldBlock => break,
+            else => return err,
+        };
+        if (n == 0) break;
+        try out.appendSlice(allocator, chunk[0..n]);
+        if (std.mem.indexOfScalar(u8, out.items, '\n') != null) break;
+    }
+    if (out.items.len == 0) return error.EndOfStream;
+    return out.toOwnedSlice(allocator);
+}
+
 pub fn formatSwitch(buf: []u8, name: []const u8, device_id: ?[]const u8) []const u8 {
     if (device_id) |dev| {
         const len = (std.fmt.bufPrint(buf, "SWITCH {s} --device {s}\n", .{ name, dev }) catch return buf[0..0]).len;
@@ -257,11 +293,11 @@ pub fn queryStatusDevices(allocator: std.mem.Allocator, socket_path: []const u8,
         return null;
     };
     defer posix.close(fd);
-    var buf: [4096]u8 = undefined;
-    const resp = sendCommandTimeout(fd, "STATUS\n", &buf, timeout_ms) catch |err| {
+    const resp = sendCommandAlloc(allocator, fd, "STATUS\n", timeout_ms) catch |err| {
         std.log.debug("daemon status query: no response: {}", .{err});
         return null;
     };
+    defer allocator.free(resp);
     return parseStatusLine(resp, allocator) catch null;
 }
 

--- a/src/cli/status.zig
+++ b/src/cli/status.zig
@@ -2,18 +2,18 @@ const std = @import("std");
 const posix = std.posix;
 const socket_client = @import("socket_client.zig");
 
-pub fn run(socket_path: []const u8, writer: anytype, err_writer: anytype) u8 {
+pub fn run(allocator: std.mem.Allocator, socket_path: []const u8, writer: anytype, err_writer: anytype) u8 {
     const fd = socket_client.connectToSocket(socket_path) catch {
         socket_client.reportConnectFailure(err_writer, socket_path);
         return 1;
     };
     defer posix.close(fd);
 
-    var buf: [4096]u8 = undefined;
-    const resp = socket_client.sendCommand(fd, "STATUS\n", &buf) catch {
+    const resp = socket_client.sendCommandAlloc(allocator, fd, "STATUS\n", 3000) catch {
         err_writer.writeAll("error: no response from daemon\n") catch {};
         return 1;
     };
+    defer allocator.free(resp);
 
     writer.writeAll(resp) catch {};
     if (resp.len == 0 or resp[resp.len - 1] != '\n') {
@@ -67,12 +67,12 @@ test "run: ERR response returns 1" {
 
     std.Thread.sleep(10 * std.time.ns_per_ms);
 
-    const rc = run(sock_path, std.io.null_writer, std.io.null_writer);
+    const rc = run(allocator, sock_path, std.io.null_writer, std.io.null_writer);
     try testing.expectEqual(@as(u8, 1), rc);
 }
 
 test "run: connection failure returns 1" {
-    const rc = run("/tmp/padctl-nonexistent-test.sock", std.io.null_writer, std.io.null_writer);
+    const rc = run(testing.allocator, "/tmp/padctl-nonexistent-test.sock", std.io.null_writer, std.io.null_writer);
     try testing.expectEqual(@as(u8, 1), rc);
 }
 
@@ -80,7 +80,7 @@ test "run: connection failure prints socket path and doctor hint" {
     var err_buf: std.ArrayList(u8) = .{};
     defer err_buf.deinit(testing.allocator);
 
-    const rc = run("/tmp/padctl-nonexistent-test.sock", std.io.null_writer, err_buf.writer(testing.allocator));
+    const rc = run(testing.allocator, "/tmp/padctl-nonexistent-test.sock", std.io.null_writer, err_buf.writer(testing.allocator));
     try testing.expectEqual(@as(u8, 1), rc);
     try testing.expectEqualStrings(
         "error: cannot connect to padctl daemon at /tmp/padctl-nonexistent-test.sock\n" ++

--- a/src/io/shadow_grab.zig
+++ b/src/io/shadow_grab.zig
@@ -60,6 +60,16 @@ pub const GrabList = struct {
         }
     }
 
+    /// Record a foreign-held (EBUSY) node with no owned fd. Used by tests to
+    /// populate a list without touching /dev/input.
+    pub fn pushUnownedForTest(self: *GrabList, node: []const u8) void {
+        if (self.len >= MAX_GRABS or node.len > NAME_CAP) return;
+        var g = Grab{ .fd = -1, .name_buf = undefined, .name_len = @intCast(node.len), .owned = false };
+        @memcpy(g.name_buf[0..node.len], node);
+        self.grabs[self.len] = g;
+        self.len += 1;
+    }
+
     /// Closing a grabbed fd implicitly releases its EVIOCGRAB.
     pub fn releaseAll(self: *GrabList) void {
         for (self.grabs[0..self.len]) |*g| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -980,7 +980,7 @@ pub fn main() !void {
 
     // status subcommand
     if (parsed.status_cmd) {
-        const rc = cli.status.run(parsed.socket_path, stdout_writer, stderr_writer);
+        const rc = cli.status.run(allocator, parsed.socket_path, stdout_writer, stderr_writer);
         std.process.exit(rc);
     }
 

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -2049,12 +2049,26 @@ pub const Supervisor = struct {
 
     pub fn handleStatus(self: *Supervisor, fd: posix.fd_t) void {
         var cs = &self.ctrl_sock.?;
-        var buf: [4096]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&buf);
-        const w = stream.writer();
+        var line: std.ArrayList(u8) = .{};
+        defer line.deinit(self.allocator);
+        self.buildStatusLine(&line) catch {
+            cs.sendResponse(fd, "STATUS\n");
+            return;
+        };
+        cs.sendResponse(fd, line.items);
+    }
+
+    // STATUS is a single newline-terminated line whose length grows with the
+    // managed-device count and with device/mapping name lengths. A fixed buffer
+    // truncated the tail fields (shadow_grabs/shadow_nodes appended last) once
+    // enough long-named devices were attached, so the line is built into a
+    // heap buffer that grows to fit the full reply.
+    fn buildStatusLine(self: *Supervisor, line: *std.ArrayList(u8)) !void {
+        const a = self.allocator;
+        const w = line.writer(a);
         const now_ns = self.nowNs();
 
-        w.writeAll("STATUS") catch return;
+        try w.writeAll("STATUS");
         for (self.managed.items) |*m| {
             const name = m.instance.device_cfg.device.name;
             const state_str: []const u8 = if (m.suspended) "suspended" else "active";
@@ -2069,7 +2083,7 @@ pub const Supervisor = struct {
                 }
                 break :blk "(none)";
             };
-            w.print(" device={s} state={s} mapping={s}", .{ name, state_str, mapping_name }) catch break;
+            try w.print(" device={s} state={s} mapping={s}", .{ name, state_str, mapping_name });
 
             // Diagnostic fields (issue #236).
             const vid: u16 = @intCast(m.instance.device_cfg.device.vid);
@@ -2080,20 +2094,20 @@ pub const Supervisor = struct {
                 .uhid => "uhid",
             };
             const output_fd_alive: bool = m.instance.owner != .none;
-            w.print(" phys_key={s} vid=0x{x:0>4} pid=0x{x:0>4} output_kind={s} output_fd_alive={}", .{
+            try w.print(" phys_key={s} vid=0x{x:0>4} pid=0x{x:0>4} output_kind={s} output_fd_alive={}", .{
                 m.phys_key, vid, pid, output_kind, output_fd_alive,
-            }) catch break;
+            });
 
             if (m.grace_deadline_ns) |dl| {
                 const remaining_ms: u64 = if (dl > now_ns) (dl - now_ns) / std.time.ns_per_ms else 0;
-                w.print(" grace_deadline_remaining_ms={d}", .{remaining_ms}) catch {};
+                try w.print(" grace_deadline_remaining_ms={d}", .{remaining_ms});
             }
 
             var evdev_buf: [256]u8 = undefined;
             const evdev_node = resolveEvdevNode(vid, pid, &evdev_buf) orelse "<unresolved>";
-            w.print(" evdev_node={s}", .{evdev_node}) catch {};
+            try w.print(" evdev_node={s}", .{evdev_node});
 
-            w.print(" hotplug_pending={d}", .{self.hotplug_pending.items.len}) catch {};
+            try w.print(" hotplug_pending={d}", .{self.hotplug_pending.items.len});
 
             // write_in_flight_ms=0 when no write is currently blocked; a sustained
             // non-zero value (hundreds of ms) is the smoking gun for a kernel-side
@@ -2104,14 +2118,13 @@ pub const Supervisor = struct {
             const inb_ago_ms: u64 = if (inb == 0 or now_ns < inb) 0 else (now_ns - inb) / std.time.ns_per_ms;
             const outb_ago_ms: u64 = if (outb == 0 or now_ns < outb) 0 else (now_ns - outb) / std.time.ns_per_ms;
             const inflight_ms: u64 = if (ifs == 0 or now_ns < ifs) 0 else (now_ns - ifs) / std.time.ns_per_ms;
-            w.print(" last_inbound_ms_ago={d} last_outbound_ms_ago={d} write_in_flight_ms={d}", .{
+            try w.print(" last_inbound_ms_ago={d} last_outbound_ms_ago={d} write_in_flight_ms={d}", .{
                 inb_ago_ms, outb_ago_ms, inflight_ms,
-            }) catch {};
+            });
 
-            m.shadow_grabs.appendStatusFields(w) catch {};
+            try m.shadow_grabs.appendStatusFields(w);
         }
-        w.writeByte('\n') catch return;
-        cs.sendResponse(fd, stream.getWritten());
+        try w.writeByte('\n');
     }
 
     fn handleList(self: *Supervisor, fd: posix.fd_t) void {
@@ -5548,6 +5561,115 @@ test "supervisor: handleStatus includes diagnostic fields (issue #236)" {
         sup.stopAll();
         sup.ctrl_sock = null;
         sup.deinit();
+    }
+}
+
+// Many managed devices with long names overflow the old fixed 4096 STATUS
+// buffer; the tail fields (shadow_grabs/shadow_nodes, appended last) were
+// dropped first and the trailing newline lost. The reply must stay complete.
+test "supervisor: handleStatus does not truncate tail fields under many devices" {
+    const allocator = testing.allocator;
+
+    const long_name_toml =
+        \\[device]
+        \\name = "MegaController With A Deliberately Long Product Name 0123456789"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 3
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x01]
+        \\[report.fields]
+        \\left_x = { offset = 1, type = "i16le" }
+    ;
+
+    const parsed_dev = try device_mod.parseString(allocator, long_name_toml);
+    defer parsed_dev.deinit();
+
+    const N = 24;
+    var mocks: [N]*MockDeviceIO = undefined;
+    var mock_count: usize = 0;
+
+    var sup = try Supervisor.initForTest(allocator);
+
+    var i: usize = 0;
+    while (i < N) : (i += 1) {
+        const mock = try allocator.create(MockDeviceIO);
+        mock.* = try MockDeviceIO.init(allocator, &.{});
+        mocks[mock_count] = mock;
+        mock_count += 1;
+
+        const inst = try makeTestInstance(allocator, mock, &parsed_dev.value);
+        var devname_buf: [32]u8 = undefined;
+        var phys_buf: [48]u8 = undefined;
+        const devname = try std.fmt.bufPrint(&devname_buf, "hidraw{d}", .{i});
+        const phys = try std.fmt.bufPrint(&phys_buf, "usb-0000:00:14.0-{d}.{d}/input0", .{ i, i });
+        try sup.attachWithInstance(devname, phys, inst, null);
+
+        var node_buf: [24]u8 = undefined;
+        const node = try std.fmt.bufPrint(&node_buf, "event{d}-shadow", .{i});
+        sup.managed.items[i].shadow_grabs.pushUnownedForTest(node);
+    }
+
+    const resp_fds = try testSocketpair();
+    defer posix.close(resp_fds[0]);
+    defer posix.close(resp_fds[1]);
+    sup.ctrl_sock = .{
+        .listen_fd = -1,
+        .client_fds = .{ -1, -1, -1, -1 },
+        .client_count = 0,
+        .path = "",
+        .allocator = allocator,
+    };
+
+    sup.handleStatus(resp_fds[0]);
+
+    var resp: std.ArrayList(u8) = .{};
+    defer resp.deinit(allocator);
+    var chunk: [65536]u8 = undefined;
+    while (true) {
+        const n = try posix.read(resp_fds[1], &chunk);
+        if (n == 0) break;
+        try resp.appendSlice(allocator, chunk[0..n]);
+        if (std.mem.indexOfScalar(u8, resp.items, '\n') != null) break;
+        if (n < chunk.len) break;
+    }
+    const line = resp.items;
+
+    try testing.expect(line.len > 4096);
+    try testing.expect(std.mem.endsWith(u8, line, "\n"));
+
+    var devices: usize = 0;
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, line, search, "device=")) |pos| {
+        devices += 1;
+        search = pos + "device=".len;
+    }
+    try testing.expectEqual(@as(usize, N), devices);
+
+    try testing.expect(std.mem.indexOf(u8, line, "event23-shadow") != null);
+
+    const parsed = try socket_client.parseStatusLine(line, allocator);
+    defer socket_client.freeStatusDevices(allocator, parsed);
+    try testing.expectEqual(@as(usize, N), parsed.len);
+    try testing.expectEqual(@as(usize, 1), parsed[N - 1].shadow_grabs);
+    try testing.expect(std.mem.indexOf(u8, parsed[N - 1].shadow_nodes, "event23-shadow") != null);
+
+    defer {
+        sup.stopAll();
+        sup.ctrl_sock = null;
+        sup.deinit();
+        var k: usize = 0;
+        while (k < mock_count) : (k += 1) {
+            mocks[k].deinit();
+            allocator.destroy(mocks[k]);
+        }
     }
 }
 


### PR DESCRIPTION
## What

The control-socket `STATUS` reply was built into a fixed 4096-byte stack buffer on both the producer (`Supervisor.handleStatus`) and the consuming read paths. With many managed devices and long device/mapping names, the single newline-terminated line overflowed 4096 bytes:

- Producer writes used `catch break` / `catch {}`, so once the buffer filled, the loop stopped mid-device and per-field writes were silently dropped. The trailing `\n` (`writeByte('\n') catch return`) was also lost.
- The newest additive fields `shadow_grabs` / `shadow_nodes` are appended **last** per device, so they were the first to be dropped.
- Consumers (`queryStatusDevices`, `status`, `doctor`) read into their own fixed 4096-byte buffers, so even a full producer line would be cut.

## Changes

- **Producer**: build the `STATUS` line into a heap `std.ArrayList(u8)` that grows to fit the full reply (`Supervisor.buildStatusLine`); send the whole buffer. OOM falls back to a bare `STATUS\n`.
- **Consumer**: add `socket_client.sendCommandAlloc`, which reads the full newline-terminated reply into a heap buffer with no fixed cap. Route `queryStatusDevices`, `cli/status.run`, and `cli/doctor` through it.
- **Wire format unchanged**: still one newline-terminated `STATUS` line; `parseStatusLine` and all existing parsers are untouched. `parseDeviceFromStatus` paths (which only need the leading `device=`) keep their fixed read buffer.

## Test plan

- New regression test `supervisor: handleStatus does not truncate tail fields under many devices`: attaches 24 long-named devices each with a shadow grab, then asserts the reply is >4096 bytes, ends in `\n`, contains all 24 `device=` entries and the last device's shadow node, and round-trips through `parseStatusLine` (24 devices, last device `shadow_grabs=1`, `shadow_nodes` contains the expected node).
- RED/GREEN verified: with the old fixed-4096 producer the new test fails (`error.TestUnexpectedResult` on the `>4096` / trailing-newline / shadow-field assertions); with the heap-buffer producer the full suite passes.
- `zig build test` (Docker `ghcr.io/bananasjim/padctl-build:0.15.2`): all tests pass.

Refs #419