### PR TITLE
Fix rumble pending frame retry

### DIFF
--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -168,9 +168,33 @@ fn slotStr(buf: *const [256]u8) []const u8 {
 /// Write a single rumble frame (strong, weak) to the HID device using the
 /// device's `commands.rumble` (or alternate FF type) template. Used by
 /// both the uinput-FF-event path and the userspace auto-stop timerfd path.
-/// Returns true if the frame was successfully written to HID. Callers
-/// must only advance the throttle clock (`last_rumble_ns`) when this returns
-/// true; scheduler accounting advances independently of emit.
+/// Returns whether a rumble frame was written, skipped as permanently
+/// unconfigured, or failed on the HID write path. Callers only retry write
+/// failures; scheduler accounting advances independently of emit.
+const RUMBLE_MIN_INTERVAL_NS: i128 = 10_000_000; // 10ms
+const RUMBLE_RETRY_INTERVAL_NS: i128 = 10_000_000; // 10ms
+const RUMBLE_MAX_RETRY_ATTEMPTS: u8 = 3;
+
+const RumbleEmitResult = enum {
+    written,
+    unconfigured,
+    write_failed,
+    disconnected,
+};
+
+fn minDeadline(a: ?i128, b: ?i128) ?i128 {
+    if (a) |av| {
+        if (b) |bv| return @min(av, bv);
+        return av;
+    }
+    return b;
+}
+
+fn elapsedNsForLog(elapsed: i128) u64 {
+    if (elapsed <= 0) return 0;
+    return @intCast(@min(elapsed, std.math.maxInt(u64)));
+}
+
 fn emitRumbleFrame(
     devices: []DeviceIO,
     alloc: std.mem.Allocator,
@@ -178,20 +202,38 @@ fn emitRumbleFrame(
     strong: u16,
     weak: u16,
     tag: []const u8,
-) bool {
-    const cmds = dcfg.commands orelse return false;
+) RumbleEmitResult {
+    const cmds = dcfg.commands orelse {
+        rumble_log.debug("[{s}] HID_WRITE: rumble unconfigured strong={d} weak={d} reason=missing commands", .{ tag, strong, weak });
+        return .unconfigured;
+    };
     const ff_type = if (dcfg.output) |out|
         if (out.force_feedback) |ff_cfg| ff_cfg.type else "rumble"
     else
         "rumble";
-    const cmd = cmds.map.get(ff_type) orelse return false;
-    const iface_idx = resolveIfaceIdx(dcfg, cmd.interface) orelse return false;
-    if (iface_idx >= devices.len) return false;
+    const cmd = cmds.map.get(ff_type) orelse {
+        rumble_log.debug("[{s}] HID_WRITE: rumble unconfigured cmd={s} strong={d} weak={d} reason=missing command", .{ tag, ff_type, strong, weak });
+        return .unconfigured;
+    };
+    const iface_idx = resolveIfaceIdx(dcfg, cmd.interface) orelse {
+        rumble_log.debug("[{s}] HID_WRITE: rumble unconfigured cmd={s} strong={d} weak={d} reason=unknown interface", .{ tag, ff_type, strong, weak });
+        return .unconfigured;
+    };
+    if (iface_idx >= devices.len) {
+        rumble_log.debug("[{s}] HID_WRITE: rumble unconfigured cmd={s} strong={d} weak={d} iface={d} devices={d} reason=interface out of range", .{
+            tag, ff_type, strong, weak, iface_idx, devices.len,
+        });
+        return .unconfigured;
+    }
     const params = [_]Param{
         .{ .name = "strong", .value = strong },
         .{ .name = "weak", .value = weak },
     };
-    const bytes = fillTemplate(alloc, cmd.template, &params) catch return false;
+    const bytes = fillTemplate(alloc, cmd.template, &params) catch |err| {
+        rumble_log.debug("[{s}] HID_WRITE: template fill FAILED cmd={s} strong={d} weak={d} err={}", .{ tag, ff_type, strong, weak, err });
+        if (err == error.OutOfMemory) return .write_failed;
+        return .unconfigured;
+    };
     defer alloc.free(bytes);
     if (cmd.checksum) |*cs| applyChecksum(bytes, cs);
 
@@ -212,9 +254,12 @@ fn emitRumbleFrame(
 
     devices[iface_idx].write(bytes) catch |err| {
         rumble_log.debug("[{s}] HID_WRITE: FAILED cmd={s} strong={d} weak={d} err={}", .{ tag, ff_type, strong, weak, err });
-        return false;
+        return switch (err) {
+            DeviceIO.WriteError.Disconnected => .disconnected,
+            DeviceIO.WriteError.Io => .write_failed,
+        };
     };
-    return true;
+    return .written;
 }
 
 /// Disarm a timerfd by setting all fields to zero.
@@ -245,6 +290,9 @@ fn quiesceTimersAndRumbleImpl(
     disarmTimer(self.rumble_stop_fd);
     self.rumble_scheduler = .{};
     self.last_rumble_ns = 0;
+    self.pending_rumble_frame = null;
+    self.pending_rumble_deadline_ns = null;
+    self.pending_rumble_retry_count = 0;
     if (dcfg) |cfg| {
         _ = emitRumbleFrame(devices, alloc, cfg, 0, 0, tag);
     }
@@ -385,6 +433,9 @@ pub const EventLoop = struct {
     gamepad_state: state.GamepadState,
     last_ts: i128,
     last_rumble_ns: i128,
+    pending_rumble_frame: ?RumbleScheduler.Frame,
+    pending_rumble_deadline_ns: ?i128,
+    pending_rumble_retry_count: u8,
     last_heartbeat_ns: i128 = 0,
 
     pub fn init() !EventLoop {
@@ -445,6 +496,9 @@ pub const EventLoop = struct {
             .gamepad_state = .{},
             .last_ts = monotonicNs(),
             .last_rumble_ns = 0,
+            .pending_rumble_frame = null,
+            .pending_rumble_deadline_ns = null,
+            .pending_rumble_retry_count = 0,
         };
 
         loop.pollfds[Slots.signal] = .{ .fd = sig_fd, .events = posix.POLL.IN, .revents = 0 };
@@ -505,6 +559,96 @@ pub const EventLoop = struct {
         } else {
             self.last_rumble_ns = now_ns;
         }
+    }
+
+    fn queuePendingRumble(self: *EventLoop, frame: RumbleScheduler.Frame, deadline_ns: i128, retry_count: u8) void {
+        self.pending_rumble_frame = frame;
+        self.pending_rumble_deadline_ns = deadline_ns;
+        self.pending_rumble_retry_count = retry_count;
+    }
+
+    fn clearPendingRumble(self: *EventLoop) void {
+        self.pending_rumble_frame = null;
+        self.pending_rumble_deadline_ns = null;
+        self.pending_rumble_retry_count = 0;
+    }
+
+    fn emitRumbleFrameForContext(self: *EventLoop, ctx: EventLoopContext, frame: RumbleScheduler.Frame, now_ns: i128) RumbleEmitResult {
+        const alloc = ctx.allocator orelse {
+            rumble_log.debug("[{s}] HID_WRITE: rumble unconfigured strong={d} weak={d} reason=missing allocator", .{ ctx.device_tag, frame.strong, frame.weak });
+            self.clearPendingRumble();
+            return .unconfigured;
+        };
+        const dcfg = ctx.device_config orelse {
+            rumble_log.debug("[{s}] HID_WRITE: rumble unconfigured strong={d} weak={d} reason=missing device_config", .{ ctx.device_tag, frame.strong, frame.weak });
+            self.clearPendingRumble();
+            return .unconfigured;
+        };
+        const result = emitRumbleFrame(ctx.devices, alloc, dcfg, frame.strong, frame.weak, ctx.device_tag);
+        if (result == .written) {
+            self.recordRumbleWrite(frame, now_ns);
+            self.clearPendingRumble();
+        } else if (result == .unconfigured) {
+            self.clearPendingRumble();
+        }
+        return result;
+    }
+
+    fn handleRumbleDisconnect(self: *EventLoop, ctx: EventLoopContext, frame: RumbleScheduler.Frame) void {
+        rumble_log.debug("[{s}] HID_WRITE: disconnected while emitting strong={d} weak={d}", .{
+            ctx.device_tag, frame.strong, frame.weak,
+        });
+        self.clearPendingRumble();
+        self.disconnected = true;
+        self.running = false;
+    }
+
+    fn queueRumbleRetry(self: *EventLoop, ctx: EventLoopContext, frame: RumbleScheduler.Frame, now_ns: i128) void {
+        const retry_count: u8 = if (self.pending_rumble_frame) |pending|
+            if (pending.strong == frame.strong and pending.weak == frame.weak)
+                self.pending_rumble_retry_count +| 1
+            else
+                1
+        else
+            1;
+
+        if (retry_count > RUMBLE_MAX_RETRY_ATTEMPTS) {
+            rumble_log.debug("[{s}] HID_WRITE: retry limit exceeded strong={d} weak={d}; marking disconnected", .{
+                ctx.device_tag, frame.strong, frame.weak,
+            });
+            self.clearPendingRumble();
+            self.disconnected = true;
+            self.running = false;
+            return;
+        }
+
+        self.queuePendingRumble(frame, now_ns + RUMBLE_RETRY_INTERVAL_NS, retry_count);
+    }
+
+    fn emitOrQueueRumble(self: *EventLoop, ctx: EventLoopContext, frame: RumbleScheduler.Frame, now_ns: i128) void {
+        switch (self.emitRumbleFrameForContext(ctx, frame, now_ns)) {
+            .written, .unconfigured => {},
+            .write_failed => self.queueRumbleRetry(ctx, frame, now_ns),
+            .disconnected => self.handleRumbleDisconnect(ctx, frame),
+        }
+    }
+
+    fn flushPendingRumbleIfDue(self: *EventLoop, ctx: EventLoopContext, now_ns: i128) void {
+        const deadline = self.pending_rumble_deadline_ns orelse return;
+        if (deadline > now_ns) return;
+        const frame = self.pending_rumble_frame orelse {
+            self.pending_rumble_deadline_ns = null;
+            return;
+        };
+        switch (self.emitRumbleFrameForContext(ctx, frame, now_ns)) {
+            .written, .unconfigured => {},
+            .write_failed => self.queueRumbleRetry(ctx, frame, now_ns),
+            .disconnected => self.handleRumbleDisconnect(ctx, frame),
+        }
+    }
+
+    fn armRumbleTimer(self: *EventLoop, scheduler_deadline_ns: ?i128) void {
+        armRumbleStopFd(self.rumble_stop_fd, minDeadline(scheduler_deadline_ns, self.pending_rumble_deadline_ns));
     }
 
     pub fn run(self: *EventLoop, ctx: EventLoopContext) !void {
@@ -700,17 +844,12 @@ pub const EventLoop = struct {
                     });
                 }
                 if (result.frame) |frame| {
-                    if (ctx.allocator) |alloc| {
-                        if (ctx.device_config) |dcfg| {
-                            if (emitRumbleFrame(ctx.devices, alloc, dcfg, frame.strong, frame.weak, ctx.device_tag)) {
-                                self.recordRumbleWrite(frame, now_ns);
-                            } else {
-                                rumble_log.debug("[{s}] TIMERFD: frame FAILED to emit", .{ctx.device_tag});
-                            }
-                        }
-                    }
+                    self.clearPendingRumble();
+                    self.emitOrQueueRumble(ctx, frame, now_ns);
+                    if (self.pending_rumble_frame != null) rumble_log.debug("[{s}] TIMERFD: frame FAILED to emit; queued retry", .{ctx.device_tag});
                 }
-                armRumbleStopFd(self.rumble_stop_fd, result.next_deadline_ns);
+                self.flushPendingRumbleIfDue(ctx, now_ns);
+                self.armRumbleTimer(result.next_deadline_ns);
             }
 
             // Check uinput FF fd after physical input fds. The optional FF fd
@@ -724,7 +863,7 @@ pub const EventLoop = struct {
                     };
                     if (ff_result) |ff_ev| {
                         const now_ns = monotonicNs();
-                        const min_interval_ns: i128 = 10_000_000; // 10ms
+                        const min_interval_ns = RUMBLE_MIN_INTERVAL_NS;
                         const is_stop = ff_ev.strong == 0 and ff_ev.weak == 0;
                         const scheduler_on = autoStopEnabled(ctx.device_config);
 
@@ -748,28 +887,17 @@ pub const EventLoop = struct {
                                 else
                                     null;
                                 if (frame_to_emit) |frame| {
-                                    if (ctx.allocator) |alloc| {
-                                        if (ctx.device_config) |dcfg| {
-                                            if (emitRumbleFrame(ctx.devices, alloc, dcfg, frame.strong, frame.weak, ctx.device_tag)) {
-                                                self.recordRumbleWrite(frame, now_ns);
-                                            } else {
-                                                rumble_log.debug("[{s}] FF_STOP: frame FAILED to emit", .{ctx.device_tag});
-                                            }
-                                        }
-                                    }
+                                    self.clearPendingRumble();
+                                    self.emitOrQueueRumble(ctx, frame, now_ns);
+                                    if (self.pending_rumble_frame != null) rumble_log.debug("[{s}] FF_STOP: frame FAILED to emit; queued retry", .{ctx.device_tag});
                                 }
-                                armRumbleStopFd(self.rumble_stop_fd, result.next_deadline_ns);
+                                self.armRumbleTimer(result.next_deadline_ns);
                             } else {
                                 rumble_log.debug("[{s}] FF_STOP: auto_stop disabled, direct zero frame", .{ctx.device_tag});
-                                if (ctx.allocator) |alloc| {
-                                    if (ctx.device_config) |dcfg| {
-                                        if (emitRumbleFrame(ctx.devices, alloc, dcfg, 0, 0, ctx.device_tag)) {
-                                            self.recordRumbleWrite(.{ .strong = 0, .weak = 0 }, now_ns);
-                                        } else {
-                                            rumble_log.debug("[{s}] FF_STOP: direct zero frame FAILED to emit", .{ctx.device_tag});
-                                        }
-                                    }
-                                }
+                                self.clearPendingRumble();
+                                self.emitOrQueueRumble(ctx, .{ .strong = 0, .weak = 0 }, now_ns);
+                                if (self.pending_rumble_frame != null) rumble_log.debug("[{s}] FF_STOP: direct zero frame FAILED to emit; queued retry", .{ctx.device_tag});
+                                self.armRumbleTimer(null);
                             }
                         } else {
                             if (scheduler_on) {
@@ -790,41 +918,28 @@ pub const EventLoop = struct {
                                 if (result.frame) |frame| {
                                     const elapsed = now_ns - self.last_rumble_ns;
                                     if (elapsed >= min_interval_ns) {
-                                        if (ctx.allocator) |alloc| {
-                                            if (ctx.device_config) |dcfg| {
-                                                if (emitRumbleFrame(ctx.devices, alloc, dcfg, frame.strong, frame.weak, ctx.device_tag)) {
-                                                    self.recordRumbleWrite(frame, now_ns);
-                                                } else {
-                                                    rumble_log.debug("[{s}] FF_PLAY: emitRumbleFrame FAILED id={d}", .{ ctx.device_tag, ff_ev.effect_id });
-                                                }
-                                            }
-                                        }
+                                        self.emitOrQueueRumble(ctx, frame, now_ns);
+                                        if (self.pending_rumble_frame != null) rumble_log.debug("[{s}] FF_PLAY: emitRumbleFrame FAILED id={d}; queued retry", .{ ctx.device_tag, ff_ev.effect_id });
                                     } else {
+                                        self.queuePendingRumble(frame, self.last_rumble_ns + min_interval_ns, 0);
                                         rumble_log.debug("[{s}] FF_PLAY: THROTTLED id={d} elapsed={d}ns", .{
-                                            ctx.device_tag,                                          ff_ev.effect_id,
-                                            @as(u64, @intCast(@min(elapsed, std.math.maxInt(u64)))),
+                                            ctx.device_tag, ff_ev.effect_id, elapsedNsForLog(elapsed),
                                         });
                                     }
                                 }
-                                armRumbleStopFd(self.rumble_stop_fd, result.next_deadline_ns);
+                                self.armRumbleTimer(result.next_deadline_ns);
                             } else {
                                 const elapsed = now_ns - self.last_rumble_ns;
                                 if (elapsed >= min_interval_ns) {
-                                    if (ctx.allocator) |alloc| {
-                                        if (ctx.device_config) |dcfg| {
-                                            if (emitRumbleFrame(ctx.devices, alloc, dcfg, ff_ev.strong, ff_ev.weak, ctx.device_tag)) {
-                                                self.recordRumbleWrite(.{ .strong = ff_ev.strong, .weak = ff_ev.weak }, now_ns);
-                                            } else {
-                                                rumble_log.debug("[{s}] FF_PLAY: emitRumbleFrame FAILED id={d}", .{ ctx.device_tag, ff_ev.effect_id });
-                                            }
-                                        }
-                                    }
+                                    self.emitOrQueueRumble(ctx, .{ .strong = ff_ev.strong, .weak = ff_ev.weak }, now_ns);
+                                    if (self.pending_rumble_frame != null) rumble_log.debug("[{s}] FF_PLAY: emitRumbleFrame FAILED id={d}; queued retry", .{ ctx.device_tag, ff_ev.effect_id });
                                 } else {
+                                    self.queuePendingRumble(.{ .strong = ff_ev.strong, .weak = ff_ev.weak }, self.last_rumble_ns + min_interval_ns, 0);
                                     rumble_log.debug("[{s}] FF_PLAY: THROTTLED id={d} elapsed={d}ns", .{
-                                        ctx.device_tag,                                          ff_ev.effect_id,
-                                        @as(u64, @intCast(@min(elapsed, std.math.maxInt(u64)))),
+                                        ctx.device_tag, ff_ev.effect_id, elapsedNsForLog(elapsed),
                                     });
                                 }
+                                self.armRumbleTimer(null);
                             }
                         }
                     }
@@ -1339,6 +1454,39 @@ const minimal_toml =
     \\[report.fields]
     \\left_x = { offset = 1, type = "i16le" }
 ;
+
+test "event_loop: rumble template OOM queues retry as write failure" {
+    const allocator = testing.allocator;
+
+    const rumble_toml =
+        \\[device]
+        \\name = "T"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 1
+        \\[commands.rumble]
+        \\interface = 0
+        \\template = "00 08 00 {strong:u8} {weak:u8} 00 00 00"
+    ;
+    const parsed = try device_mod.parseString(allocator, rumble_toml);
+    defer parsed.deinit();
+
+    var mock_dev = try MockDeviceIO.init(allocator, &.{});
+    defer mock_dev.deinit();
+    var devs = [_]DeviceIO{mock_dev.deviceIO()};
+
+    var failing = testing.FailingAllocator.init(allocator, .{ .fail_index = 0 });
+    const result = emitRumbleFrame(&devs, failing.allocator(), &parsed.value, 0x8000, 0x4000, "test");
+
+    try testing.expectEqual(RumbleEmitResult.write_failed, result);
+    try testing.expectEqual(@as(usize, 0), mock_dev.write_log.items.len);
+}
 
 test "event_loop: EventLoop mini: device frame dispatched to interpreter and output" {
     const allocator = testing.allocator;

--- a/src/test/event_loop_rumble_test.zig
+++ b/src/test/event_loop_rumble_test.zig
@@ -370,15 +370,13 @@ const MockFfOutputSeq = struct {
 };
 
 /// Drain-aware variant of MockFfOutputSeq. Each `mockPollFf` call reads one
-/// byte from the test's ff_pipe before returning the next event. That forces
-/// a strict 1:1 correspondence between pipe writes and event consumption so
-/// real-time delays between pipe writes are respected — which matters when a
-/// test wants its second play frame to land AFTER the 10ms play-frame
-/// throttle window closes.
+/// byte from the test's ff_pipe before returning the next event. Tests can pass
+/// `ack_write` to learn when the loop has taken the event from the output fd.
 const MockFfOutputDrain = struct {
     events: []const ?uinput.FfEvent,
     call_count: usize = 0,
     pipe_read: posix.fd_t,
+    ack_write: ?posix.fd_t = null,
 
     fn outputDevice(self: *MockFfOutputDrain) uinput.OutputDevice {
         return .{ .ptr = self, .vtable = &vtable };
@@ -399,6 +397,9 @@ const MockFfOutputDrain = struct {
         if (self.call_count < self.events.len) {
             const ev = self.events[self.call_count];
             self.call_count += 1;
+            if (ev != null) {
+                if (self.ack_write) |fd| _ = posix.write(fd, &[_]u8{1}) catch {};
+            }
             return ev;
         }
         return null;
@@ -406,6 +407,25 @@ const MockFfOutputDrain = struct {
 
     fn mockClose(_: *anyopaque) void {}
 };
+
+fn waitForAck(ack_read: posix.fd_t) !void {
+    var pfd = [1]posix.pollfd{.{ .fd = ack_read, .events = posix.POLL.IN, .revents = 0 }};
+    const n = posix.poll(&pfd, 2000) catch return error.AckTimeout;
+    if (n == 0) return error.AckTimeout;
+    var buf: [1]u8 = undefined;
+    _ = posix.read(ack_read, &buf) catch {};
+}
+
+fn sendFfAndWait(ff_write: posix.fd_t, ack_read: posix.fd_t) !void {
+    _ = try posix.write(ff_write, &[_]u8{1});
+    try waitForAck(ack_read);
+}
+
+fn waitForNoAck(ack_read: posix.fd_t, timeout_ms: u64) !void {
+    var pfd = [1]posix.pollfd{.{ .fd = ack_read, .events = posix.POLL.IN, .revents = 0 }};
+    const n = posix.poll(&pfd, @intCast(timeout_ms)) catch return error.UnexpectedAck;
+    if (n != 0) return error.UnexpectedAck;
+}
 
 fn runThrottledPlayScenario(allocator: std.mem.Allocator, wait_ns: u64) ![]u8 {
     var loop = try EventLoop.initManaged();
@@ -598,6 +618,93 @@ const NoopOutput = struct {
     fn pollFf(_: *anyopaque) uinput.PollFfError!?uinput.FfEvent {
         return null;
     }
+    fn close(_: *anyopaque) void {}
+};
+
+const FailingWriteDeviceIO = struct {
+    allocator: std.mem.Allocator,
+    write_log: std.ArrayList(u8),
+    write_times: std.ArrayList(i128),
+    attempt_times: std.ArrayList(i128),
+    pipe_r: posix.fd_t,
+    pipe_w: posix.fd_t,
+    write_attempts: usize = 0,
+    first_fail_index: usize,
+    fail_write_count: usize,
+    fail_error: DeviceIO.WriteError,
+    write_ack: ?posix.fd_t = null,
+
+    fn init(allocator: std.mem.Allocator, fail_write_index: usize) !FailingWriteDeviceIO {
+        return initRange(allocator, fail_write_index, 1, DeviceIO.WriteError.Io);
+    }
+
+    fn initNoFail(allocator: std.mem.Allocator) !FailingWriteDeviceIO {
+        return initRange(allocator, 1, 0, DeviceIO.WriteError.Io);
+    }
+
+    fn initRange(allocator: std.mem.Allocator, first_fail_index: usize, fail_write_count: usize, fail_error: DeviceIO.WriteError) !FailingWriteDeviceIO {
+        const fds = try posix.pipe2(.{ .NONBLOCK = true });
+        return .{
+            .allocator = allocator,
+            .write_log = .{},
+            .write_times = .{},
+            .attempt_times = .{},
+            .pipe_r = fds[0],
+            .pipe_w = fds[1],
+            .first_fail_index = first_fail_index,
+            .fail_write_count = fail_write_count,
+            .fail_error = fail_error,
+        };
+    }
+
+    fn setWriteAck(self: *FailingWriteDeviceIO, fd: posix.fd_t) void {
+        self.write_ack = fd;
+    }
+
+    fn deinit(self: *FailingWriteDeviceIO) void {
+        self.write_log.deinit(self.allocator);
+        self.write_times.deinit(self.allocator);
+        self.attempt_times.deinit(self.allocator);
+        posix.close(self.pipe_r);
+        posix.close(self.pipe_w);
+    }
+
+    fn deviceIO(self: *FailingWriteDeviceIO) DeviceIO {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = DeviceIO.VTable{
+        .read = read,
+        .write = write,
+        .feature_report = featureReport,
+        .pollfd = pollfd,
+        .close = close,
+    };
+
+    fn read(_: *anyopaque, _: []u8) DeviceIO.ReadError!usize {
+        return DeviceIO.ReadError.Again;
+    }
+
+    fn write(ptr: *anyopaque, data: []const u8) DeviceIO.WriteError!void {
+        const self: *FailingWriteDeviceIO = @ptrCast(@alignCast(ptr));
+        self.write_attempts += 1;
+        self.attempt_times.append(self.allocator, event_loop_mod.monotonicNs()) catch return DeviceIO.WriteError.Io;
+        if (self.fail_write_count > 0) {
+            const fail_end = self.first_fail_index + self.fail_write_count;
+            if (self.write_attempts >= self.first_fail_index and self.write_attempts < fail_end) return self.fail_error;
+        }
+        self.write_log.appendSlice(self.allocator, data) catch return DeviceIO.WriteError.Io;
+        self.write_times.append(self.allocator, event_loop_mod.monotonicNs()) catch return DeviceIO.WriteError.Io;
+        if (self.write_ack) |fd| _ = posix.write(fd, &[_]u8{1}) catch {};
+    }
+
+    fn featureReport(_: *anyopaque, _: []const u8) DeviceIO.WriteError!void {}
+
+    fn pollfd(ptr: *anyopaque) posix.pollfd {
+        const self: *FailingWriteDeviceIO = @ptrCast(@alignCast(ptr));
+        return .{ .fd = self.pipe_r, .events = posix.POLL.IN, .revents = 0 };
+    }
+
     fn close(_: *anyopaque) void {}
 };
 
@@ -906,15 +1013,22 @@ test "event_loop: non-zero restore frame refreshes rumble throttle clock" {
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
 
-    var mock_dev = try MockDeviceIO.init(allocator, &.{});
-    defer mock_dev.deinit();
-    const dev = mock_dev.deviceIO();
+    var write_dev = try FailingWriteDeviceIO.initNoFail(allocator);
+    defer write_dev.deinit();
+    const dev = write_dev.deviceIO();
     try loop.addDevice(dev);
 
     const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
     defer posix.close(ff_pipe[0]);
     defer posix.close(ff_pipe[1]);
     try loop.addUinputFf(ff_pipe[0]);
+    const ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ack_pipe[0]);
+    defer posix.close(ack_pipe[1]);
+    const write_ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(write_ack_pipe[0]);
+    defer posix.close(write_ack_pipe[1]);
+    write_dev.setWriteAck(write_ack_pipe[1]);
 
     const parsed = try device_mod.parseString(allocator, ff_toml);
     defer parsed.deinit();
@@ -927,7 +1041,7 @@ test "event_loop: non-zero restore frame refreshes rumble throttle clock" {
         .{ .effect_type = 0x50, .effect_id = 2, .strong = 0x7000, .weak = 0x3000, .duration_ms = 500 },
         null,
     };
-    var ff_out = MockFfOutputDrain{ .events = &seq, .pipe_read = ff_pipe[0] };
+    var ff_out = MockFfOutputDrain{ .events = &seq, .pipe_read = ff_pipe[0], .ack_write = ack_pipe[1] };
 
     const RunCtx = struct {
         loop: *EventLoop,
@@ -954,21 +1068,406 @@ test "event_loop: non-zero restore frame refreshes rumble throttle clock" {
     };
     const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
 
-    _ = try posix.write(ff_pipe[1], &[_]u8{1});
+    const frame_size = 8;
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForAck(write_ack_pipe[0]);
     std.Thread.sleep(15 * std.time.ns_per_ms);
-    _ = try posix.write(ff_pipe[1], &[_]u8{1});
-    std.Thread.sleep(15 * std.time.ns_per_ms);
-    _ = try posix.write(ff_pipe[1], &[_]u8{1});
-    _ = try posix.write(ff_pipe[1], &[_]u8{1});
-    std.Thread.sleep(30 * std.time.ns_per_ms);
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForAck(write_ack_pipe[0]);
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForAck(write_ack_pipe[0]);
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForNoAck(write_ack_pipe[0], 5);
+    try waitForAck(write_ack_pipe[0]);
     loop.stop();
     thread.join();
 
+    try testing.expectEqual(@as(usize, 4 * frame_size), write_dev.write_log.items.len);
+    try testing.expectEqual(@as(usize, 4), write_dev.write_times.items.len);
+    try testing.expect(write_dev.write_times.items[3] - write_dev.write_times.items[2] >= 8 * std.time.ns_per_ms);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 }, write_dev.write_log.items[0..frame_size]);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, write_dev.write_log.items[frame_size .. 2 * frame_size]);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 }, write_dev.write_log.items[2 * frame_size .. 3 * frame_size]);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x70, 0x30, 0x00, 0x00, 0x00 }, write_dev.write_log.items[3 * frame_size .. 4 * frame_size]);
+}
+
+test "event_loop: throttled non-zero play is flushed after throttle deadline" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var write_dev = try FailingWriteDeviceIO.initNoFail(allocator);
+    defer write_dev.deinit();
+    const dev = write_dev.deviceIO();
+    try loop.addDevice(dev);
+    loop.last_rumble_ns = event_loop_mod.monotonicNs() + 50 * std.time.ns_per_ms;
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+    const ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ack_pipe[0]);
+    defer posix.close(ack_pipe[1]);
+    const write_ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(write_ack_pipe[0]);
+    defer posix.close(write_ack_pipe[1]);
+    write_dev.setWriteAck(write_ack_pipe[1]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x2000, .weak = 0x1000, .duration_ms = 500 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x6000, .weak = 0x3000, .duration_ms = 500 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 500 },
+        null,
+    };
+    var ff_out = MockFfOutputDrain{ .events = &seq, .pipe_read = ff_pipe[0], .ack_write = ack_pipe[1] };
+
+    const RunCtx = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        ff_out: *MockFfOutputDrain,
+        cfg: *const device_mod.DeviceConfig,
+        alloc: std.mem.Allocator,
+    };
+    var devs = [_]DeviceIO{dev};
+    var ctx = RunCtx{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .ff_out = &ff_out,
+        .cfg = &parsed.value,
+        .alloc = allocator,
+    };
+
+    const T = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 200 });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
+
     const frame_size = 8;
