### PR TITLE
fix(install): modprobe at install + COPR userunit/version + deb prerm user-scope

### DIFF
--- a/contrib/copr/padctl.spec
+++ b/contrib/copr/padctl.spec
@@ -1,6 +1,6 @@
 # Version: update this field when cutting a new COPR release (not overwritten by release.yml).
 Name:           padctl
-Version:        0.1.0
+Version:        0.1.16
 Release:        1%{?dist}
 Summary:        HID gamepad remapper with declarative TOML config
 
@@ -44,7 +44,7 @@ systemd socket activation and udev integration.
 %{_bindir}/padctl-capture
 %{_bindir}/padctl-debug
 %{_bindir}/padctl-reconnect
-%{_unitdir}/padctl.service
+%{_userunitdir}/padctl.service
 %{_udevrulesdir}/60-padctl.rules
 %{_udevrulesdir}/61-padctl-driver-block.rules
 %{_udevrulesdir}/90-padctl.rules
@@ -52,15 +52,23 @@ systemd socket activation and udev integration.
 %{_datadir}/padctl/
 
 %post
-%systemd_post padctl.service
+%systemd_user_post padctl.service
+# modules-load.d only loads at next boot; load now so the daemon works first run.
+modprobe uhid uinput || true
 
 %preun
-%systemd_preun padctl.service
+%systemd_user_preun padctl.service
 
 %postun
-%systemd_postun_with_restart padctl.service
+%systemd_user_postun_with_restart padctl.service
 
 %changelog
+* Mon Jun 16 2026 padctl maintainers <maintainers@padctl.dev> - 0.1.16-1
+- Bump to 0.1.16
+- Fix %%files: padctl install writes the user unit to %%{_userunitdir}, not %%{_unitdir}
+- Use systemd user-scope scriptlet macros to match the user unit
+- modprobe uhid uinput in %%post so the daemon works before the next boot
+
 * Fri Apr 04 2026 padctl maintainers <maintainers@padctl.dev> - 0.1.0-1
 - Fix ExclusiveArch (was incorrectly BuildArch)
 - Update udev rules: 99-padctl.rules -> 60-padctl.rules + 61-padctl-driver-block.rules

--- a/contrib/deb/DEBIAN-BIN/postinst
+++ b/contrib/deb/DEBIAN-BIN/postinst
@@ -5,3 +5,5 @@ if [ -d /run/systemd/system ]; then
 fi
 udevadm control --reload-rules 2>/dev/null || true
 udevadm trigger 2>/dev/null || true
+# modules-load.d only loads at next boot; load now so the daemon works first run.
+modprobe uhid uinput 2>/dev/null || true

--- a/contrib/deb/DEBIAN-BIN/prerm
+++ b/contrib/deb/DEBIAN-BIN/prerm
@@ -2,9 +2,14 @@
 set -e
 if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then
     if [ -d /run/systemd/system ]; then
-        # padctl-resume.service was removed in issue #131 Problem B fix;
-        # still attempt stop/disable to clean up upgrades from v0.1.2.
-        systemctl stop padctl.service padctl-resume.service 2>/dev/null || true
-        systemctl disable padctl.service padctl-resume.service 2>/dev/null || true
+        # padctl ships a user unit to /usr/lib/systemd/user, so a system-scope
+        # `systemctl stop/disable` is a no-op. --global disable clears any
+        # system-global enablement without needing a session bus; a per-user
+        # `systemctl --user enable` symlink in $HOME is untouched (the user
+        # should disable/stop their own instance, see below).
+        systemctl --global disable padctl.service padctl-resume.service 2>/dev/null || true
+        # A user instance running right now lives on a per-user session bus a
+        # maintainer script cannot reliably reach. Stop it yourself if it is
+        # still running:  systemctl --user stop padctl.service
     fi
 fi

--- a/src/cli/install/phase.zig
+++ b/src/cli/install/phase.zig
@@ -170,6 +170,7 @@ pub fn run(allocator: std.mem.Allocator, opts: InstallOptions) !void {
         runCmd(&.{ "udevadm", "control", "--reload-rules" });
         runCmd(&.{ "udevadm", "trigger" });
         udev.applyDriverState(allocator, &plan, device_entries.items);
+        udev.loadModules(&plan);
     }
     var start_outcome = services.StartOutcome{};
     if (plan.do_enable_systemctl) {

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -63,6 +63,7 @@ const generateDriverBlockRules = _udev.generateDriverBlockRules;
 const generateDriverBlockRulesFromEntries = _udev.generateDriverBlockRulesFromEntries;
 const daemon_socket_guard = udev_mod.daemon_socket_guard;
 const shouldProactiveUnbind = udev_mod.shouldProactiveUnbind;
+const shouldLoadModules = udev_mod.shouldLoadModules;
 
 // migration.zig
 const ensureUserXdgDirs = migration_mod.ensureUserXdgDirs;
@@ -2060,6 +2061,42 @@ test "install: #137 shouldProactiveUnbind truth table" {
         const plan = try InstallPlan.compute(testing.allocator, c.opts, c.env);
         defer plan.deinit(testing.allocator);
         try testing.expectEqual(c.want, shouldProactiveUnbind(&plan));
+    }
+}
+
+// FAILS if loadModules is not gated to live-root installs. Staging mode and
+// non-root installs must never modprobe (no live kernel / would fail).
+test "install: shouldLoadModules only on live root install" {
+    const testing = std.testing;
+    const Case = struct {
+        opts: InstallOptions,
+        env: EnvSnapshot,
+        want: bool,
+    };
+    const cases = [_]Case{
+        // live root install → true
+        .{
+            .opts = .{ .prefix = "/usr" },
+            .env = .{ .uid = 0, .home = "/root", .sudo_user = null, .sudo_uid = null },
+            .want = true,
+        },
+        // staged package build (destdir set) → false even as root
+        .{
+            .opts = .{ .destdir = "/tmp/stage-modprobe" },
+            .env = .{ .uid = 0, .home = "/root", .sudo_user = null, .sudo_uid = null },
+            .want = false,
+        },
+        // unprivileged user install → false
+        .{
+            .opts = .{ .prefix = "/home/a/.local" },
+            .env = .{ .uid = 1000, .home = "/home/a", .sudo_user = null, .sudo_uid = null },
+            .want = false,
+        },
+    };
+    for (cases) |c| {
+        const plan = try InstallPlan.compute(testing.allocator, c.opts, c.env);
+        defer plan.deinit(testing.allocator);
+        try testing.expectEqual(c.want, shouldLoadModules(&plan));
     }
 }
 

