### PR TITLE
fix(capture): correct multi-byte button_group and non-contiguous match in toml_gen

### DIFF
--- a/src/capture/toml_gen.zig
+++ b/src/capture/toml_gen.zig
@@ -43,12 +43,18 @@ pub fn emitToml(result: analyse.AnalysisResult, info: DeviceInfo, allocator: std
         .{ info.vid, info.pid, info.interface_id, info.interface_id, result.report_size },
     );
 
-    // match section if we have magic bytes
+    // MatchConfig expresses only a single offset + contiguous expect run, so emit
+    // the contiguous run from the first invariant byte; drop non-contiguous bytes.
     if (result.magic.len > 0) {
+        const start: usize = result.magic[0].offset;
+        var run_len: usize = 1;
+        while (run_len < result.magic.len and
+            @as(usize, result.magic[run_len].offset) == start + run_len) : (run_len += 1)
+        {}
         try writer.writeAll("[report.match]\n");
         try writer.print("offset = {d}\n", .{result.magic[0].offset});
         try writer.writeAll("expect = [");
-        for (result.magic, 0..) |m, i| {
+        for (result.magic[0..run_len], 0..) |m, i| {
             if (i > 0) try writer.writeAll(", ");
             try writer.print("0x{x:0>2}", .{m.value});
         }
@@ -73,21 +79,33 @@ pub fn emitToml(result: analyse.AnalysisResult, info: DeviceInfo, allocator: std
         try writer.writeAll("\n");
     }
 
-    // button_group section
-    if (result.buttons.len > 0) {
-        // group consecutive high-confidence bits by byte
-        const first = result.buttons[0];
-        try writer.writeAll("[report.button_group]\n");
-        try writer.print("source = {{ offset = {d}, size = 1 }}\n", .{first.byte_offset});
-        try writer.writeAll("map = {");
-        var first_entry = true;
+    // button_group section — the interpreter reads `size` bytes from `offset` and
+    // treats each map bit index as group-global, so encode the full byte span and
+    // re-base each button's bit to (byte - min_byte)*8 + bit.
+    {
+        var min_byte: u16 = std.math.maxInt(u16);
+        var max_byte: u16 = 0;
+        var any = false;
         for (result.buttons) |btn| {
             if (!btn.high_confidence) continue;
-            if (!first_entry) try writer.writeAll(", ");
-            try writer.print(" btn_{d}_{d} = {d}", .{ btn.byte_offset, btn.bit, btn.bit });
-            first_entry = false;
+            any = true;
+            min_byte = @min(min_byte, btn.byte_offset);
+            max_byte = @max(max_byte, btn.byte_offset);
         }
-        try writer.writeAll(" }\n\n");
+        if (any) {
+            try writer.writeAll("[report.button_group]\n");
+            try writer.print("source = {{ offset = {d}, size = {d} }}\n", .{ min_byte, max_byte - min_byte + 1 });
+            try writer.writeAll("map = {");
+            var first_entry = true;
+            for (result.buttons) |btn| {
+                if (!btn.high_confidence) continue;
+                if (!first_entry) try writer.writeAll(", ");
+                const global_bit = (@as(u16, btn.byte_offset) - min_byte) * 8 + btn.bit;
+                try writer.print(" btn_{d}_{d} = {d}", .{ btn.byte_offset, btn.bit, global_bit });
+                first_entry = false;
+            }
+            try writer.writeAll(" }\n\n");
+        }
     }
 
     // unknown bytes comment

--- a/src/test/capture_e2e_test.zig
+++ b/src/test/capture_e2e_test.zig
@@ -173,6 +173,86 @@ test "capture: emitToml — contains [device], [[report]], [report.fields]" {
     try testing.expect(std.mem.indexOf(u8, out, "\"u8\"") != null);
 }
 
+test "capture: emitToml — non-contiguous magic emits only the contiguous run (F2)" {
+    const allocator = testing.allocator;
+    // Invariant bytes at offsets 0 and 4, with a varying gap at 1..3.
+    // MatchConfig is a single offset + contiguous expect run, so the byte at
+    // offset 4 cannot be expressed and must be dropped — never packed at offset 1.
+    var magic = [_]analyse_mod.MagicByte{
+        .{ .offset = 0, .value = 0x5a },
+        .{ .offset = 4, .value = 0xc3 },
+    };
+    const result = AnalysisResult{
+        .report_size = 16,
+        .magic = &magic,
+        .buttons = &[_]analyse_mod.ButtonCandidate{},
+        .axes = &[_]analyse_mod.AxisCandidate{},
+    };
+    const info = DeviceInfo{ .name = "Pad", .vid = 0x1111, .pid = 0x2222, .interface_id = 0 };
+
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(allocator);
+    try toml_gen_mod.emitToml(result, info, allocator, buf.writer(allocator));
+    const out = buf.items;
+
+    try testing.expect(std.mem.indexOf(u8, out, "expect = [0x5a]") != null);
+    // 0xc3 lives at the non-contiguous offset 4 and must NOT be packed in.
+    try testing.expect(std.mem.indexOf(u8, out, "0xc3") == null);
+}
+
+test "capture: emitToml — contiguous magic run is kept intact (F2)" {
+    const allocator = testing.allocator;
+    // Adjacent invariant bytes 0 and 1 form one contiguous run: both must be emitted.
+    var magic = [_]analyse_mod.MagicByte{
+        .{ .offset = 0, .value = 0x5a },
+        .{ .offset = 1, .value = 0xa5 },
+    };
+    const result = AnalysisResult{
+        .report_size = 16,
+        .magic = &magic,
+        .buttons = &[_]analyse_mod.ButtonCandidate{},
+        .axes = &[_]analyse_mod.AxisCandidate{},
+    };
+    const info = DeviceInfo{ .name = "Pad", .vid = 0x1111, .pid = 0x2222, .interface_id = 0 };
+
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(allocator);
+    try toml_gen_mod.emitToml(result, info, allocator, buf.writer(allocator));
+
+    try testing.expect(std.mem.indexOf(u8, buf.items, "expect = [0x5a, 0xa5]") != null);
+}
+
+test "capture: emitToml — multi-byte button group spans bytes with group-global bits (F3)" {
+    const allocator = testing.allocator;
+    // Buttons in two different bytes: byte 5 bit 2, byte 6 bit 1. The interpreter
+    // reads `size` bytes from `offset` and treats each map bit index as
+    // group-global, so size must cover the span and bit indices must be re-based:
+    // byte 6 bit 1 → (6-5)*8 + 1 = 9.
+    var buttons = [_]analyse_mod.ButtonCandidate{
+        .{ .byte_offset = 5, .bit = 2, .toggle_count = 8, .high_confidence = true },
+        .{ .byte_offset = 6, .bit = 1, .toggle_count = 8, .high_confidence = true },
+    };
+    const result = AnalysisResult{
+        .report_size = 16,
+        .magic = &[_]analyse_mod.MagicByte{},
+        .buttons = &buttons,
+        .axes = &[_]analyse_mod.AxisCandidate{},
+    };
+    const info = DeviceInfo{ .name = "Pad", .vid = 0x1111, .pid = 0x2222, .interface_id = 0 };
+
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(allocator);
+    try toml_gen_mod.emitToml(result, info, allocator, buf.writer(allocator));
+    const out = buf.items;
+
+    try testing.expect(std.mem.indexOf(u8, out, "size = 2 }") != null);
+    // the old single-byte hardcode must be gone
+    try testing.expect(std.mem.indexOf(u8, out, "size = 1 }") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "btn_6_1 = 9") != null);
+    // the first-byte button keeps its group-global index 2
+    try testing.expect(std.mem.indexOf(u8, out, "btn_5_2 = 2") != null);
+}
+
 // --- debug render ---
 
 test "capture: renderFrame — ANSI sequences present" {


### PR DESCRIPTION
## What

Two generator-only bugs in `src/capture/toml_gen.zig` (the `padctl capture` → device TOML scaffolder) produced configs the interpreter mis-reads:

- **button_group (multi-byte)**: emitter hardcoded `source.size = 1`, anchored on `buttons[0].byte_offset`, and wrote byte-local bit indices. The interpreter reads `size` bytes from `offset` and treats each map bit as group-global, so any button outside the first byte was silently lost or collided. Fix: compute the byte span over high-confidence buttons (`size = max-min+1`) and re-base each bit to `(byte_offset - min_byte)*8 + bit`.
- **match (non-contiguous magic)**: `MatchConfig` is a single `offset` + contiguous `expect` list; `checkMatch` reads `raw[off+i]`. The emitter packed every invariant byte's value into one list anchored at `magic[0].offset`, placing non-contiguous bytes at the wrong offsets. Fix: emit only the contiguous run starting at the first invariant byte.

Both are scaffold-generation defects; the interpreter/validator semantics were already correct.

## Tests

New regression tests in `src/test/capture_e2e_test.zig` (already CI-compiled host):
- multi-byte button group → `size = 2`, group-global bit `(6-5)*8+1 = 9`, old `size = 1` gone
- non-contiguous magic `[{0},{4}]` → byte 4 dropped, only contiguous run emitted
- contiguous magic `[{0},{1}]` → both bytes kept (guards the run logic)

Verified RED→GREEN on the Docker oracle (full `zig build test` green) and under `zig build test-safe` (ReleaseSafe, no safety panic). Backward-compatible: single-byte / fully-contiguous inputs emit byte-identical output to before.

## Notes

- `test-tsan` pre-push hook bypassed via `SKIP_TSAN=1` due to the host #147 native-link wall (R_X86_64_PC64); CI runs tsan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed magic byte serialization to emit only contiguous runs, omitting non-expressible gaps.
  * Improved button group encoding for multi-byte spans with correct global bit indexing.

* **Tests**
  * Added end-to-end tests validating magic byte handling and multi-byte button group generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->