### PR TITLE
fix: harden offline switch and layer gesture cleanup

### DIFF
--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -730,12 +730,12 @@ pub const Mapper = struct {
             self.handleLayerActiveChanged(&events.aux, now_ns);
             events.gamepad = self.currentMappedGamepadFrame();
         } else if (th_res.layer_activated) {
+            // Plain hold activation has no active_changed apply() chokepoint, so
+            // perform the gesture/layer-hold cleanup here without touching the
+            // macro queue; layer-timer expiry is not the macro timerfd.
             self.prev.dpad_x = 0;
             self.prev.dpad_y = 0;
-            // Plain hold activation has no active_changed apply() chokepoint, so
-            // drive the `hold` passthrough here. updateLayerHold releases the
-            // prior layer's hold first, so it must run even when the newly-active
-            // layer has no hold target — otherwise a stale hold leaks forever.
+            self.cancelGestureStateForLayerChange(&events.aux, now_ns);
             self.updateLayerHold(&events.aux);
             events.gamepad = self.currentMappedGamepadFrame();
         }
@@ -786,7 +786,13 @@ pub const Mapper = struct {
         releasePendingAuxTapReleases(self, aux, now_ns);
         // Discard tap bits staged from a cancelled macro's timer expiry.
         self.macro_timer_tap_pending = 0;
-        // Cancel in-flight gestures; mirror the macro-cancel above.
+        self.cancelGestureStateForLayerChange(aux, now_ns);
+        self.updateLayerHold(aux);
+    }
+
+    fn cancelGestureStateForLayerChange(self: *Mapper, aux: *AuxEventList, now_ns: i128) void {
+        // Cancel in-flight gestures and release any key/mouse hold whose release
+        // edge would otherwise be lost when the layer changes source routing.
         for (self.gesture_tokens.entries) |maybe| {
             if (maybe) |e| self.timer_queue.cancel(e.token, now_ns);
         }
@@ -794,15 +800,12 @@ pub const Mapper = struct {
         self.gesture_engine.reset();
         self.gesture_timer_tap_pending = 0;
         self.gesture_held_gamepad = 0;
-        // The engine reset above forgets any in-flight gesture hold; release the
-        // key/mouse it was holding so it isn't stranded down with no release edge.
         for (&self.gesture_aux_down_targets) |*target| {
             if (target.*) |down| {
                 emitAuxDownRelease(down, aux);
                 target.* = null;
             }
         }
-        self.updateLayerHold(aux);
     }
 
     // Single chokepoint for the layer `hold` passthrough output. Releases the
@@ -1543,6 +1546,49 @@ test "mapper: gesture hold key released on layer activation (no stranded key)" {
     try testing.expect(m.gesture_aux_down_targets[a_idx] == null);
     var saw_release = false;
     for (ev.aux.slice()) |e| switch (e) {
+        .key => |k| {
+            if (k.code == key_y and !k.pressed) saw_release = true;
+        },
+        else => {},
+    };
+    try testing.expect(saw_release);
+}
+
+test "mapper: gesture hold key released on plain hold layer timer activation" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[[layer]]
+        \\name = "fn"
+        \\trigger = "LB"
+        \\activation = "hold"
+        \\hold_timeout = 200
+        \\
+        \\[layer.remap]
+        \\A = "disabled"
+        \\
+        \\[remap]
+        \\A = { tap = "KEY_X", hold = "KEY_Y", hold_ms = 300 }
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const a_mask = buttonBit("A");
+    const lb_mask = buttonBit("LB");
+    const a_idx = @intFromEnum(ButtonId.A);
+    const key_y: u16 = 21; // KEY_Y
+
+    _ = try m.apply(.{ .buttons = a_mask }, 16, 0);
+    _ = m.onMacroTimerExpired(300 * std.time.ns_per_ms + 1);
+    try testing.expect(m.gesture_aux_down_targets[a_idx] != null);
+
+    _ = try m.apply(.{ .buttons = a_mask | lb_mask }, 16, 310 * std.time.ns_per_ms);
+    const timer = m.onLayerTimerExpiredAt(520 * std.time.ns_per_ms);
+
+    try testing.expect(m.gesture_aux_down_targets[a_idx] == null);
+    var saw_release = false;
+    for (timer.aux.slice()) |e| switch (e) {
         .key => |k| {
             if (k.code == key_y and !k.pressed) saw_release = true;
         },

--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -1693,6 +1693,7 @@ test "DeviceInstance: rebindDeviceIO re-points FfbForwarder at the fresh fd" {
 
     // A force-feedback wheel borrows devices[0]'s fd through the forwarder.
     inst.ffb_forwarder = FfbForwarder.init(inst.devices[0].pollfd().fd);
+    inst.ffb_forwarder.?.state = .disabled;
 
     inst.closeDeviceIO();
 
@@ -1703,6 +1704,7 @@ test "DeviceInstance: rebindDeviceIO re-points FfbForwarder at the fresh fd" {
 
     // Without the re-point the forwarder keeps writing to the closed old fd.
     try testing.expectEqual(mock_b.deviceIO().pollfd().fd, inst.ffb_forwarder.?.physical_fd);
+    try testing.expectEqual(.active, inst.ffb_forwarder.?.state);
 }
 
 // issue #397: openDeviceWithRetry must NOT sleep/retry on the supervisor

--- a/src/main.zig
+++ b/src/main.zig
@@ -1690,6 +1690,7 @@ fn persistDefaultOffline(allocator: std.mem.Allocator, mapping_name: []const u8,
         _ = error_hint_mod.hintFor(err_writer, "mapping-not-found", mapping_name);
         return 1;
     }
+    if (!validateMappingFileForOfflineSwitch(allocator, resolved.?, mapping_name, err_writer)) return 1;
 
     const user_dir = paths.userConfigDir(allocator) catch {
         err_writer.writeAll("error: could not write ~/.config/padctl/config.toml\n") catch {};
@@ -1705,9 +1706,9 @@ fn persistDefaultOffline(allocator: std.mem.Allocator, mapping_name: []const u8,
         },
     };
 
-    const count = writeDefaultForAllDevices(allocator, user_dir, mapping_name) catch |err| switch (err) {
+    const result = writeDefaultForOfflineConfig(allocator, user_dir, paths.systemConfigDir(), mapping_name) catch |err| switch (err) {
         error.MalformedConfig => {
-            err_writer.writeAll("error: user config.toml is malformed — fix or remove it first\n") catch {};
+            err_writer.writeAll("error: config.toml is malformed — fix or remove it first\n") catch {};
             return 1;
         },
         else => {
@@ -1716,15 +1717,75 @@ fn persistDefaultOffline(allocator: std.mem.Allocator, mapping_name: []const u8,
         },
     };
 
-    if (count == 0) {
+    if (result.count == 0) {
         err_writer.writeAll("warning: no controller connected and no devices recorded yet.\n") catch {};
         err_writer.writeAll("hint: connect your controller once so padctl records it, then run `padctl switch <name>` again.\n") catch {};
         return 1;
     }
 
-    out_writer.print("set default mapping to \"{s}\" for {d} recorded device(s)\n", .{ mapping_name, count }) catch {};
+    out_writer.print("set default mapping to \"{s}\" for {d} recorded device(s)\n", .{ mapping_name, result.count }) catch {};
+    if (result.source == .system) {
+        err_writer.writeAll("info: seeded user config from /etc/padctl/config.toml\n") catch {};
+    }
     err_writer.writeAll("warning: no controller connected; it will apply when the controller is next connected.\n") catch {};
     return 0;
+}
+
+fn validateMappingFileForOfflineSwitch(
+    allocator: std.mem.Allocator,
+    mapping_path: []const u8,
+    mapping_name: []const u8,
+    err_writer: anytype,
+) bool {
+    const mapping_cfg = @import("config/mapping.zig");
+    const error_hint_mod = @import("cli/error_hint.zig");
+
+    var parsed_mapping = mapping_cfg.parseFile(allocator, mapping_path) catch {
+        _ = error_hint_mod.hintFor(err_writer, "mapping-parse-failed", mapping_name);
+        return false;
+    };
+    parsed_mapping.deinit();
+    return true;
+}
+
+const OfflineConfigSource = enum { none, user, system };
+
+const OfflineConfigResult = struct {
+    count: usize,
+    source: OfflineConfigSource,
+};
+
+fn writeDefaultForOfflineConfig(
+    allocator: std.mem.Allocator,
+    user_dir: []const u8,
+    system_dir: []const u8,
+    mapping_name: []const u8,
+) !OfflineConfigResult {
+    const user_config_mod = @import("config/user_config.zig");
+
+    var user_existing = user_config_mod.loadFromDir(allocator, user_dir) catch |err| switch (err) {
+        error.MalformedConfig => return error.MalformedConfig,
+    };
+    defer if (user_existing) |*e| e.deinit();
+    if (user_existing) |*e| {
+        return .{
+            .count = try writeDefaultFromParsedDevices(allocator, user_dir, e, mapping_name),
+            .source = .user,
+        };
+    }
+
+    var system_existing = user_config_mod.loadFromDir(allocator, system_dir) catch |err| switch (err) {
+        error.MalformedConfig => return error.MalformedConfig,
+    };
+    defer if (system_existing) |*e| e.deinit();
+    if (system_existing) |*e| {
+        return .{
+            .count = try writeDefaultFromParsedDevices(allocator, user_dir, e, mapping_name),
+            .source = .system,
+        };
+    }
+
+    return .{ .count = 0, .source = .none };
 }
 
 /// Set default_mapping = mapping_name for ALL recorded [[device]] entries in
@@ -1738,10 +1799,22 @@ fn writeDefaultForAllDevices(allocator: std.mem.Allocator, dir: []const u8, mapp
     };
     defer if (existing) |*e| e.deinit();
 
-    const old_devices = if (existing) |e| e.value.device else null;
-    if (old_devices == null or old_devices.?.len == 0) return 0;
+    if (existing) |*e| {
+        return writeDefaultFromParsedDevices(allocator, dir, e, mapping_name);
+    }
+    return 0;
+}
 
-    const devs = old_devices.?;
+fn writeDefaultFromParsedDevices(
+    allocator: std.mem.Allocator,
+    dir: []const u8,
+    existing: anytype,
+    mapping_name: []const u8,
+) !usize {
+    const user_config_mod = @import("config/user_config.zig");
+
+    const devs = existing.value.device orelse return 0;
+    if (devs.len == 0) return 0;
     const new_devices = try allocator.alloc(user_config_mod.DeviceEntry, devs.len);
     defer allocator.free(new_devices);
 
@@ -1750,11 +1823,11 @@ fn writeDefaultForAllDevices(allocator: std.mem.Allocator, dir: []const u8, mapp
     }
 
     const cfg = user_config_mod.UserConfig{
-        .version = if (existing) |e| e.value.version else null,
+        .version = existing.value.version,
         .device = new_devices,
-        .diagnostics = if (existing) |e| e.value.diagnostics else .{},
-        .supervisor = if (existing) |e| e.value.supervisor else .{},
-        .chord_switch = if (existing) |e| e.value.chord_switch else null,
+        .diagnostics = existing.value.diagnostics,
+        .supervisor = existing.value.supervisor,
+        .chord_switch = existing.value.chord_switch,
     };
 
     const config_path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{dir});
@@ -2231,4 +2304,76 @@ test "writeDefaultForAllDevices: no config.toml returns 0" {
 
     const count = try writeDefaultForAllDevices(allocator, dir_path, "nioh");
     try testing.expectEqual(@as(usize, 0), count);
+}
+
+test "writeDefaultForOfflineConfig: missing user config seeds devices from system config" {
+    const allocator = testing.allocator;
+    const user_config_mod = @import("config/user_config.zig");
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makeDir("user");
+    try tmp.dir.makeDir("system");
+
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    const user_dir = try std.fs.path.join(allocator, &.{ root, "user" });
+    defer allocator.free(user_dir);
+    const system_dir = try std.fs.path.join(allocator, &.{ root, "system" });
+    defer allocator.free(system_dir);
+
+    const seed =
+        \\version = 1
+        \\
+        \\[diagnostics]
+        \\dump = true
+        \\
+        \\[[device]]
+        \\name = "Vader 5 Pro"
+        \\default_mapping = "old"
+    ;
+    {
+        const f = try tmp.dir.createFile("system/config.toml", .{});
+        defer f.close();
+        try f.writeAll(seed);
+    }
+
+    const result = try writeDefaultForOfflineConfig(allocator, user_dir, system_dir, "nioh");
+    try testing.expectEqual(@as(usize, 1), result.count);
+    try testing.expectEqual(OfflineConfigSource.system, result.source);
+
+    var user_loaded = (try user_config_mod.loadFromDir(allocator, user_dir)).?;
+    defer user_loaded.deinit();
+    const devs = user_loaded.value.device orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(@as(usize, 1), devs.len);
+    try testing.expectEqualStrings("Vader 5 Pro", devs[0].name);
+    try testing.expectEqualStrings("nioh", devs[0].default_mapping.?);
+    try testing.expectEqual(true, user_loaded.value.diagnostics.dump);
+
+    var system_loaded = (try user_config_mod.loadFromDir(allocator, system_dir)).?;
+    defer system_loaded.deinit();
+    try testing.expectEqualStrings("old", system_loaded.value.device.?[0].default_mapping.?);
+}
+
+test "validateMappingFileForOfflineSwitch: rejects invalid mapping file" {
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    {
+        const f = try tmp.dir.createFile("bad.toml", .{});
+        defer f.close();
+        try f.writeAll("[[[broken = not valid toml\n");
+    }
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    const path = try std.fs.path.join(allocator, &.{ root, "bad.toml" });
+    defer allocator.free(path);
+
+    var buf = std.ArrayList(u8){};
+    defer buf.deinit(allocator);
+
+    try testing.expect(!validateMappingFileForOfflineSwitch(allocator, path, "bad", buf.writer(allocator)));
+    try testing.expect(std.mem.indexOf(u8, buf.items, "could not be parsed") != null);
 }


### PR DESCRIPTION
## Summary
- release gesture-held key/mouse outputs when a plain hold layer activates from the layer timer, without draining the macro queue
- make offline switch seed user config from system config when the user config is absent
- reject invalid mapping files before persisting an offline default
- extend the FFB rebind regression to assert the forwarder is re-armed

## Reproduction evidence
- Added mapper regression first; it failed on current main at gesture_aux_down_targets not being cleared.
- Reproduced system-only config in Docker with fake daemon returning ERR no-devices: before fix rc=1 and no user config was written.
- Reproduced invalid mapping in Docker: before fix rc=0 and default_mapping was set to the bad profile.

## Verification
- ./scripts/padctl-docker test --summary all
- PATH=/home/jim_z/.local/bin:/home/jim_z/.elan/bin:/home/jim_z/.npm-global/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/home/jim_z/.codex/tmp/arg0/codex-arg0TITfGW:/home/jim_z/.bun/bin:/home/jim_z/bin:/home/jim_z/.local/share/gem/ruby/3.4.0/bin:/home/jim_z/.npm-global/bin:/home/jim_z/.elan/bin:/home/jim_z/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/cuda/bin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/opt/rocm/bin:/home/jim_z/.local/bin:/home/jim_z/.cargo/bin/:/home/jim_z/.local/bin/:/home/jim_z/.local/bin:/home/jim_z/.local/bin git push ran pre-push; host Zig hit the known .sframe limit and the hook fell back to Docker test-tsan, which passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offline default-mapping setup now better explains where defaults come from and whether they will apply immediately or on the next connection.
  * Added safer handling when no controller is connected, including a clearer warning in that case.

* **Bug Fixes**
  * Fixed a layer transition issue that could leave a gesture-held key or auxiliary output stuck after a plain hold activation.
  * Improved device rebinding so force-feedback state updates correctly after switching to a new device connection.
  * Added validation to prevent applying offline defaults from an invalid mapping file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->