### PR TITLE
fix(cli): harden config.toml and install/switch argument handling

### DIFF
--- a/src/config/user_config.zig
+++ b/src/config/user_config.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const toml = @import("toml");
 const paths = @import("paths.zig");
+const toml_lint = @import("toml_lint.zig");
 
 /// Current schema version written by the installer's binding writer.
 /// Bumping this requires adding migration logic in the loader.
@@ -49,6 +50,20 @@ pub const UserConfig = struct {
 };
 
 pub const ParseResult = toml.Parsed(UserConfig);
+
+fn lintAllowlistFor(header: []const u8) ?[]const []const u8 {
+    const sf = toml_lint.structFieldNames;
+    if (header.len == 0) return sf(UserConfig);
+    if (std.mem.eql(u8, header, "diagnostics")) return sf(DiagnosticsConfig);
+    if (std.mem.eql(u8, header, "supervisor")) return sf(SupervisorConfig);
+    if (std.mem.eql(u8, header, "chord_switch")) return sf(ChordSwitchConfig);
+    if (std.mem.eql(u8, header, "device")) return sf(DeviceEntry);
+    return null;
+}
+
+pub fn lintUnknownFields(allocator: std.mem.Allocator, raw_toml: []const u8) !std.ArrayList(toml_lint.LintFinding) {
+    return toml_lint.lint(allocator, raw_toml, lintAllowlistFor);
+}
 
 /// Load user config with system fallback.
 ///
@@ -133,6 +148,14 @@ pub fn loadFromDir(allocator: std.mem.Allocator, dir_path: []const u8) LoadDirEr
             std.log.warn("user config: {s} has version {d}, expected <= {d} — some fields may not be understood", .{ config_path, v, CURRENT_VERSION });
         }
     }
+
+    if (lintUnknownFields(allocator, content)) |findings| {
+        defer {
+            var f = findings;
+            f.deinit(allocator);
+        }
+        toml_lint.warnFindings(findings.items);
+    } else |_| {} // lint failure (OOM) must not break parsing
 
     return result;
 }
@@ -765,6 +788,61 @@ test "escapeTomlString escapes backslash and double-quote" {
     defer buf.deinit(a);
     try escapeTomlString(buf.writer(a), "a\\b\"c");
     try std.testing.expectEqualStrings("a\\\\b\\\"c", buf.items);
+}
+
+test "lintUnknownFields: typo'd [[device]] key is flagged" {
+    const allocator = std.testing.allocator;
+    const toml_str =
+        \\version = 1
+        \\
+        \\[[device]]
+        \\name = "Vader 5 Pro"
+        \\defualt_mapping = "fps"
+    ;
+    var findings = try lintUnknownFields(allocator, toml_str);
+    defer findings.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 1), findings.items.len);
+    try std.testing.expectEqualStrings("defualt_mapping", findings.items[0].unknown_key);
+    try std.testing.expectEqualStrings("device", findings.items[0].table);
+}
+
+test "lintUnknownFields: clean user config returns no findings" {
+    const allocator = std.testing.allocator;
+    const toml_str =
+        \\version = 1
+        \\
+        \\[diagnostics]
+        \\dump = false
+        \\max_log_size_mb = 100
+        \\
+        \\[supervisor]
+        \\suspend_grace_sec = 15
+        \\
+        \\[[device]]
+        \\name = "Vader 5 Pro"
+        \\default_mapping = "fps"
+    ;
+    var findings = try lintUnknownFields(allocator, toml_str);
+    defer findings.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 0), findings.items.len);
+}
+
+// loadFromDir must propagate error.MalformedConfig (not null) so a broken user
+// config is distinguishable from an absent one.
+test "loadFromDir: malformed config propagates MalformedConfig not null" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+    {
+        const f = try tmp.dir.createFile("config.toml", .{});
+        defer f.close();
+        try f.writeAll("[[[broken = not valid toml");
+    }
+    // Must be error.MalformedConfig, not null. resolveDefaultMapping branches on
+    // this error to emit "config.toml is malformed" instead of "no config.toml found".
+    try std.testing.expectError(error.MalformedConfig, loadFromDir(allocator, dir_path));
 }
 
 test "user_config: [chord_switch] section parses modifier + selectors + hold_ms" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -269,6 +269,14 @@ const ConfigCmd = union(enum) {
     @"test": struct { config: ?[]const u8, mapping: ?[]const u8, raw: bool },
 };
 
