### PR TITLE
feat(config): bound report.size + unknown-field linter in device validate()

### DIFF
--- a/devices/sony/dualsense.toml
+++ b/devices/sony/dualsense.toml
@@ -103,7 +103,6 @@ expect = { offset = 74, type = "u32le" }
 # --- WASM plugin: IMU calibration via Feature Report 0x05 ---
 [wasm]
 plugin = "plugins/sony_imu_calibration.wasm"
-calibration_reports = [0x05]
 
 [wasm.overrides]
 process_report = true

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -1,10 +1,20 @@
 const std = @import("std");
 const toml = @import("toml");
+const toml_lint = @import("toml_lint.zig");
 const state = @import("../core/state.zig");
 const presets = @import("presets.zig");
 const input_codes = @import("input_codes.zig");
 
 pub const ButtonId = state.ButtonId;
+
+// Largest report a read path can deliver. The hidraw read buffer
+// (src/event_loop.zig — `var buf: [512]u8`) caps HID reports at 512 bytes; the
+// libusb ring slot (src/io/usbraw.zig — SLOT_SIZE = 64) truncates vendor reads
+// to 64. A report.size above MAX_REPORT_SIZE can never be filled, so the
+// interpreter (src/core/interpreter.zig — `raw.len < cr.src.size` guard) drops
+// every report with no diagnostic. Reject at validate time instead.
+pub const MAX_REPORT_SIZE: i64 = 512;
+pub const LIBUSB_SLOT_SIZE: i64 = 64;
 
 pub const InterfaceConfig = struct {
     id: i64,
@@ -342,6 +352,8 @@ pub fn validate(cfg: *const DeviceConfig) !void {
     }
 
     for (cfg.report) |report| {
+        if (report.size < 0 or report.size > MAX_REPORT_SIZE) return error.ReportSizeTooLarge;
+
         if (report.fields) |fields| {
             var seen_buf: [64][]const u8 = undefined;
             var seen_len: usize = 0;
@@ -490,6 +502,61 @@ pub fn validate(cfg: *const DeviceConfig) !void {
     }
 }
 
+// --- schema lint: detect unknown keys in device config tables ---
+//
+// sam701/zig-toml silently drops unknown fields, so a typo'd device key (e.g.
+// `ofset` for `offset`) parses cleanly and is never applied. devices/*.toml is
+// the primary contribution surface, so flag stray keys the same way mapping
+// configs do. Free-form HashMap sections (report.fields, output.axes/buttons/
+// mapping, button_group.map, command/aux button maps) accept arbitrary keys
+// and are skipped.
+pub const LintFinding = toml_lint.LintFinding;
+
+fn lintAllowlistFor(header: []const u8) ?[]const []const u8 {
+    const sf = toml_lint.structFieldNames;
+    if (header.len == 0) return null; // device config has no top-level keys
+
+    if (std.mem.eql(u8, header, "device")) return sf(DeviceInfo);
+    if (std.mem.eql(u8, header, "device.init")) return sf(InitConfig);
+    if (std.mem.eql(u8, header, "device.interface")) return sf(InterfaceConfig);
+
+    if (std.mem.eql(u8, header, "report")) return sf(ReportConfig);
+    if (std.mem.eql(u8, header, "report.match")) return sf(MatchConfig);
+    if (std.mem.eql(u8, header, "report.button_group")) return sf(ButtonGroupConfig);
+    if (std.mem.eql(u8, header, "report.fields")) return null; // free-form
+    if (std.mem.eql(u8, header, "report.checksum")) return sf(ChecksumConfig);
+
+    if (std.mem.eql(u8, header, "output")) return sf(OutputConfig);
+    if (std.mem.eql(u8, header, "output.dpad")) return sf(DpadOutputConfig);
+    if (std.mem.eql(u8, header, "output.force_feedback")) return sf(ForceFeedbackConfig);
+    if (std.mem.eql(u8, header, "output.aux")) return sf(AuxConfig);
+    if (std.mem.eql(u8, header, "output.touchpad")) return sf(TouchpadConfig);
+    if (std.mem.eql(u8, header, "output.imu")) return sf(ImuConfig);
+    if (std.mem.eql(u8, header, "output.axes") or
+        std.mem.eql(u8, header, "output.buttons") or
+        std.mem.eql(u8, header, "output.mapping") or
+        std.mem.eql(u8, header, "output.aux.buttons")) return null; // free-form
+
+    if (std.mem.eql(u8, header, "wasm")) return sf(WasmConfig);
+    if (std.mem.eql(u8, header, "wasm.overrides")) return sf(WasmOverridesConfig);
+
+    // commands.<name> -> CommandConfig; commands.<name>.checksum -> CommandChecksumConfig.
+    if (std.mem.startsWith(u8, header, "commands.")) {
+        if (std.mem.endsWith(u8, header, ".checksum")) return sf(CommandChecksumConfig);
+        return sf(CommandConfig);
+    }
+
+    return null; // unrecognised header — skip (forward-compat)
+}
+
+pub fn lintUnknownFields(allocator: std.mem.Allocator, raw_toml: []const u8) !std.ArrayList(LintFinding) {
+    return toml_lint.lint(allocator, raw_toml, lintAllowlistFor);
+}
+
+fn warnLintFindings(findings: []const LintFinding) void {
+    toml_lint.warnFindings(findings);
+}
+
 pub const ParseResult = toml.Parsed(DeviceConfig);
 
 // Parse + apply presets without running validate(). The CLI lint tool needs the
@@ -508,6 +575,13 @@ pub fn parseStringRaw(allocator: std.mem.Allocator, content: []const u8) !ParseR
             };
         }
     }
