### PR TITLE
fix(device): warn when force feedback is unavailable on the UHID backend

### DIFF
--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -289,6 +289,8 @@ IMU (accelerometer + gyroscope) output via a separate UHID node. When declared, 
 
 See ADR-015 for the design rationale. This section enables SDL3-visible sensor pairing on Steam games.
 
+> **Force feedback limitation:** enabling `[output.imu] backend="uhid"` places the primary gamepad on the UHID backend. On current kernels, evdev force feedback is unavailable for UHID devices unless the kernel's `hid-universal-pidff` module recognises the device VID/PID — generic UHID nodes get `capabilities/ff=0`. Wine/Lutris evdev rumble will not work in this mode. Rumble via SDL or Steam (HIDAPI path) is unaffected.
+
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `backend` | string | no | `"uhid"` | Must be `"uhid"`; only legal value (validator rejects `"uinput"`) |

--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -422,6 +422,9 @@ pub const DeviceInstance = struct {
                         }
                     }
                 }
+                if (ffbUnavailableOverUhid(true, out_cfg.force_feedback)) {
+                    std.log.warn("force_feedback is configured but evdev force feedback is unavailable over the UHID backend (active when imu.backend=uhid): the kernel binds force feedback only for allowlisted device IDs. Wine/Lutris evdev rumble will not work; rumble via SDL/Steam HIDAPI is unaffected.", .{});
+                }
             } else {
                 const uinput_ptr = try UinputDevice.initBoxed(allocator, out_cfg);
                 errdefer {
@@ -1687,4 +1690,18 @@ test "openDeviceWithRetry returns promptly on a failing open (no in-thread sleep
     try testing.expectError(error.NotFound, result);
     // Old code: >= 7s. New code: a bare /dev scan, well under 3s.
     try testing.expect(elapsed_ns < 3 * std.time.ns_per_s);
+}
+
+/// Returns true when force feedback is configured but evdev FF is unavailable
+/// because the device runs on the UHID backend with a non-PID rumble config.
+/// The kernel's hid-universal-pidff binds FF only for allowlisted device IDs;
+/// a generic UHID device gets capabilities/ff=0, so evdev rumble never works.
+/// False when use_uhid=false, ffb=null, or when backend=uhid + kind=pid
+/// (PID passthrough handles its own FF channel).
+pub fn ffbUnavailableOverUhid(use_uhid: bool, ffb: ?device_cfg.ForceFeedbackConfig) bool {
+    if (!use_uhid) return false;
+    const f = ffb orelse return false;
+    const is_pid_passthrough = std.mem.eql(u8, f.backend, "uhid") and
+        std.mem.eql(u8, f.kind, "pid");
+    return !is_pid_passthrough;
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -156,6 +156,7 @@ pub const testing_support = struct {
     pub const uhid_simulator = @import("test/harness/uhid_simulator.zig");
     pub const uhid_test_cleanup = @import("test/uhid_test_cleanup.zig");
     pub const device_instance_imu_ownership_test = @import("test/device_instance_imu_ownership_test.zig");
+    pub const ffb_uhid_guardrail_test = @import("test/ffb_uhid_guardrail_test.zig");
     pub const supervisor_suspended_attach_takeover_test = @import("test/supervisor_suspended_attach_takeover_test.zig");
     pub const supervisor_suspend_output_continuity_test = @import("test/supervisor_suspend_output_continuity_test.zig");
     pub const wedge_instrumentation_test = @import("test/wedge_instrumentation_test.zig");

--- a/src/test/ffb_uhid_guardrail_test.zig
+++ b/src/test/ffb_uhid_guardrail_test.zig
@@ -21,3 +21,8 @@ test "ffbUnavailableOverUhid: use_uhid=false + rumble => false" {
 test "ffbUnavailableOverUhid: use_uhid=true + ffb=null => false" {
     try testing.expect(!ffbUnavailableOverUhid(true, null));
 }
+
+test "ffbUnavailableOverUhid: use_uhid=true + backend=uhid kind=rumble => true" {
+    const ffb = device_cfg.ForceFeedbackConfig{ .backend = "uhid", .kind = "rumble" };
+    try testing.expect(ffbUnavailableOverUhid(true, ffb));
+}

--- a/src/test/ffb_uhid_guardrail_test.zig
+++ b/src/test/ffb_uhid_guardrail_test.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+const testing = std.testing;
+const device_cfg = @import("../config/device.zig");
+const ffbUnavailableOverUhid = @import("../device_instance.zig").ffbUnavailableOverUhid;
+
+test "ffbUnavailableOverUhid: use_uhid=true + rumble backend => true" {
+    const ffb = device_cfg.ForceFeedbackConfig{ .backend = "uinput", .kind = "rumble" };
+    try testing.expect(ffbUnavailableOverUhid(true, ffb));
+}
+
+test "ffbUnavailableOverUhid: use_uhid=true + backend=uhid kind=pid => false" {
+    const ffb = device_cfg.ForceFeedbackConfig{ .backend = "uhid", .kind = "pid" };
+    try testing.expect(!ffbUnavailableOverUhid(true, ffb));
+}
+
+test "ffbUnavailableOverUhid: use_uhid=false + rumble => false" {
+    const ffb = device_cfg.ForceFeedbackConfig{ .backend = "uinput", .kind = "rumble" };
+    try testing.expect(!ffbUnavailableOverUhid(false, ffb));
+}
+
+test "ffbUnavailableOverUhid: use_uhid=true + ffb=null => false" {
+    try testing.expect(!ffbUnavailableOverUhid(true, null));
+}


### PR DESCRIPTION
## Problem

When `[output.imu] backend="uhid"` is set (the documented way to get SDL sensor pairing, issue #81), a single device-wide `use_uhid` flag forces the **entire gamepad — including force feedback** — onto the UHID backend. A `kind=rumble` UHID device emits only a vendor output report (no PID collection), so on current kernels the evdev node has `capabilities/ff=0` and Wine/Lutris evdev rumble silently fails.

This is a kernel constraint, not something padctl can paper over: `hid-universal-pidff` binds force feedback only for allowlisted device IDs (no wildcard), and UHID provides no transport-level FF init. Making a UHID rumble pad expose evdev FF would require cloning an allowlisted wheel VID/PID, which breaks the gamepad's SDL/Steam identity — self-defeating. Full analysis in ADR-025 (docs repo).

## Change

- `src/device_instance.zig`: add a pure `ffbUnavailableOverUhid` helper; emit a `std.log.warn` at device setup when force feedback is configured but unavailable over the UHID backend (i.e. not the PID-passthrough path). Replaces the previous silent failure.
- `docs/src/device-config.md`: document the limitation in the `[output.imu]` section — evdev FF is unavailable in this mode; SDL/Steam (HIDAPI) rumble is unaffected.
- `src/test/ffb_uhid_guardrail_test.zig`: Layer-0 tests for the helper (4 cases).

## Test plan

- `zig build test` (Docker oracle `ghcr.io/bananasjim/padctl-build:0.15.2`): full suite green; 4 new guardrail tests pass.
- Red→green verified: a stub helper fails the rumble-over-uhid case; the correct logic passes.
- uinput default path (no `[output.imu]`) unchanged — existing rumble path unaffected.

Refs #444
