### PR TITLE
refactor: remove dead-duplicate escapeTomlString from main.zig

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1611,26 +1611,6 @@ fn makeTempDir(allocator: std.mem.Allocator) ![]u8 {
     return error.TempDirCreationFailed;
 }
 
-fn escapeTomlString(writer: anytype, s: []const u8) !void {
-    for (s) |c| {
-        switch (c) {
-            '\\' => try writer.writeAll("\\\\"),
-            '"' => try writer.writeAll("\\\""),
-            '\n' => try writer.writeAll("\\n"),
-            '\r' => try writer.writeAll("\\r"),
-            '\t' => try writer.writeAll("\\t"),
-            0x08 => try writer.writeAll("\\b"),
-            0x0C => try writer.writeAll("\\f"),
-            0...0x07, 0x0B, 0x0E...0x1F, 0x7F => {
-                var buf: [6]u8 = undefined;
-                const escaped = std.fmt.bufPrint(&buf, "\\u{X:0>4}", .{c}) catch unreachable;
-                try writer.writeAll(escaped);
-            },
-            else => try writer.writeByte(c),
-        }
-    }
-}
-
 /// Write a config.toml with a single device binding. Reads the existing
 /// file so every section ([diagnostics], [supervisor], [chord_switch],
 /// unrelated [[device]] entries) survives the round-trip; only the target
@@ -1980,21 +1960,6 @@ test "main: parseDeviceFromStatus + findDefaultMapping: no default_mapping retur
     // Device not in config → returns null → caller emits specific error, not "no devices connected"
     const mapping = user_config_mod.findDefaultMapping(&result, device_name.?);
     try testing.expectEqual(@as(?[]const u8, null), mapping);
-}
-
-test "escapeTomlString: escapes special characters" {
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(testing.allocator);
-    try escapeTomlString(buf.writer(testing.allocator), "Device \"X\"\\\nTab\there");
-    try testing.expectEqualStrings("Device \\\"X\\\"\\\\\\nTab\\there", buf.items);
-}
-
-test "escapeTomlString: covers full TOML control-char set" {
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(testing.allocator);
-    // \r → \r, \b (0x08) → \b, \f (0x0C) → \f, 0x01 → \u0001
-    try escapeTomlString(buf.writer(testing.allocator), "\r\x08\x0C\x01");
-    try testing.expectEqualStrings("\\r\\b\\f\\u0001", buf.items);
 }
 
 test "main: parseHexBytes via init_seq" {


### PR DESCRIPTION
The private `escapeTomlString` in `src/main.zig` had **zero production callers** — every real caller uses the public `user_config.escapeTomlString` (`src/config/user_config.zig`). Removes the dead function and its two tests (35 lines).

Found via an internal docs/code review.

## Test plan
- `git grep` confirms no non-test caller of the main.zig-local function.
- Full Layer 0/1 suite green in the canonical Docker image (`zig build test`, exit 0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an internal implementation detail and its related test coverage. No user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->