+    if (lintUnknownFields(allocator, content)) |findings| {
+        defer {
+            var f = findings;
+            f.deinit(allocator);
+        }
+        warnLintFindings(findings.items);
+    } else |_| {} // lint failure (OOM) must not break parsing
     return result;
 }
 
@@ -1974,4 +2048,141 @@ test "device: init referencing nonexistent interface id is rejected" {
         \\commands = ["5aa5"]
     ;
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad_init_toml));
+}
+
+// --- report.size bound tests ---
+
+fn reportSizeToml(comptime size: []const u8) []const u8 {
+    return "[device]\n" ++
+        "name = \"T\"\n" ++
+        "vid = 1\n" ++
+        "pid = 2\n" ++
+        "[[device.interface]]\n" ++
+        "id = 0\n" ++
+        "class = \"hid\"\n" ++
+        "[[report]]\n" ++
+        "name = \"r\"\n" ++
+        "interface = 0\n" ++
+        "size = " ++ size ++ "\n";
+}
+
+test "device: report.size at the 512-byte cap validates" {
+    const allocator = std.testing.allocator;
+    const result = try parseString(allocator, reportSizeToml("512"));
+    defer result.deinit();
+    try std.testing.expectEqual(@as(i64, 512), result.value.report[0].size);
+}
+
+test "device: report.size above the 512-byte cap is rejected" {
+    const allocator = std.testing.allocator;
+    try std.testing.expectError(error.ReportSizeTooLarge, parseString(allocator, reportSizeToml("513")));
+}
+
+test "device: report.size far above the cap is rejected" {
+    const allocator = std.testing.allocator;
+    try std.testing.expectError(error.ReportSizeTooLarge, parseString(allocator, reportSizeToml("4096")));
+}
+
+// --- unknown-field linter tests ---
+
+test "device: lintUnknownFields flags an unknown key in [device]" {
+    const allocator = std.testing.allocator;
+    const typo =
+        \\[device]
+        \\name = "T"
+        \\vid = 1
+        \\pid = 2
+        \\nam = "typo"
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 8
+    ;
+    var findings = try lintUnknownFields(allocator, typo);
+    defer findings.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 1), findings.items.len);
+    try std.testing.expectEqualStrings("nam", findings.items[0].unknown_key);
+    try std.testing.expectEqualStrings("device", findings.items[0].table);
+}
+
+test "device: lintUnknownFields flags a typo'd [[report]] key" {
+    const allocator = std.testing.allocator;
+    const typo =
+        \\[device]
+        \\name = "T"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\siz = 8
+    ;
+    var findings = try lintUnknownFields(allocator, typo);
+    defer findings.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 1), findings.items.len);
+    try std.testing.expectEqualStrings("siz", findings.items[0].unknown_key);
+    try std.testing.expectEqualStrings("report", findings.items[0].table);
+}
+
+test "device: lintUnknownFields leaves a clean config unflagged" {
+    const allocator = std.testing.allocator;
+    var findings = try lintUnknownFields(allocator, test_toml);
+    defer findings.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 0), findings.items.len);
+}
+
+test "device: lintUnknownFields does not flag free-form HashMap sections" {
+    const allocator = std.testing.allocator;
+    const toml_str =
+        \\[device]
+        \\name = "T"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 8
+        \\[report.fields]
+        \\any_user_field = { offset = 0, type = "u8" }
+        \\[output]
+        \\name = "T"
+        \\[output.buttons]
+        \\A = "BTN_SOUTH"
+        \\Whatever = "BTN_NORTH"
+    ;
+    var findings = try lintUnknownFields(allocator, toml_str);
+    defer findings.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 0), findings.items.len);
+}
+
+test "device: all shipped devices/*.toml lint clean" {
+    const allocator = std.testing.allocator;
+    var dir = try std.fs.cwd().openDir("devices", .{ .iterate = true });
+    defer dir.close();
+    var walker = try dir.walk(allocator);
+    defer walker.deinit();
+    var checked: usize = 0;
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file or !std.mem.endsWith(u8, entry.basename, ".toml")) continue;
+        const content = try dir.readFileAlloc(allocator, entry.path, 1024 * 1024);
+        defer allocator.free(content);
+        var findings = try lintUnknownFields(allocator, content);
+        defer findings.deinit(allocator);
+        if (findings.items.len > 0) {
+            for (findings.items) |f|
+                std.debug.print("  {s}: unknown key '{s}' in [{s}] (line {d})\n", .{ entry.path, f.unknown_key, f.table, f.line });
+        }
+        try std.testing.expectEqual(@as(usize, 0), findings.items.len);
+        checked += 1;
+    }
+    try std.testing.expect(checked >= 1);
 }

