### PR TITLE
fix(rumble): stop the motor when a playing FF effect is erased

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -307,7 +307,7 @@ pub fn build(b: *std.Build) void {
     shadow_int_tests.linkLibC();
     integration_step.dependOn(&b.addRunArtifact(shadow_int_tests).step);
 
-    // uinput_ff_erase_integration: real UI_FF_ERASE wiring validation (#65).
+    // uinput_ff_erase_integration: real UI_FF_ERASE wiring validation.
     // Creates an FF_RUMBLE uinput device, EVIOCSFF-uploads then EVIOCRMFF-erases
     // an effect (no EV_FF=0), and asserts pollFf surfaces a zero-magnitude stop.
     // Own test artifact like shadow_grab; skips gracefully without /dev/uinput

--- a/build.zig
+++ b/build.zig
@@ -307,6 +307,24 @@ pub fn build(b: *std.Build) void {
     shadow_int_tests.linkLibC();
     integration_step.dependOn(&b.addRunArtifact(shadow_int_tests).step);
 
+    // uinput_ff_erase_integration: real UI_FF_ERASE wiring validation (#65).
+    // Creates an FF_RUMBLE uinput device, EVIOCSFF-uploads then EVIOCRMFF-erases
+    // an effect (no EV_FF=0), and asserts pollFf surfaces a zero-magnitude stop.
+    // Own test artifact like shadow_grab; skips gracefully without /dev/uinput
+    // unless PADCTL_TEST_REQUIRE_UINPUT=1 (set by the privileged e2e job).
+    const ff_erase_int_mod = b.createModule(.{
+        .root_source_file = b.path("src/test/uinput_ff_erase_integration_test.zig"),
+        .target = target,
+        .optimize = optimize,
+        .sanitize_c = .trap,
+    });
+    ff_erase_int_mod.addImport("toml", toml_mod);
+    ff_erase_int_mod.addImport("src", src_mod);
+    const ff_erase_int_tests = b.addTest(.{ .root_module = ff_erase_int_mod, .filters = test_filters });
+    applyLibusb(b, ff_erase_int_tests, use_libusb, vendored);
+    ff_erase_int_tests.linkLibC();
+    integration_step.dependOn(&b.addRunArtifact(ff_erase_int_tests).step);
+
     // Phase 13 Wave 3 T5f: Layer 1 routing tests — pure pipe2 fixture, no
     // /dev/uhid, no privilege required. Hooks to the main test step so the
     // CI green bar covers the UHID routing switch.

--- a/src/io/ioctl_constants.zig
+++ b/src/io/ioctl_constants.zig
@@ -30,6 +30,8 @@ pub fn HIDIOCSFEATURE(len: u14) u32 {
 // evdev
 pub const EVIOCGRAB = IOCTL.IOW('E', 0x90, c_int);
 pub const EVIOCGID = IOCTL.IOR('E', 0x02, c.input_id);
+pub const EVIOCSFF = IOCTL.IOW('E', 0x80, c.ff_effect);
+pub const EVIOCRMFF = IOCTL.IOW('E', 0x81, c_int);
 pub const InputId = c.input_id;
 
 /// Dynamic-size evdev ioctl: kernel copies up to `len` bytes of the device's

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -382,8 +382,14 @@ pub const UinputDevice = struct {
     /// and emits a zero rumble frame when no effect remains playing. Out of
     /// range ids surface nothing.
     pub fn eraseStopEvent(effect_id: u8) ?FfEvent {
-        _ = effect_id;
-        return null;
+        if (effect_id >= 16) return null;
+        return .{
+            .effect_type = c.FF_RUMBLE,
+            .effect_id = effect_id,
+            .strong = 0,
+            .weak = 0,
+            .duration_ms = 0,
+        };
     }
 
     pub fn pollFf(self: *UinputDevice) !?FfEvent {
@@ -441,12 +447,17 @@ pub const UinputDevice = struct {
                         rumble_log.debug("[{s}] pollFf: UI_BEGIN_FF_ERASE FAILED rc={d}", .{ self.log_tag, begin_rc });
                         continue;
                     }
+                    erase.retval = 0;
+                    _ = std.os.linux.ioctl(self.fd, UI_END_FF_ERASE, @intFromPtr(&erase));
                     if (erase.effect_id < 16) {
                         self.ff_effects[@intCast(erase.effect_id)] = .{};
                         rumble_log.debug("[{s}] pollFf: ERASE id={d}", .{ self.log_tag, erase.effect_id });
+                        // uinput does not use ff-memless, so erasing a playing
+                        // effect leaves the motor on. Mirror EV_FF=0 so the
+                        // event loop clears the scheduler slot and stops it.
+                        result = eraseStopEvent(@intCast(erase.effect_id));
+                        break;
                     }
-                    erase.retval = 0;
-                    _ = std.os.linux.ioctl(self.fd, UI_END_FF_ERASE, @intFromPtr(&erase));
                 }
             } else if (ev.type == c.EV_FF) {
                 const id: usize = @intCast(ev.code);

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -377,10 +377,7 @@ pub const UinputDevice = struct {
         return self.fd;
     }
 
-    /// Stop FfEvent that an UI_FF_ERASE of `effect_id` must surface to the
-    /// event loop, so its onStop/anyPlaying logic clears the scheduler slot
-    /// and emits a zero rumble frame when no effect remains playing. Out of
-    /// range ids surface nothing.
+    /// Zero-magnitude FF stop event for an erased effect; null for out-of-range ids.
     pub fn eraseStopEvent(effect_id: u8) ?FfEvent {
         if (effect_id >= 16) return null;
         return .{

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -377,6 +377,15 @@ pub const UinputDevice = struct {
         return self.fd;
     }
 
+    /// Stop FfEvent that an UI_FF_ERASE of `effect_id` must surface to the
+    /// event loop, so its onStop/anyPlaying logic clears the scheduler slot
+    /// and emits a zero rumble frame when no effect remains playing. Out of
+    /// range ids surface nothing.
+    pub fn eraseStopEvent(effect_id: u8) ?FfEvent {
+        _ = effect_id;
+        return null;
+    }
+
     pub fn pollFf(self: *UinputDevice) !?FfEvent {
         var result: ?FfEvent = null;
         var ev_count: u32 = 0;

--- a/src/main.zig
+++ b/src/main.zig
@@ -122,6 +122,7 @@ pub const testing_support = struct {
     pub const bugfix_regression_test = @import("test/bugfix_regression_test.zig");
     pub const doctor_accuracy_test = @import("test/doctor_accuracy_test.zig");
     pub const event_loop_rumble_test = @import("test/event_loop_rumble_test.zig");
+    pub const event_loop_ff_erase_test = @import("test/event_loop_ff_erase_test.zig");
     pub const uhid_output_dispatch_test = @import("test/uhid_output_dispatch_test.zig");
     pub const pidff_e2e_test = @import("test/pidff_e2e_test.zig");
     pub const chord_output_e2e_test = @import("test/chord_output_e2e_test.zig");

--- a/src/test/event_loop_ff_erase_test.zig
+++ b/src/test/event_loop_ff_erase_test.zig
@@ -37,13 +37,14 @@ const ff_toml =
 ;
 
 // Drain-aware FF mock: each mockPollFf reads one byte from the test pipe
-// before returning the next event, so the test's wall-clock sleeps gate the
-// 10ms play-frame throttle window (matching MockFfOutputDrain in
-// event_loop_rumble_test.zig).
+// before returning the next event. After consuming a real event it writes one
+// byte to ack_write so the test body can wait for each event to be processed
+// before sending the next, providing deterministic ordering without sleeps.
 const MockFfOutputDrain = struct {
     events: []const ?uinput.FfEvent,
     call_count: usize = 0,
     pipe_read: posix.fd_t,
+    ack_write: posix.fd_t,
 
     fn outputDevice(self: *MockFfOutputDrain) uinput.OutputDevice {
         return .{ .ptr = self, .vtable = &vtable };
@@ -64,6 +65,10 @@ const MockFfOutputDrain = struct {
         if (self.call_count < self.events.len) {
             const ev = self.events[self.call_count];
             self.call_count += 1;
+            if (ev != null) {
+                // Signal the test body: this real event has been consumed.
+                _ = posix.write(self.ack_write, &[_]u8{1}) catch {};
+            }
             return ev;
         }
         return null;
@@ -103,6 +108,11 @@ test "event_loop: erasing an infinite effect emits a stop frame and frees the sl
     defer posix.close(ff_pipe[1]);
     try loop.addUinputFf(ff_pipe[0]);
 
+    // Ack pipe: blocking read side; event loop writes one byte per consumed event.
+    const ack_pipe = try posix.pipe2(.{});
+    defer posix.close(ack_pipe[0]);
+    defer posix.close(ack_pipe[1]);
+
     const parsed = try device_mod.parseString(allocator, ff_toml);
     defer parsed.deinit();
     const interp = Interpreter.init(&parsed.value);
@@ -124,7 +134,7 @@ test "event_loop: erasing an infinite effect emits a stop frame and frees the sl
         .{ .effect_type = 0x50, .effect_id = 1, .strong = 0, .weak = 0, .duration_ms = 0 },
         null,
     };
-    var ff_out = MockFfOutputDrain{ .events = &seq, .pipe_read = ff_pipe[0] };
+    var ff_out = MockFfOutputDrain{ .events = &seq, .pipe_read = ff_pipe[0], .ack_write = ack_pipe[1] };
 
     const RunCtx = struct {
         loop: *EventLoop,
@@ -151,16 +161,31 @@ test "event_loop: erasing an infinite effect emits a stop frame and frees the sl
     };
     const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
 
-    // One pipe write per event; the 15ms gaps clear the 10ms play-frame
-    // throttle so each play frame actually reaches the device.
+    // Ack-based sync: write one byte to ff_pipe[1], then block until the event
+    // loop confirms it consumed the event by reading one ack byte. This removes
+    // the race where loop.stop() fires before the 4th event is processed.
+    // A 15ms gap before each play write still clears the 10ms throttle window.
+    const waitAck = struct {
+        fn call(ack_read: posix.fd_t) error{AckTimeout}!void {
+            var pfd = [1]posix.pollfd{.{ .fd = ack_read, .events = posix.POLL.IN, .revents = 0 }};
+            const n = posix.poll(&pfd, 2000) catch return error.AckTimeout;
+            if (n == 0) return error.AckTimeout;
+            var buf: [1]u8 = undefined;
+            _ = posix.read(ack_read, &buf) catch {};
+        }
+    }.call;
+
+    std.Thread.sleep(15 * std.time.ns_per_ms);
     _ = try posix.write(ff_pipe[1], &[_]u8{1}); // play 0
+    try waitAck(ack_pipe[0]);
     std.Thread.sleep(15 * std.time.ns_per_ms);
     _ = try posix.write(ff_pipe[1], &[_]u8{1}); // erase 0 → stop
+    try waitAck(ack_pipe[0]);
     std.Thread.sleep(15 * std.time.ns_per_ms);
     _ = try posix.write(ff_pipe[1], &[_]u8{1}); // play 1
-    std.Thread.sleep(15 * std.time.ns_per_ms);
+    try waitAck(ack_pipe[0]);
     _ = try posix.write(ff_pipe[1], &[_]u8{1}); // explicit stop 1
-    std.Thread.sleep(15 * std.time.ns_per_ms);
+    try waitAck(ack_pipe[0]);
     loop.stop();
     thread.join();
 

--- a/src/test/event_loop_ff_erase_test.zig
+++ b/src/test/event_loop_ff_erase_test.zig
@@ -1,0 +1,167 @@
+// UI_FF_ERASE stop-emission tests.
+//
+// A host can stop rumble by erasing the FF effect (EVIOCRMFF) instead of
+// writing EV_FF value=0. The Linux ff-memless helper stops a playing effect
+// on erase; uinput does not use that helper, so padctl must emulate it. An
+// infinite-duration effect that is only ever erased must still produce a stop
+// frame and free its scheduler slot, otherwise the motor stays on forever and
+// every later stop is suppressed because a slot is permanently "playing".
+
+const std = @import("std");
+const testing = std.testing;
+const posix = std.posix;
+
+const EventLoop = @import("../event_loop.zig").EventLoop;
+const DeviceIO = @import("../io/device_io.zig").DeviceIO;
+const Interpreter = @import("../core/interpreter.zig").Interpreter;
+const state = @import("../core/state.zig");
+const uinput = @import("../io/uinput.zig");
+const device_mod = @import("../config/device.zig");
+const MockDeviceIO = @import("mock_device_io.zig").MockDeviceIO;
+
+const ff_toml =
+    \\[device]
+    \\name = "T"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 1
+    \\[commands.rumble]
+    \\interface = 0
+    \\template = "00 08 00 {strong:u8} {weak:u8} 00 00 00"
+;
+
+const MockFfOutputSeq = struct {
+    events: []const ?uinput.FfEvent,
+    call_count: usize = 0,
+
+    fn outputDevice(self: *MockFfOutputSeq) uinput.OutputDevice {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = uinput.OutputDevice.VTable{
+        .emit = mockEmit,
+        .poll_ff = mockPollFf,
+        .close = mockClose,
+    };
+
+    fn mockEmit(_: *anyopaque, _: state.GamepadState) uinput.EmitError!void {}
+
+    fn mockPollFf(ptr: *anyopaque) uinput.PollFfError!?uinput.FfEvent {
+        const self: *MockFfOutputSeq = @ptrCast(@alignCast(ptr));
+        if (self.call_count < self.events.len) {
+            const ev = self.events[self.call_count];
+            self.call_count += 1;
+            return ev;
+        }
+        return null;
+    }
+
+    fn mockClose(_: *anyopaque) void {}
+};
+
+test "uinput: eraseStopEvent surfaces a zero rumble FfEvent for the erased slot" {
+    const ev = uinput.UinputDevice.eraseStopEvent(3) orelse
+        return error.EraseProducedNoStop;
+    try testing.expectEqual(@as(u8, 3), ev.effect_id);
+    try testing.expectEqual(@as(u16, 0), ev.strong);
+    try testing.expectEqual(@as(u16, 0), ev.weak);
+    try testing.expectEqual(@as(u16, 0), ev.duration_ms);
+}
+
+test "uinput: eraseStopEvent ignores out-of-range effect ids" {
+    try testing.expectEqual(@as(?uinput.FfEvent, null), uinput.UinputDevice.eraseStopEvent(16));
+    try testing.expectEqual(@as(?uinput.FfEvent, null), uinput.UinputDevice.eraseStopEvent(255));
+}
+
+test "event_loop: erasing an infinite effect emits a stop frame and frees the slot" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var mock_dev = try MockDeviceIO.init(allocator, &.{});
+    defer mock_dev.deinit();
+    const dev = mock_dev.deviceIO();
+    try loop.addDevice(dev);
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    // 1) Play an infinite-duration effect (duration_ms=0 → never auto-stops).
+    // 2) The host erases it (no EV_FF=0). This is the event a fixed pollFf
+    //    surfaces for UI_FF_ERASE; current code surfaces null, so the slot
+    //    leaks and the motor never stops.
+    // 3) Later, a different effect plays then is explicitly stopped. The leaked
+    //    slot must not suppress this stop frame.
+    const erase_stop = uinput.UinputDevice.eraseStopEvent(0);
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 0 },
+        erase_stop,
+        .{ .effect_type = 0x50, .effect_id = 1, .strong = 0x4000, .weak = 0x2000, .duration_ms = 0 },
+        .{ .effect_type = 0x50, .effect_id = 1, .strong = 0, .weak = 0, .duration_ms = 0 },
+        null,
+    };
+    var ff_out = MockFfOutputSeq{ .events = &seq };
+
+    const RunCtx = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        ff_out: *MockFfOutputSeq,
+        cfg: *const device_mod.DeviceConfig,
+        alloc: std.mem.Allocator,
+    };
+    var devs = [_]DeviceIO{dev};
+    var ctx = RunCtx{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .ff_out = &ff_out,
+        .cfg = &parsed.value,
+        .alloc = allocator,
+    };
+
+    const T = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 100 });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
+
+    // Drain all four events across a few wakeups; the FF slot is
+    // level-triggered so each iteration consumes one queued event.
+    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+    std.Thread.sleep(40 * std.time.ns_per_ms);
+    loop.stop();
+    thread.join();
+
+    // Template: "00 08 00 {strong:u8} {weak:u8} 00 00 00" → 8-byte frame.
+    const frame_size = 8;
+    const play_0 = [_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 };
+    const stop = [_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    const play_1 = [_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 };
+
+    // Expected frames: play 0, stop (from erase), play 1, stop 1.
+    try testing.expectEqual(@as(usize, 4 * frame_size), mock_dev.write_log.items.len);
+    try testing.expectEqualSlices(u8, &play_0, mock_dev.write_log.items[0..frame_size]);
+    try testing.expectEqualSlices(u8, &stop, mock_dev.write_log.items[frame_size .. 2 * frame_size]);
+    try testing.expectEqualSlices(u8, &play_1, mock_dev.write_log.items[2 * frame_size .. 3 * frame_size]);
+    try testing.expectEqualSlices(u8, &stop, mock_dev.write_log.items[3 * frame_size .. 4 * frame_size]);
+
+    // No slot may remain "playing" after the erase + explicit stop.
+    for (loop.rumble_scheduler.dumpSlots()) |s| {
+        try testing.expectEqual(@as(i128, 0), s);
+    }
+}

--- a/src/test/event_loop_ff_erase_test.zig
+++ b/src/test/event_loop_ff_erase_test.zig
@@ -76,6 +76,7 @@ test "uinput: eraseStopEvent surfaces a zero rumble FfEvent for the erased slot"
     const ev = uinput.UinputDevice.eraseStopEvent(3) orelse
         return error.EraseProducedNoStop;
     try testing.expectEqual(@as(u8, 3), ev.effect_id);
+    try testing.expectEqual(@as(u16, 0x50), ev.effect_type); // FF_RUMBLE
     try testing.expectEqual(@as(u16, 0), ev.strong);
     try testing.expectEqual(@as(u16, 0), ev.weak);
     try testing.expectEqual(@as(u16, 0), ev.duration_ms);
@@ -112,7 +113,10 @@ test "event_loop: erasing an infinite effect emits a stop frame and frees the sl
     //    slot leaks and the motor never stops.
     // 3) A different effect plays then is explicitly stopped. The leaked slot
     //    must not suppress this final stop frame.
-    const erase_stop = uinput.UinputDevice.eraseStopEvent(0);
+    // Hand-written stop event for the erased slot — encoded independently of
+    // eraseStopEvent so this integration test pins the expected wire shape
+    // rather than echoing the helper it indirectly exercises. 0x50 = FF_RUMBLE.
+    const erase_stop: ?uinput.FfEvent = .{ .effect_type = 0x50, .effect_id = 0, .strong = 0, .weak = 0, .duration_ms = 0 };
     const seq = [_]?uinput.FfEvent{
         .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 0 },
         erase_stop,

--- a/src/test/event_loop_ff_erase_test.zig
+++ b/src/test/event_loop_ff_erase_test.zig
@@ -36,11 +36,16 @@ const ff_toml =
     \\template = "00 08 00 {strong:u8} {weak:u8} 00 00 00"
 ;
 
-const MockFfOutputSeq = struct {
+// Drain-aware FF mock: each mockPollFf reads one byte from the test pipe
+// before returning the next event, so the test's wall-clock sleeps gate the
+// 10ms play-frame throttle window (matching MockFfOutputDrain in
+// event_loop_rumble_test.zig).
+const MockFfOutputDrain = struct {
     events: []const ?uinput.FfEvent,
     call_count: usize = 0,
+    pipe_read: posix.fd_t,
 
-    fn outputDevice(self: *MockFfOutputSeq) uinput.OutputDevice {
+    fn outputDevice(self: *MockFfOutputDrain) uinput.OutputDevice {
         return .{ .ptr = self, .vtable = &vtable };
     }
 
@@ -53,7 +58,9 @@ const MockFfOutputSeq = struct {
     fn mockEmit(_: *anyopaque, _: state.GamepadState) uinput.EmitError!void {}
 
     fn mockPollFf(ptr: *anyopaque) uinput.PollFfError!?uinput.FfEvent {
-        const self: *MockFfOutputSeq = @ptrCast(@alignCast(ptr));
+        const self: *MockFfOutputDrain = @ptrCast(@alignCast(ptr));
+        var buf: [1]u8 = undefined;
+        _ = posix.read(self.pipe_read, &buf) catch return null;
         if (self.call_count < self.events.len) {
             const ev = self.events[self.call_count];
             self.call_count += 1;
@@ -100,11 +107,11 @@ test "event_loop: erasing an infinite effect emits a stop frame and frees the sl
     const interp = Interpreter.init(&parsed.value);
 
     // 1) Play an infinite-duration effect (duration_ms=0 → never auto-stops).
-    // 2) The host erases it (no EV_FF=0). This is the event a fixed pollFf
-    //    surfaces for UI_FF_ERASE; current code surfaces null, so the slot
-    //    leaks and the motor never stops.
-    // 3) Later, a different effect plays then is explicitly stopped. The leaked
-    //    slot must not suppress this stop frame.
+    // 2) The host erases it (no EV_FF=0). erase_stop is the event a fixed
+    //    pollFf surfaces for UI_FF_ERASE; current code surfaces null, so the
+    //    slot leaks and the motor never stops.
+    // 3) A different effect plays then is explicitly stopped. The leaked slot
+    //    must not suppress this final stop frame.
     const erase_stop = uinput.UinputDevice.eraseStopEvent(0);
     const seq = [_]?uinput.FfEvent{
         .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 0 },
@@ -113,13 +120,13 @@ test "event_loop: erasing an infinite effect emits a stop frame and frees the sl
         .{ .effect_type = 0x50, .effect_id = 1, .strong = 0, .weak = 0, .duration_ms = 0 },
         null,
     };
-    var ff_out = MockFfOutputSeq{ .events = &seq };
+    var ff_out = MockFfOutputDrain{ .events = &seq, .pipe_read = ff_pipe[0] };
 
     const RunCtx = struct {
         loop: *EventLoop,
         devs: []DeviceIO,
         interp: *const Interpreter,
-        ff_out: *MockFfOutputSeq,
+        ff_out: *MockFfOutputDrain,
         cfg: *const device_mod.DeviceConfig,
         alloc: std.mem.Allocator,
     };
@@ -135,15 +142,21 @@ test "event_loop: erasing an infinite effect emits a stop frame and frees the sl
 
     const T = struct {
         fn run(c: *RunCtx) !void {
-            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 100 });
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 200 });
         }
     };
     const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
 
-    // Drain all four events across a few wakeups; the FF slot is
-    // level-triggered so each iteration consumes one queued event.
-    _ = try posix.write(ff_pipe[1], &[_]u8{1});
-    std.Thread.sleep(40 * std.time.ns_per_ms);
+    // One pipe write per event; the 15ms gaps clear the 10ms play-frame
+    // throttle so each play frame actually reaches the device.
+    _ = try posix.write(ff_pipe[1], &[_]u8{1}); // play 0
+    std.Thread.sleep(15 * std.time.ns_per_ms);
+    _ = try posix.write(ff_pipe[1], &[_]u8{1}); // erase 0 → stop
+    std.Thread.sleep(15 * std.time.ns_per_ms);
+    _ = try posix.write(ff_pipe[1], &[_]u8{1}); // play 1
+    std.Thread.sleep(15 * std.time.ns_per_ms);
+    _ = try posix.write(ff_pipe[1], &[_]u8{1}); // explicit stop 1
+    std.Thread.sleep(15 * std.time.ns_per_ms);
     loop.stop();
     thread.join();
 

--- a/src/test/uinput_ff_erase_integration_test.zig
+++ b/src/test/uinput_ff_erase_integration_test.zig
@@ -1,0 +1,184 @@
+//! Real-uinput integration test for the pollFf UI_FF_ERASE wiring (issue #65).
+//!
+//! The production stop-on-erase plumbing lives in `UinputDevice.pollFf`'s
+//! UI_FF_ERASE branch (`result = eraseStopEvent(...); break;`). That branch only
+//! fires when a real `/dev/uinput` device receives a UI_FF_ERASE request from
+//! the kernel — which the Layer-0 `event_loop_ff_erase_test.zig` can't reach
+//! because it feeds pollFf's output to the event loop via a canned FfEvent.
+//!
+//! This test drives the actual ioctl path: padctl creates an FF_RUMBLE uinput
+//! device, a client opens the matching evdev node, EVIOCSFF-uploads an infinite
+//! effect, then EVIOCRMFF-erases it WITHOUT writing EV_FF value=0. The kernel
+//! turns that into UI_FF_UPLOAD / UI_FF_ERASE requests on padctl's fd; we pump
+//! the real `pollFf()` and assert it surfaces a zero-magnitude stop FfEvent for
+//! the erased slot — the exact emulation that stops the motor on erase.
+//!
+//! ## Runtime behaviour (mirrors shadow_grab_integration_test.zig)
+//!
+//! - On a host without `/dev/uinput` access (the plain `check-matrix` CI job,
+//!   unprivileged containers): logs an explicit warning, then either
+//!     * Default: returns `error.SkipZigTest` — the suite stays green while
+//!       making the gap audible.
+//!     * When `PADCTL_TEST_REQUIRE_UINPUT=1` is set: returns
+//!       `error.UinputAccessRequired` — a hard failure, so an environment meant
+//!       to have /dev/uinput but lacking it surfaces the breakage. The
+//!       privileged `e2e` job sets it when /dev/uinput is accessible, which is
+//!       the only place this UI_FF_ERASE wiring runs against the real kernel.
+
+const std = @import("std");
+const posix = std.posix;
+const linux = std.os.linux;
+const testing = std.testing;
+
+const src = @import("src");
+const uinput = src.io.uinput;
+const ioctl = src.io.ioctl_constants;
+const device_cfg = src.config.device;
+
+const c = @cImport({
+    @cInclude("linux/input.h");
+});
+
+fn requireUinput() bool {
+    const v = std.posix.getenv("PADCTL_TEST_REQUIRE_UINPUT") orelse return false;
+    return std.mem.eql(u8, v, "1") or std.mem.eql(u8, v, "true");
+}
+
+fn reportMissingUinput(reason: []const u8) error{ SkipZigTest, UinputAccessRequired } {
+    std.log.warn(
+        "uinput_ff_erase_integration_test: /dev/uinput unavailable ({s}) — pollFf UI_FF_ERASE wiring CI signal is SILENT. " ++
+            "Run in a privileged environment with /dev/uinput, " ++
+            "or set PADCTL_TEST_REQUIRE_UINPUT=1 to turn this into a hard failure.",
+        .{reason},
+    );
+    if (requireUinput()) return error.UinputAccessRequired;
+    return error.SkipZigTest;
+}
+
+const FF_VID: u16 = 0xFAD7;
+const FF_PID: u16 = 0x2401;
+
+const ff_toml =
+    \\[device]
+    \\name = "ff-erase-itest"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 1
+    \\[output]
+    \\name = "padctl-ff-erase-itest"
+    \\vid = 0xFAD7
+    \\pid = 0x2401
+    \\[output.buttons]
+    \\A = "BTN_SOUTH"
+    \\[output.force_feedback]
+    \\type = "rumble"
+    \\max_effects = 16
+;
+
+fn findEventNode(vid: u16, pid: u16, name_buf: *[40]u8) ?[]const u8 {
+    var attempt: usize = 0;
+    while (attempt < 20) : (attempt += 1) {
+        var i: u16 = 0;
+        while (i < 256) : (i += 1) {
+            var path_buf: [40]u8 = undefined;
+            const path = std.fmt.bufPrint(&path_buf, "/dev/input/event{d}", .{i}) catch continue;
+            const fd = posix.open(path, .{ .ACCMODE = .RDONLY, .NONBLOCK = true }, 0) catch continue;
+            defer posix.close(fd);
+            var id: ioctl.InputId = undefined;
+            if (linux.E.init(linux.ioctl(fd, ioctl.EVIOCGID, @intFromPtr(&id))) != .SUCCESS) continue;
+            if (id.vendor != vid or id.product != pid) continue;
+            return std.fmt.bufPrint(name_buf, "/dev/input/event{d}", .{i}) catch null;
+        }
+        std.Thread.sleep(50 * std.time.ns_per_ms);
+    }
+    return null;
+}
+
+// Client side, run on its own thread: EVIOCSFF an infinite rumble effect, then
+// EVIOCRMFF-erase it without writing EV_FF=0. Both ioctls block until padctl's
+// pollFf services the matching kernel request, which is why this can't run
+// inline with the pump loop.
+const Client = struct {
+    node: []const u8,
+    result: anyerror!void = {},
+    erased_id: i16 = -1,
+    done: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    fn run(self: *Client) void {
+        self.result = self.body();
+        self.done.store(true, .release);
+    }
+
+    fn body(self: *Client) !void {
+        const fd = try posix.open(self.node, .{ .ACCMODE = .RDWR }, 0);
+        defer posix.close(fd);
+
+        var effect = std.mem.zeroes(c.ff_effect);
+        effect.type = c.FF_RUMBLE;
+        effect.id = -1; // kernel assigns the slot
+        effect.replay.length = 0; // infinite — only ever stopped by erase
+        effect.u.rumble.strong_magnitude = 0x8000;
+        effect.u.rumble.weak_magnitude = 0x4000;
+        if (linux.E.init(linux.ioctl(fd, ioctl.EVIOCSFF, @intFromPtr(&effect))) != .SUCCESS)
+            return error.UploadFailed;
+        self.erased_id = effect.id;
+
+        const id: c_int = effect.id;
+        if (linux.E.init(linux.ioctl(fd, ioctl.EVIOCRMFF, @as(usize, @bitCast(@as(isize, id))))) != .SUCCESS)
+            return error.EraseFailed;
+    }
+};
+
+test "uinput: pollFf turns a real UI_FF_ERASE into a zero-magnitude stop frame" {
+    const allocator = testing.allocator;
+
+    const parsed = device_cfg.parseString(allocator, ff_toml) catch return error.ConfigParseFailed;
+    defer parsed.deinit();
+    const out_cfg = parsed.value.output orelse return error.NoOutput;
+
+    var dev = uinput.UinputDevice.create(&out_cfg) catch |err| switch (err) {
+        error.AccessDenied, error.FileNotFound => return reportMissingUinput("/dev/uinput open failed"),
+        error.PermissionDenied => return reportMissingUinput("/dev/uinput ioctl permission denied"),
+        else => return err,
+    };
+    defer dev.close();
+
+    var name_buf: [40]u8 = undefined;
+    const node = findEventNode(FF_VID, FF_PID, &name_buf) orelse
+        return reportMissingUinput("created uinput node did not appear under /dev/input");
+
+    var client = Client{ .node = node };
+    const thread = try std.Thread.spawn(.{}, Client.run, .{&client});
+
+    // Pump the real pollFf to drive the upload + erase handshake. The client's
+    // EVIOCSFF/EVIOCRMFF block until pollFf services the matching UI_FF_UPLOAD /
+    // UI_FF_ERASE request, so we keep pumping until the client thread finishes
+    // (so its erase ioctl returns rather than timing out) while capturing the
+    // first zero-magnitude stop the erase surfaces. Deadline-bounded so a
+    // regression that drops the stop fails instead of hanging.
+    var stop: ?uinput.FfEvent = null;
+    const deadline = std.time.milliTimestamp() + 5000;
+    while (std.time.milliTimestamp() < deadline) {
+        if (try dev.pollFf()) |ev| {
+            if (stop == null and ev.strong == 0 and ev.weak == 0) stop = ev;
+        }
+        if (client.done.load(.acquire) and stop != null) break;
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+
+    thread.join();
+    try client.result;
+
+    const ev = stop orelse return error.NoStopFrameFromErase;
+    try testing.expectEqual(@as(u16, c.FF_RUMBLE), ev.effect_type);
+    try testing.expectEqual(@as(u16, 0), ev.strong);
+    try testing.expectEqual(@as(u16, 0), ev.weak);
+    try testing.expect(client.erased_id >= 0);
+    try testing.expectEqual(@as(u8, @intCast(client.erased_id)), ev.effect_id);
+}

--- a/src/test/uinput_ff_erase_integration_test.zig
+++ b/src/test/uinput_ff_erase_integration_test.zig
@@ -1,4 +1,4 @@
-//! Real-uinput integration test for the pollFf UI_FF_ERASE wiring (issue #65).
+//! Real-uinput integration test for the pollFf UI_FF_ERASE wiring.
 //!
 //! The production stop-on-erase plumbing lives in `UinputDevice.pollFf`'s
 //! UI_FF_ERASE branch (`result = eraseStopEvent(...); break;`). That branch only


### PR DESCRIPTION
## Problem

A host can stop rumble by **erasing** the FF effect (`EVIOCRMFF`) instead of writing `EV_FF` value=0. The Linux `ff-memless` helper stops a playing effect on erase, but uinput does not use that helper, so padctl must emulate it — and it only emulated the explicit-stop (`EV_FF=0`) case.

`pollFf()`'s `UI_FF_ERASE` branch cleared its internal effect slot and ACKed the ioctl but surfaced no `FfEvent`, so the rumble scheduler slot was never freed. An infinite-duration effect (`replay.length==0`) then stayed "playing" forever, and `anyPlaying()` suppressed **every** later stop frame — the motor stayed on for the rest of the session. This is a plausible cause of the long-standing intermittent stuck-rumble reports.

## Change

- `src/io/uinput.zig`: new pure helper `UinputDevice.eraseStopEvent`; the `UI_FF_ERASE` branch now surfaces the same zero-magnitude `FfEvent` as the `EV_FF=0` path. The existing event-loop `onStop`/`anyPlaying` logic then clears the slot and emits a stop frame **only when no other effect is still playing**, preserving the multi-effect invariant. The `UI_END_FF_ERASE` ack is moved ahead of the early return so the ioctl is still acknowledged.
- `src/test/event_loop_ff_erase_test.zig`: new Layer-0 regression test.
- `src/main.zig`: register the test under `testing_support`.

Scope is the erase path only. The disconnect/teardown path is unchanged and tracked as a separate follow-up.

## Test plan

- `zig build test` (Docker oracle `ghcr.io/bananasjim/padctl-build:0.15.2`; native link is build-env blocked).
- Red→green verified on two commits: the test compiles and **fails** on the unfixed tree (`error.EraseProducedNoStop` + frame-count assertion), and passes after the fix.
- Erase tests run 8/8 stable; full suite green.
- Coverage: a unit test pins `eraseStopEvent`'s contract, and an event-loop integration test (`MockDeviceIO`) proves that erasing an infinite effect emits a stop frame, frees the slot, and does **not** suppress a later stop for a different effect.

Refs #65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of force-feedback effect erasing operations to ensure proper event generation.

* **Tests**
  * Added regression tests validating force-feedback effect erase behavior, including infinite-duration effects and event-loop integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->