### PR TITLE
fix(install): tolerate inline comments on clone_vid_pid in the udev scanner

### DIFF
--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -908,8 +908,7 @@ fn extractVidPid(allocator: std.mem.Allocator, path: []const u8, entries: *std.A
         } else if (in_ffb_section) {
             if (isFieldKey(trimmed, "clone_vid_pid")) {
                 if (std.mem.indexOf(u8, trimmed, "=")) |eq| {
-                    const val = std.mem.trim(u8, trimmed[eq + 1 ..], " \t");
-                    clone_vid_pid = std.mem.eql(u8, val, "true");
+                    clone_vid_pid = clonesVidPid(trimmed[eq + 1 ..]);
                 }
             }
         } else if (in_interface_section) {
@@ -972,4 +971,15 @@ pub fn setupTestUdev() void {
         f.writeAll(rule) catch {};
     } else |_| {}
     runCmd(&.{ "udevadm", "control", "--reload-rules" });
+}
+
+fn clonesVidPid(raw: []const u8) bool {
+    return std.mem.eql(u8, std.mem.trim(u8, toml_extract.beforeHash(raw), " \t"), "true");
+}
+
+test "udev: clonesVidPid tolerates inline comments" {
+    try std.testing.expect(clonesVidPid(" true"));
+    try std.testing.expect(clonesVidPid(" true  # masquerade as wheel"));
+    try std.testing.expect(!clonesVidPid(" false  # x"));
+    try std.testing.expect(!clonesVidPid(" yes"));
 }

--- a/src/cli/toml_extract.zig
+++ b/src/cli/toml_extract.zig
@@ -25,9 +25,9 @@ fn parseHexOrDec(comptime T: type, s: []const u8) !T {
     return std.fmt.parseInt(T, t, 10);
 }
 
-// Strip a TOML inline comment; safe here because vid/pid/driver-name values
-// never contain a literal '#'.
-fn beforeHash(s: []const u8) []const u8 {
+// Strip a TOML inline comment from a bare scalar value (vid/pid/bool/identifier,
+// which never contain a literal '#'). NOT quote-aware — not for free-form strings.
+pub fn beforeHash(s: []const u8) []const u8 {
     return if (std.mem.indexOfScalar(u8, s, '#')) |h| s[0..h] else s;
 }
 


### PR DESCRIPTION
## What
`udev.zig::extractVidPid` (a separate fast scanner from `extractDeviceVidPid`) now tolerates an inline comment on `clone_vid_pid`.

## Why
`clone_vid_pid = true  # masquerade` was trimmed with `" \t"` only, leaving the comment, so `eql(val, "true")` failed → the clone flag was silently unset → no per-VID/PID clone udev rule generated. Same bug class as #450 (`extractDeviceVidPid` inline comments), in the sibling scanner #450 didn't cover (flagged by the #450 review).

## Fix
- Export `toml_extract.beforeHash` (was private).
- New `clonesVidPid` helper strips the comment via `beforeHash` before the `== "true"` check.
- `name` is deliberately NOT routed through `beforeHash`: a device name is a free-form quoted string that may legitimately contain `#`, and `beforeHash` is not quote-aware.

## Test plan
- New Layer-0 test `udev: clonesVidPid tolerates inline comments` — red before the fix (helper without beforeHash), green after.
- Full `zig build test`: 1845/1854 passed, 0 failed.
- `zig fmt` clean (0.15.2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TOML configuration parsing to properly handle inline comments in device settings, making configuration files more flexible and robust.

* **Tests**
  * Added unit tests for comment and whitespace handling in configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->