### PR TITLE
fix(supervisor): restore multi-second hotplug retry budget lost in #402

### DIFF
--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -194,6 +194,12 @@ const HotplugPending = struct {
 
 const PendingKind = enum { hidraw, input_grab };
 
+// Per-attempt delay (ms) for the event-driven hotplug attach retry. The array
+// length is the give-up cap; the cumulative window (~7.6s) covers a cold-boot /
+// upgrade transient where udev permissions, kernel driver bind, or firmware are
+// not yet settled and a single ADD uevent must not be dropped permanently.
+const HOTPLUG_RETRY_BACKOFF_MS = [_]u32{ 300, 300, 500, 800, 1200, 1500, 1500, 1500 };
+
 // 8 fixed (stop, hup, netlink, inotify, debounce, hotplug_retry, grace, liveness) + 1 listen + 4 clients.
 pub const SUPERVISOR_MAX_FDS: usize = 8 + 1 + 4;
 
@@ -253,6 +259,12 @@ pub const Supervisor = struct {
     /// "restart failed after bookkeeping" branch without racing real
     /// thread creation.
     test_fail_rebind_restart: bool = false,
+    /// Test-only seam: when non-null, `attachWithRoot()` returns
+    /// `error.HotplugTransient` and decrements this counter on each call until
+    /// it reaches zero, then attaches normally. Lets retry-budget tests drive a
+    /// device that is transient for a controllable number of consecutive
+    /// retries without touching real device nodes.
+    test_attach_transient_remaining: ?usize = null,
     /// Daemon-wide fallback counter for UHID uniq strings when `phys_key` is
     /// null (virtual / Bluetooth devices without sysfs phys). Passed by pointer
     /// into every `DeviceInstance.init` call site; see `src/io/uniq.zig`.
@@ -2609,6 +2621,16 @@ pub const Supervisor = struct {
 
     pub fn attachWithRoot(self: *Supervisor, devname: []const u8, dev_root: []const u8) !void {
         self.last_attach_node_gone = false;
+        if (builtin.is_test) {
+            if (self.test_attach_transient_remaining) |remaining| {
+                if (remaining > 0) {
+                    self.test_attach_transient_remaining = remaining - 1;
+                    return error.HotplugTransient;
+                }
+                self.test_attach_transient_remaining = null;
+                return;
+            }
+        }
         var path_buf: [128]u8 = undefined;
         const path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ dev_root, devname });
 
@@ -3218,6 +3240,61 @@ test "supervisor: hotplug rawinfo failure is transient" {
 
     try testing.expectError(error.HotplugTransient, sup.attachWithRoot("hidraw7", dev_root));
 }
+
+// Drives the real event-driven retry path once per call: arms the timerfd so
+// the NONBLOCK read inside drainHotplugRetry succeeds, then drains.
+fn pumpHotplugRetry(sup: *Supervisor) void {
+    const spec = linux.itimerspec{
+        .it_value = .{ .sec = 0, .nsec = 1 },
+        .it_interval = .{ .sec = 0, .nsec = 0 },
+    };
+    _ = linux.timerfd_settime(sup.hotplug_retry_fd, .{}, &spec, null);
+    var ev: [8]u8 = undefined;
+    while (true) {
+        const n = posix.read(sup.hotplug_retry_fd, &ev) catch break;
+        if (n == 0) break;
+    }
+    sup.drainHotplugRetry();
+}
+
+test "supervisor: hotplug retry rides out a multi-second transient (issue #431/#402 budget)" {
+    const allocator = testing.allocator;
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer sup.deinit();
+    sup.hotplug_retry_fd = try posix.timerfd_create(.MONOTONIC, .{ .CLOEXEC = true, .NONBLOCK = true });
+
+    // (a) A device transient for 5 consecutive retries — past the old 3-retry
+    // give-up cap — must survive and attach once the transient clears.
+    sup.test_attach_transient_remaining = 5;
+    sup.enqueueHotplugRetry("hidraw9");
+    try testing.expectEqual(@as(usize, 1), sup.hotplug_pending.items.len);
+
+    var pumps: usize = 0;
+    while (sup.hotplug_pending.items.len > 0 and pumps < HOTPLUG_RETRY_BACKOFF_MS.len + 2) : (pumps += 1) {
+        pumpHotplugRetry(&sup);
+    }
+    // Cleared after exactly 5 transient retries + 1 successful attach; the entry
+    // is gone because it attached, not because the budget was exhausted.
+    try testing.expectEqual(@as(usize, 0), sup.hotplug_pending.items.len);
+    try testing.expectEqual(@as(?usize, null), sup.test_attach_transient_remaining);
+    try testing.expectEqual(@as(usize, 6), pumps);
+
+    // (b) A permanently-transient device must still be given up within a bounded
+    // number of retries (== the backoff array length), never looping forever.
+    sup.test_attach_transient_remaining = std.math.maxInt(usize);
+    sup.enqueueHotplugRetry("hidraw10");
+    try testing.expectEqual(@as(usize, 1), sup.hotplug_pending.items.len);
+
+    var giveup_pumps: usize = 0;
+    while (sup.hotplug_pending.items.len > 0 and giveup_pumps < HOTPLUG_RETRY_GIVEUP_GUARD) : (giveup_pumps += 1) {
+        pumpHotplugRetry(&sup);
+    }
+    try testing.expectEqual(@as(usize, 0), sup.hotplug_pending.items.len);
+    try testing.expectEqual(HOTPLUG_RETRY_BACKOFF_MS.len, giveup_pumps);
+}
+
+const HOTPLUG_RETRY_GIVEUP_GUARD: usize = 100;
 
 test "supervisor: attachWithInstanceResult reports duplicate devname without taking instance" {
     const allocator = testing.allocator;

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -1515,11 +1515,7 @@ pub const Supervisor = struct {
         entry.retries = 0;
         entry.kind = kind;
         self.hotplug_pending.append(self.allocator, entry) catch return;
-        const spec = linux.itimerspec{
-            .it_value = .{ .sec = 0, .nsec = 300_000_000 },
-            .it_interval = .{ .sec = 0, .nsec = 0 },
-        };
-        _ = linux.timerfd_settime(self.hotplug_retry_fd, .{}, &spec, null);
+        self.armHotplugRetry();
     }
 
     fn enqueueHotplugRetryForPath(self: *Supervisor, path: []const u8) void {
@@ -1578,11 +1574,11 @@ pub const Supervisor = struct {
                     continue;
                 }
                 p.retries += 1;
-                if (p.retries >= 3) {
+                if (p.retries >= HOTPLUG_RETRY_BACKOFF_MS.len) {
                     if (self.last_attach_node_gone) {
                         std.log.debug("hotplug: {s} removed before attach (claimed or unplugged), giving up", .{name});
                     } else {
-                        std.log.warn("hotplug: giving up on {s} after 3 retries", .{name});
+                        std.log.warn("hotplug: giving up on {s} after {d} retries", .{ name, p.retries });
                     }
                     _ = self.hotplug_pending.swapRemove(i);
                 } else {
@@ -1593,12 +1589,30 @@ pub const Supervisor = struct {
             _ = self.hotplug_pending.swapRemove(i);
         }
         if (self.hotplug_pending.items.len > 0) {
-            const spec = linux.itimerspec{
-                .it_value = .{ .sec = 0, .nsec = 300_000_000 },
-                .it_interval = .{ .sec = 0, .nsec = 0 },
-            };
-            _ = linux.timerfd_settime(self.hotplug_retry_fd, .{}, &spec, null);
+            self.armHotplugRetry();
         }
+    }
+
+    fn hotplugRetryDelayMs(p: *const HotplugPending) u32 {
+        return switch (p.kind) {
+            .input_grab => 300,
+            .hidraw => HOTPLUG_RETRY_BACKOFF_MS[@min(p.retries, HOTPLUG_RETRY_BACKOFF_MS.len - 1)],
+        };
+    }
+
+    fn armHotplugRetry(self: *Supervisor) void {
+        if (self.hotplug_retry_fd < 0) return;
+        var min_ms: u32 = std.math.maxInt(u32);
+        for (self.hotplug_pending.items) |*p| {
+            const ms = hotplugRetryDelayMs(p);
+            if (ms < min_ms) min_ms = ms;
+        }
+        if (min_ms == std.math.maxInt(u32)) return;
+        const spec = linux.itimerspec{
+            .it_value = .{ .sec = 0, .nsec = @as(i64, min_ms) * std.time.ns_per_ms },
+            .it_interval = .{ .sec = 0, .nsec = 0 },
+        };
+        _ = linux.timerfd_settime(self.hotplug_retry_fd, .{}, &spec, null);
     }
 
     fn drainInotify(self: *Supervisor) void {
@@ -2641,11 +2655,7 @@ pub const Supervisor = struct {
                     else => false,
                 };
                 self.last_attach_node_gone = node_gone;
-                if (node_gone) {
-                    std.log.debug("hotplug: {s} not ready ({s}), will retry", .{ path, @errorName(err) });
-                } else {
-                    std.log.warn("hotplug: {s} not ready ({s}), will retry", .{ path, @errorName(err) });
-                }
+                std.log.debug("hotplug: {s} not ready ({s}), will retry", .{ path, @errorName(err) });
                 return error.HotplugTransient;
             }
             return err;
@@ -3241,6 +3251,8 @@ test "supervisor: hotplug rawinfo failure is transient" {
     try testing.expectError(error.HotplugTransient, sup.attachWithRoot("hidraw7", dev_root));
 }
 
+const HOTPLUG_RETRY_GIVEUP_GUARD: usize = 100;
+
 // Drives the real event-driven retry path once per call: arms the timerfd so
 // the NONBLOCK read inside drainHotplugRetry succeeds, then drains.
 fn pumpHotplugRetry(sup: *Supervisor) void {
@@ -3293,8 +3305,6 @@ test "supervisor: hotplug retry rides out a multi-second transient (issue #431/#
     try testing.expectEqual(@as(usize, 0), sup.hotplug_pending.items.len);
     try testing.expectEqual(HOTPLUG_RETRY_BACKOFF_MS.len, giveup_pumps);
 }
-
-const HOTPLUG_RETRY_GIVEUP_GUARD: usize = 100;
 
 test "supervisor: attachWithInstanceResult reports duplicate devname without taking instance" {
     const allocator = testing.allocator;

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -3352,12 +3352,11 @@ test "supervisor: hotplug retry rides out a multi-second transient (issue #431/#
     try testing.expectEqual(HOTPLUG_RETRY_BACKOFF_MS.len, drains);
 }
 
-// BUG 2 guard: a slow entry (Vader5 at the 1500ms slot) co-pending with a fast,
-// permanently-failing entry must keep its OWN backoff cadence. Under the old
-// shared-min-delay / retry-all behaviour the slow entry was retried at the fast
-// entry's pace, collapsing its ~7.6s window — so it would give up far earlier
-// in virtual time. Here the device-under-test must NOT be retried before its
-// own next_deadline_ns regardless of the co-pending entry's faster schedule.
+// BUG 2 guard: a slow hidraw entry (seeded deep into the backoff at the 1500ms
+// slot) co-pending with a genuinely faster entry (fresh, 300ms slot) must keep
+// its OWN deadline. Under the old shared-min-delay / retry-all behaviour the slow
+// entry was retried on every wake the fast entry triggered, collapsing its
+// window. The per-entry deadline gate must hold it until its own deadline.
 test "supervisor: per-entry deadline survives a faster co-pending entry (issue #431 BUG2)" {
     const allocator = testing.allocator;
 
@@ -3368,49 +3367,44 @@ test "supervisor: per-entry deadline survives a faster co-pending entry (issue #
     const base: u64 = 10 * std.time.ns_per_s;
     sup.test_now_override_ns = base;
 
-    // Both entries route through the shared transient seam, so both keep failing
-    // on every attempt they actually take. "fast" is enqueued first; the
-    // device-under-test ("dut") is the slow Vader5-style entry we protect.
-    sup.test_attach_transient_remaining = std.math.maxInt(usize);
-    sup.enqueueHotplugRetry("hidraw_fast");
-    sup.enqueueHotplugRetry("hidraw_dut");
-    try testing.expectEqual(@as(usize, 2), sup.hotplug_pending.items.len);
-
-    const dut = struct {
-        fn find(s: *Supervisor) ?*HotplugPending {
-            for (s.hotplug_pending.items) |*p| {
-                if (std.mem.eql(u8, p.devname[0..p.len], "hidraw_dut")) return p;
+    const find = struct {
+        fn p(s: *Supervisor, name: []const u8) ?*HotplugPending {
+            for (s.hotplug_pending.items) |*it| {
+                if (std.mem.eql(u8, it.devname[0..it.len], name)) return it;
             }
             return null;
         }
-    };
+    }.p;
 
-    // Advance virtual time slot-by-slot up to (but not reaching) the DUT's full
-    // budget. At every wake the fast entry is eligible far more often, but the
-    // DUT's retry count must track ONLY its own cumulative backoff schedule:
-    // after virtual time T, the DUT has taken exactly as many attempts as its
-    // schedule permits, never more.
-    var t_ms: u64 = 0;
-    var guard: usize = 0;
-    const full_budget_ms = hidrawDeadlineAfter(HOTPLUG_RETRY_BACKOFF_MS.len) / std.time.ns_per_ms;
-    while (t_ms < full_budget_ms and guard < HOTPLUG_RETRY_GIVEUP_GUARD) : (guard += 1) {
-        t_ms += 100;
+    // Both route through the shared transient seam so neither ever attaches.
+    sup.test_attach_transient_remaining = std.math.maxInt(usize);
+    sup.enqueueHotplugRetry("hidraw_fast"); // fresh -> 300ms deadline
+    sup.enqueueHotplugRetry("hidraw_dut");
+
+    // Seed the device-under-test deep into the backoff so it is genuinely slower
+    // than the co-pending fast entry.
+    const seed_slot: u8 = 5; // 1500ms
+    {
+        const d = find(&sup, "hidraw_dut").?;
+        d.retries = seed_slot;
+        d.next_deadline_ns = base + Supervisor.delayNsFor(.hidraw, seed_slot);
+    }
+    const dut_due_ms = HOTPLUG_RETRY_BACKOFF_MS[seed_slot]; // 1500
+
+    // The fast entry is eligible every 300ms and is retried repeatedly, but the
+    // DUT must hold its seeded retry count until its own 1500ms deadline.
+    var t_ms: u64 = 100;
+    while (t_ms < dut_due_ms) : (t_ms += 100) {
         sup.test_now_override_ns = base + t_ms * std.time.ns_per_ms;
         sup.drainHotplugRetry();
-        if (dut.find(&sup)) |p| {
-            // expected attempts = number of schedule deadlines <= elapsed t_ms
-            var expected: u8 = 0;
-            while (expected < HOTPLUG_RETRY_BACKOFF_MS.len and
-                hidrawDeadlineAfter(expected + 1) / std.time.ns_per_ms <= t_ms) : (expected += 1)
-            {}
-            try testing.expectEqual(expected, p.retries);
-        }
+        try testing.expectEqual(seed_slot, find(&sup, "hidraw_dut").?.retries);
     }
 
-    // The DUT is given up only after its full cumulative budget elapsed in
-    // virtual time, NOT accelerated by the fast co-pending entry. (Reaching here
-    // means it was never retried ahead of schedule above.)
-    try testing.expect(t_ms >= full_budget_ms);
+    // At its own deadline the DUT advances by exactly one attempt — proof it was
+    // never dragged forward by the faster co-pending entry.
+    sup.test_now_override_ns = base + dut_due_ms * std.time.ns_per_ms;
+    sup.drainHotplugRetry();
+    try testing.expectEqual(@as(u8, seed_slot + 1), find(&sup, "hidraw_dut").?.retries);
 }
 
 // BUG 1 guard: armHotplugRetry must split a >=1000ms delay into sec+nsec. The

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -190,6 +190,10 @@ const HotplugPending = struct {
     len: u8,
     retries: u8,
     kind: PendingKind,
+    // Absolute CLOCK_MONOTONIC deadline for this entry's next attempt. Each
+    // entry rides its own backoff schedule so a shared timer firing for the
+    // nearest entry never collapses a slower entry's window.
+    next_deadline_ns: u64,
 };
 
 const PendingKind = enum { hidraw, input_grab };
@@ -1514,6 +1518,7 @@ pub const Supervisor = struct {
         entry.len = @intCast(n);
         entry.retries = 0;
         entry.kind = kind;
+        entry.next_deadline_ns = self.nowNs() + delayNsFor(kind, 0);
         self.hotplug_pending.append(self.allocator, entry) catch return;
         self.armHotplugRetry();
     }
@@ -1552,6 +1557,12 @@ pub const Supervisor = struct {
         var i: usize = 0;
         while (i < self.hotplug_pending.items.len) {
             const p = &self.hotplug_pending.items[i];
+            // Each entry rides its own backoff schedule: skip it until its
+            // absolute deadline so a co-pending fast entry never accelerates it.
+            if (self.nowNs() < p.next_deadline_ns) {
+                i += 1;
+                continue;
+            }
             const name = p.devname[0..p.len];
             if (p.kind == .input_grab) {
                 if (self.tryGrabForManaged(name) == .access_denied) {
@@ -1560,6 +1571,7 @@ pub const Supervisor = struct {
                         std.log.debug("shadow grab: giving up on {s} after 3 retries", .{name});
                         _ = self.hotplug_pending.swapRemove(i);
                     } else {
+                        p.next_deadline_ns = self.nowNs() + delayNsFor(p.kind, p.retries);
                         i += 1;
                     }
                 } else {
@@ -1582,6 +1594,7 @@ pub const Supervisor = struct {
                     }
                     _ = self.hotplug_pending.swapRemove(i);
                 } else {
+                    p.next_deadline_ns = self.nowNs() + delayNsFor(p.kind, p.retries);
                     i += 1;
                 }
                 continue;
@@ -1593,23 +1606,30 @@ pub const Supervisor = struct {
         }
     }
 
-    fn hotplugRetryDelayMs(p: *const HotplugPending) u32 {
-        return switch (p.kind) {
+    fn delayNsFor(kind: PendingKind, retries: u8) u64 {
+        const ms: u64 = switch (kind) {
             .input_grab => 300,
-            .hidraw => HOTPLUG_RETRY_BACKOFF_MS[@min(p.retries, HOTPLUG_RETRY_BACKOFF_MS.len - 1)],
+            .hidraw => HOTPLUG_RETRY_BACKOFF_MS[@min(retries, HOTPLUG_RETRY_BACKOFF_MS.len - 1)],
         };
+        return ms * std.time.ns_per_ms;
     }
 
     fn armHotplugRetry(self: *Supervisor) void {
         if (self.hotplug_retry_fd < 0) return;
-        var min_ms: u32 = std.math.maxInt(u32);
+        var nearest: u64 = std.math.maxInt(u64);
         for (self.hotplug_pending.items) |*p| {
-            const ms = hotplugRetryDelayMs(p);
-            if (ms < min_ms) min_ms = ms;
+            if (p.next_deadline_ns < nearest) nearest = p.next_deadline_ns;
         }
-        if (min_ms == std.math.maxInt(u32)) return;
+        if (nearest == std.math.maxInt(u64)) return;
+        const now = self.nowNs();
+        // Arm at least ~1us so the timerfd fires promptly when a deadline has
+        // already passed (also keeps `it_value` non-zero, i.e. armed).
+        const delay_ns: u64 = if (nearest > now) nearest - now else 1_000;
         const spec = linux.itimerspec{
-            .it_value = .{ .sec = 0, .nsec = @as(i64, min_ms) * std.time.ns_per_ms },
+            .it_value = .{
+                .sec = @intCast(delay_ns / std.time.ns_per_s),
+                .nsec = @intCast(delay_ns % std.time.ns_per_s),
+            },
             .it_interval = .{ .sec = 0, .nsec = 0 },
         };
         _ = linux.timerfd_settime(self.hotplug_retry_fd, .{}, &spec, null);
@@ -3129,6 +3149,9 @@ test "supervisor: input grab retry dedups per kind and drains non-denied nodes" 
     defer sup.deinit();
     sup.hotplug_retry_fd = try posix.timerfd_create(.MONOTONIC, .{ .CLOEXEC = true, .NONBLOCK = true });
 
+    const base: u64 = 10 * std.time.ns_per_s;
+    sup.test_now_override_ns = base;
+
     sup.enqueueRetry(.input_grab, "event5");
     sup.enqueueRetry(.input_grab, "event5");
     try testing.expectEqual(@as(usize, 1), sup.hotplug_pending.items.len);
@@ -3139,7 +3162,9 @@ test "supervisor: input grab retry dedups per kind and drains non-denied nodes" 
     try testing.expectEqual(@as(usize, 2), sup.hotplug_pending.items.len);
     _ = sup.hotplug_pending.swapRemove(1);
 
-    // Node gone (or readable but not a shadow): the retry entry is dropped.
+    // Advance past the input_grab deadline (300ms); node gone (or readable but
+    // not a shadow): the retry entry is dropped.
+    sup.test_now_override_ns = base + 300 * std.time.ns_per_ms;
     sup.drainHotplugRetry();
     try testing.expectEqual(@as(usize, 0), sup.hotplug_pending.items.len);
 }
@@ -3253,19 +3278,23 @@ test "supervisor: hotplug rawinfo failure is transient" {
 
 const HOTPLUG_RETRY_GIVEUP_GUARD: usize = 100;
 
-// Drives the real event-driven retry path once per call: arms the timerfd so
-// the NONBLOCK read inside drainHotplugRetry succeeds, then drains.
-fn pumpHotplugRetry(sup: *Supervisor) void {
-    const spec = linux.itimerspec{
-        .it_value = .{ .sec = 0, .nsec = 1 },
-        .it_interval = .{ .sec = 0, .nsec = 0 },
-    };
-    _ = linux.timerfd_settime(sup.hotplug_retry_fd, .{}, &spec, null);
-    var ev: [8]u8 = undefined;
-    while (true) {
-        const n = posix.read(sup.hotplug_retry_fd, &ev) catch break;
-        if (n == 0) break;
+// Cumulative virtual deadline reached after `n` hidraw retries, i.e. the sum of
+// the first `n` backoff slots. Lets a test advance the clock exactly to an
+// entry's nth attempt without re-deriving the schedule by hand.
+fn hidrawDeadlineAfter(n: usize) u64 {
+    var total: u64 = 0;
+    var i: usize = 0;
+    while (i < n) : (i += 1) {
+        total += HOTPLUG_RETRY_BACKOFF_MS[@min(i, HOTPLUG_RETRY_BACKOFF_MS.len - 1)];
     }
+    return total * std.time.ns_per_ms;
+}
+
+// Advances virtual time to `at_ns` and drains once. drainHotplugRetry's
+// NONBLOCK read no-ops on a disarmed fd, so the deadline gate is what decides
+// which entries are attempted — exactly the production semantics.
+fn drainAtVirtual(sup: *Supervisor, base_ns: u64, at_ns: u64) void {
+    sup.test_now_override_ns = base_ns + at_ns;
     sup.drainHotplugRetry();
 }
 
@@ -3276,34 +3305,153 @@ test "supervisor: hotplug retry rides out a multi-second transient (issue #431/#
     defer sup.deinit();
     sup.hotplug_retry_fd = try posix.timerfd_create(.MONOTONIC, .{ .CLOEXEC = true, .NONBLOCK = true });
 
+    const base: u64 = 10 * std.time.ns_per_s;
+    sup.test_now_override_ns = base;
+
     // (a) A device transient for 5 consecutive retries — past the old 3-retry
-    // give-up cap — must survive and attach once the transient clears.
+    // give-up cap — must survive and attach once the transient clears. Drive it
+    // on its own backoff schedule via virtual time; a drain before the next
+    // deadline must NOT consume a retry.
     sup.test_attach_transient_remaining = 5;
     sup.enqueueHotplugRetry("hidraw9");
     try testing.expectEqual(@as(usize, 1), sup.hotplug_pending.items.len);
 
-    var pumps: usize = 0;
-    while (sup.hotplug_pending.items.len > 0 and pumps < HOTPLUG_RETRY_BACKOFF_MS.len + 2) : (pumps += 1) {
-        pumpHotplugRetry(&sup);
+    var attempt: usize = 0;
+    while (sup.hotplug_pending.items.len > 0 and attempt < HOTPLUG_RETRY_BACKOFF_MS.len + 2) : (attempt += 1) {
+        // A premature drain (1ns before the deadline) is a no-op: the retry
+        // counter must not advance until the entry's own deadline arrives.
+        const before = sup.hotplug_pending.items[0].retries;
+        drainAtVirtual(&sup, base, hidrawDeadlineAfter(attempt + 1) - 1);
+        if (sup.hotplug_pending.items.len == 0) break;
+        try testing.expectEqual(before, sup.hotplug_pending.items[0].retries);
+        // At the deadline the attempt fires.
+        drainAtVirtual(&sup, base, hidrawDeadlineAfter(attempt + 1));
     }
     // Cleared after exactly 5 transient retries + 1 successful attach; the entry
     // is gone because it attached, not because the budget was exhausted.
     try testing.expectEqual(@as(usize, 0), sup.hotplug_pending.items.len);
     try testing.expectEqual(@as(?usize, null), sup.test_attach_transient_remaining);
-    try testing.expectEqual(@as(usize, 6), pumps);
+    // 5 transient deadline drains + 1 successful attach drain == 6 iterations.
+    try testing.expectEqual(@as(usize, 6), attempt);
 
     // (b) A permanently-transient device must still be given up within a bounded
     // number of retries (== the backoff array length), never looping forever.
+    sup.test_now_override_ns = base;
     sup.test_attach_transient_remaining = std.math.maxInt(usize);
     sup.enqueueHotplugRetry("hidraw10");
     try testing.expectEqual(@as(usize, 1), sup.hotplug_pending.items.len);
 
-    var giveup_pumps: usize = 0;
-    while (sup.hotplug_pending.items.len > 0 and giveup_pumps < HOTPLUG_RETRY_GIVEUP_GUARD) : (giveup_pumps += 1) {
-        pumpHotplugRetry(&sup);
+    var drains: usize = 0;
+    while (sup.hotplug_pending.items.len > 0 and drains < HOTPLUG_RETRY_GIVEUP_GUARD) {
+        drains += 1;
+        drainAtVirtual(&sup, base, hidrawDeadlineAfter(drains));
     }
     try testing.expectEqual(@as(usize, 0), sup.hotplug_pending.items.len);
-    try testing.expectEqual(HOTPLUG_RETRY_BACKOFF_MS.len, giveup_pumps);
+    // Each deadline drain consumes exactly one retry; give-up lands at the
+    // backoff array length, never looping forever.
+    try testing.expectEqual(HOTPLUG_RETRY_BACKOFF_MS.len, drains);
+}
+
+// BUG 2 guard: a slow entry (Vader5 at the 1500ms slot) co-pending with a fast,
+// permanently-failing entry must keep its OWN backoff cadence. Under the old
+// shared-min-delay / retry-all behaviour the slow entry was retried at the fast
+// entry's pace, collapsing its ~7.6s window — so it would give up far earlier
+// in virtual time. Here the device-under-test must NOT be retried before its
+// own next_deadline_ns regardless of the co-pending entry's faster schedule.
+test "supervisor: per-entry deadline survives a faster co-pending entry (issue #431 BUG2)" {
+    const allocator = testing.allocator;
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer sup.deinit();
+    sup.hotplug_retry_fd = try posix.timerfd_create(.MONOTONIC, .{ .CLOEXEC = true, .NONBLOCK = true });
+
+    const base: u64 = 10 * std.time.ns_per_s;
+    sup.test_now_override_ns = base;
+
+    // Both entries route through the shared transient seam, so both keep failing
+    // on every attempt they actually take. "fast" is enqueued first; the
+    // device-under-test ("dut") is the slow Vader5-style entry we protect.
+    sup.test_attach_transient_remaining = std.math.maxInt(usize);
+    sup.enqueueHotplugRetry("hidraw_fast");
+    sup.enqueueHotplugRetry("hidraw_dut");
+    try testing.expectEqual(@as(usize, 2), sup.hotplug_pending.items.len);
+
+    const dut = struct {
+        fn find(s: *Supervisor) ?*HotplugPending {
+            for (s.hotplug_pending.items) |*p| {
+                if (std.mem.eql(u8, p.devname[0..p.len], "hidraw_dut")) return p;
+            }
+            return null;
+        }
+    };
+
+    // Advance virtual time slot-by-slot up to (but not reaching) the DUT's full
+    // budget. At every wake the fast entry is eligible far more often, but the
+    // DUT's retry count must track ONLY its own cumulative backoff schedule:
+    // after virtual time T, the DUT has taken exactly as many attempts as its
+    // schedule permits, never more.
+    var t_ms: u64 = 0;
+    var guard: usize = 0;
+    const full_budget_ms = hidrawDeadlineAfter(HOTPLUG_RETRY_BACKOFF_MS.len) / std.time.ns_per_ms;
+    while (t_ms < full_budget_ms and guard < HOTPLUG_RETRY_GIVEUP_GUARD) : (guard += 1) {
+        t_ms += 100;
+        sup.test_now_override_ns = base + t_ms * std.time.ns_per_ms;
+        sup.drainHotplugRetry();
+        if (dut.find(&sup)) |p| {
+            // expected attempts = number of schedule deadlines <= elapsed t_ms
+            var expected: u8 = 0;
+            while (expected < HOTPLUG_RETRY_BACKOFF_MS.len and
+                hidrawDeadlineAfter(expected + 1) / std.time.ns_per_ms <= t_ms) : (expected += 1)
+            {}
+            try testing.expectEqual(expected, p.retries);
+        }
+    }
+
+    // The DUT is given up only after its full cumulative budget elapsed in
+    // virtual time, NOT accelerated by the fast co-pending entry. (Reaching here
+    // means it was never retried ahead of schedule above.)
+    try testing.expect(t_ms >= full_budget_ms);
+}
+
+// BUG 1 guard: armHotplugRetry must split a >=1000ms delay into sec+nsec. The
+// old code wrote nsec = 1.5e9 (> 999_999_999), so timerfd_settime returned
+// EINVAL and the timer was left DISARMED — gettime then reports it_value == 0
+// and the high backoff slots never fire. Drive the real arm path and read the
+// kernel timer back.
+test "supervisor: armHotplugRetry produces a valid timer for high backoff slots (issue #431 BUG1)" {
+    const allocator = testing.allocator;
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer sup.deinit();
+    sup.hotplug_retry_fd = try posix.timerfd_create(.MONOTONIC, .{ .CLOEXEC = true, .NONBLOCK = true });
+
+    const base: u64 = 10 * std.time.ns_per_s;
+    sup.test_now_override_ns = base;
+
+    // Place a single hidraw entry at retries=5 → the 1500ms slot, whose delay
+    // exceeds the 999_999_999 ns timespec ceiling unless split correctly.
+    sup.enqueueHotplugRetry("hidraw_slow");
+    try testing.expectEqual(@as(usize, 1), sup.hotplug_pending.items.len);
+    const p = &sup.hotplug_pending.items[0];
+    p.retries = 5;
+    p.next_deadline_ns = base + Supervisor.delayNsFor(.hidraw, p.retries);
+    try testing.expectEqual(@as(u32, 1500), HOTPLUG_RETRY_BACKOFF_MS[p.retries]);
+
+    // Disarm first so the only thing that can arm the timer is this call. Without
+    // this, the valid 300ms timer set at enqueue would mask a rejected high-slot
+    // settime and the buggy code would read back non-zero.
+    const disarm = linux.itimerspec{ .it_value = .{ .sec = 0, .nsec = 0 }, .it_interval = .{ .sec = 0, .nsec = 0 } };
+    _ = linux.timerfd_settime(sup.hotplug_retry_fd, .{}, &disarm, null);
+
+    sup.armHotplugRetry();
+
+    var cur: linux.itimerspec = undefined;
+    const rc = linux.timerfd_gettime(sup.hotplug_retry_fd, &cur);
+    try testing.expectEqual(@as(usize, 0), rc);
+    // A correctly-armed 1500ms timer reports a non-zero remaining it_value. The
+    // buggy sec=0,nsec=1.5e9 form is rejected (EINVAL), leaving the disarmed
+    // timer at zero.
+    try testing.expect(cur.it_value.sec > 0 or cur.it_value.nsec > 0);
 }
 
 test "supervisor: attachWithInstanceResult reports duplicate devname without taking instance" {


### PR DESCRIPTION
## Problem

After a reboot or upgrade the controller (Flydigi Vader 5 Pro) is not seen until it is reconnected a second time — an ON-OFF-ON cycle. Issue #431; same root as #355.

#402 (564fb4c) replaced an in-thread open-retry loop (~7s: 1+2+4s) with the event-driven hotplug queue but capped it at 3 retries x 300ms (~900ms). At cold boot / upgrade the device is transiently unavailable longer than 900ms (udev permission race -> AccessDenied; kernel driver still binding -> Busy; firmware not ready -> InitFailed), so the single ADD uevent is given up on permanently until a physical OFF-ON resets the retry counter.

## Change

- Restore a ~7.6s retry budget via an 8-entry backoff schedule (300/300/500/800/1200/1500/1500/1500 ms) on the existing timerfd — no thread blocking reintroduced (the #397 status-hang cause stays fixed; `openDeviceWithRetry`'s single-shot no-sleep contract is untouched).
- Give-up cap = backoff array length; the shared retry timer re-arms to the minimum next delay among pending entries.
- `input_grab` (shadow-grab) retry path is unchanged (keeps its own 3-retry cap).
- Per-retry "not ready, will retry" line dropped to `debug` so the wider window adds no boot-log noise on persistently permission-denied unmanaged nodes; the single give-up warning is unchanged.

## Test

- New Layer-0 regression test drives the real `enqueueHotplugRetry -> drainHotplugRetry -> armHotplugRetry` loop: a device transient for 5 consecutive retries now attaches (was dropped at 3); a permanently-transient device is still given up within a bounded number of retries (never loops forever).
- Falsifiable: reverting the give-up cap to 3 turns the test red (`giving up after 3 retries`, `expected null, found 2`).
- `zig build test` green in Docker (0.15.2): 17/17 steps, 1807/1823 passed, 16 skipped.

Refs #431 #355


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device hotplug retries using per-device, deadline-based scheduling so retries trigger at the right time even when multiple devices are queued.
  * Updated hidraw attach give-up logic to follow the backoff schedule, improving recovery from longer transient “not ready” periods.
  * Refined transient open failure logging to reduce unnecessary noise while retaining debug detail.
* **Tests**
  * Expanded hotplug retry tests with virtual-time/deadline scenarios, including multi-second transient budgets, deadline isolation for mixed retry speeds, and correct timer scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->