--- a/src/config/mapping.zig
+++ b/src/config/mapping.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const toml = @import("toml");
+const toml_lint = @import("toml_lint.zig");
 const input_codes = @import("input_codes.zig");
 const remap_mod = @import("../core/remap.zig");
 const state = @import("../core/state.zig");
@@ -664,233 +665,45 @@ pub fn needsTriggerThresholdWarn(cfg: *const MappingConfig) bool {
 // unknown fields by design (forward-compat). For mapping configs that is the
 // wrong tradeoff — typos like `trigger_threshold = 128` placed inside
 // [[layer]] (instead of top-level) silently break the user's setup (#163).
-// This linter re-walks the raw TOML text and warns on any key that does not
-// belong to the schema for the current table context.
+// The generic text walk lives in toml_lint.zig; here we supply the mapping
+// schema classifier.
 
-pub const LintFinding = struct {
-    line: usize, // 1-based line number
-    table: []const u8, // table path or "" for top-level; borrowed from input
-    unknown_key: []const u8, // borrowed from input
-};
+pub const LintFinding = toml_lint.LintFinding;
 
-const TableKind = enum {
-    top_level,
-    free_form, // HashMap-backed: any key allowed
-    mapping_config,
-    layer_config,
-    gyro_config,
-    stick_pair_config,
-    stick_config,
-    dpad_config,
-    adaptive_trigger_config,
-    adaptive_trigger_param_config,
-    macro_config,
-    unknown, // unrecognised header — skip lint (do not punish forward-compat sections)
-};
+fn allowlistFor(header: []const u8) ?[]const []const u8 {
+    const sf = toml_lint.structFieldNames;
+    if (header.len == 0) return sf(MappingConfig);
 
-fn structFieldNames(comptime T: type) []const []const u8 {
-    const fields = @typeInfo(T).@"struct".fields;
-    comptime var names: [fields.len][]const u8 = undefined;
-    inline for (fields, 0..) |f, i| names[i] = f.name;
-    const final = names;
-    return &final;
-}
-
-fn allowlistFor(kind: TableKind) ?[]const []const u8 {
-    return switch (kind) {
-        .top_level, .mapping_config => structFieldNames(MappingConfig),
-        .layer_config => structFieldNames(LayerConfig),
-        .gyro_config => structFieldNames(GyroConfig),
-        .stick_pair_config => structFieldNames(StickPairConfig),
-        .stick_config => structFieldNames(StickConfig),
-        .dpad_config => structFieldNames(DpadConfig),
-        .adaptive_trigger_config => structFieldNames(AdaptiveTriggerConfig),
-        .adaptive_trigger_param_config => structFieldNames(AdaptiveTriggerParamConfig),
-        .macro_config => structFieldNames(Macro),
-        .free_form, .unknown => null,
-    };
-}
-
-fn classifyTable(header: []const u8) TableKind {
-    if (header.len == 0) return .top_level;
-
-    if (std.mem.eql(u8, header, "remap")) return .free_form;
-    if (std.mem.eql(u8, header, "gyro")) return .gyro_config;
-    if (std.mem.eql(u8, header, "stick")) return .stick_pair_config;
-    if (std.mem.eql(u8, header, "stick.left") or std.mem.eql(u8, header, "stick.right")) return .stick_config;
-    if (std.mem.eql(u8, header, "dpad")) return .dpad_config;
-    if (std.mem.eql(u8, header, "adaptive_trigger")) return .adaptive_trigger_config;
+    if (std.mem.eql(u8, header, "remap")) return null; // free-form HashMap
+    if (std.mem.eql(u8, header, "gyro")) return sf(GyroConfig);
+    if (std.mem.eql(u8, header, "stick")) return sf(StickPairConfig);
+    if (std.mem.eql(u8, header, "stick.left") or std.mem.eql(u8, header, "stick.right")) return sf(StickConfig);
+    if (std.mem.eql(u8, header, "dpad")) return sf(DpadConfig);
+    if (std.mem.eql(u8, header, "adaptive_trigger")) return sf(AdaptiveTriggerConfig);
     if (std.mem.eql(u8, header, "adaptive_trigger.left") or
-        std.mem.eql(u8, header, "adaptive_trigger.right")) return .adaptive_trigger_param_config;
+        std.mem.eql(u8, header, "adaptive_trigger.right")) return sf(AdaptiveTriggerParamConfig);
 
-    if (std.mem.eql(u8, header, "layer")) return .layer_config;
-    if (std.mem.eql(u8, header, "layer.remap")) return .free_form;
-    if (std.mem.eql(u8, header, "layer.gyro")) return .gyro_config;
+    if (std.mem.eql(u8, header, "layer")) return sf(LayerConfig);
+    if (std.mem.eql(u8, header, "layer.remap")) return null; // free-form HashMap
+    if (std.mem.eql(u8, header, "layer.gyro")) return sf(GyroConfig);
     if (std.mem.eql(u8, header, "layer.stick_left") or
-        std.mem.eql(u8, header, "layer.stick_right")) return .stick_config;
-    if (std.mem.eql(u8, header, "layer.dpad")) return .dpad_config;
-    if (std.mem.eql(u8, header, "layer.adaptive_trigger")) return .adaptive_trigger_config;
+        std.mem.eql(u8, header, "layer.stick_right")) return sf(StickConfig);
+    if (std.mem.eql(u8, header, "layer.dpad")) return sf(DpadConfig);
+    if (std.mem.eql(u8, header, "layer.adaptive_trigger")) return sf(AdaptiveTriggerConfig);
     if (std.mem.eql(u8, header, "layer.adaptive_trigger.left") or
-        std.mem.eql(u8, header, "layer.adaptive_trigger.right")) return .adaptive_trigger_param_config;
+        std.mem.eql(u8, header, "layer.adaptive_trigger.right")) return sf(AdaptiveTriggerParamConfig);
 
