### PR TITLE
fix(mapper): release gesture hold key/mouse on layer activation

### DIFF
--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -794,6 +794,14 @@ pub const Mapper = struct {
         self.gesture_engine.reset();
         self.gesture_timer_tap_pending = 0;
         self.gesture_held_gamepad = 0;
+        // The engine reset above forgets any in-flight gesture hold; release the
+        // key/mouse it was holding so it isn't stranded down with no release edge.
+        for (&self.gesture_aux_down_targets) |*target| {
+            if (target.*) |down| {
+                emitAuxDownRelease(down, aux);
+                target.* = null;
+            }
+        }
         self.updateLayerHold(aux);
     }
 
@@ -1496,6 +1504,51 @@ test "mapper: releaseHeldAux releases old trigger-threshold aux down" {
     try testing.expectEqual(@as(usize, 1), release.len);
     try testing.expectEqual(@as(u16, 183), release.get(0).key.code);
     try testing.expect(!release.get(0).key.pressed);
+}
+
+test "mapper: gesture hold key released on layer activation (no stranded key)" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[[layer]]
+        \\name = "fn"
+        \\trigger = "Select"
+        \\activation = "toggle"
+        \\
+        \\[remap]
+        \\A = { tap = "KEY_X", hold = "KEY_Y", hold_ms = 300 }
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const a_mask = buttonBit("A");
+    const sel_mask = buttonBit("Select");
+    const a_idx = @intFromEnum(ButtonId.A);
+    const key_y: u16 = 21; // KEY_Y
+
+    // Fire the gesture hold leg while A is held: KEY_Y goes down and is recorded
+    // as a held gesture target.
+    _ = try m.apply(.{ .buttons = a_mask }, 16, 0);
+    _ = m.onMacroTimerExpired(300 * std.time.ns_per_ms + 1);
+    try testing.expect(m.gesture_aux_down_targets[a_idx] != null);
+
+    // Toggle a layer on while A's hold key is still down: Select press then
+    // release. Toggle activation fires on the release edge, so the second apply
+    // is the frame that runs the layer transition — it must release the key the
+    // gesture was holding, otherwise KEY_Y stays stranded down.
+    _ = try m.apply(.{ .buttons = a_mask | sel_mask }, 16, 310 * std.time.ns_per_ms);
+    const ev = try m.apply(.{ .buttons = a_mask }, 16, 320 * std.time.ns_per_ms);
+
+    try testing.expect(m.gesture_aux_down_targets[a_idx] == null);
+    var saw_release = false;
+    for (ev.aux.slice()) |e| switch (e) {
+        .key => |k| {
+            if (k.code == key_y and !k.pressed) saw_release = true;
+        },
+        else => {},
+    };
+    try testing.expect(saw_release);
 }
 
 test "mapper: base remap gamepad_button: A -> B" {


### PR DESCRIPTION
## What
A gesture **hold** leg targeting a key or mouse button records the held target in `gesture_aux_down_targets` and emits a press. `handleLayerActiveChanged` resets the gesture engine on a layer transition but never released those held targets — so the engine forgets the button while the key stays physically down with no release edge, leaving a **stuck key** until the next full mapping switch or disconnect.

## Fix
Drain `gesture_aux_down_targets` (emit releases) in `handleLayerActiveChanged`, mirroring the existing drain in `releaseHeldAux`.

## Test plan
- New regression test `mapper: gesture hold key released on layer activation (no stranded key)`: fires a gesture hold key, then toggles a layer while held, and asserts the key is released and the target cleared.
- Verified red→green: the test fails on the unfixed code (stranded `gesture_aux_down_targets`) and passes after the drain.
- Full Layer 0/1 suite green in the canonical Docker image (`zig build test`, exit 0).

Found via an internal audit of the mapper layer-transition cleanup path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where gesture-based auxiliary key or mouse inputs could remain stuck after switching layers.
  * Layer changes now properly release any active hold-style inputs, preventing stray keys from staying pressed.
  * Added coverage for a layer-toggle scenario to verify held gesture inputs are released correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->