### PR TITLE
ci(test): run shadow-grab integration test in e2e with REQUIRE_UINPUT gate

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,14 +55,25 @@ jobs:
             echo "uhid_ok=false" >> "$GITHUB_OUTPUT"
             echo "::warning::UHID gate DISABLED — /dev/uhid not accessible on this runner. Layer 2/3 tests will skip."
           fi
+      - name: Probe /dev/uinput accessibility
+        id: uinput_probe
+        run: |
+          if [ -r /dev/uinput ] && [ -w /dev/uinput ]; then
+            echo "uinput_ok=true" >> "$GITHUB_OUTPUT"
+            echo "uinput gate ENABLED — /dev/uinput is accessible, enforcing PADCTL_TEST_REQUIRE_UINPUT=1"
+          else
+            echo "uinput_ok=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::uinput gate DISABLED — /dev/uinput not accessible on this runner. shadow-grab integration test will skip."
+          fi
       - name: Run e2e tests
         env:
           PADCTL_TEST_REQUIRE_UHID: ${{ steps.uhid_probe.outputs.uhid_ok == 'true' && '1' || '0' }}
         run: zig build test-e2e
-      - name: Run integration tests (UHID)
-        if: steps.uhid_probe.outputs.uhid_ok == 'true'
+      - name: Run integration tests (UHID + uinput)
+        if: steps.uhid_probe.outputs.uhid_ok == 'true' || steps.uinput_probe.outputs.uinput_ok == 'true'
         env:
-          PADCTL_TEST_REQUIRE_UHID: "1"
+          PADCTL_TEST_REQUIRE_UHID: ${{ steps.uhid_probe.outputs.uhid_ok == 'true' && '1' || '0' }}
+          PADCTL_TEST_REQUIRE_UINPUT: ${{ steps.uinput_probe.outputs.uinput_ok == 'true' && '1' || '0' }}
         run: zig build test-integration
       - name: Run UHID kernel-touching unit tests (test-uhid)
         if: steps.uhid_probe.outputs.uhid_ok == 'true'

