### PR TITLE
docs: document gyro minimum_output mapping option

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -148,6 +148,7 @@ invert_y = true
 | `invert_x` | bool | — | Invert X axis |
 | `invert_y` | bool | — | Invert Y axis |
 | `blend_stick` | bool | `false` | When `true`, gyro joystick output is **added** to the physical stick value (`clamp(physical + gyro, -32767..32767)`) instead of replacing it. Only applies when `mode = "joystick"`. Ignored for `mode = "mouse"`. |
+| `minimum_output` | float | `0.0` | Minimum stick deflection magnitude while gyro is active, as a fraction of full scale (clamped to `0.0`–`1.0`, where `1.0` ≈ `20000` stick units). When the computed output magnitude is non-zero but below this floor, it is scaled up to exactly `minimum_output` while preserving direction. `0.0` disables the floor (default, no-op). A still controller stays at zero, and `deadzone` always wins (input absorbed by the deadzone produces zero output, never resurrected by the floor). Only applies when `mode = "joystick"`; ignored for `mode = "mouse"`. Useful for escaping an in-game stick deadzone so small gyro motion still registers. |
 
 ## `[stick.left]` / `[stick.right]`
 

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -252,6 +252,25 @@ This lets the physical stick handle coarse movement while the gyro provides fine
 
 > **Note:** when the physical stick is already at full deflection (±32767), the gyro contribution is clamped out entirely. `blend_stick` has no effect when `mode = "mouse"`.
 
+#### Escaping an in-game deadzone (`minimum_output`)
+
+Some games apply their own deadzone to the right stick, so a small gyro deflection produces no in-game camera movement at all — slow, precise aiming simply does nothing until you move past the game's threshold. `minimum_output` raises the gyro output to a floor whenever gyro is active, so even a slight motion clears that deadzone:
+
+```toml
+[gyro]
+mode           = "joystick"
+target         = "right_stick"
+activate       = "LS"
+sensitivity    = 100
+deadzone       = 200
+smoothing      = 0.3
+minimum_output = 0.15      # floor stick output at 15% of full scale while gyro moves
+```
+
+`minimum_output` is a fraction of full scale clamped to the `0.0`–`1.0` range (where `1.0` corresponds to roughly `20000` stick units). When the computed output magnitude is non-zero but below this floor, padctl scales it up to exactly `minimum_output` while preserving the aim direction — so a 5% deflection becomes a 15% deflection pointing the same way. The floor only kicks in for motion that already cleared the gyro `deadzone`: a perfectly still controller stays at zero, and any input absorbed by `deadzone` is never resurrected by `minimum_output`. Tune the value so the smallest deliberate motion just clears the game's own stick deadzone — start around `0.10`–`0.20` and raise it if slow aiming still produces no movement.
+
+> **Note:** `minimum_output` only applies in `mode = "joystick"`. Mouse mode integrates motion frame by frame, so it has no deadzone to escape and ignores this field. The default `minimum_output = 0.0` disables the floor entirely.
+
 ### Sticks (`[stick.left]` / `[stick.right]`)
 
 Three modes:


### PR DESCRIPTION
## What changed

- `docs/src/mapping-config.md`: added the `minimum_output` field row to the `[gyro]` reference table (type `float`, default `0.0`, joystick-only).
- `docs/src/mapping-guide.md`: added a worked "Escaping an in-game deadzone (`minimum_output`)" subsection under joystick mode, showing a gyro-to-right-stick config that floors output to clear a game's own stick deadzone.

The `minimum_output` option is code-complete and unit-tested in `src/core/gyro.zig` (8+ tests) but appeared 0 times in the user docs. Documentation matches the code: a fraction clamped to `0.0`-`1.0` (`1.0` ≈ 20000 stick units), scales sub-floor output magnitude up while preserving direction, joystick-mode only, deadzone takes precedence, `0.0` is a no-op default.

## Why

Documents the option that the gyro-to-stick deadzone-compensation use case depends on (previously undocumented).

## Test plan

- Docs-only change; no `.zig` source touched.
- Verified field name/type/default/behavior against `src/core/gyro.zig` (lines 23, 86-100) and its `minimum_output` unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the new `minimum_output` configuration option for gyroscope settings in joystick mode. This option sets a configurable floor (0.0–1.0) for gyro output magnitude. Includes configuration examples and clarifies behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->