--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -241,6 +241,24 @@ pub fn installUdevRules(allocator: std.mem.Allocator, plan: *const InstallPlan, 
     };
 }
 
+/// Modules are loaded only on a live root install — never in staging/package
+/// mode (no live kernel to act on) and never unprivileged (modprobe would
+/// fail). Pure predicate so tests can table-drive it. Same gate as
+/// applyDriverState.
+pub fn shouldLoadModules(plan: *const InstallPlan) bool {
+    return !plan.staging_mode and plan.is_root;
+}
+
+/// Best-effort load of the kernel modules padctl needs at runtime (uhid,
+/// uinput). modules-load.d only fires at the next boot, so a first live
+/// `padctl install` on a host where these are not yet resident would otherwise
+/// crash-loop the daemon until reboot. modprobe failure (absent binary,
+/// builtin module) is ignored by runCmd — it must never fail the install.
+pub fn loadModules(plan: *const InstallPlan) void {
+    if (!shouldLoadModules(plan)) return;
+    runCmd(&.{ "modprobe", "uhid", "uinput" });
+}
+
 /// Mutate live kernel driver state to match the freshly written udev rules.
 /// MUST be called AFTER `udevadm control --reload-rules`: re-probe generates
 /// bind uevents that udevd evaluates against its currently loaded ruleset, so a


### PR DESCRIPTION
Three install/packaging robustness fixes so first-run works across all channels (Bazzite/SteamOS/Arch/Fedora/Debian).

## Changes

### 1. Best-effort `modprobe uhid uinput` at install time
`modules-load.d` only loads modules at the next boot, so a first `sudo padctl install` on a host where `uhid`/`uinput` are not resident crash-loops the daemon until reboot.
- `src/cli/install/udev.zig`: new `loadModules()` + pure `shouldLoadModules()` predicate, gated identically to `applyDriverState` (live root install only; skipped in staging/package mode and when non-root). `runCmd` ignores exit status, so an absent/unprivileged/builtin modprobe never fails the install.
- `src/cli/install/phase.zig`: call `loadModules()` right after `applyDriverState`, inside the existing live-path block.
- `contrib/deb/DEBIAN-BIN/postinst` and `contrib/copr/padctl.spec %post`: `modprobe uhid uinput || true` so package installs (which never run `padctl install`) also load the modules first run.
- Unblocks: all channels on hosts where uhid/uinput are modules and not yet loaded.

### 2. Fix the COPR spec (`contrib/copr/padctl.spec`)
- `%files` listed `%{_unitdir}/padctl.service` (system, /usr/lib/systemd/system) but `padctl install` writes the USER unit to `/usr/lib/systemd/user` (`resolveServiceDir`, plan.zig:65, when prefix=/usr). The listed file is empty -> `rpmbuild %files` error -> the whole Fedora/Bazzite-rpm channel is broken. Changed to `%{_userunitdir}/padctl.service`.
- Switched scriptlets to user-scope macros (`%systemd_user_post`/`_preun`/`_postun_with_restart`) to match the user unit; the system-scope variants operated on the wrong scope.
- Bumped `Version:` 0.1.0 -> 0.1.16 to match `build.zig.zon` (SSOT).
- Unblocks: Fedora/Bazzite-rpm install (previously a build failure).

### 3. deb prerm must address the USER unit (`contrib/deb/DEBIAN-BIN/prerm`)
The unit ships to `/usr/lib/systemd/user` (release.yml:232), but prerm ran system-scope `systemctl stop/disable padctl.service` -- a no-op for a user unit, so `apt remove` never stopped the running --user daemon.
- Dropped the misleading system-scope no-op; use `systemctl --global disable` (root-runnable, removes user-scope enablement for all users without a session bus) plus a clear note that a currently-running per-user instance must be stopped by the user (a maintainer script cannot reach each user's session bus).
- Unblocks: clean Debian/Ubuntu removal.

## Test / verification
- `zig build test` (Docker `padctl-build:0.15.2`): green -- `17/17 steps succeeded; 1828/1839 tests passed; 11 skipped`. Added `shouldLoadModules` truth-table test (live-root true; staging false; non-root false).
- **CI-verified**: the deb changes are exercised by `install-flow.yml` (rootless-docker sandbox) and the `pkg / deb structure invariants` checks on this PR.
- **Inspection-only**: COPR has no CI (rpmbuild is not run anywhere); the `%files`/Version/scriptlet changes are verified against the real install layout (`resolveServiceDir` plan.zig:65 -> `/usr/lib/systemd/user` = `%{_userunitdir}` when prefix=/usr).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kernel modules (uhid and uinput) are now automatically loaded during installation and post-install, enabling the daemon to function properly on first use without requiring a system reboot.

* **Bug Fixes**
  * Fixed systemd user unit installation paths and improved handling for user-scope versus system-scope installations to ensure correct behavior across different deployment scenarios.

* **Chores**
  * Package version updated to 0.1.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->