### PR TITLE
chore(release): bump version to 0.1.18

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.17",
+    .version = "0.1.18",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
Version bump for the v0.1.18 release.

Delta over v0.1.17 (all already merged + CI-green on main):
- fix(rumble): stop the motor when a playing FF effect is erased (#443)
- fix(device): warn when force feedback is unavailable on the UHID backend (#445)
- fix(config): reject negative button_group source.offset in validate (#448)
- fix(install): tolerate inline comments in toml_extract / clone_vid_pid scanners (#450, #451)
- fix(capture): correct multi-byte button_group + non-contiguous match in toml_gen (#455)
- test/refactor: pin UHID FF caps, dedup validate/install, dead-code cleanup (#447, #449, #452, #453, #454, #456)

Release: merge, then tag v0.1.18 (triggers release.yml).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version to **0.1.18**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->