-    if (std.mem.eql(u8, header, "macro")) return .macro_config;
+    if (std.mem.eql(u8, header, "macro")) return sf(Macro);
 
-    return .unknown;
+    return null; // unrecognised header — skip (do not punish forward-compat sections)
 }
 
-// Find the first occurrence of `c` in `s` outside of double-quoted spans.
-fn indexOfUnquoted(s: []const u8, c: u8) ?usize {
-    var in_str = false;
-    var i: usize = 0;
-    while (i < s.len) : (i += 1) {
-        const ch = s[i];
-        if (ch == '\\' and i + 1 < s.len and in_str) {
-            i += 1;
-            continue;
-        }
-        if (ch == '"') {
-            in_str = !in_str;
-            continue;
-        }
-        if (!in_str and ch == c) return i;
-    }
-    return null;
-}
-
-fn trimWhitespace(s: []const u8) []const u8 {
-    return std.mem.trim(u8, s, " \t\r\n");
-}
-
-fn isValidBareKey(key: []const u8) bool {
-    if (key.len == 0) return false;
-    for (key) |c| {
-        const ok = (c >= 'A' and c <= 'Z') or
-            (c >= 'a' and c <= 'z') or
-            (c >= '0' and c <= '9') or
-            c == '_' or c == '-';
-        if (!ok) return false;
-    }
-    return true;
-}
-
-// Increase / decrease bracket depth for chars on a line, respecting
-// quoted spans. Returns net depth delta.
-fn bracketDelta(s: []const u8) i32 {
-    var depth: i32 = 0;
-    var in_str = false;
-    var i: usize = 0;
-    while (i < s.len) : (i += 1) {
-        const ch = s[i];
-        if (ch == '\\' and i + 1 < s.len and in_str) {
-            i += 1;
-            continue;
-        }
-        if (ch == '"') {
-            in_str = !in_str;
-            continue;
-        }
-        if (in_str) continue;
-        if (ch == '#') break; // comment to end-of-line
-        switch (ch) {
-            '[', '{' => depth += 1,
-            ']', '}' => depth -= 1,
-            else => {},
-        }
-    }
-    return depth;
-}
-
-fn keyIsKnown(allowlist: []const []const u8, key: []const u8) bool {
-    for (allowlist) |name| {
-        if (std.mem.eql(u8, name, key)) return true;
-    }
-    return false;
-}
-
-/// Walk raw TOML text and collect findings for keys that do not match the
-/// schema of the enclosing table. Caller owns the returned ArrayList.
-///
-/// This is intentionally a lightweight line-based scan — it does NOT replace
-/// the TOML parser. Multi-line values (arrays, inline tables spanning lines)
-/// are skipped while bracket depth is non-zero, so keys nested inside arrays
-/// of inline tables (e.g. macro `steps = [{ tap = "B" }, ...]`) are not
-/// mis-classified as top-level keys.
 pub fn lintUnknownFields(allocator: std.mem.Allocator, raw_toml: []const u8) !std.ArrayList(LintFinding) {
-    var findings: std.ArrayList(LintFinding) = .empty;
-    errdefer findings.deinit(allocator);
-
-    var current_header: []const u8 = "";
-    var depth: i32 = 0;
-    var line_no: usize = 0;
-
-    var it = std.mem.splitScalar(u8, raw_toml, '\n');
-    while (it.next()) |raw_line| {
-        line_no += 1;
-
-        // Strip a trailing comment but only when not inside an open bracket /
-        // quoted span — the cheap path is fine for our purposes.
-        const trimmed_full = trimWhitespace(raw_line);
-        if (trimmed_full.len == 0) continue;
-        if (trimmed_full[0] == '#') continue;
-
-        // If currently inside a multi-line value, just track depth.
-        if (depth > 0) {
-            depth += bracketDelta(raw_line);
-            if (depth < 0) depth = 0;
-            continue;
-        }
-
-        // Section header: [foo] or [[foo]]
-        if (trimmed_full[0] == '[') {
-            if (std.mem.startsWith(u8, trimmed_full, "[[")) {
-                const end = std.mem.indexOf(u8, trimmed_full, "]]") orelse continue;
-                current_header = trimWhitespace(trimmed_full[2..end]);
-            } else {
-                const end = std.mem.indexOfScalar(u8, trimmed_full, ']') orelse continue;
-                current_header = trimWhitespace(trimmed_full[1..end]);
-            }
-            continue;
-        }
-
-        // Otherwise: candidate `key = value` line.
-        const eq_idx = indexOfUnquoted(trimmed_full, '=') orelse continue;
-        const key_raw = trimWhitespace(trimmed_full[0..eq_idx]);
-        const value_raw = if (eq_idx + 1 < trimmed_full.len) trimmed_full[eq_idx + 1 ..] else "";
-
-        // Bare keys only — quoted/dotted keys are uncommon in our schema and
-        // safer to skip than to mis-flag.
-        if (!isValidBareKey(key_raw)) {
-            depth += bracketDelta(value_raw);
-            if (depth < 0) depth = 0;
-            continue;
-        }
-
-        const kind = classifyTable(current_header);
-        if (allowlistFor(kind)) |allow| {
-            if (!keyIsKnown(allow, key_raw)) {
-                try findings.append(allocator, .{
-                    .line = line_no,
-                    .table = current_header,
-                    .unknown_key = key_raw,
-                });
-            }
-        }
-
-        depth += bracketDelta(value_raw);
-        if (depth < 0) depth = 0;
-    }
-
-    return findings;
+    return toml_lint.lint(allocator, raw_toml, allowlistFor);
 }
 
 fn warnLintFindings(findings: []const LintFinding) void {
-    for (findings) |f| {
-        if (f.table.len == 0) {
-            std.log.warn("config: unknown key '{s}' at top-level (line {d}) — typo or misplaced field?", .{ f.unknown_key, f.line });
-        } else {
-            std.log.warn("config: unknown key '{s}' inside [{s}] (line {d}) — typo or misplaced field?", .{ f.unknown_key, f.table, f.line });
-        }
-    }
+    toml_lint.warnFindings(findings);
 }
 
 // --- remap key/target pre-flight findings (runtime path unchanged) ---