-    try testing.expectEqual(@as(usize, 3 * frame_size), mock_dev.write_log.items.len);
-    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 }, mock_dev.write_log.items[0..frame_size]);
-    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, mock_dev.write_log.items[frame_size .. 2 * frame_size]);
-    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 }, mock_dev.write_log.items[2 * frame_size .. 3 * frame_size]);
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForNoAck(write_ack_pipe[0], 5);
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForNoAck(write_ack_pipe[0], 5);
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForAck(write_ack_pipe[0]);
+    loop.stop();
+    thread.join();
+
+    try testing.expectEqual(@as(usize, frame_size), write_dev.write_log.items.len);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, write_dev.write_log.items[0..frame_size]);
+}
+
+test "event_loop: stop cancels pending throttled rumble frame" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var write_dev = try FailingWriteDeviceIO.initNoFail(allocator);
+    defer write_dev.deinit();
+    const dev = write_dev.deviceIO();
+    try loop.addDevice(dev);
+    loop.last_rumble_ns = event_loop_mod.monotonicNs() + 50 * std.time.ns_per_ms;
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+    const ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ack_pipe[0]);
+    defer posix.close(ack_pipe[1]);
+    const write_ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(write_ack_pipe[0]);
+    defer posix.close(write_ack_pipe[1]);
+    write_dev.setWriteAck(write_ack_pipe[1]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x2000, .weak = 0x1000, .duration_ms = 500 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 500 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0, .weak = 0, .duration_ms = 0 },
+        null,
+    };
+    var ff_out = MockFfOutputDrain{ .events = &seq, .pipe_read = ff_pipe[0], .ack_write = ack_pipe[1] };
+
+    const RunCtx = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        ff_out: *MockFfOutputDrain,
+        cfg: *const device_mod.DeviceConfig,
+        alloc: std.mem.Allocator,
+    };
+    var devs = [_]DeviceIO{dev};
+    var ctx = RunCtx{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .ff_out = &ff_out,
+        .cfg = &parsed.value,
+        .alloc = allocator,
+    };
+
+    const T = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 200 });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
+
+    const frame_size = 8;
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForNoAck(write_ack_pipe[0], 5);
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForNoAck(write_ack_pipe[0], 5);
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForAck(write_ack_pipe[0]);
+    try waitForNoAck(write_ack_pipe[0], 100);
+    loop.stop();
+    thread.join();
+
+    try testing.expectEqual(@as(usize, frame_size), write_dev.write_log.items.len);
+    try testing.expectEqual(@as(?rumble_scheduler_mod.RumbleScheduler.Frame, null), loop.pending_rumble_frame);
+    try testing.expectEqual(@as(?i128, null), loop.pending_rumble_deadline_ns);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, write_dev.write_log.items[0..frame_size]);
+}
+
+test "event_loop: failed stop frame is retried from pending rumble queue" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var fail_dev = try FailingWriteDeviceIO.initRange(allocator, 2, 2, DeviceIO.WriteError.Io);
+    defer fail_dev.deinit();
+    const dev = fail_dev.deviceIO();
+    try loop.addDevice(dev);
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+    const ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ack_pipe[0]);
+    defer posix.close(ack_pipe[1]);
+    const write_ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(write_ack_pipe[0]);
+    defer posix.close(write_ack_pipe[1]);
+    fail_dev.setWriteAck(write_ack_pipe[1]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 500 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0, .weak = 0, .duration_ms = 0 },
+        null,
+    };
+    var ff_out = MockFfOutputDrain{ .events = &seq, .pipe_read = ff_pipe[0], .ack_write = ack_pipe[1] };
+
+    const RunCtx = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        ff_out: *MockFfOutputDrain,
+        cfg: *const device_mod.DeviceConfig,
+        alloc: std.mem.Allocator,
+    };
+    var devs = [_]DeviceIO{dev};
+    var ctx = RunCtx{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .ff_out = &ff_out,
+        .cfg = &parsed.value,
+        .alloc = allocator,
+    };
+
+    const T = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 200 });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
+
+    const frame_size = 8;
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForAck(write_ack_pipe[0]);
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForAck(write_ack_pipe[0]);
+    loop.stop();
+    thread.join();
+
+    try testing.expectEqual(@as(usize, 4), fail_dev.write_attempts);
+    try testing.expectEqual(@as(usize, 4), fail_dev.attempt_times.items.len);
+    try testing.expect(fail_dev.attempt_times.items[2] - fail_dev.attempt_times.items[1] >= @as(i128, 8 * std.time.ns_per_ms));
+    try testing.expect(fail_dev.attempt_times.items[3] - fail_dev.attempt_times.items[2] >= @as(i128, 8 * std.time.ns_per_ms));
+    try testing.expectEqual(@as(usize, 2 * frame_size), fail_dev.write_log.items.len);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, fail_dev.write_log.items[0..frame_size]);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, fail_dev.write_log.items[frame_size .. 2 * frame_size]);
+}
+
+test "event_loop: disconnected rumble write exits without retry queue" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var fail_dev = try FailingWriteDeviceIO.initRange(allocator, 2, 1, DeviceIO.WriteError.Disconnected);
+    defer fail_dev.deinit();
+    const dev = fail_dev.deviceIO();
+    try loop.addDevice(dev);
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+    const ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ack_pipe[0]);
+    defer posix.close(ack_pipe[1]);
+    const write_ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(write_ack_pipe[0]);
+    defer posix.close(write_ack_pipe[1]);
+    fail_dev.setWriteAck(write_ack_pipe[1]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 500 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0, .weak = 0, .duration_ms = 0 },
+        null,
+    };
+    var ff_out = MockFfOutputDrain{ .events = &seq, .pipe_read = ff_pipe[0], .ack_write = ack_pipe[1] };
+
+    const RunCtx = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        ff_out: *MockFfOutputDrain,
+        cfg: *const device_mod.DeviceConfig,
+        alloc: std.mem.Allocator,
+    };
+    var devs = [_]DeviceIO{dev};
+    var ctx = RunCtx{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .ff_out = &ff_out,
+        .cfg = &parsed.value,
+        .alloc = allocator,
+    };
+
+    const T = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 200 });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
+
+    const frame_size = 8;
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForAck(write_ack_pipe[0]);
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForNoAck(write_ack_pipe[0], 30);
+    loop.stop();
+    thread.join();
+
+    try testing.expectEqual(@as(usize, 2), fail_dev.write_attempts);
+    try testing.expect(loop.disconnected);
+    try testing.expectEqual(@as(?rumble_scheduler_mod.RumbleScheduler.Frame, null), loop.pending_rumble_frame);
+    try testing.expectEqual(@as(?i128, null), loop.pending_rumble_deadline_ns);
+    try testing.expectEqual(@as(usize, frame_size), fail_dev.write_log.items.len);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, fail_dev.write_log.items[0..frame_size]);
+}
+
+test "event_loop: repeated rumble write failures stop retrying and mark disconnected" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var fail_dev = try FailingWriteDeviceIO.initRange(allocator, 2, 4, DeviceIO.WriteError.Io);
+    defer fail_dev.deinit();
+    const dev = fail_dev.deviceIO();
+    try loop.addDevice(dev);
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+    const ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ack_pipe[0]);
+    defer posix.close(ack_pipe[1]);
+    const write_ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(write_ack_pipe[0]);
+    defer posix.close(write_ack_pipe[1]);
+    fail_dev.setWriteAck(write_ack_pipe[1]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 500 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0, .weak = 0, .duration_ms = 0 },
+        null,
+    };
+    var ff_out = MockFfOutputDrain{ .events = &seq, .pipe_read = ff_pipe[0], .ack_write = ack_pipe[1] };
+
+    const RunCtx = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        ff_out: *MockFfOutputDrain,
+        cfg: *const device_mod.DeviceConfig,
+        alloc: std.mem.Allocator,
+    };
+    var devs = [_]DeviceIO{dev};
+    var ctx = RunCtx{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .ff_out = &ff_out,
+        .cfg = &parsed.value,
+        .alloc = allocator,
+    };
+
+    const T = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 200 });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
+
+    const frame_size = 8;
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForAck(write_ack_pipe[0]);
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForNoAck(write_ack_pipe[0], 100);
+    loop.stop();
+    thread.join();
+
+    try testing.expectEqual(@as(usize, 5), fail_dev.write_attempts);
+    try testing.expect(loop.disconnected);
+    try testing.expectEqual(@as(?rumble_scheduler_mod.RumbleScheduler.Frame, null), loop.pending_rumble_frame);
+    try testing.expectEqual(@as(?i128, null), loop.pending_rumble_deadline_ns);
+    try testing.expectEqual(@as(usize, frame_size), fail_dev.write_log.items.len);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, fail_dev.write_log.items[0..frame_size]);
 }
 
 test "event_loop: auto_stop=false never emits a scheduler-driven stop frame" {
@@ -1036,6 +1535,78 @@ test "event_loop: auto_stop=false never emits a scheduler-driven stop frame" {
     try testing.expectEqual(@as(usize, frame_size), mock_dev.write_log.items.len);
     const play_frame = mock_dev.write_log.items[0..frame_size];
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, play_frame);
+}
+
+test "event_loop: auto_stop=false throttled play still flushes pending rumble frame" {
+    const allocator = testing.allocator;
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+
+    var write_dev = try FailingWriteDeviceIO.initNoFail(allocator);
+    defer write_dev.deinit();
+    const dev = write_dev.deviceIO();
+    try loop.addDevice(dev);
+    loop.last_rumble_ns = event_loop_mod.monotonicNs() + 50 * std.time.ns_per_ms;
+
+    const ff_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ff_pipe[0]);
+    defer posix.close(ff_pipe[1]);
+    try loop.addUinputFf(ff_pipe[0]);
+    const ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(ack_pipe[0]);
+    defer posix.close(ack_pipe[1]);
+    const write_ack_pipe = try posix.pipe2(.{ .NONBLOCK = true });
+    defer posix.close(write_ack_pipe[0]);
+    defer posix.close(write_ack_pipe[1]);
+    write_dev.setWriteAck(write_ack_pipe[1]);
+
+    const parsed = try device_mod.parseString(allocator, ff_toml_no_autostop);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x2000, .weak = 0x1000, .duration_ms = 25 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 25 },
+        null,
+    };
+    var ff_out = MockFfOutputDrain{ .events = &seq, .pipe_read = ff_pipe[0], .ack_write = ack_pipe[1] };
+
+    const RunCtx = struct {
+        loop: *EventLoop,
+        devs: []DeviceIO,
+        interp: *const Interpreter,
+        ff_out: *MockFfOutputDrain,
+        cfg: *const device_mod.DeviceConfig,
+        alloc: std.mem.Allocator,
+    };
+    var devs = [_]DeviceIO{dev};
+    var ctx = RunCtx{
+        .loop = &loop,
+        .devs = &devs,
+        .interp = &interp,
+        .ff_out = &ff_out,
+        .cfg = &parsed.value,
+        .alloc = allocator,
+    };
+
+    const T = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(.{ .devices = c.devs, .interpreter = c.interp, .output = c.ff_out.outputDevice(), .allocator = c.alloc, .device_config = c.cfg, .poll_timeout_ms = 100 });
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, T.run, .{&ctx});
+
+    const frame_size = 8;
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForNoAck(write_ack_pipe[0], 5);
+    try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
+    try waitForAck(write_ack_pipe[0]);
+    loop.stop();
+    thread.join();
+
+    try testing.expectEqual(@as(usize, frame_size), write_dev.write_log.items.len);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, write_dev.write_log.items[0..frame_size]);
 }
 
 test "event_loop: explicit stop before duration_ms disarms auto-stop (no double stop)" {
@@ -1449,22 +2020,25 @@ test "event_loop: throttled play still rearms auto-stop deadline" {
     //
     // Sequence:
     //   T0  FF_PLAY effect 0, 50ms duration   -> emitted, first deadline armed
-    //   T1  FF_PLAY effect 0, 300ms duration  -> throttled, no HID frame, but
-    //                                            scheduler deadline must extend
+    //   T1  FF_PLAY effect 0, 300ms duration  -> throttled, then flushed after
+    //                                            10ms; scheduler deadline must extend
     //
     // If the second onPlay were gated by "frame forwarded", the first 50ms
-    // deadline would fire and emit a premature stop.
+    // deadline would fire and emit a premature stop. If the throttled frame were
+    // dropped, the device would keep the first strength until final stop.
     const allocator = testing.allocator;
     const frame_size = 8;
 
     const early_log = try runThrottledPlayScenario(allocator, 120 * std.time.ns_per_ms);
     defer allocator.free(early_log);
-    try testing.expectEqual(@as(usize, frame_size), early_log.len);
-    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 }, early_log);
+    try testing.expectEqual(@as(usize, 2 * frame_size), early_log.len);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 }, early_log[0..frame_size]);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, early_log[frame_size .. 2 * frame_size]);
 
     const late_log = try runThrottledPlayScenario(allocator, 420 * std.time.ns_per_ms);
     defer allocator.free(late_log);
