### PR TITLE
Fix stuck rumble after FF stops

### DIFF
--- a/src/core/rumble_scheduler.zig
+++ b/src/core/rumble_scheduler.zig
@@ -15,19 +15,32 @@ pub const MAX_EFFECTS = 16;
 /// memless helper — so effects uploaded to padctl's virtual gamepad are never
 /// auto-stopped by the kernel. This module fills that gap in userspace.
 pub const RumbleScheduler = struct {
-    /// Per-slot deadline, indexed by FF effect id (0..MAX_EFFECTS-1).
-    /// 0 = not playing.
-    /// INFINITE = playing with `replay.length == 0` (never auto-stops on its own).
-    /// positive, < INFINITE = absolute monotonic deadline in nanoseconds.
-    slots: [MAX_EFFECTS]i128 = @splat(0),
+    pub const Slot = struct {
+        /// 0 = not playing.
+        /// INFINITE = playing with `replay.length == 0`.
+        /// positive, < INFINITE = absolute monotonic deadline in nanoseconds.
+        deadline_ns: i128 = 0,
+        strong: u16 = 0,
+        weak: u16 = 0,
+    };
+
+    pub const Frame = struct {
+        strong: u16,
+        weak: u16,
+    };
+
+    /// Per-effect state, indexed by FF effect id (0..MAX_EFFECTS-1).
+    slots: [MAX_EFFECTS]Slot = @splat(.{}),
 
     /// Sentinel deadline for effects with infinite duration.
     pub const INFINITE: i128 = std.math.maxInt(i128);
 
     pub const ExpiryResult = struct {
-        /// When true, the event loop must emit a stop frame to the HID device
-        /// because no effect remains playing.
-        emit_stop_frame: bool,
+        /// Frame to emit to the HID device when the aggregate active rumble
+        /// changed. `null` means the hardware command state is already correct.
+        frame: ?Frame,
+        /// True when any effect remains active after the mutation.
+        active_after: bool,
         /// Next instant at which the host timerfd should wake, or null to
         /// disarm the timerfd entirely.
         next_deadline_ns: ?i128,
@@ -36,31 +49,43 @@ pub const RumbleScheduler = struct {
     /// Record that `effect_id` started playing with the given length.
     /// `length_ms == 0` means infinite (never auto-stops on its own).
     /// Out-of-range effect ids are ignored defensively.
-    /// Returns the new earliest finite deadline, or null if none is pending.
-    pub fn onPlay(self: *RumbleScheduler, effect_id: u8, length_ms: u16, now_ns: i128) ?i128 {
-        if (effect_id >= MAX_EFFECTS) return self.nextDeadline();
-        self.slots[effect_id] = if (length_ms == 0)
-            INFINITE
-        else
-            now_ns + @as(i128, length_ms) * std.time.ns_per_ms;
-        return self.nextDeadline();
+    pub fn onPlay(self: *RumbleScheduler, effect_id: u8, strong: u16, weak: u16, length_ms: u16, now_ns: i128) ExpiryResult {
+        const before = self.aggregateFrame();
+        if (effect_id < MAX_EFFECTS) {
+            self.slots[effect_id] = .{
+                .deadline_ns = if (length_ms == 0)
+                    INFINITE
+                else
+                    now_ns + @as(i128, length_ms) * std.time.ns_per_ms,
+                .strong = strong,
+                .weak = weak,
+            };
+        }
+        const after = self.aggregateFrame();
+        return .{
+            .frame = changedFrame(before, after),
+            .active_after = self.anyPlaying(),
+            .next_deadline_ns = self.nextDeadline(),
+        };
     }
 
     /// Record that `effect_id` was explicitly stopped by the client
     /// (EV_FF value=0). Out-of-range ids are ignored defensively.
     ///
     /// Returns an `ExpiryResult`:
-    /// - `emit_stop_frame` is true ONLY when no effect remains playing
-    ///   (finite or infinite). The caller must not emit a zero frame to
-    ///   HID when another effect is still active, otherwise the long
-    ///   effect's motor would be cut off mid-playback.
+    /// - `frame` is the new aggregate hardware rumble state when it changed.
+    ///   This may be a zero stop frame or a non-zero restore frame for another
+    ///   effect that is still active.
     /// - `next_deadline_ns` is the next pending finite deadline, or null.
     pub fn onStop(self: *RumbleScheduler, effect_id: u8) ExpiryResult {
+        const before = self.aggregateFrame();
         if (effect_id < MAX_EFFECTS) {
-            self.slots[effect_id] = 0;
+            self.slots[effect_id] = .{};
         }
+        const after = self.aggregateFrame();
         return .{
-            .emit_stop_frame = !self.anyPlaying(),
+            .frame = changedFrame(before, after),
+            .active_after = self.anyPlaying(),
             .next_deadline_ns = self.nextDeadline(),
         };
     }
@@ -70,31 +95,52 @@ pub const RumbleScheduler = struct {
     /// emitted (no slots remain playing at all) and where the timerfd
     /// should be armed next.
     pub fn onTimerExpired(self: *RumbleScheduler, now_ns: i128) ExpiryResult {
+        const before = self.aggregateFrame();
         for (&self.slots) |*s| {
-            if (s.* > 0 and s.* != INFINITE and s.* <= now_ns) {
-                s.* = 0;
+            if (s.deadline_ns > 0 and s.deadline_ns != INFINITE and s.deadline_ns <= now_ns) {
+                s.* = .{};
             }
         }
+        const after = self.aggregateFrame();
         return .{
-            .emit_stop_frame = !self.anyPlaying(),
+            .frame = changedFrame(before, after),
+            .active_after = self.anyPlaying(),
             .next_deadline_ns = self.nextDeadline(),
         };
     }
 
-    /// True when any slot has a non-zero deadline (finite OR infinite).
-    /// Used by `onStop` and `onTimerExpired` to decide whether the event
-    /// loop must emit a zero rumble frame to HID.
     fn anyPlaying(self: *const RumbleScheduler) bool {
         for (self.slots) |s| {
-            if (s != 0) return true;
+            if (s.deadline_ns != 0) return true;
         }
         return false;
+    }
+
+    /// Aggregate all active effects into the single rumble command the
+    /// physical controller can actually hold. This intentionally uses
+    /// per-motor max: it preserves an active stronger effect, restores weaker
+    /// effects after stronger overlaps stop, and avoids synthetic overdrive.
+    fn aggregateFrame(self: *const RumbleScheduler) Frame {
+        var out = Frame{ .strong = 0, .weak = 0 };
+        for (self.slots) |s| {
+            if (s.deadline_ns == 0) continue;
+            out.strong = @max(out.strong, s.strong);
+            out.weak = @max(out.weak, s.weak);
+        }
+        return out;
+    }
+
+    fn changedFrame(before: Frame, after: Frame) ?Frame {
+        if (before.strong == after.strong and before.weak == after.weak) return null;
+        return after;
     }
 
     /// Returns the raw slot array for diagnostic logging. The caller can
     /// format it without pulling I/O into the scheduler.
     pub fn dumpSlots(self: *const RumbleScheduler) [MAX_EFFECTS]i128 {
-        return self.slots;
+        var out: [MAX_EFFECTS]i128 = undefined;
+        for (self.slots, 0..) |s, i| out[i] = s.deadline_ns;
+        return out;
     }
 
     /// Returns the earliest finite pending deadline, or null if nothing is
@@ -104,8 +150,8 @@ pub const RumbleScheduler = struct {
         var min: i128 = INFINITE;
         var found = false;
         for (self.slots) |s| {
-            if (s > 0 and s != INFINITE and s < min) {
-                min = s;
+            if (s.deadline_ns > 0 and s.deadline_ns != INFINITE and s.deadline_ns < min) {
+                min = s.deadline_ns;
                 found = true;
             }
         }
@@ -116,6 +162,16 @@ pub const RumbleScheduler = struct {
 // --- tests ---
 
 const testing = std.testing;
+
+fn expectFrame(actual: ?RumbleScheduler.Frame, strong: u16, weak: u16) !void {
+    const frame = actual orelse return error.ExpectedFrame;
+    try testing.expectEqual(strong, frame.strong);
+    try testing.expectEqual(weak, frame.weak);
+}
+
+fn expectNoFrame(actual: ?RumbleScheduler.Frame) !void {
+    try testing.expectEqual(@as(?RumbleScheduler.Frame, null), actual);
+}
 
 test "rumble_scheduler: empty scheduler has no pending deadline" {
     var sched: RumbleScheduler = .{};
@@ -128,8 +184,9 @@ test "rumble_scheduler: onPlay records finite deadline at now + length_ms" {
     const length_ms: u16 = 500;
     const expected: i128 = now + @as(i128, length_ms) * std.time.ns_per_ms;
 
-    const next = sched.onPlay(0, length_ms, now);
-    try testing.expectEqual(@as(?i128, expected), next);
+    const result = sched.onPlay(0, 0x8000, 0x4000, length_ms, now);
+    try expectFrame(result.frame, 0x8000, 0x4000);
+    try testing.expectEqual(@as(?i128, expected), result.next_deadline_ns);
     try testing.expectEqual(@as(?i128, expected), sched.nextDeadline());
 }
 
@@ -139,10 +196,10 @@ test "rumble_scheduler: onTimerExpired at deadline clears slot and emits stop" {
     const length_ms: u16 = 500;
     const deadline = now + @as(i128, length_ms) * std.time.ns_per_ms;
 
-    _ = sched.onPlay(0, length_ms, now);
+    _ = sched.onPlay(0, 0x8000, 0x4000, length_ms, now);
 
     const result = sched.onTimerExpired(deadline);
-    try testing.expect(result.emit_stop_frame);
+    try expectFrame(result.frame, 0, 0);
     try testing.expectEqual(@as(?i128, null), result.next_deadline_ns);
     // Slot is cleared
     try testing.expectEqual(@as(?i128, null), sched.nextDeadline());
@@ -156,14 +213,15 @@ test "rumble_scheduler: infinite duration never contributes a deadline but stays
     // The scheduler should disarm the timerfd (nothing to auto-stop) but
     // still consider the slot "playing" so a spurious timer fire does not
     // emit a stop frame.
-    const next_after_play = sched.onPlay(3, 0, now);
-    try testing.expectEqual(@as(?i128, null), next_after_play);
+    const next_after_play = sched.onPlay(3, 0x1000, 0x2000, 0, now);
+    try expectFrame(next_after_play.frame, 0x1000, 0x2000);
+    try testing.expectEqual(@as(?i128, null), next_after_play.next_deadline_ns);
     try testing.expectEqual(@as(?i128, null), sched.nextDeadline());
 
     // If the timerfd fires later for some reason (e.g., another effect
     // expired and left this one), we must not emit a stop frame.
     const result = sched.onTimerExpired(now + 10 * std.time.ns_per_s);
-    try testing.expect(!result.emit_stop_frame);
+    try expectNoFrame(result.frame);
     try testing.expectEqual(@as(?i128, null), result.next_deadline_ns);
 }
 
@@ -175,19 +233,20 @@ test "rumble_scheduler: long-then-short overlap does not prematurely emit stop" 
     const t1000 = 1000 * std.time.ns_per_ms;
 
     // A plays for 1000ms starting at t=0
-    _ = sched.onPlay(0, 1000, t0);
+    _ = sched.onPlay(0, 0x1000, 0x0800, 1000, t0);
     // B plays for 200ms starting at t=100 → deadline t=300
-    const next_after_b = sched.onPlay(1, 200, t100);
-    try testing.expectEqual(@as(?i128, t300), next_after_b);
+    const next_after_b = sched.onPlay(1, 0x8000, 0x4000, 200, t100);
+    try expectFrame(next_after_b.frame, 0x8000, 0x4000);
+    try testing.expectEqual(@as(?i128, t300), next_after_b.next_deadline_ns);
 
-    // Timer fires at t=300 → B expires, A still playing, no stop frame
+    // Timer fires at t=300 → B expires, A still playing, restore A.
     const first = sched.onTimerExpired(t300);
-    try testing.expect(!first.emit_stop_frame);
+    try expectFrame(first.frame, 0x1000, 0x0800);
     try testing.expectEqual(@as(?i128, t1000), first.next_deadline_ns);
 
     // Timer fires at t=1000 → A expires, nothing remaining, stop frame emitted
     const second = sched.onTimerExpired(t1000);
-    try testing.expect(second.emit_stop_frame);
+    try expectFrame(second.frame, 0, 0);
     try testing.expectEqual(@as(?i128, null), second.next_deadline_ns);
 }
 
@@ -197,14 +256,15 @@ test "rumble_scheduler: same-id reuse replaces the deadline (latest play wins)" 
     const t100 = 100 * std.time.ns_per_ms;
 
     // Initial play: 500ms → deadline t=500
-    _ = sched.onPlay(0, 500, t0);
+    _ = sched.onPlay(0, 0x1000, 0x0800, 500, t0);
     try testing.expectEqual(@as(?i128, 500 * std.time.ns_per_ms), sched.nextDeadline());
 
     // Reuse the same effect id 100ms later with a 300ms duration →
     // new deadline is t=100+300=400, replacing the old one.
-    const next_after_reuse = sched.onPlay(0, 300, t100);
+    const next_after_reuse = sched.onPlay(0, 0x2000, 0x1000, 300, t100);
     const expected = t100 + 300 * std.time.ns_per_ms;
-    try testing.expectEqual(@as(?i128, expected), next_after_reuse);
+    try expectFrame(next_after_reuse.frame, 0x2000, 0x1000);
+    try testing.expectEqual(@as(?i128, expected), next_after_reuse.next_deadline_ns);
     try testing.expectEqual(@as(?i128, expected), sched.nextDeadline());
 }
 
@@ -212,47 +272,46 @@ test "rumble_scheduler: onStop of only playing effect emits stop frame" {
     var sched: RumbleScheduler = .{};
     const now: i128 = 0;
 
-    _ = sched.onPlay(0, 500, now);
+    _ = sched.onPlay(0, 0x8000, 0x4000, 500, now);
     try testing.expect(sched.nextDeadline() != null);
 
     const result = sched.onStop(0);
     // The only playing effect stopped → event loop must emit a stop frame
     // and the timerfd must be disarmed.
-    try testing.expect(result.emit_stop_frame);
+    try expectFrame(result.frame, 0, 0);
     try testing.expectEqual(@as(?i128, null), result.next_deadline_ns);
     try testing.expectEqual(@as(?i128, null), sched.nextDeadline());
 }
 
-test "rumble_scheduler: onStop of one effect while another still plays must NOT emit stop" {
+test "rumble_scheduler: onStop of one effect while another still plays restores aggregate" {
     var sched: RumbleScheduler = .{};
     const t0: i128 = 0;
     const t100 = 100 * std.time.ns_per_ms;
     const a_deadline = 1000 * std.time.ns_per_ms;
 
     // Long effect A is playing.
-    _ = sched.onPlay(0, 1000, t0);
+    _ = sched.onPlay(0, 0x1000, 0x0800, 1000, t0);
     // Overlapping short effect B starts.
-    _ = sched.onPlay(1, 500, t100);
+    _ = sched.onPlay(1, 0x8000, 0x4000, 500, t100);
 
     // Client explicitly stops B. A is still supposed to be playing, so the
-    // event loop must NOT cut the motor — emit_stop_frame must be false.
-    // The timerfd must be rearmed for A's remaining deadline.
+    // event loop must restore A's lower magnitude instead of leaving B stuck.
     const result = sched.onStop(1);
-    try testing.expect(!result.emit_stop_frame);
+    try expectFrame(result.frame, 0x1000, 0x0800);
     try testing.expectEqual(@as(?i128, a_deadline), result.next_deadline_ns);
 }
 
-test "rumble_scheduler: onStop of infinite-duration effect while another plays must NOT emit stop" {
+test "rumble_scheduler: onStop of finite effect while infinite effect remains restores aggregate" {
     var sched: RumbleScheduler = .{};
     const now: i128 = 0;
     const b_deadline = 500 * std.time.ns_per_ms;
 
-    _ = sched.onPlay(0, 0, now); // infinite
-    _ = sched.onPlay(1, 500, now); // finite
+    _ = sched.onPlay(0, 0x1000, 0x0800, 0, now); // infinite
+    _ = sched.onPlay(1, 0x8000, 0x4000, 500, now); // finite
 
-    // Stop the finite one; the infinite effect is still live → no stop frame.
+    // Stop the finite one; the infinite effect is still live.
     const result = sched.onStop(1);
-    try testing.expect(!result.emit_stop_frame);
+    try expectFrame(result.frame, 0x1000, 0x0800);
     // nextDeadline returns null (infinite is not a finite deadline).
     try testing.expectEqual(@as(?i128, null), result.next_deadline_ns);
     _ = b_deadline;
@@ -264,12 +323,12 @@ test "rumble_scheduler: out-of-range effect_id does not corrupt other slots" {
     const t500 = 500 * std.time.ns_per_ms;
 
     // Valid effect on slot 0
-    _ = sched.onPlay(0, 500, now);
+    _ = sched.onPlay(0, 0x8000, 0x4000, 500, now);
 
     // Out-of-range ids (>= MAX_EFFECTS=16) must be ignored and must not
     // affect the nextDeadline of the valid slot.
-    _ = sched.onPlay(16, 100, now);
-    _ = sched.onPlay(255, 100, now);
+    _ = sched.onPlay(16, 0xffff, 0xffff, 100, now);
+    _ = sched.onPlay(255, 0xffff, 0xffff, 100, now);
     _ = sched.onStop(16);
     _ = sched.onStop(200);
 
@@ -284,20 +343,21 @@ test "rumble_scheduler: short-then-long overlap rearms for the longer deadline" 
     const t1100 = 1100 * std.time.ns_per_ms;
 
     // A plays for 200ms starting at t=0 → deadline t=200
-    _ = sched.onPlay(0, 200, t0);
+    _ = sched.onPlay(0, 0x8000, 0x4000, 200, t0);
     // B plays for 1000ms starting at t=100 → deadline t=1100
     // Next wake still t=200 because that's the earliest.
-    const next_after_b = sched.onPlay(1, 1000, t100);
-    try testing.expectEqual(@as(?i128, t200), next_after_b);
+    const next_after_b = sched.onPlay(1, 0x1000, 0x0800, 1000, t100);
+    try expectNoFrame(next_after_b.frame);
+    try testing.expectEqual(@as(?i128, t200), next_after_b.next_deadline_ns);
 
-    // Timer fires at t=200 → A expires, B still playing, no stop, rearm at t=1100
+    // Timer fires at t=200 → A expires, B still playing, restore B.
     const first = sched.onTimerExpired(t200);
-    try testing.expect(!first.emit_stop_frame);
+    try expectFrame(first.frame, 0x1000, 0x0800);
     try testing.expectEqual(@as(?i128, t1100), first.next_deadline_ns);
 
     // Timer fires at t=1100 → B expires, stop frame emitted
     const second = sched.onTimerExpired(t1100);
-    try testing.expect(second.emit_stop_frame);
+    try expectFrame(second.frame, 0, 0);
     try testing.expectEqual(@as(?i128, null), second.next_deadline_ns);
 }
 
@@ -314,16 +374,16 @@ test "rumble_scheduler: state identical regardless of dump_enabled" {
     // Run with dump off.
     padctl_log.setEnabled(false);
     var s1: RumbleScheduler = .{};
-    _ = s1.onPlay(0, 500, t0);
-    _ = s1.onPlay(1, 0, t0);
+    _ = s1.onPlay(0, 0x8000, 0x4000, 500, t0);
+    _ = s1.onPlay(1, 0x1000, 0x0800, 0, t0);
     _ = s1.onStop(0);
     const slots1 = s1.dumpSlots();
 
     // Run with dump on.
     padctl_log.setEnabled(true);
     var s2: RumbleScheduler = .{};
-    _ = s2.onPlay(0, 500, t0);
-    _ = s2.onPlay(1, 0, t0);
+    _ = s2.onPlay(0, 0x8000, 0x4000, 500, t0);
+    _ = s2.onPlay(1, 0x1000, 0x0800, 0, t0);
     _ = s2.onStop(0);
     const slots2 = s2.dumpSlots();
 

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -574,124 +574,22 @@ pub const EventLoop = struct {
                 const result = self.rumble_scheduler.onTimerExpired(now_ns);
                 if (padctl_log.shouldWriteToFile(.debug)) {
                     const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
-                    rumble_log.debug("[{s}] TIMERFD: expired now={d} emit_stop={} next_dl={?d} {s}", .{
-                        ctx.device_tag, now_ns, result.emit_stop_frame, result.next_deadline_ns, slotStr(&slot_buf),
+                    rumble_log.debug("[{s}] TIMERFD: expired now={d} frame={?} next_dl={?d} {s}", .{
+                        ctx.device_tag, now_ns, result.frame, result.next_deadline_ns, slotStr(&slot_buf),
                     });
                 }
-                if (result.emit_stop_frame) {
+                if (result.frame) |frame| {
                     if (ctx.allocator) |alloc| {
                         if (ctx.device_config) |dcfg| {
-                            if (!emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
-                                rumble_log.debug("[{s}] TIMERFD: stop frame FAILED to emit", .{ctx.device_tag});
+                            if (emitRumbleFrame(ctx.devices, alloc, dcfg, frame.strong, frame.weak, ctx.device_tag)) {
+                                if (frame.strong == 0 and frame.weak == 0) self.last_rumble_ns = 0;
+                            } else {
+                                rumble_log.debug("[{s}] TIMERFD: frame FAILED to emit", .{ctx.device_tag});
                             }
                         }
                     }
                 }
                 armRumbleStopFd(self.rumble_stop_fd, result.next_deadline_ns);
-            }
-
-            // Check uinput FF fd.
-            if (self.uinput_ff_slot) |slot| {
-                if (self.pollfds[slot].revents & posix.POLL.IN != 0) {
-                    const ff_result = ctx.output.pollFf() catch |err| blk: {
-                        rumble_log.debug("[{s}] FF_ERROR: pollFf failed err={}", .{ ctx.device_tag, err });
-                        break :blk null;
-                    };
-                    if (ff_result) |ff_ev| {
-                        const now_ns = monotonicNs();
-                        const min_interval_ns: i128 = 10_000_000; // 10ms
-                        const is_stop = ff_ev.strong == 0 and ff_ev.weak == 0;
-                        const scheduler_on = autoStopEnabled(ctx.device_config);
-
-                        rumble_log.debug("[{s}] FF_EVENT: id={d} strong={d} weak={d} dur={d}ms is_stop={} sched_on={}", .{
-                            ctx.device_tag,    ff_ev.effect_id, ff_ev.strong, ff_ev.weak,
-                            ff_ev.duration_ms, is_stop,         scheduler_on,
-                        });
-
-                        if (is_stop) {
-                            if (scheduler_on) {
-                                const result = self.rumble_scheduler.onStop(ff_ev.effect_id);
-                                if (padctl_log.shouldWriteToFile(.debug)) {
-                                    const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
-                                    rumble_log.debug("[{s}] FF_STOP: id={d} emit_stop={} next_dl={?d} {s}", .{
-                                        ctx.device_tag,          ff_ev.effect_id,    result.emit_stop_frame,
-                                        result.next_deadline_ns, slotStr(&slot_buf),
-                                    });
-                                }
-                                if (result.emit_stop_frame) {
-                                    if (ctx.allocator) |alloc| {
-                                        if (ctx.device_config) |dcfg| {
-                                            if (!emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
-                                                rumble_log.debug("[{s}] FF_STOP: stop frame FAILED to emit", .{ctx.device_tag});
-                                            }
-                                        }
-                                    }
-                                }
-                                armRumbleStopFd(self.rumble_stop_fd, result.next_deadline_ns);
-                            } else {
-                                rumble_log.debug("[{s}] FF_STOP: auto_stop disabled, direct zero frame", .{ctx.device_tag});
-                                if (ctx.allocator) |alloc| {
-                                    if (ctx.device_config) |dcfg| {
-                                        if (!emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
-                                            rumble_log.debug("[{s}] FF_STOP: direct zero frame FAILED to emit", .{ctx.device_tag});
-                                        }
-                                    }
-                                }
-                            }
-                        } else {
-                            // Play event: throttle applies to play frames.
-                            const elapsed = now_ns - self.last_rumble_ns;
-                            if (elapsed >= min_interval_ns) {
-                                if (ctx.allocator) |alloc| {
-                                    if (ctx.device_config) |dcfg| {
-                                        if (emitRumbleFrame(ctx.devices, alloc, dcfg, ff_ev.strong, ff_ev.weak, ctx.device_tag)) {
-                                            self.last_rumble_ns = now_ns;
-                                        } else {
-                                            rumble_log.debug("[{s}] FF_PLAY: emitRumbleFrame FAILED id={d}", .{ ctx.device_tag, ff_ev.effect_id });
-                                        }
-                                    }
-                                }
-                            } else {
-                                rumble_log.debug("[{s}] FF_PLAY: THROTTLED id={d} elapsed={d}ns", .{
-                                    ctx.device_tag,                                          ff_ev.effect_id,
-                                    @as(u64, @intCast(@min(elapsed, std.math.maxInt(u64)))),
-                                });
-                            }
-                            if (scheduler_on) {
-                                const next_dl = self.rumble_scheduler.onPlay(
-                                    ff_ev.effect_id,
-                                    ff_ev.duration_ms,
-                                    now_ns,
-                                );
-                                if (padctl_log.shouldWriteToFile(.debug)) {
-                                    const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
-                                    rumble_log.debug("[{s}] FF_PLAY: id={d} dur={d}ms next_dl={?d} {s}", .{
-                                        ctx.device_tag, ff_ev.effect_id,    ff_ev.duration_ms,
-                                        next_dl,        slotStr(&slot_buf),
-                                    });
-                                }
-                                armRumbleStopFd(self.rumble_stop_fd, next_dl);
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Drain UHID_OUTPUT events. Only active when uhid_output_slot is set
-            // (backend=uhid, kind=pid).
-            if (self.uhid_output_slot) |slot| {
-                if (self.pollfds[slot].revents & posix.POLL.IN != 0) {
-                    if (ctx.uhid_primary) |uhid_dev| {
-                        var uhid_buf: [uhid_mod.UHID_EVENT_SIZE]u8 = undefined;
-                        while (true) {
-                            const report = uhid_dev.pollOutputReport(&uhid_buf) catch break;
-                            const r = report orelse break;
-                            if (uhid_dev.output_cb) |cb| {
-                                cb(uhid_dev.output_ctx.?, r);
-                            }
-                        }
-                    }
-                }
             }
 
             // Check device fds
@@ -799,6 +697,142 @@ pub const EventLoop = struct {
                                     };
                                 }
                                 if (ctx.touchpad_output) |tp| tp.emitTouch(self.gamepad_state) catch {};
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Check uinput FF fd after physical input fds. The optional FF fd
+            // is appended after device slots, and preserving that priority keeps
+            // rumble-heavy games from delaying controller input handling.
+            if (self.uinput_ff_slot) |slot| {
+                if (self.pollfds[slot].revents & posix.POLL.IN != 0) {
+                    const ff_result = ctx.output.pollFf() catch |err| blk: {
+                        rumble_log.debug("[{s}] FF_ERROR: pollFf failed err={}", .{ ctx.device_tag, err });
+                        break :blk null;
+                    };
+                    if (ff_result) |ff_ev| {
+                        const now_ns = monotonicNs();
+                        const min_interval_ns: i128 = 10_000_000; // 10ms
+                        const is_stop = ff_ev.strong == 0 and ff_ev.weak == 0;
+                        const scheduler_on = autoStopEnabled(ctx.device_config);
+
+                        rumble_log.debug("[{s}] FF_EVENT: id={d} strong={d} weak={d} dur={d}ms is_stop={} sched_on={}", .{
+                            ctx.device_tag,    ff_ev.effect_id, ff_ev.strong, ff_ev.weak,
+                            ff_ev.duration_ms, is_stop,         scheduler_on,
+                        });
+
+                        if (is_stop) {
+                            if (scheduler_on) {
+                                const result = self.rumble_scheduler.onStop(ff_ev.effect_id);
+                                if (padctl_log.shouldWriteToFile(.debug)) {
+                                    const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                                    rumble_log.debug("[{s}] FF_STOP: id={d} frame={?} next_dl={?d} {s}", .{
+                                        ctx.device_tag,          ff_ev.effect_id,    result.frame,
+                                        result.next_deadline_ns, slotStr(&slot_buf),
+                                    });
+                                }
+                                const frame_to_emit = result.frame orelse if (!result.active_after)
+                                    RumbleScheduler.Frame{ .strong = 0, .weak = 0 }
+                                else
+                                    null;
+                                if (frame_to_emit) |frame| {
+                                    if (ctx.allocator) |alloc| {
+                                        if (ctx.device_config) |dcfg| {
+                                            if (emitRumbleFrame(ctx.devices, alloc, dcfg, frame.strong, frame.weak, ctx.device_tag)) {
+                                                if (frame.strong == 0 and frame.weak == 0) self.last_rumble_ns = 0;
+                                            } else {
+                                                rumble_log.debug("[{s}] FF_STOP: frame FAILED to emit", .{ctx.device_tag});
+                                            }
+                                        }
+                                    }
+                                }
+                                armRumbleStopFd(self.rumble_stop_fd, result.next_deadline_ns);
+                            } else {
+                                rumble_log.debug("[{s}] FF_STOP: auto_stop disabled, direct zero frame", .{ctx.device_tag});
+                                if (ctx.allocator) |alloc| {
+                                    if (ctx.device_config) |dcfg| {
+                                        if (emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
+                                            self.last_rumble_ns = 0;
+                                        } else {
+                                            rumble_log.debug("[{s}] FF_STOP: direct zero frame FAILED to emit", .{ctx.device_tag});
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            if (scheduler_on) {
+                                const result = self.rumble_scheduler.onPlay(
+                                    ff_ev.effect_id,
+                                    ff_ev.strong,
+                                    ff_ev.weak,
+                                    ff_ev.duration_ms,
+                                    now_ns,
+                                );
+                                if (padctl_log.shouldWriteToFile(.debug)) {
+                                    const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                                    rumble_log.debug("[{s}] FF_PLAY: id={d} dur={d}ms frame={?} next_dl={?d} {s}", .{
+                                        ctx.device_tag,          ff_ev.effect_id,    ff_ev.duration_ms, result.frame,
+                                        result.next_deadline_ns, slotStr(&slot_buf),
+                                    });
+                                }
+                                if (result.frame) |frame| {
+                                    const elapsed = now_ns - self.last_rumble_ns;
+                                    if (elapsed >= min_interval_ns) {
+                                        if (ctx.allocator) |alloc| {
+                                            if (ctx.device_config) |dcfg| {
+                                                if (emitRumbleFrame(ctx.devices, alloc, dcfg, frame.strong, frame.weak, ctx.device_tag)) {
+                                                    self.last_rumble_ns = now_ns;
+                                                } else {
+                                                    rumble_log.debug("[{s}] FF_PLAY: emitRumbleFrame FAILED id={d}", .{ ctx.device_tag, ff_ev.effect_id });
+                                                }
+                                            }
+                                        }
+                                    } else {
+                                        rumble_log.debug("[{s}] FF_PLAY: THROTTLED id={d} elapsed={d}ns", .{
+                                            ctx.device_tag,                                          ff_ev.effect_id,
+                                            @as(u64, @intCast(@min(elapsed, std.math.maxInt(u64)))),
+                                        });
+                                    }
+                                }
+                                armRumbleStopFd(self.rumble_stop_fd, result.next_deadline_ns);
+                            } else {
+                                const elapsed = now_ns - self.last_rumble_ns;
+                                if (elapsed >= min_interval_ns) {
+                                    if (ctx.allocator) |alloc| {
+                                        if (ctx.device_config) |dcfg| {
+                                            if (emitRumbleFrame(ctx.devices, alloc, dcfg, ff_ev.strong, ff_ev.weak, ctx.device_tag)) {
+                                                self.last_rumble_ns = now_ns;
+                                            } else {
+                                                rumble_log.debug("[{s}] FF_PLAY: emitRumbleFrame FAILED id={d}", .{ ctx.device_tag, ff_ev.effect_id });
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    rumble_log.debug("[{s}] FF_PLAY: THROTTLED id={d} elapsed={d}ns", .{
+                                        ctx.device_tag,                                          ff_ev.effect_id,
+                                        @as(u64, @intCast(@min(elapsed, std.math.maxInt(u64)))),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Drain UHID_OUTPUT events. Only active when uhid_output_slot is set
+            // (backend=uhid, kind=pid). This is also output-side work, so it
+            // follows physical input fd handling.
+            if (self.uhid_output_slot) |slot| {
+                if (self.pollfds[slot].revents & posix.POLL.IN != 0) {
+                    if (ctx.uhid_primary) |uhid_dev| {
+                        var uhid_buf: [uhid_mod.UHID_EVENT_SIZE]u8 = undefined;
+                        while (true) {
+                            const report = uhid_dev.pollOutputReport(&uhid_buf) catch break;
+                            const r = report orelse break;
+                            if (uhid_dev.output_cb) |cb| {
+                                cb(uhid_dev.output_ctx.?, r);
                             }
                         }
                     }
@@ -1169,7 +1203,7 @@ test "event_loop: quiesceTimersAndRumble disarms layer macro and rumble timers" 
     armTimer(loop.macro_timer_fd, 5000);
     armRumbleStopFd(loop.rumble_stop_fd, monotonicNs() + 5 * std.time.ns_per_s);
     loop.last_rumble_ns = monotonicNs();
-    _ = loop.rumble_scheduler.onPlay(0, 1000, loop.last_rumble_ns);
+    _ = loop.rumble_scheduler.onPlay(0, 0x8000, 0x4000, 1000, loop.last_rumble_ns);
 
     loop.quiesceTimersAndRumble(&.{}, testing.allocator, null, "test");
 

--- a/src/test/event_loop_rumble_test.zig
+++ b/src/test/event_loop_rumble_test.zig
@@ -384,6 +384,66 @@ const MockFfOutputDrain = struct {
     fn mockClose(_: *anyopaque) void {}
 };
 
+fn runThrottledPlayScenario(allocator: std.mem.Allocator, wait_ns: u64) ![]u8 {
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var mock_dev = try MockDeviceIO.init(allocator, &.{});
+    defer mock_dev.deinit();
+    const dev = mock_dev.deviceIO();
+    try loop.addDevice(dev);
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x4000, .weak = 0x2000, .duration_ms = 50 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 300 },
+        null,
+    };
+    var ff_out = MockFfOutputSeq{ .allocator = allocator, .events = &seq };
+
+    const RunCtx = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        ff_out: *MockFfOutputSeq,
+        cfg: *const device_mod.DeviceConfig,
+        alloc: std.mem.Allocator,
+    };
+    var devs = [_]DeviceIO{dev};
+    var ctx = RunCtx{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .ff_out = &ff_out,
+        .cfg = &parsed.value,
+        .alloc = allocator,
+    };
+    const T = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 100 });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
+
+    // The sequence mock does not drain the fd, so this one byte keeps the FF
+    // slot readable long enough for both PLAY events to arrive in one burst.
+    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+
+    std.Thread.sleep(wait_ns);
+    loop.stop();
+    thread.join();
+
+    return allocator.dupe(u8, mock_dev.write_log.items);
+}
+
 const PriorityProbeOutput = struct {
     ff_pipe_read: posix.fd_t,
     mock_device: *MockDeviceIO,
@@ -1044,19 +1104,8 @@ test "event_loop: FF scheduler state identical with dump on vs off" {
 }
 
 test "event_loop: replay after stop is forwarded and arms auto-stop deadline" {
-    // Regression test for #65 (stuck rumble).
-    //
-    // Sequence:
-    //   T0  FF_PLAY  effect 0, 100ms duration  → emitted, scheduler deadline armed
-    //   T1  FF_STOP  effect 0                  → slot cleared, timerfd disarmed
-    //   T2  FF_PLAY  effect 0, 100ms duration  → forwarded because STOP clears
-    //                                             the play throttle window, and
-    //                                             scheduler MUST arm deadline
-    //
-    // Pre-fix: onPlay() was gated by `forwarded` (only true when a frame was
-    // emitted). A throttled replay skipped onPlay() → timerfd never rearmed
-    // → motor never stopped → stuck rumble.
-    // Post-fix: onPlay() runs unconditionally whenever scheduler_on.
+    // STOP clears the play throttle window, so a replay after explicit stop is
+    // forwarded immediately and still arms the new auto-stop deadline.
     const allocator = testing.allocator;
 
     var loop = try EventLoop.initManaged();
@@ -1131,4 +1180,30 @@ test "event_loop: replay after stop is forwarded and arms auto-stop deadline" {
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, replay_frame);
     const auto_stop = mock_dev.write_log.items[3 * frame_size .. 4 * frame_size];
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, auto_stop);
+}
+
+test "event_loop: throttled play still rearms auto-stop deadline" {
+    // Regression test for #65 (stuck rumble): scheduler state must update even
+    // when a PLAY frame is suppressed by the 10ms hardware-write throttle.
+    //
+    // Sequence:
+    //   T0  FF_PLAY effect 0, 50ms duration   -> emitted, first deadline armed
+    //   T1  FF_PLAY effect 0, 300ms duration  -> throttled, no HID frame, but
+    //                                            scheduler deadline must extend
+    //
+    // If the second onPlay were gated by "frame forwarded", the first 50ms
+    // deadline would fire and emit a premature stop.
+    const allocator = testing.allocator;
+    const frame_size = 8;
+
+    const early_log = try runThrottledPlayScenario(allocator, 120 * std.time.ns_per_ms);
+    defer allocator.free(early_log);
+    try testing.expectEqual(@as(usize, frame_size), early_log.len);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 }, early_log);
+
+    const late_log = try runThrottledPlayScenario(allocator, 420 * std.time.ns_per_ms);
+    defer allocator.free(late_log);
+    try testing.expectEqual(@as(usize, 2 * frame_size), late_log.len);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 }, late_log[0..frame_size]);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, late_log[frame_size .. 2 * frame_size]);
 }

--- a/src/test/event_loop_rumble_test.zig
+++ b/src/test/event_loop_rumble_test.zig
@@ -384,6 +384,105 @@ const MockFfOutputDrain = struct {
     fn mockClose(_: *anyopaque) void {}
 };
 
+const PriorityProbeOutput = struct {
+    ff_pipe_read: posix.fd_t,
+    mock_device: *MockDeviceIO,
+    ff_before_device_read: bool = false,
+
+    fn outputDevice(self: *PriorityProbeOutput) uinput.OutputDevice {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = uinput.OutputDevice.VTable{
+        .emit = mockEmit,
+        .poll_ff = mockPollFf,
+        .close = mockClose,
+    };
+
+    fn mockEmit(_: *anyopaque, _: state.GamepadState) uinput.EmitError!void {}
+
+    fn mockPollFf(ptr: *anyopaque) uinput.PollFfError!?uinput.FfEvent {
+        const self: *PriorityProbeOutput = @ptrCast(@alignCast(ptr));
+        var buf: [1]u8 = undefined;
+        _ = posix.read(self.ff_pipe_read, &buf) catch return null;
+        if (self.mock_device.frame_idx == 0) {
+            self.ff_before_device_read = true;
+        }
+        return null;
+    }
+
+    fn mockClose(_: *anyopaque) void {}
+};
+
+test "event_loop: device input is handled before uinput FF when both are ready" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    const frame = [_]u8{ 0x01, 0x00, 0x00 };
+    var mock_dev = try MockDeviceIO.init(allocator, &.{&frame});
+    defer mock_dev.deinit();
+    const dev = mock_dev.deviceIO();
+    try loop.addDevice(dev);
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+
+    const parsed = try device_mod.parseString(allocator, minimal_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    var output = PriorityProbeOutput{
+        .ff_pipe_read = ff_pipe[0],
+        .mock_device = &mock_dev,
+    };
+
+    var devs = [_]DeviceIO{dev};
+
+    // Make both fds readable before entering the loop. The design slot order
+    // puts device fds before optional output fds, so this must process the
+    // input frame before looking at the uinput FF wake.
+    try mock_dev.signal();
+    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+
+    const RunCtx = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        output: *PriorityProbeOutput,
+        cfg: *const device_mod.DeviceConfig,
+    };
+    var ctx = RunCtx{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .output = &output,
+        .cfg = &parsed.value,
+    };
+
+    const T = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(.{
+                .devices = c.devs,
+                .interpreter = c.interp,
+                .output = c.output.outputDevice(),
+                .device_config = c.cfg,
+                .poll_timeout_ms = 100,
+            });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
+    std.Thread.sleep(20 * std.time.ns_per_ms);
+    loop.stop();
+    thread.join();
+
+    try testing.expectEqual(@as(usize, 1), mock_dev.frame_idx);
+    try testing.expect(!output.ff_before_device_read);
+}
+
 test "event_loop: stop frame forwarded even within 10ms throttle window" {
     const allocator = testing.allocator;
 
@@ -458,7 +557,7 @@ test "event_loop: stop frame forwarded even within 10ms throttle window" {
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, stop_frame);
 }
 
-test "event_loop: explicit stop of one of two overlapping effects does not cut the long effect" {
+test "event_loop: stopping a short overlapping effect restores the remaining long effect" {
     const allocator = testing.allocator;
 
     var loop = try EventLoop.initManaged();
@@ -479,20 +578,21 @@ test "event_loop: explicit stop of one of two overlapping effects does not cut t
     const interp = Interpreter.init(&parsed.value);
 
     // Sequence:
-    //   1) play A (slot 0, 300ms duration, magnitude 0x8000/0x4000)
-    //   2) play B (slot 1, 100ms duration, magnitude 0x4000/0x2000)
+    //   1) play A (slot 0, 300ms duration, magnitude 0x4000/0x2000)
+    //   2) play B (slot 1, 100ms duration, magnitude 0x8000/0x4000)
     //   3) explicit stop B (slot 1)
     //
     // Use the drain-aware mock so each pipe write advances the mock by
     // exactly one event and the test's wall-clock sleeps actually gate
     // the 10ms play-frame throttle.
     //
-    // Expected: three HID frames — play A, play B, then ONE stop frame
-    // when A's 300ms auto-stop deadline fires. No stop frame from the
-    // explicit stop of B, because A was still live.
+    // Expected: four HID frames — play A, play B, restore A when B stops,
+    // then stop when A's 300ms auto-stop deadline fires. The hardware only
+    // has one rumble command state, so suppressing output while A remains
+    // active leaves B's stronger command stuck on the controller.
     const seq = [_]?uinput.FfEvent{
-        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 300 },
-        .{ .effect_type = 0x50, .effect_id = 1, .strong = 0x4000, .weak = 0x2000, .duration_ms = 100 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x4000, .weak = 0x2000, .duration_ms = 300 },
+        .{ .effect_type = 0x50, .effect_id = 1, .strong = 0x8000, .weak = 0x4000, .duration_ms = 100 },
         .{ .effect_type = 0x50, .effect_id = 1, .strong = 0, .weak = 0, .duration_ms = 0 },
         null,
     };
@@ -537,16 +637,16 @@ test "event_loop: explicit stop of one of two overlapping effects does not cut t
     loop.stop();
     thread.join();
 
-    // Expect exactly 3 frames: play A, play B, auto-stop.
-    // The explicit stop of B must NOT have produced a zero frame while A
-    // was still playing.
+    // Expect exactly 4 frames: play A, play B, restore A, auto-stop.
     const frame_size = 8;
-    try testing.expectEqual(@as(usize, 3 * frame_size), mock_dev.write_log.items.len);
+    try testing.expectEqual(@as(usize, 4 * frame_size), mock_dev.write_log.items.len);
     const play_a = mock_dev.write_log.items[0..frame_size];
-    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, play_a);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 }, play_a);
     const play_b = mock_dev.write_log.items[frame_size .. 2 * frame_size];
-    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 }, play_b);
-    const final_stop = mock_dev.write_log.items[2 * frame_size .. 3 * frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, play_b);
+    const restore_a = mock_dev.write_log.items[2 * frame_size .. 3 * frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 }, restore_a);
+    const final_stop = mock_dev.write_log.items[3 * frame_size .. 4 * frame_size];
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, final_stop);
 }
 
@@ -943,14 +1043,15 @@ test "event_loop: FF scheduler state identical with dump on vs off" {
     try testing.expectEqualSlices(u8, r_off.write_log, r_on.write_log);
 }
 
-test "event_loop: throttled replay after stop still arms auto-stop deadline" {
+test "event_loop: replay after stop is forwarded and arms auto-stop deadline" {
     // Regression test for #65 (stuck rumble).
     //
     // Sequence:
     //   T0  FF_PLAY  effect 0, 100ms duration  → emitted, scheduler deadline armed
     //   T1  FF_STOP  effect 0                  → slot cleared, timerfd disarmed
-    //   T2  FF_PLAY  effect 0, 100ms duration  → THROTTLED (T2-T0 < 10ms)
-    //                                             scheduler MUST still arm deadline
+    //   T2  FF_PLAY  effect 0, 100ms duration  → forwarded because STOP clears
+    //                                             the play throttle window, and
+    //                                             scheduler MUST arm deadline
     //
     // Pre-fix: onPlay() was gated by `forwarded` (only true when a frame was
     // emitted). A throttled replay skipped onPlay() → timerfd never rearmed
@@ -975,7 +1076,7 @@ test "event_loop: throttled replay after stop still arms auto-stop deadline" {
     defer parsed.deinit();
     const interp = Interpreter.init(&parsed.value);
 
-    // play, explicit stop, then a replay of effect 0; the replay is throttled.
+    // play, explicit stop, then a replay of effect 0.
     const seq = [_]?uinput.FfEvent{
         .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 100 },
         .{ .effect_type = 0x50, .effect_id = 0, .strong = 0, .weak = 0, .duration_ms = 0 },
@@ -1018,14 +1119,16 @@ test "event_loop: throttled replay after stop still arms auto-stop deadline" {
     loop.stop();
     thread.join();
 
-    // Three frames: play, explicit stop, and the auto-stop — the third only
-    // appears if the throttled replay rearmed the deadline.
+    // Four frames: play, explicit stop, replay, and the auto-stop. The final
+    // stop only appears if the replay rearmed the deadline.
     const frame_size = 8;
-    try testing.expectEqual(@as(usize, 3 * frame_size), mock_dev.write_log.items.len);
+    try testing.expectEqual(@as(usize, 4 * frame_size), mock_dev.write_log.items.len);
     const play_frame = mock_dev.write_log.items[0..frame_size];
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, play_frame);
     const explicit_stop = mock_dev.write_log.items[frame_size .. 2 * frame_size];
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, explicit_stop);
-    const auto_stop = mock_dev.write_log.items[2 * frame_size .. 3 * frame_size];
+    const replay_frame = mock_dev.write_log.items[2 * frame_size .. 3 * frame_size];
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, replay_frame);
+    const auto_stop = mock_dev.write_log.items[3 * frame_size .. 4 * frame_size];
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, auto_stop);
 }


### PR DESCRIPTION
## Summary
- Track per-effect rumble magnitudes in the userspace scheduler so STOP/timer events can restore the aggregate frame for remaining active effects.
- Handle physical device input before output-side FF/UHID drains, preserving documented slot priority under rumble-heavy workloads.
- Add regressions for input-vs-FF priority, overlapping rumble restore, and replay-after-stop auto-stop rearming.

Fixes #65.

## Test evidence
- ./scripts/padctl-docker test --summary all
- ./scripts/padctl-docker build test-safe --summary all
- ./scripts/padctl-docker build check-fmt
- ./scripts/padctl-docker build -Dwasm=false test --summary all
- ./scripts/padctl-docker build -Dwasm=false test-safe --summary all
- ./scripts/padctl-docker build -Dlibusb=false test --summary all
- ./scripts/padctl-docker build -Dlibusb=false test-safe --summary all

## Notes
- Local hardware validation with Vader 5 Pro / Rocket League was not available in this environment.
- PR merge should wait for code review and hosted checks.