--- a/src/config/toml_lint.zig
+++ b/src/config/toml_lint.zig
@@ -1,0 +1,178 @@
+const std = @import("std");
+
+// Shared unknown-field linter for TOML configs.
+//
+// The underlying TOML library (sam701/zig-toml) silently ignores unknown
+// fields by design (forward-compat). For our schemas that is the wrong
+// tradeoff — a typo'd key (e.g. `ofset` for `offset`) parses cleanly and is
+// silently dropped, leaving the author no diagnostic. This walks the raw TOML
+// text and reports any key that does not belong to the schema of its enclosing
+// table.
+//
+// This is a lightweight line-based scan, NOT a second TOML parser. Multi-line
+// values (arrays, inline tables spanning lines) are skipped while bracket depth
+// is non-zero, so keys nested inside arrays of inline tables are not
+// mis-classified as table keys.
+
+pub const LintFinding = struct {
+    line: usize, // 1-based line number
+    table: []const u8, // table path or "" for top-level; borrowed from input
+    unknown_key: []const u8, // borrowed from input
+};
+
+// Maps a table header to its allowed key set. Return null to skip linting the
+// table (free-form HashMap sections and unrecognised forward-compat headers).
+pub const Classifier = *const fn (header: []const u8) ?[]const []const u8;
+
+pub fn structFieldNames(comptime T: type) []const []const u8 {
+    const fields = @typeInfo(T).@"struct".fields;
+    comptime var names: [fields.len][]const u8 = undefined;
+    inline for (fields, 0..) |f, i| names[i] = f.name;
+    const final = names;
+    return &final;
+}
+
+fn keyIsKnown(allowlist: []const []const u8, key: []const u8) bool {
+    for (allowlist) |name| {
+        if (std.mem.eql(u8, name, key)) return true;
+    }
+    return false;
+}
+
+fn trimWhitespace(s: []const u8) []const u8 {
+    return std.mem.trim(u8, s, " \t\r\n");
+}
+
+fn isValidBareKey(key: []const u8) bool {
+    if (key.len == 0) return false;
+    for (key) |c| {
+        const ok = (c >= 'A' and c <= 'Z') or
+            (c >= 'a' and c <= 'z') or
+            (c >= '0' and c <= '9') or
+            c == '_' or c == '-';
+        if (!ok) return false;
+    }
+    return true;
+}
+
+// First occurrence of `c` in `s` outside double-quoted spans.
+fn indexOfUnquoted(s: []const u8, c: u8) ?usize {
+    var in_str = false;
+    var i: usize = 0;
+    while (i < s.len) : (i += 1) {
+        const ch = s[i];
+        if (ch == '\\' and i + 1 < s.len and in_str) {
+            i += 1;
+            continue;
+        }
+        if (ch == '"') {
+            in_str = !in_str;
+            continue;
+        }
+        if (!in_str and ch == c) return i;
+    }
+    return null;
+}
+
+// Net bracket-depth delta for a line, respecting quoted spans and comments.
+fn bracketDelta(s: []const u8) i32 {
+    var depth: i32 = 0;
+    var in_str = false;
+    var i: usize = 0;
+    while (i < s.len) : (i += 1) {
+        const ch = s[i];
+        if (ch == '\\' and i + 1 < s.len and in_str) {
+            i += 1;
+            continue;
+        }
+        if (ch == '"') {
+            in_str = !in_str;
+            continue;
+        }
+        if (in_str) continue;
+        if (ch == '#') break;
+        switch (ch) {
+            '[', '{' => depth += 1,
+            ']', '}' => depth -= 1,
+            else => {},
+        }
+    }
+    return depth;
+}
+
+/// Walk raw TOML text and collect findings for keys that do not match the
+/// schema of the enclosing table, as resolved by `classify`. Caller owns the
+/// returned ArrayList.
+pub fn lint(
+    allocator: std.mem.Allocator,
+    raw_toml: []const u8,
+    classify: Classifier,
+) !std.ArrayList(LintFinding) {
+    var findings: std.ArrayList(LintFinding) = .empty;
+    errdefer findings.deinit(allocator);
+
+    var current_header: []const u8 = "";
+    var depth: i32 = 0;
+    var line_no: usize = 0;
+
+    var it = std.mem.splitScalar(u8, raw_toml, '\n');
+    while (it.next()) |raw_line| {
+        line_no += 1;
+
+        const trimmed_full = trimWhitespace(raw_line);
+        if (trimmed_full.len == 0) continue;
+        if (trimmed_full[0] == '#') continue;
+
+        if (depth > 0) {
+            depth += bracketDelta(raw_line);
+            if (depth < 0) depth = 0;
+            continue;
+        }
+
+        if (trimmed_full[0] == '[') {
+            if (std.mem.startsWith(u8, trimmed_full, "[[")) {
+                const end = std.mem.indexOf(u8, trimmed_full, "]]") orelse continue;
+                current_header = trimWhitespace(trimmed_full[2..end]);
+            } else {
+                const end = std.mem.indexOfScalar(u8, trimmed_full, ']') orelse continue;
+                current_header = trimWhitespace(trimmed_full[1..end]);
+            }
+            continue;
+        }
+
+        const eq_idx = indexOfUnquoted(trimmed_full, '=') orelse continue;
+        const key_raw = trimWhitespace(trimmed_full[0..eq_idx]);
+        const value_raw = if (eq_idx + 1 < trimmed_full.len) trimmed_full[eq_idx + 1 ..] else "";
+
+        if (!isValidBareKey(key_raw)) {
+            depth += bracketDelta(value_raw);
+            if (depth < 0) depth = 0;
+            continue;
+        }
+
+        if (classify(current_header)) |allow| {
+            if (!keyIsKnown(allow, key_raw)) {
+                try findings.append(allocator, .{
+                    .line = line_no,
+                    .table = current_header,
+                    .unknown_key = key_raw,
+                });
+            }
+        }
+
+        depth += bracketDelta(value_raw);
+        if (depth < 0) depth = 0;
+    }
+
+    return findings;
+}
+
+pub fn warnFindings(findings: []const LintFinding) void {
+    for (findings) |f| {
+        if (f.table.len == 0) {
+            std.log.warn("config: unknown key '{s}' at top-level (line {d}) — typo or misplaced field?", .{ f.unknown_key, f.line });
+        } else {
+            std.log.warn("config: unknown key '{s}' inside [{s}] (line {d}) — typo or misplaced field?", .{ f.unknown_key, f.table, f.line });
+        }
+    }
+}

