### PR TITLE
refactor(config): collapse redundant validate/bind branches

### DIFF
--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -464,13 +464,7 @@ pub fn validate(cfg: *const DeviceConfig) !void {
     // [output.imu] is declared; unknown strings fail closed.
     if (cfg.output) |out| {
         if (out.imu) |imu| {
-            if (std.mem.eql(u8, imu.backend, "uhid")) {
-                // legal
-            } else if (std.mem.eql(u8, imu.backend, "uinput")) {
-                return error.InvalidConfig;
-            } else {
-                return error.InvalidConfig;
-            }
+            if (!std.mem.eql(u8, imu.backend, "uhid")) return error.InvalidConfig;
         }
     }
 
@@ -490,8 +484,7 @@ pub fn validate(cfg: *const DeviceConfig) !void {
 
             // uhid+pid requires [output.imu] as the UHID routing gate.
             if (is_uhid and is_pid) {
-                const imu_present = if (out.imu) |_| true else false;
-                if (!imu_present) return error.InvalidConfig;
+                if (out.imu == null) return error.InvalidConfig;
             }
 
             // clone_vid_pid=true is meaningless without a real VID/PID to clone.

--- a/src/io/control_socket.zig
+++ b/src/io/control_socket.zig
@@ -58,7 +58,7 @@ pub const ControlSocket = struct {
         var addr: linux.sockaddr.un = .{ .family = posix.AF.UNIX, .path = undefined };
         @memset(&addr.path, 0);
         if (path_z.len > addr.path.len - 1) return error.PathTooLong;
-        @memcpy(addr.path[0..path_z.len], path_z[0..path_z.len]);
+        @memcpy(addr.path[0..path_z.len], path_z);
 
         try posix.bind(fd, @ptrCast(&addr), @sizeOf(linux.sockaddr.un));
         errdefer std.fs.deleteFileAbsolute(path) catch {};


### PR DESCRIPTION
## What
Three behavior-preserving simplifications (net −7 lines) in config validation + socket bind.

## Changes
- `config/device.zig` IMU backend validation: a three-branch `if/else if/else` (uhid legal, uinput→error, else→error) collapses to `if (!eql uhid) return error.InvalidConfig` — uinput and unknown both fail closed identically.
- `config/device.zig` uhid+pid IMU-presence: `const x = if (out.imu) |_| true else false; if (!x)` → `if (out.imu == null)`.
- `io/control_socket.zig` bind: drop a redundant `path_z[0..path_z.len]` re-slice (`path_z` is already a `[:0]u8` of that length, and the dest slice is `[0..path_z.len]`).

## Test plan
- Full `zig build test`: 1843/1852 passed, 0 failed — identical to before. Existing tests cover every affected branch (IMU uhid-legal / uinput→InvalidConfig / unknown→InvalidConfig, and the uhid+pid IMU-presence gate).
- `zig fmt` clean (0.15.2).