--- a/build.zig
+++ b/build.zig
@@ -290,6 +290,23 @@ pub fn build(b: *std.Build) void {
     grace_int_tests.linkLibC();
     integration_step.dependOn(&b.addRunArtifact(grace_int_tests).step);
 
+    // shadow_grab_integration: watchdog real-kernel validation.
+    // Creates a uinput shadow node, sweeps, and asserts EVIOCGRAB exclusivity.
+    // Own test artifact so its test{} blocks execute under test-integration; the
+    // check-matrix container has no /dev/uinput so it skips gracefully unless
+    // PADCTL_TEST_REQUIRE_UINPUT=1 (set by the privileged e2e job).
+    const shadow_int_mod = b.createModule(.{
+        .root_source_file = b.path("src/test/shadow_grab_integration_test.zig"),
+        .target = target,
+        .optimize = optimize,
+        .sanitize_c = .trap,
+    });
+    shadow_int_mod.addImport("src", src_mod);
+    const shadow_int_tests = b.addTest(.{ .root_module = shadow_int_mod, .filters = test_filters });
+    applyLibusb(b, shadow_int_tests, use_libusb, vendored);
+    shadow_int_tests.linkLibC();
+    integration_step.dependOn(&b.addRunArtifact(shadow_int_tests).step);
+
     // Phase 13 Wave 3 T5f: Layer 1 routing tests — pure pipe2 fixture, no
     // /dev/uhid, no privilege required. Hooks to the main test step so the
     // CI green bar covers the UHID routing switch.

--- a/src/main.zig
+++ b/src/main.zig
@@ -157,7 +157,9 @@ pub const testing_support = struct {
     pub const supervisor_suspend_output_continuity_test = @import("test/supervisor_suspend_output_continuity_test.zig");
     pub const wedge_instrumentation_test = @import("test/wedge_instrumentation_test.zig");
     pub const libusb_capability_test = @import("test/libusb_capability_test.zig");
-    pub const shadow_grab_integration_test = @import("test/shadow_grab_integration_test.zig");
+    // shadow_grab_integration_test runs as its own `test-integration` artifact
+    // (it needs /dev/uinput); the unprivileged `zig build test` run could only
+    // ever SkipZigTest it, so it is intentionally NOT registered here.
     // Permanent canary — proves test discovery walks into testing_support.
     // If the discovery mechanism breaks again, this test stops running and
     // we can prove the regression with a deliberate failure.

--- a/src/test/shadow_grab_integration_test.zig
+++ b/src/test/shadow_grab_integration_test.zig
@@ -1,18 +1,52 @@
-//! Integration test for the shadow input-node watchdog (issue #406).
+//! Integration test for the shadow input-node watchdog (issue #406 / #411).
 //!
 //! Creates a uinput device that mimics a kernel-driver shadow node (BUS_USB
 //! plus the managed pad's physical VID/PID, no uniq), runs the sweep, and
 //! asserts the node is exclusively grabbed — a second EVIOCGRAB fails with
-//! EBUSY — and released again by releaseAll(). Skips when /dev/uinput or the
-//! created node is unavailable, same gating as the other uinput tests.
+//! EBUSY — and released again by releaseAll().
+//!
+//! ## Runtime behaviour (mirrors uhid_uniq_pairing_test.zig)
+//!
+//! - On a host without `/dev/uinput` access (unprivileged containers, the
+//!   plain `check-matrix` CI job): logs an explicit warning so the absence is
+//!   visible, then behaves one of two ways:
+//!     * Default: returns `error.SkipZigTest` — the suite stays green while
+//!       making the gap audible.
+//!     * When `PADCTL_TEST_REQUIRE_UINPUT=1` is set: returns
+//!       `error.UinputAccessRequired` — a hard failure, so an environment
+//!       meant to have /dev/uinput access but lacking it surfaces the breakage
+//!       immediately. The privileged `e2e` job sets it when /dev/uinput is
+//!       accessible, which is the only place this flagship #406/#411 watchdog
+//!       test runs for real and a regression turns it RED.
 
 const std = @import("std");
 const posix = std.posix;
 const linux = std.os.linux;
 const testing = std.testing;
 
-const shadow_grab = @import("../io/shadow_grab.zig");
-const ioctl = @import("../io/ioctl_constants.zig");
+// Imported via the `src` barrel (same as the other Layer 2 integration tests)
+// so this file is built as its own `test-integration` artifact rather than
+// pulled into the unprivileged `zig build test` run, where /dev/uinput is
+// never available and the watchdog assertions can only ever SkipZigTest.
+const src = @import("src");
+const shadow_grab = src.io.shadow_grab;
+const ioctl = src.io.ioctl_constants;
+
+fn requireUinput() bool {
+    const v = std.posix.getenv("PADCTL_TEST_REQUIRE_UINPUT") orelse return false;
+    return std.mem.eql(u8, v, "1") or std.mem.eql(u8, v, "true");
+}
+
+fn reportMissingUinput(reason: []const u8) error{ SkipZigTest, UinputAccessRequired } {
+    std.log.warn(
+        "shadow_grab_integration_test: /dev/uinput unavailable ({s}) — shadow-grab watchdog CI signal is SILENT. " ++
+            "Run in a privileged environment with /dev/uinput, " ++
+            "or set PADCTL_TEST_REQUIRE_UINPUT=1 to turn this into a hard failure.",
+        .{reason},
+    );
+    if (requireUinput()) return error.UinputAccessRequired;
+    return error.SkipZigTest;
+}
 
 const BUS_USB: u16 = 0x03;
 const BUS_VIRTUAL: u16 = 0x06;
@@ -31,7 +65,7 @@ fn expectIoctlOk(rc: usize) !void {
 
 fn createPad(bustype: u16, vid: u16, pid: u16) !posix.fd_t {
     const fd = posix.open("/dev/uinput", .{ .ACCMODE = .RDWR }, 0) catch |err| switch (err) {
-        error.AccessDenied, error.FileNotFound => return error.SkipZigTest,
+        error.AccessDenied, error.FileNotFound => return reportMissingUinput("/dev/uinput open failed"),
         else => return err,
     };
     errdefer posix.close(fd);
@@ -79,7 +113,7 @@ test "shadow_grab: sweep grabs a USB-bus shadow node exclusively and releases it
     defer destroyPad(ufd);
 
     var name_buf: [24]u8 = undefined;
-    const node = findEventNode(vid, pid, &name_buf) orelse return error.SkipZigTest;
+    const node = findEventNode(vid, pid, &name_buf) orelse return reportMissingUinput("created uinput node did not appear under /dev/input");
 
     var list = shadow_grab.GrabList{};
     defer list.releaseAll();
@@ -119,7 +153,7 @@ test "shadow_grab: sweep prunes a grab whose device is gone (ENODEV)" {
     defer if (!destroyed) destroyPad(ufd);
 
     var name_buf: [24]u8 = undefined;
-    const node = findEventNode(vid, pid, &name_buf) orelse return error.SkipZigTest;
+    const node = findEventNode(vid, pid, &name_buf) orelse return reportMissingUinput("created uinput node did not appear under /dev/input");
 
     var list = shadow_grab.GrabList{};
     defer list.releaseAll();
@@ -141,7 +175,7 @@ test "shadow_grab: a node already grabbed by another reader is counted (EBUSY)" 
     defer destroyPad(ufd);
 
     var name_buf: [24]u8 = undefined;
-    const node = findEventNode(vid, pid, &name_buf) orelse return error.SkipZigTest;
+    const node = findEventNode(vid, pid, &name_buf) orelse return reportMissingUinput("created uinput node did not appear under /dev/input");
     const params: shadow_grab.Params = .{ .phys_vendor = vid, .phys_product = pid };
 
     // First reader takes the exclusive grab.
@@ -171,7 +205,7 @@ test "shadow_grab: sweep re-grabs an unowned EBUSY node once the foreign holder 
     defer destroyPad(ufd);
 
     var name_buf: [24]u8 = undefined;
-    const node = findEventNode(vid, pid, &name_buf) orelse return error.SkipZigTest;
+    const node = findEventNode(vid, pid, &name_buf) orelse return reportMissingUinput("created uinput node did not appear under /dev/input");
     const params: shadow_grab.Params = .{ .phys_vendor = vid, .phys_product = pid };
 
     var path_buf: [40]u8 = undefined;
@@ -210,7 +244,7 @@ test "shadow_grab: sweep skips virtual-bus nodes (padctl's own uinput outputs)" 
     defer destroyPad(ufd);
 
     var name_buf: [24]u8 = undefined;
-    const node = findEventNode(vid, pid, &name_buf) orelse return error.SkipZigTest;
+    const node = findEventNode(vid, pid, &name_buf) orelse return reportMissingUinput("created uinput node did not appear under /dev/input");
 
     var list = shadow_grab.GrabList{};
     defer list.releaseAll();


### PR DESCRIPTION
## The gap

The flagship shadow-grab watchdog (#406 / #411) had **no real-kernel CI protection**. `src/test/shadow_grab_integration_test.zig` is the only EVIOCGRAB integration test of the watchdog, but it ran nowhere green-meaningfully:

- It was registered under `src/main.zig:160` (`testing_support`), so the only place it ran was the unprivileged `zig build test` → `check-matrix` job. That container has **no `/dev/uinput`** (`createPad` opens `/dev/uinput` at `shadow_grab_integration_test.zig:62` and on `AccessDenied`/`FileNotFound` returned `error.SkipZigTest`), so all 5 cases hit `SkipZigTest` silently.
- The privileged `e2e` job (which **does** have `/dev/uinput` via `--privileged -v /dev:/dev`, `e2e.yml:37`) runs `test-e2e` / `test-integration` / `test-uhid` — none of whose root modules included this file, so it never built there.
- Unlike the UHID path, which has a `PADCTL_TEST_REQUIRE_UHID` hard-fail guard (`uhid_uniq_pairing_test.zig:42-56`, set in `e2e.yml:60/65/70`), there was **no `PADCTL_TEST_REQUIRE_UINPUT` guard**, so the skip was invisible.

Net: the test that proves the #406/#411 defense could only ever skip — a regression would never turn CI red.

## The fix (mirrors the UHID gate exactly)

- **Env guard** in `shadow_grab_integration_test.zig`: add `requireUinput()` + `reportMissingUinput()` mirroring `requireUhid()`/`reportMissingUhid()`. Default = graceful `SkipZigTest` with a loud warning; `PADCTL_TEST_REQUIRE_UINPUT=1` turns a missing `/dev/uinput` into a hard `error.UinputAccessRequired`. All open-failure + node-not-found paths route through it.
- **Make it actually run** where uinput exists: switch the file to the `src` barrel (`src.io.shadow_grab` / `src.io.ioctl_constants`) like the other Layer 2 integration tests, and build it as its own `test-integration` `addTest` artifact in `build.zig` (so its `test{}` blocks execute). Drop the `testing_support` registration that could only `SkipZigTest` it under the unprivileged run.
- **e2e.yml**: add a `/dev/uinput` probe and set `PADCTL_TEST_REQUIRE_UINPUT=1` on the integration step when accessible (mirroring the `PADCTL_TEST_REQUIRE_UHID` gating block). Non-uinput jobs still skip cleanly.

## Test plan

- `docker run … padctl-build:0.15.2 zig build test --summary all` → green, `17/17 steps; 1809/1820 passed; 11 skipped` (shadow-grab no longer in the unprivileged skip set).
- `zig build test-integration --summary all` (no env, container has no uinput) → `16/16 steps succeeded; 13 skipped` — skips gracefully, does **not** hard-fail.
- `PADCTL_TEST_REQUIRE_UINPUT=1 zig build test-integration` (env set, no uinput) → the 5 shadow-grab cases **hard-fail** with `error.UinputAccessRequired` — proves the gate flips RED on regression.
- Matrix variants `-Dwasm=false` / `-Dlibusb=false` compile + pass.
- `zig build check-fmt` (0.15.2) passes.

The real run-for-real validation — the test creating a uinput node and asserting EVIOCGRAB exclusivity, with `REQUIRE_UINPUT=1` enforced — happens on the GitHub `e2e` runner where `/dev/uinput` is accessible.

Refs #406 #411