### PR TITLE
refactor(install): dedup parseStringArray onto the production scanner + tolerate trailing comma

### DIFF
--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -56,7 +56,7 @@ const modules_load_content = udev_mod.modules_load_content;
 const _udev = udev_mod._internals_for_tests;
 const extractVidPid = _udev.extractVidPid;
 const isFieldKey = _udev.isFieldKey;
-const parseStringArray = _udev.parseStringArray;
+const parseStringArray = @import("../toml_extract.zig").parseStringArray;
 const parseHexOrDec = _udev.parseHexOrDec;
 const generateUdevRules = _udev.generateUdevRules;
 const generateDriverBlockRules = _udev.generateDriverBlockRules;
@@ -1563,6 +1563,18 @@ test "install: parseStringArray rejects command injection" {
     // Shell metacharacters must be rejected
     const result = try parseStringArray(allocator, "[\"x'; rm -rf / #\"]");
     try testing.expectEqual(@as(usize, 0), result.len);
+}
+
+test "install: parseStringArray tolerates a trailing comma" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const result = try parseStringArray(allocator, "[\"xpad\", ]");
+    defer {
+        for (result) |s| allocator.free(s);
+        allocator.free(result);
+    }
+    try testing.expectEqual(@as(usize, 1), result.len);
+    try testing.expectEqualStrings("xpad", result[0]);
 }
 
 test "install: isValidIdentifier accepts safe names" {

--- a/src/cli/install/udev.zig
+++ b/src/cli/install/udev.zig
@@ -842,34 +842,6 @@ pub fn isValidIdentifier(s: []const u8) bool {
     return true;
 }
 
-/// Parse a TOML inline array of strings, e.g. `["xpad", "hid_generic"]`.
-fn parseStringArray(allocator: std.mem.Allocator, value: []const u8) ![]const []const u8 {
-    const trimmed = std.mem.trim(u8, value, " \t");
-    if (trimmed.len < 2 or trimmed[0] != '[' or trimmed[trimmed.len - 1] != ']') return &.{};
-    const inner = trimmed[1 .. trimmed.len - 1];
-    if (std.mem.trim(u8, inner, " \t").len == 0) return &.{};
-
-    var count: usize = 0;
-    var it = std.mem.splitScalar(u8, inner, ',');
-    while (it.next()) |_| count += 1;
-
-    const result = try allocator.alloc([]const u8, count);
-    var idx: usize = 0;
-    it = std.mem.splitScalar(u8, inner, ',');
-    while (it.next()) |elem| {
-        const clean = std.mem.trim(u8, elem, " \t\"'");
-        // ! Reject unsafe identifiers — these are interpolated into udev shell commands.
-        if (!isValidIdentifier(clean)) {
-            for (result[0..idx]) |prev| allocator.free(prev);
-            allocator.free(result);
-            return &.{};
-        }
-        result[idx] = try allocator.dupe(u8, clean);
-        idx += 1;
-    }
-    return result;
-}
-
 fn extractVidPid(allocator: std.mem.Allocator, path: []const u8, entries: *std.ArrayList(UdevEntry)) !void {
     var f = try std.fs.openFileAbsolute(path, .{});
     defer f.close();
@@ -947,7 +919,6 @@ fn parseHexOrDec(comptime T: type, s: []const u8) !T {
 /// + generateUdevRulesFromEntries instead of reaching through this namespace.
 pub const _internals_for_tests = struct {
     pub const isFieldKey = @import("udev.zig").isFieldKey;
-    pub const parseStringArray = @import("udev.zig").parseStringArray;
     pub const extractVidPid = @import("udev.zig").extractVidPid;
     pub const parseHexOrDec = @import("udev.zig").parseHexOrDec;
     pub const collectDeviceEntries = @import("udev.zig").collectDeviceEntries;

--- a/src/cli/toml_extract.zig
+++ b/src/cli/toml_extract.zig
@@ -31,7 +31,7 @@ pub fn beforeHash(s: []const u8) []const u8 {
     return if (std.mem.indexOfScalar(u8, s, '#')) |h| s[0..h] else s;
 }
 
-fn parseStringArray(allocator: std.mem.Allocator, value: []const u8) ![]const []const u8 {
+pub fn parseStringArray(allocator: std.mem.Allocator, value: []const u8) ![]const []const u8 {
     const trimmed = std.mem.trim(u8, value, " \t");
     if (trimmed.len < 2 or trimmed[0] != '[' or trimmed[trimmed.len - 1] != ']') return &.{};
     const inner = trimmed[1 .. trimmed.len - 1];
@@ -39,13 +39,16 @@ fn parseStringArray(allocator: std.mem.Allocator, value: []const u8) ![]const []
 
     var count: usize = 0;
     var it = std.mem.splitScalar(u8, inner, ',');
-    while (it.next()) |_| count += 1;
+    while (it.next()) |elem| {
+        if (std.mem.trim(u8, elem, " \t\"'").len > 0) count += 1;
+    }
 
     const result = try allocator.alloc([]const u8, count);
     var idx: usize = 0;
     it = std.mem.splitScalar(u8, inner, ',');
     while (it.next()) |elem| {
         const clean = std.mem.trim(u8, elem, " \t\"'");
+        if (clean.len == 0) continue; // tolerate a trailing/extra comma
         if (!isValidIdentifier(clean)) {
             for (result[0..idx]) |prev| allocator.free(prev);
             allocator.free(result);


### PR DESCRIPTION
## What
Deduplicate `parseStringArray` onto the single production scanner and fix a trailing-comma drop.

## Why
`udev.zig` carried a `parseStringArray` identical to `toml_extract`'s but with **no production call site** — reachable only via `_internals_for_tests`. So `install/tests.zig`'s 4 `parseStringArray` tests exercised a **dead duplicate**, while the actual production path (`extractVidPid → extractDeviceVidPid → toml_extract.parseStringArray`) had no direct test (false coverage).

Separately, a **legal trailing comma** `["xpad", ]` produced an empty trailing element that failed `isValidIdentifier`, dropping the **whole array** → no driver-block udev rule generated.

## Changes
- Remove the dead `udev.zig` copy + its `_internals_for_tests` re-export.
- Make `toml_extract.parseStringArray` `pub`; re-point the 4 tests onto it so they now cover the production scanner.
- Skip empty elements (tolerate trailing/extra comma); add a regression test.

Net −14 lines.

## Test plan
- New test `parseStringArray tolerates a trailing comma` — falsifiable (reverting the skip flips it red: `expected 1, found 0`, verified).
- The 4 re-pointed tests (parse / empty / single / injection-reject) still pass against the production fn.
- Full `zig build test`: 1846/1855 passed, 0 failed.
- `zig fmt` clean (0.15.2).