-    try testing.expectEqual(@as(usize, 2 * frame_size), late_log.len);
+    try testing.expectEqual(@as(usize, 3 * frame_size), late_log.len);
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00 }, late_log[0..frame_size]);
-    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, late_log[frame_size .. 2 * frame_size]);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, late_log[frame_size .. 2 * frame_size]);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, late_log[2 * frame_size .. 3 * frame_size]);
 }


### PR DESCRIPTION
Refs #65

## Summary
- keep the latest throttled non-zero rumble frame pending and flush it at the 10ms throttle deadline
- share the timerfd deadline between scheduler auto-stop and pending rumble flushes, including `auto_stop=false`
- retry transient rumble HID write failures with a bounded 10ms retry queue and stop on disconnect/retry exhaustion
- clear stale pending rumble frames on explicit stop and quiesce

## Test evidence
- baseline old-main reproduction: `event_loop: throttled play still rearms auto-stop deadline` fails with `expected 16, found 8`
- `/home/jim_z/.local/bin/zig build test -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false -Dtest-filter=rumble --summary all`
- `/home/jim_z/.local/bin/zig build test -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false -Dtest-filter=event_loop --summary all`
- `/home/jim_z/.local/bin/zig build test-safe -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false -Dtest-filter=rumble --summary all`
- `/home/jim_z/.local/bin/zig build test-safe -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false -Dtest-filter=event_loop --summary all`
- `/home/jim_z/.local/bin/zig build test -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false -Dtest-filter=ff --summary all`
- `/home/jim_z/.local/bin/zig build test-safe -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false -Dtest-filter=ff --summary all`
- `/home/jim_z/.local/bin/zig build check-fmt --summary all`
- `PADCTL_TEST_REQUIRE_UINPUT=1 /home/jim_z/.local/bin/zig build test-integration -Dtarget=x86_64-linux-musl -Dlibusb=false -Dwasm=false -Dtest-filter=pollFf --summary all`

## Notes
- `test-tsan` is still unavailable in this environment: the musl TSAN test runner terminates with SIGSEGV before producing useful race evidence.
- Issue #65 remains open; this PR intentionally does not include a closing keyword.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rumble feedback now handles temporary write failures more gracefully by retrying queued frames instead of dropping them.
  * Throttled rumble updates are preserved and sent later once timing allows.

* **Bug Fixes**
  * Improved stop/play rumble handling so pending frames are cleared, retried, or canceled correctly.
  * Fixed rumble auto-stop behavior to stay in sync when delayed updates occur.

* **Tests**
  * Added more deterministic rumble integration coverage for retries, throttling, disconnects, and stop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->