+fn validateDestdir(destdir: []const u8) error{RelativeDestdir}!void {
+    if (destdir.len > 0 and !std.fs.path.isAbsolute(destdir)) return error.RelativeDestdir;
+}
+
+fn validateSwitchArgs(persist: bool, device_id: ?[]const u8) error{PersistWithDevice}!void {
+    if (persist and device_id != null) return error.PersistWithDevice;
+}
+
 fn parseArgs(allocator: std.mem.Allocator) !Cli {
     var args = try std.process.argsWithAllocator(allocator);
     defer args.deinit();
@@ -300,6 +308,10 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                     opts.prefix = args.next() orelse return error.MissingArgValue;
                 } else if (std.mem.eql(u8, iarg, "--destdir")) {
                     opts.destdir = args.next() orelse return error.MissingArgValue;
+                    validateDestdir(opts.destdir) catch {
+                        cli.errors.message(stderr_writer, "--destdir must be an absolute path");
+                        return error.UnknownArgument;
+                    };
                 } else if (std.mem.eql(u8, iarg, "--immutable")) {
                     opts.immutable = true;
                 } else if (std.mem.eql(u8, iarg, "--no-immutable")) {
@@ -343,6 +355,10 @@ fn parseArgs(allocator: std.mem.Allocator) !Cli {
                     opts.prefix = args.next() orelse return error.MissingArgValue;
                 } else if (std.mem.eql(u8, iarg, "--destdir")) {
                     opts.destdir = args.next() orelse return error.MissingArgValue;
+                    validateDestdir(opts.destdir) catch {
+                        cli.errors.message(stderr_writer, "--destdir must be an absolute path");
+                        return error.UnknownArgument;
+                    };
                 } else if (std.mem.eql(u8, iarg, "--immutable")) {
                     opts.immutable = true;
                 } else if (std.mem.eql(u8, iarg, "--no-immutable")) {
@@ -1046,6 +1062,11 @@ pub fn main() !void {
             break :blk resolveDefaultMapping(allocator, parsed.socket_path, stderr_writer);
         };
 
+        validateSwitchArgs(sw.persist, sw.device_id) catch {
+            stderr_writer.writeAll("error: --persist with --device is not yet supported (multi-device ambiguity)\n") catch {};
+            std.process.exit(1);
+        };
+
         const outcome = cli.switch_mapping.run(allocator, mapping_name, sw.device_id, parsed.socket_path, stdout_writer, stderr_writer);
         switch (outcome) {
             .ok => {
@@ -1057,13 +1078,8 @@ pub fn main() !void {
                     saveToUserConfig(allocator, mapping_name, parsed.socket_path, stderr_writer);
                 }
                 if (sw.persist) {
-                    if (sw.device_id != null) {
-                        stderr_writer.writeAll("error: --persist with --device is not yet supported (multi-device ambiguity)\n") catch {};
+                    if (!persistToSystemConfig(allocator, mapping_name, parsed.socket_path, stderr_writer)) {
                         std.process.exit(1);
-                    } else {
-                        if (!persistToSystemConfig(allocator, mapping_name, parsed.socket_path, stderr_writer)) {
-                            std.process.exit(1);
-                        }
                     }
                 }
                 std.process.exit(0);
@@ -1340,12 +1356,40 @@ test {
     _ = @import("test/gen/transition_id.zig");
 }
 
+test "validateDestdir: relative path is rejected" {
+    try std.testing.expectError(error.RelativeDestdir, validateDestdir("relative/path"));
+    try std.testing.expectError(error.RelativeDestdir, validateDestdir("subdir"));
+    try std.testing.expectError(error.RelativeDestdir, validateDestdir("./subdir"));
+}
+
+test "validateDestdir: absolute path is accepted" {
+    try validateDestdir("/tmp/staging");
+    try validateDestdir("/");
+}
+
+test "validateDestdir: empty string is accepted (no --destdir given)" {
+    try validateDestdir("");
+}
+
+test "validateSwitchArgs: persist with device_id is rejected" {
+    try std.testing.expectError(error.PersistWithDevice, validateSwitchArgs(true, "hidraw0"));
+}
+
+test "validateSwitchArgs: persist without device is accepted" {
+    try validateSwitchArgs(true, null);
+}
+
+test "validateSwitchArgs: device without persist is accepted" {
+    try validateSwitchArgs(false, "hidraw0");
+}
+
 /// Resolve the default mapping name from the user's config.toml for the
 /// currently connected device (queried from daemon STATUS). Used by bare
 /// `padctl switch` (no mapping name given).
 fn resolveDefaultMapping(allocator: std.mem.Allocator, socket_path: []const u8, err_writer: anytype) []const u8 {
     const socket_client = @import("cli/socket_client.zig");
     const user_config_mod = @import("config/user_config.zig");
+    const paths_mod = @import("config/paths.zig");
 
     const fd = socket_client.connectToSocket(socket_path) catch {
         socket_client.reportConnectFailure(err_writer, socket_path);
@@ -1362,10 +1406,26 @@ fn resolveDefaultMapping(allocator: std.mem.Allocator, socket_path: []const u8, 
         std.process.exit(1);
     };
 
-    var result = user_config_mod.load(allocator) orelse {
-        err_writer.writeAll("error: no config.toml found; provide a mapping name explicitly\n") catch {};
-        err_writer.writeAll("  usage: padctl switch <name>\n") catch {};
-        std.process.exit(1);
+    // Try user config first, distinguishing malformed from absent.
+    var result: user_config_mod.ParseResult = blk: {
+        if (paths_mod.userConfigDir(allocator) catch null) |ud| {
+            defer allocator.free(ud);
+            const from_user = user_config_mod.loadFromDir(allocator, ud) catch {
+                // MalformedConfig: distinct message, not "no config found".
+                err_writer.writeAll("error: config.toml is malformed — fix it or pass a mapping name explicitly\n") catch {};
+                err_writer.writeAll("  usage: padctl switch <name>\n") catch {};
+                std.process.exit(1);
+            };
+            if (from_user) |r| break :blk r;
+        }
+        // User file absent or HOME not set; try system fallback.
+        const sys_dir = paths_mod.systemConfigDir();
+        const from_sys = user_config_mod.loadFromDir(allocator, sys_dir) catch null;
+        break :blk from_sys orelse {
+            err_writer.writeAll("error: no config.toml found; provide a mapping name explicitly\n") catch {};
+            err_writer.writeAll("  usage: padctl switch <name>\n") catch {};
+            std.process.exit(1);
+        };
     };
     return user_config_mod.findDefaultMapping(&result, device_name) orelse {
         err_writer.print("error: no default_mapping in config.toml for device \"{s}\"\n", .{device_name}) catch {};


### PR DESCRIPTION
Four small, independent robustness fixes found via an internal audit (each confirmed against current code).

## Fixes
- **config.toml unknown-field linter** — `toml_lint` was wired for device/mapping TOMLs but not user config, so a typo'd `[[device]]` key (e.g. `defualt_mapping`) was silently dropped and the user just got "no default_mapping" with no hint. Now linted + warned, mirroring the device/mapping call sites.
- **relative `--destdir` rejected** — was unchecked and flowed into `createFileAbsolute` (panic in safe builds / wrong location in ReleaseFast). Now rejected at parse time, before any filesystem work.
- **`switch --device --persist`** — the incompatibility was detected *after* the switch already applied (exit 1 after success). Now validated before `switch_mapping.run`.
- **malformed vs absent config** — a malformed `config.toml` reported "no config.toml found" (contradicting the parse-error warning). `resolveDefaultMapping` now distinguishes the two.

## Test plan
- New unit tests for each validator/seam: `validateDestdir`, `validateSwitchArgs`, `lintUnknownFields` (typo flagged / clean returns none), `loadFromDir` malformed-propagation.
- Full Layer 0/1 suite green in the canonical Docker image (`zig build test`, exit 0).