### PR TITLE
fix(io): re-point FfbForwarder at the fresh fd on device rebind

### DIFF
--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -727,6 +727,11 @@ pub const DeviceInstance = struct {
         if (new_devices.len != self.devices.len) return error.DeviceCountMismatch;
         try self.loop.rebindDevices(new_devices);
         @memcpy(self.devices, new_devices);
+        // The FFB forwarder borrows devices[0]'s fd; closeDeviceIO just closed
+        // the old one, so re-point it at the fresh fd (mirrors init).
+        if (self.ffb_forwarder) |*fwd| {
+            if (self.devices.len > 0) fwd.setPhysicalFd(self.devices[0].pollfd().fd);
+        }
     }
 
     /// Re-run the device init sequence (e.g. handshake packets) using the
@@ -1669,6 +1674,35 @@ test "DeviceInstance: rebindDeviceIO rejects device count mismatch" {
 
     var empty = [_]DeviceIO{};
     try testing.expectError(error.DeviceCountMismatch, inst.rebindDeviceIO(&empty));
+}
+
+test "DeviceInstance: rebindDeviceIO re-points FfbForwarder at the fresh fd" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, minimal_toml);
+    defer parsed.deinit();
+
+    var mock_a = try MockDeviceIO.init(allocator, &.{});
+    defer mock_a.deinit();
+
+    var inst = try testInstance(allocator, &mock_a, &parsed.value);
+    defer {
+        inst.loop.deinit();
+        allocator.free(inst.devices);
+    }
+
+    // A force-feedback wheel borrows devices[0]'s fd through the forwarder.
+    inst.ffb_forwarder = FfbForwarder.init(inst.devices[0].pollfd().fd);
+
+    inst.closeDeviceIO();
+
+    var mock_b = try MockDeviceIO.init(allocator, &.{});
+    defer mock_b.deinit();
+    var new_devs = [_]DeviceIO{mock_b.deviceIO()};
+    try inst.rebindDeviceIO(&new_devs);
+
+    // Without the re-point the forwarder keeps writing to the closed old fd.
+    try testing.expectEqual(mock_b.deviceIO().pollfd().fd, inst.ffb_forwarder.?.physical_fd);
 }
 
 // issue #397: openDeviceWithRetry must NOT sleep/retry on the supervisor

--- a/src/io/ffb_forwarder.zig
+++ b/src/io/ffb_forwarder.zig
@@ -20,6 +20,14 @@ pub const FfbForwarder = struct {
         return .{ .physical_fd = physical_fd };
     }
 
+    /// Re-point the forwarder at a fresh physical hidraw fd after a device
+    /// rebind (sleep/wake). The old fd was closed by the supervisor, so re-arm
+    /// in case the forwarder had disabled itself on the now-stale fd.
+    pub fn setPhysicalFd(self: *FfbForwarder, fd: posix.fd_t) void {
+        self.physical_fd = fd;
+        self.state = .active;
+    }
+
     pub fn attachWedge(self: *FfbForwarder, wedge: *WedgeAtomics) void {
         self.wedge = wedge;
     }


### PR DESCRIPTION
## Bug
`FfbForwarder` captures `devices[0]`'s hidraw fd by value at init. On a sleep/wake rebind, `closeDeviceIO` closes the old fd and `rebindDeviceIO` swaps in a new one, but the forwarder kept the **stale** fd. After resume it wrote PID FFB reports to a closed (→ EBADF, forwarder permanently disabled) or recycled fd (→ wrong file). Only affects `force_feedback backend="uhid" kind="pid"` wheels that suspend/resume.

## Fix
Add `FfbForwarder.setPhysicalFd` and call it from `rebindDeviceIO` to re-point at the new `devices[0]` fd, re-arming a forwarder that may have disabled itself on the stale fd.

## Test plan
- New regression test `DeviceInstance: rebindDeviceIO re-points FfbForwarder at the fresh fd`. Verified red→green: it fails on the unfixed code (`physical_fd` stuck on the old fd) and passes after the re-point.
- Full Layer 0/1 suite green in the canonical Docker image (`zig build test`, exit 0).