### PR TITLE
fix(io): self-guard oversized descriptors in UhidDevice.sendCreate

### DIFF
--- a/src/io/uhid.zig
+++ b/src/io/uhid.zig
@@ -337,8 +337,8 @@ pub const UhidDevice = struct {
         const uniq_copy = @min(cfg.uniq.len, ev.payload.uniq.len - 1);
         if (uniq_copy != 0) @memcpy(ev.payload.uniq[0..uniq_copy], cfg.uniq[0..uniq_copy]);
 
-        ev.payload.rd_size = std.math.cast(u16, cfg.descriptor.len) orelse
-            return error.DescriptorTooLarge;
+        if (cfg.descriptor.len > HID_MAX_DESCRIPTOR_SIZE) return error.DescriptorTooLarge;
+        ev.payload.rd_size = @intCast(cfg.descriptor.len);
         ev.payload.bus = cfg.bus;
         ev.payload.vendor = cfg.vid;
         ev.payload.product = cfg.pid;
@@ -621,6 +621,16 @@ test "uhid: init rejects descriptor too large" {
         .descriptor = too_big,
     };
     try testing.expectError(error.DescriptorTooLarge, UhidDevice.init(alloc, cfg));
+}
+
+test "uhid: sendCreate self-guards an oversized descriptor (bypassing init)" {
+    const alloc = testing.allocator;
+    const too_big = try alloc.alloc(u8, HID_MAX_DESCRIPTOR_SIZE + 1);
+    defer alloc.free(too_big);
+    @memset(too_big, 0);
+    const cfg = Config{ .vid = 0xFADE, .pid = 0xCAFE, .name = "x", .descriptor = too_big };
+    // Guard returns before any fd write, so fd = -1 is never touched.
+    try testing.expectError(error.DescriptorTooLarge, UhidDevice.sendCreate(-1, cfg));
 }
 
 test "uhid_device_vtable_match: emit + close frame UHID_INPUT2 / UHID_DESTROY" {


### PR DESCRIPTION
## What
`UhidDevice.sendCreate` now rejects descriptors larger than `HID_MAX_DESCRIPTOR_SIZE` (4096) instead of only `>65535`.

## Why
`sendCreate` cast the descriptor length to `u16` (rejecting `>65535`), but `rd_data` is `[4096]u8`. A 4097..65535-byte descriptor passed the cast and then **panicked** at `@memcpy(rd_data[0..len])` (`index out of bounds: index 4097, len 4096`). `init`/`initWithFd` already guard `>4096`, so it's unreachable via them — but `sendCreate` is a `pub` entry point and should self-guard.

## Fix
Replace the weak `u16` cast with `if (cfg.descriptor.len > HID_MAX_DESCRIPTOR_SIZE) return error.DescriptorTooLarge;` + `@intCast`.

## Test plan
- New Layer-0 test drives `sendCreate(-1, oversized)` directly (bypassing init's guard); the guard returns before any fd write so `fd=-1` is never touched.
- **Falsifiable** (verified): reverting to the `u16` cast makes the test panic with `index out of bounds: index 4097, len 4096`.
- Full `zig build test`: 1843/1852 passed, 0 failed.
- `zig fmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for HID device descriptor validation to explicitly reject oversized descriptors with a clear error message.

* **Tests**
  * Added unit test to verify proper validation of descriptor size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->