### PR TITLE
chore(release): bump version to 0.1.17

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.16",
+    .version = "0.1.17",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
Bump `build.zig.zon` to 0.1.17 for the v0.1.17 release (the release gate requires tag == build.zig.zon version).

## In this release (16 commits since v0.1.16)
- `#433` restore multi-second hotplug retry budget (root-fix for #431 reconnect)
- `#434` fix nix flake for current zig2nix + commit flake.lock (#432)
- `#436` document gyro `minimum_output` (#311)
- `#437` actionable error hints for `switch`/`status`
- `#438` run the shadow-grab integration test in e2e with a REQUIRE_UINPUT gate (#406/#411)
- `#439` bound `report.size` + device-TOML unknown-field linter
- `#440` install-time modprobe + COPR/deb packaging fixes
- `#441` complete the device-authoring loop UX
- `#423`–`#430` 0.1.17 backlog (shadow identity, STATUS truncation, CLI ergonomics, packaging)

All constituent PRs were CI-green + reviewed before merge; integrated main is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.1.17

<!-- end of auto-generated comment: release notes by coderabbit.ai -->