--- a/src/tools/validate.zig
+++ b/src/tools/validate.zig
@@ -60,6 +60,16 @@ fn validateExtended(
     errors: *std.ArrayList(ValidationError),
     allocator: std.mem.Allocator,
 ) !void {
+    const libusb = device.usesLibusb(cfg);
+    for (cfg.report) |report| {
+        // report.size must fit a read buffer or every report is silently dropped.
+        if (report.size < 0 or report.size > device.MAX_REPORT_SIZE) {
+            try addError(errors, allocator, file, "report '{s}': size {d} exceeds max readable report size {d} bytes — reports this large are never delivered", .{ report.name, report.size, device.MAX_REPORT_SIZE });
+        } else if (libusb and report.size > device.LIBUSB_SLOT_SIZE) {
+            try addError(errors, allocator, file, "report '{s}': size {d} exceeds the {d}-byte libusb read slot — vendor/suppress transports truncate reads to {d} bytes", .{ report.name, report.size, device.LIBUSB_SLOT_SIZE, device.LIBUSB_SLOT_SIZE });
+        }
+    }
+
     for (cfg.report) |report| {
         // Pass 5: button_group bit_index < 8 * group_size
         if (report.button_group) |bg| {
@@ -125,6 +135,25 @@ fn validateExtended(
     }
 }
 
+// Pass 9: unknown keys in known device tables — typo'd keys parse cleanly but
+// are silently dropped, so surface them as diagnostics.
+fn lintDeviceFields(
+    content: []const u8,
+    file: []const u8,
+    errors: *std.ArrayList(ValidationError),
+    allocator: std.mem.Allocator,
+) !void {
+    var findings = device.lintUnknownFields(allocator, content) catch return;
+    defer findings.deinit(allocator);
+    for (findings.items) |f| {
+        if (f.table.len == 0) {
+            try addError(errors, allocator, file, "unknown key '{s}' at top-level (line {d}) — typo or misplaced field?", .{ f.unknown_key, f.line });
+        } else {
+            try addError(errors, allocator, file, "unknown key '{s}' inside [{s}] (line {d}) — typo or misplaced field?", .{ f.unknown_key, f.table, f.line });
+        }
+    }
+}
+
 /// Validate a single TOML file. Auto-detects device vs mapping schema by
 /// scanning for a `[device]` header. Returns a slice of errors (caller owns,
 /// call freeErrors). Exit semantics: 0 errors = valid, >0 = invalid.
@@ -160,6 +189,7 @@ pub fn validateFile(
             };
             defer parsed.deinit();
             try validateExtended(&parsed.value, path, &errors, allocator);
+            try lintDeviceFields(content, path, &errors, allocator);
             if (errors.items.len == 0) {
                 device.validate(&parsed.value) catch |err| {
                     const msg = try std.fmt.allocPrint(allocator, "schema error: {}", .{err});
@@ -445,6 +475,88 @@ test "validate: undeclared interface in report: error reported" {
     var found = false;
     for (errors) |e| {
         if (std.mem.indexOf(u8, e.message, "interface 99") != null) found = true;
+    }
+    try testing.expect(found);
+}
+
+test "validate: report.size over 512-byte cap: actionable error reported" {
+    const allocator = testing.allocator;
+    const bad =
+        \\[device]
+        \\name = "T"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 600
+        \\[output]
+        \\name = "T"
+    ;
+    const errors = try validateString(allocator, bad);
+    defer freeErrors(errors, allocator);
+    try testing.expect(errors.len > 0);
+    var found = false;
+    for (errors) |e| {
+        if (std.mem.indexOf(u8, e.message, "exceeds max readable report size 512") != null) found = true;
+    }
+    try testing.expect(found);
+}
+
+test "validate: report.size over libusb 64-byte slot on vendor transport: note reported" {
+    const allocator = testing.allocator;
+    const bad =
+        \\[device]
+        \\name = "T"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "vendor"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 128
+        \\[output]
+        \\name = "T"
+    ;
+    const errors = try validateString(allocator, bad);
+    defer freeErrors(errors, allocator);
+    var found = false;
+    for (errors) |e| {
+        if (std.mem.indexOf(u8, e.message, "libusb read slot") != null) found = true;
+    }
+    try testing.expect(found);
+}
+
+test "validate: device config with unknown key reports actionable error" {
+    const allocator = testing.allocator;
+    const bad =
+        \\[device]
+        \\name = "T"
+        \\vid = 1
+        \\pid = 2
+        \\siz = 8
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 8
+        \\[output]
+        \\name = "T"
+    ;
+    const errors = try validateString(allocator, bad);
+    defer freeErrors(errors, allocator);
+    try testing.expect(errors.len > 0);
+    var found = false;
+    for (errors) |e| {
+        if (std.mem.indexOf(u8, e.message, "unknown key 'siz'") != null and
+            std.mem.indexOf(u8, e.message, "[device]") != null) found = true;
     }
     try testing.expect(found);
 }


### PR DESCRIPTION
## What changed

**Change 1 — bound `report.size`**
- `device.validate()` now rejects any `report.size` outside `0..512` with `error.ReportSizeTooLarge`. The hidraw read buffer is `[512]u8` (`src/event_loop.zig:509`, used by `dev.read(&buf)` at `:724`); the libusb ring slot is `SLOT_SIZE = 64` (`src/io/usbraw.zig:34`). A report larger than the buffer is silently dropped by the interpreter guard `raw.len < cr.src.size` (`src/core/interpreter.zig:467`), so an author previously got zero diagnostics.
- The `padctl --validate` CLI emits an actionable message naming the report and the 512-byte limit, plus a note when a vendor/suppress (libusb) device declares a report over the 64-byte read slot.

**Change 2 — unknown-field linter for device configs**
- The TOML lib (sam701/zig-toml) silently drops unknown keys, so a typo'd device key (e.g. `ofset`/`siz`) parsed cleanly and was dropped with no warning. `devices/*.toml` is the primary contribution surface and now gets the same protection user mappings have had since #163/#170.
- Extracted the mapping linter's generic text-walk into a shared `src/config/toml_lint.zig` (classifier-driven). `mapping.zig` now reuses it (net ~210 fewer lines there) and `device.zig` supplies its own device-schema classifier covering `[device]`, `[device.init]`, `[[device.interface]]`, `[[report]]`, `[report.match]`, `[report.button_group]`, `[report.checksum]`, `[output]` + sub-tables, `[commands.*]` (+`.checksum`), and `[wasm]`/`[wasm.overrides]`. Free-form HashMap sections (`report.fields`, `output.axes/buttons/mapping`, button maps) are skipped.
- Warnings are emitted on the daemon/CLI parse path and surfaced as actionable diagnostics in `padctl --validate`.
- Dropped the dead `calibration_reports` key from `devices/sony/dualsense.toml`: it was not in `WasmConfig`, so the parser silently ignored it, and the WASM plugin hardcodes feature report `0x05` in C (`plugins/sony_imu_calibration.c`). The linter flagged it as the first real catch.

## Test plan
- `device.zig`: `report.size = 512` passes; `513` and `4096` rejected with `error.ReportSizeTooLarge`. Unknown key in `[device]` / `[[report]]` flagged; clean config and free-form sections not flagged; all shipped `devices/*.toml` lint clean.
- `validate.zig`: oversized `report.size` produces the "exceeds max readable report size 512" error; vendor transport over 64 bytes produces the "libusb read slot" note; unknown `[device]` key produces an "unknown key" error.
- Falsifiability verified: widening the cap turns the report.size tests red; neutering the classifier turns the unknown-field tests red.
- Full suite green in Docker (`ghcr.io/bananasjim/padctl-build:0.15.2`): 17/17 steps, 1820/1836 passed, 16 skipped.

Refs #163 #170