### PR TITLE
fix(config): reject negative button_group source.offset in validate

### DIFF
--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -402,7 +402,7 @@ pub fn validate(cfg: *const DeviceConfig) !void {
         }
 
         if (report.button_group) |bg| {
-            if (bg.source.offset + bg.source.size > report.size) return error.OffsetOutOfBounds;
+            if (bg.source.offset < 0 or bg.source.offset + bg.source.size > report.size) return error.OffsetOutOfBounds;
             const bg_source_size = bg.source.size;
             const is_generic = if (cfg.device.mode) |m| std.mem.eql(u8, m, "generic") else false;
             var it = bg.map.map.iterator();
@@ -939,6 +939,30 @@ test "device: validate rejects an all-suppress config with no readable interface
         .report = &.{},
     };
     try std.testing.expectError(error.InvalidConfig, validate(&cfg));
+}
+
+test "device: validate rejects negative button_group source.offset" {
+    const allocator = std.testing.allocator;
+    const bad =
+        \\[device]
+        \\name = "Bad ButtonGroup Offset"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\
+        \\[[report]]
+        \\name = "main"
+        \\interface = 0
+        \\size = 8
+        \\
+        \\[report.button_group]
+        \\source = { offset = -1, size = 1 }
+        \\map = { A = 0 }
+    ;
+    try std.testing.expectError(error.OffsetOutOfBounds, parseString(allocator, bad));
 }
 
 test "device: force_feedback.auto_stop defaults to true when unspecified" {


### PR DESCRIPTION
## What
`validate()` now rejects a `[report.button_group]` whose `source.offset < 0`.

## Why
Such a config passed validation (the only check was the upper bound `offset+size > report.size`) and then panicked at interpreter compile — `@intCast` of a negative offset to `usize` (`src/core/interpreter.zig`). Every sibling field in `validate()` already guards `offset < 0` (standard fields, bits, match, checksum); `button_group` was the lone gap, so `padctl --validate` and the daemon load path crashed on a hand-authored offset typo instead of returning `OffsetOutOfBounds`.

`source.size < 0` needs no guard: a non-empty map is caught by the existing `bit_val` range check and an empty map fails TOML parsing, so neither reaches the interpreter (verified — the candidate negative-size case is unreachable).

## Test plan
- New Layer-0 test `device: validate rejects negative button_group source.offset` — red before the fix (`parseString` returned success), green after (`OffsetOutOfBounds`).
- Full `zig build test`: 1843/1852 passed, 0 failed (9 privilege-gated skips); no regression.
- `zig fmt` clean (0.15.2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device configuration validation now rejects negative offset values to prevent invalid settings.

* **Tests**
  * Added test coverage for offset validation boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->