### PR TITLE
feat(cli): complete the device-authoring loop UX (capture discoverability + config-test perm hint)

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -216,6 +216,24 @@ Exit 0 = valid. Exit 1 = validation errors printed to stderr. Exit 2 = file not 
 
 The flag is repeatable: `padctl --validate a.toml --validate b.toml` validates both files and exits with the worst code seen.
 
+## Adding a new device
+
+padctl 的目标是「新设备 = 一个 `.toml`，零代码」。当 `padctl scan` 显示某个设备
+unmatched（没有匹配的 device config）时，用 `padctl-capture` 录制它的 HID 报文并
+生成一个起始 TOML 骨架：
+
+```sh
+padctl-capture --vid 0xVVVV --pid 0xPPPP --output mypad.toml
+```
+
+`padctl-capture` 会提示后续步骤。完整流程：
+
+1. **Capture** — 运行上面的命令录制报文，得到 `mypad.toml` 骨架。
+2. **Refine** — 检查并调整 `[report]` 字段的 offset / type，使按键和摇杆映射正确。
+3. **Install** — 放到用户配置目录：`mkdir -p ~/.config/padctl/devices && cp mypad.toml ~/.config/padctl/devices/`
+4. **Validate** — `padctl --validate ~/.config/padctl/devices/mypad.toml`
+5. **Test decode** — `padctl config test` 实时预览解码出的具名按键/摇杆事件，确认字段正确。
+
 ## Generate Device Docs
 
 ```sh

--- a/src/cli/config/test.zig
+++ b/src/cli/config/test.zig
@@ -7,6 +7,7 @@ const device_mod = @import("../../config/device.zig");
 const mapping_mod = @import("../../config/mapping.zig");
 const paths = @import("../../config/paths.zig");
 const scan_mod = @import("../scan.zig");
+const perm_hint = @import("../perm_hint.zig");
 const interpreter_mod = @import("../../core/interpreter.zig");
 const state_mod = @import("../../core/state.zig");
 
@@ -29,12 +30,15 @@ const OpenedDevice = struct {
     iface: ?u8,
 };
 
-fn openHidrawByVidPid(vid: u16, pid: u16) !OpenedDevice {
+fn openHidrawByVidPid(vid: u16, pid: u16, denied: *bool) !OpenedDevice {
     var i: u8 = 0;
     while (i < MAX_HIDRAW) : (i += 1) {
         var path_buf: [32]u8 = undefined;
         const path = std.fmt.bufPrint(&path_buf, "/dev/hidraw{d}", .{i}) catch continue;
-        const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch continue;
+        const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch |err| {
+            if (err == error.AccessDenied) denied.* = true;
+            continue;
+        };
 
         var info: ioctl.HidrawDevinfo = undefined;
         if (linux.ioctl(fd, ioctl.HIDIOCGRAWINFO, @intFromPtr(&info)) != 0) {
@@ -55,13 +59,17 @@ fn openAutoResolved(
     allocator: std.mem.Allocator,
     dirs: []const []const u8,
     out_config: *?[]const u8,
+    denied: *bool,
 ) !OpenedDevice {
     var fallback: ?OpenedDevice = null;
     var i: u8 = 0;
     while (i < MAX_HIDRAW) : (i += 1) {
         var path_buf: [32]u8 = undefined;
         const path = std.fmt.bufPrint(&path_buf, "/dev/hidraw{d}", .{i}) catch continue;
-        const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch continue;
+        const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch |err| {
+            if (err == error.AccessDenied) denied.* = true;
+            continue;
+        };
 
         var info: ioctl.HidrawDevinfo = undefined;
         if (linux.ioctl(fd, ioctl.HIDIOCGRAWINFO, @intFromPtr(&info)) != 0) {
@@ -164,6 +172,19 @@ fn resolveMappingNameInDirs(allocator: std.mem.Allocator, name: []const u8, dirs
     return paths.findConfig(allocator, filename, dirs);
 }
 
+/// Report why no hidraw node could be opened. When every candidate node was
+/// permission-denied, the user is not missing a device — they lack `input`
+/// group access, so route to the shared remedy instead of "no device found".
+fn reportNoDevice(writer: anytype, denied: bool) void {
+    if (denied) {
+        writer.writeAll("error: a hidraw node was permission-denied.\n") catch {};
+        perm_hint.writeInputGroupHint(writer);
+    } else {
+        writer.writeAll("error: no hidraw device found.\n") catch {};
+        writer.writeAll("hint: connect a supported controller, then run `padctl scan`.\n") catch {};
+    }
+}
+
 pub fn run(
     allocator: std.mem.Allocator,
     config_path: ?[]const u8,
@@ -205,8 +226,10 @@ pub fn run(
         parsed_device = parsed;
         const vid = std.math.cast(u16, parsed.value.device.vid) orelse return error.MalformedConfig;
         const pid = std.math.cast(u16, parsed.value.device.pid) orelse return error.MalformedConfig;
-        opened = openHidrawByVidPid(vid, pid) catch |e| {
-            std.log.err("no hidraw device matching {x:0>4}:{x:0>4}: {}", .{ vid, pid, e });
+        var denied = false;
+        opened = openHidrawByVidPid(vid, pid, &denied) catch |e| {
+            writer.print("error: no hidraw device matching {x:0>4}:{x:0>4}.\n", .{ vid, pid }) catch {};
+            if (denied) perm_hint.writeInputGroupHint(writer);
             return e;
         };
     } else {
@@ -219,8 +242,9 @@ pub fn run(
         } else |e| {
             std.log.warn("failed to resolve device config dirs: {}", .{e});
         }
-        opened = openAutoResolved(allocator, dirs, &auto_path) catch |e| {
-            std.log.warn("no hidraw device available: {}", .{e});
+        var denied = false;
+        opened = openAutoResolved(allocator, dirs, &auto_path, &denied) catch |e| {
+            reportNoDevice(writer, denied);
             return e;
         };
         if (auto_path) |p| {
@@ -317,6 +341,24 @@ fn formatReport(w: anytype, report: []const u8, remap: ?mapping_mod.RemapMap) !v
 // --- tests ---
 
 const testing = std.testing;
+
+test "reportNoDevice: all-denied routes to the input-group hint" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    reportNoDevice(buf.writer(testing.allocator), true);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "permission-denied") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "usermod -aG input $USER") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "no hidraw device found") == null);
+}
+
+test "reportNoDevice: genuinely absent device does not show the group hint" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    reportNoDevice(buf.writer(testing.allocator), false);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "no hidraw device found") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "padctl scan") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "usermod") == null);
+}
 
 test "resolveMappingPath: slash arg is used as a literal path" {
     const allocator = testing.allocator;

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -4,6 +4,7 @@ const socket_client = @import("socket_client.zig");
 const udev = @import("install/udev.zig");
 const scan = @import("scan.zig");
 const toml_extract = @import("toml_extract.zig");
+const perm_hint = @import("perm_hint.zig");
 const paths = @import("../config/paths.zig");
 
 pub const StatusDevice = socket_client.StatusDevice;
@@ -479,7 +480,8 @@ pub fn printHidrawDiagnosis(writer: anytype, path: ?[]const u8, access_denied: b
     };
     if (access_denied) {
         try writer.print("  hidraw: {s} exists but permission denied (mode/owner; you are not in the input group)\n", .{p});
-        try writer.writeAll("  hint: sudo usermod -aG input $USER && re-login (or replug to apply udev rules)\n");
+        try writer.writeAll("  ");
+        perm_hint.writeInputGroupHint(writer);
     } else {
         try writer.print("  hidraw: {s}\n", .{p});
     }

--- a/src/cli/perm_hint.zig
+++ b/src/cli/perm_hint.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+
+/// hidraw nodes are root:input mode 0660; a user not in the `input` group (or
+/// before udev `uaccess` applies) gets EACCES on open. scan, doctor, and
+/// `config test` all hit this, so the remedy is shared here to stay identical.
+pub fn writeInputGroupHint(writer: anytype) void {
+    writer.writeAll("hint: sudo usermod -aG input $USER && re-login (or replug to apply udev rules)\n") catch {};
+}
+
+const testing = std.testing;
+
+test "perm_hint: writeInputGroupHint emits the usermod remedy" {
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(testing.allocator);
+    writeInputGroupHint(buf.writer(testing.allocator));
+    try testing.expect(std.mem.indexOf(u8, buf.items, "usermod -aG input $USER") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "re-login") != null);
+}

--- a/src/cli/scan.zig
+++ b/src/cli/scan.zig
@@ -6,6 +6,7 @@ const hidraw = @import("../io/hidraw.zig");
 const readPhysicalPath = hidraw.readPhysicalPath;
 const readInterfaceId = hidraw.readInterfaceId;
 const toml_extract = @import("toml_extract.zig");
+const perm_hint = @import("perm_hint.zig");
 const socket_client = @import("socket_client.zig");
 const StatusDevice = socket_client.StatusDevice;
 
@@ -538,17 +539,18 @@ pub fn render(writer: anytype, entries: []const ScanEntry, daemon_devices: []con
     }
     if (denied > 0) {
         try writer.print("\nwarning: permission denied opening {d} hidraw node(s)\n", .{denied});
-        try writer.writeAll("hint: sudo usermod -aG input $USER && re-login (or replug to apply udev rules)\n");
+        perm_hint.writeInputGroupHint(writer);
     }
 
     if (unmatched > 0) {
         try writer.writeByte('\n');
-        try writer.writeAll("To capture an unmatched device:\n");
+        try writer.writeAll("To capture an unmatched device (records HID reports and writes a starter devices/*.toml):\n");
         for (entries) |e| {
             if (e.config_path == null) {
-                try writer.print("  padctl-capture --vid 0x{x:0>4} --pid 0x{x:0>4}\n", .{ e.vid, e.pid });
+                try writer.print("  padctl-capture --vid 0x{x:0>4} --pid 0x{x:0>4} --output <name>.toml\n", .{ e.vid, e.pid });
             }
         }
+        try writer.writeAll("See docs/src/getting-started.md (\"Adding a new device\") for the full workflow.\n");
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -29,6 +29,7 @@ pub const cli = struct {
     pub const list_mappings = @import("cli/list_mappings.zig");
     pub const socket_client = @import("cli/socket_client.zig");
     pub const error_hint = @import("cli/error_hint.zig");
+    pub const perm_hint = @import("cli/perm_hint.zig");
     pub const switch_mapping = @import("cli/switch_mapping.zig");
     pub const status = @import("cli/status.zig");
     pub const doctor = @import("cli/doctor.zig");
@@ -729,6 +730,10 @@ pub const help_text =
     \\  --output <dir>      Output directory for --doc-gen (default: docs/src/devices)
     \\  --help, -h          Show this help
     \\  --version, -V       Show version
+    \\
+    \\Companion tools:
+    \\  padctl-capture        Record a device's HID reports and emit a starter devices/*.toml
+    \\                        (run `padctl-capture --help`; see "Adding a new device" in the docs)
     \\
 ;
 

--- a/src/test/cli_e2e_test.zig
+++ b/src/test/cli_e2e_test.zig
@@ -22,6 +22,10 @@ test "help: usage block lists doctor, config, and dump" {
     try testing.expect(std.mem.indexOf(u8, usage, "padctl dump") != null);
 }
 
+test "help: mentions the padctl-capture companion tool" {
+    try testing.expect(std.mem.indexOf(u8, main_mod.help_text, "padctl-capture") != null);
+}
+
 // --- 1. Install: directory structure paths ---
 
 test "install paths: bin under prefix" {

--- a/tools/padctl-capture.zig
+++ b/tools/padctl-capture.zig
@@ -74,6 +74,23 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
     return cli;
 }
 
+/// The skeleton is a starting point, not a finished config. Print the steps
+/// that close the device-authoring loop: where to install it, how to validate
+/// the TOML, and how to watch decoded input.
+fn printNextSteps(path: []const u8) void {
+    var buf: [512]u8 = undefined;
+    const msg = std.fmt.bufPrint(&buf,
+        \\
+        \\Next steps:
+        \\  1. Review the skeleton and refine the [report] field offsets/types.
+        \\  2. Install it:   mkdir -p ~/.config/padctl/devices && cp {s} ~/.config/padctl/devices/
+        \\  3. Validate it:  padctl --validate ~/.config/padctl/devices/{s}
+        \\  4. Watch input:  padctl config test   (decodes live reports into named events)
+        \\
+    , .{ path, std.fs.path.basename(path) }) catch return;
+    _ = posix.write(posix.STDERR_FILENO, msg) catch 0;
+}
+
 fn printHelp() void {
     const help =
         \\Usage: padctl-capture [options]
@@ -351,6 +368,7 @@ pub fn main() !void {
         try toml_gen.emitToml(result, dev_info, allocator, &bw.interface);
         try bw.interface.flush();
         std.log.info("Written to {s}", .{out_path});
+        printNextSteps(out_path);
     } else {
         const stdout = std.fs.File.stdout();
         var bw = stdout.writer(&out_buf);


### PR DESCRIPTION
## What changed

Three UX fixes that close padctl's P1 "new device = a .toml, zero code" authoring loop, so a user can go scan -> capture -> validate -> test without guessing.

1. **`config test` distinguishes AccessDenied from "no device".** When every `/dev/hidraw*` node is permission-denied, `config test` previously printed "no device found", sending users to check cables instead of group membership. The all-denied path now routes to the input-group remedy (`sudo usermod -aG input $USER` + relogin). The hint string is factored into a new shared `src/cli/perm_hint.zig` helper and reused by scan and doctor (byte-identical output, just de-duplicated).

2. **`padctl-capture` is discoverable.** `padctl --help` gains a "Companion tools" section listing `padctl-capture`. The `padctl scan` capture hint now describes what the tool does and points at the docs.

3. **`padctl-capture` prints next steps after writing a skeleton.** Instead of ending at "Written to <path>", it now prints where to install the file (`~/.config/padctl/devices/`), how to validate it (`padctl --validate <file>`), and how to test decode (`padctl config test`).

`docs/src/getting-started.md` gains an "Adding a new device" section covering the full capture-to-test workflow.

## How this serves P1

P1 (Declarative First) promises new device support via a TOML file and zero code. The capture tool already generates the skeleton, but the discovery path was broken: capture was unmentioned in help, the all-denied case masqueraded as "no device", and capture gave no follow-up. These changes make the documented loop actually walkable end-to-end.

## Test plan

- New unit tests: `perm_hint.writeInputGroupHint` emits the remedy; `reportNoDevice` routes all-denied -> input-group hint and genuinely-absent -> "no device" + scan hint (no group hint); help text mentions `padctl-capture`.
- Falsifiability verified: bypassing the helper in the denied branch turns the `reportNoDevice: all-denied` test red.
- Full Docker suite green: `17/17 steps succeeded; 1831/1842 tests passed; 11 skipped`.
- Existing doctor `printHidrawDiagnosis` denied-node test stays green (output unchanged).