### PR TITLE
Add DualSense Edge output preset

### DIFF
--- a/docs/src/contributing/device-config-guide.md
+++ b/docs/src/contributing/device-config-guide.md
@@ -82,7 +82,7 @@ type = "hat"
 | `i16le` centered at 0 | none (already full range) |
 | `u8` trigger (0-255) | none |
 
-**Output emulation:** For maximum game compatibility, emulate Xbox Elite Series 2 (`vid = 0x045e, pid = 0x0b00`). See `devices/flydigi/vader5.toml` for an example. If the device is well-known (like DualSense), use its real VID/PID.
+**Output emulation:** For maximum game compatibility, emulate a well-supported controller profile. `emulate = "xbox-elite2"` gives an Xbox Elite Series 2 identity, while `emulate = "dualsense-edge"` gives a DualSense Edge identity with `M1`-`M4` on the Edge extra-button slots. If the device is well-known and you are publishing its real protocol, use its real VID/PID.
 
 ## Multiple Report Types
 

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -170,6 +170,25 @@ Declares the uinput device emitted by padctl.
 | `vid` | integer | Emulated vendor ID |
 | `pid` | integer | Emulated product ID |
 
+Built-in `emulate` profiles:
+
+| Profile | VID:PID | Notes |
+|---------|---------|-------|
+| `xbox-360` | `045e:028e` | Standard Xbox 360 layout |
+| `xbox-elite2` | `045e:0b00` | Xbox Elite Series 2 identity |
+| `dualsense` | `054c:0ce6` | DualSense identity with touchpad and mic buttons |
+| `dualsense-edge` | `054c:0df2` | DualSense Edge identity, high-resolution stick ranges, and `M1`-`M4` mapped to `BTN_TRIGGER_HAPPY1`-`BTN_TRIGGER_HAPPY4` |
+| `switch-pro` | `057e:2009` | Nintendo Switch Pro layout |
+
+`emulate` fills only missing `[output]` fields. Explicit `vid`, `pid`, `name`,
+`[output.axes]`, or `[output.buttons]` entries remain authoritative, so a device
+can use a preset identity without losing device-specific stick ranges or extra
+button layout.
+
+These profiles define the virtual gamepad identity and generic evdev/HID button
+layout. They do not synthesize vendor-specific HIDAPI reports such as native
+DualSense gyro, adaptive trigger, or touchpad packet formats.
+
 ### `[output.axes]`
 
 ```toml

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -1246,6 +1246,39 @@ test "device: emulate preset: explicit vid overrides preset" {
     try std.testing.expectEqual(@as(?i64, 0x0ce6), out.pid);
 }
 
+test "device: emulate preset: dualsense-edge resolves identity and preserves explicit axes" {
+    const allocator = std.testing.allocator;
+    const toml_str =
+        \\[device]
+        \\name = "My Device"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+        \\[output]
+        \\emulate = "dualsense-edge"
+        \\[output.axes]
+        \\left_x = { code = "ABS_X", min = -32768, max = 32767, fuzz = 16, flat = 128 }
+    ;
+    const result = try parseString(allocator, toml_str);
+    defer result.deinit();
+
+    const out = result.value.output.?;
+    try std.testing.expectEqual(@as(?i64, 0x054c), out.vid);
+    try std.testing.expectEqual(@as(?i64, 0x0df2), out.pid);
+    try std.testing.expectEqualStrings("Sony DualSense Edge", out.name.?);
+    const axes = out.axes orelse return error.MissingAxes;
+    try std.testing.expectEqual(@as(usize, 1), axes.map.count());
+    const left_x = axes.map.get("left_x") orelse return error.MissingLeftX;
+    try std.testing.expectEqual(@as(i64, -32768), left_x.min);
+    try std.testing.expectEqual(@as(i64, 32767), left_x.max);
+}
+
 test "device: emulate preset: unknown preset returns error" {
     const allocator = std.testing.allocator;
     const toml_str =

--- a/src/config/presets.zig
+++ b/src/config/presets.zig
@@ -61,6 +61,26 @@ const dualsense_buttons = [_]ButtonEntry{
     .{ .name = "Mic", .code = "BTN_MISC" },
 };
 
+const dualsense_edge_buttons = [_]ButtonEntry{
+    .{ .name = "A", .code = "BTN_SOUTH" },
+    .{ .name = "B", .code = "BTN_EAST" },
+    .{ .name = "X", .code = "BTN_WEST" },
+    .{ .name = "Y", .code = "BTN_NORTH" },
+    .{ .name = "LB", .code = "BTN_TL" },
+    .{ .name = "RB", .code = "BTN_TR" },
+    .{ .name = "Select", .code = "BTN_SELECT" },
+    .{ .name = "Start", .code = "BTN_START" },
+    .{ .name = "Home", .code = "BTN_MODE" },
+    .{ .name = "LS", .code = "BTN_THUMBL" },
+    .{ .name = "RS", .code = "BTN_THUMBR" },
+    .{ .name = "M1", .code = "BTN_TRIGGER_HAPPY1" },
+    .{ .name = "M2", .code = "BTN_TRIGGER_HAPPY2" },
+    .{ .name = "M3", .code = "BTN_TRIGGER_HAPPY3" },
+    .{ .name = "M4", .code = "BTN_TRIGGER_HAPPY4" },
+    .{ .name = "TouchPad", .code = "BTN_TOUCH" },
+    .{ .name = "Mic", .code = "BTN_MISC" },
+};
+
 const switch_pro_axes = [_]AxisEntry{
     .{ .name = "left_x", .cfg = .{ .code = "ABS_X", .min = -32768, .max = 32767, .fuzz = 0, .flat = 200 } },
     .{ .name = "left_y", .cfg = .{ .code = "ABS_Y", .min = -32768, .max = 32767, .fuzz = 0, .flat = 200 } },
@@ -106,6 +126,13 @@ const presets = [_]struct { name: []const u8, preset: Preset }{
         .name = "Sony DualSense",
         .axes = &dualsense_axes,
         .buttons = &dualsense_buttons,
+    } },
+    .{ .name = "dualsense-edge", .preset = .{
+        .vid = 0x054c,
+        .pid = 0x0df2,
+        .name = "Sony DualSense Edge",
+        .axes = &xbox360_axes,
+        .buttons = &dualsense_edge_buttons,
     } },
     .{ .name = "switch-pro", .preset = .{
         .vid = 0x057e,
@@ -185,6 +212,30 @@ test "applyPreset: dualsense preset" {
     try applyPreset(arena.allocator(), &out, "dualsense");
     try std.testing.expectEqual(@as(?i64, 0x054c), out.vid);
     try std.testing.expectEqual(@as(?i64, 0x0ce6), out.pid);
+}
+
+test "applyPreset: dualsense-edge preset keeps high-resolution sticks and Edge buttons" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var out = device.OutputConfig{};
+    try applyPreset(arena.allocator(), &out, "dualsense-edge");
+
+    try std.testing.expectEqual(@as(?i64, 0x054c), out.vid);
+    try std.testing.expectEqual(@as(?i64, 0x0df2), out.pid);
+    try std.testing.expectEqualStrings("Sony DualSense Edge", out.name.?);
+
+    const axes = out.axes orelse return error.MissingAxes;
+    const left_x = axes.map.get("left_x") orelse return error.MissingLeftX;
+    try std.testing.expectEqual(@as(i64, -32768), left_x.min);
+    try std.testing.expectEqual(@as(i64, 32767), left_x.max);
+
+    const buttons = out.buttons orelse return error.MissingButtons;
+    try std.testing.expectEqualStrings("BTN_TRIGGER_HAPPY1", buttons.map.get("M1") orelse return error.MissingM1);
+    try std.testing.expectEqualStrings("BTN_TRIGGER_HAPPY2", buttons.map.get("M2") orelse return error.MissingM2);
+    try std.testing.expectEqualStrings("BTN_TRIGGER_HAPPY3", buttons.map.get("M3") orelse return error.MissingM3);
+    try std.testing.expectEqualStrings("BTN_TRIGGER_HAPPY4", buttons.map.get("M4") orelse return error.MissingM4);
+    try std.testing.expectEqualStrings("BTN_TOUCH", buttons.map.get("TouchPad") orelse return error.MissingTouchPad);
+    try std.testing.expectEqualStrings("BTN_MISC", buttons.map.get("Mic") orelse return error.MissingMic);
 }
 
 test "applyPreset: switch-pro preset" {

--- a/src/io/uhid_descriptor.zig
+++ b/src/io/uhid_descriptor.zig
@@ -1476,6 +1476,37 @@ test "descriptor: Vader 5 keeps Steam/SDL M2 and M3 paddle order" {
     });
 }
 
+test "descriptor: DualSense Edge preset emits trigger-happy extra buttons" {
+    const alloc = testing.allocator;
+    const parsed = try device.parseString(alloc,
+        \\[device]
+        \\name = "Edge Preset Test"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+        \\[output]
+        \\emulate = "dualsense-edge"
+    );
+    defer parsed.deinit();
+    const out = parsed.value.output orelse return error.MissingOutputSection;
+
+    const desc = try UhidDescriptorBuilder.buildFromOutput(alloc, out);
+    defer alloc.free(desc);
+
+    // Edge extra buttons map to BTN_TRIGGER_HAPPY1-4, which Linux exposes as
+    // HID Button usages 17-20. BTN_TOUCH / BTN_MISC use fallback button usages.
+    try expectButtonUsages(desc, &.{
+        1,  2,  5,  4,  7,  8, 12, 11, 13, 14,
+        15, 17, 18, 19, 20, 3, 6,
+    });
+}
+
 test "descriptor: button count padding rounds to byte boundary" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/src/test/validate_e2e_test.zig
+++ b/src/test/validate_e2e_test.zig
@@ -82,6 +82,43 @@ test "E2E emulate: explicit vid overrides preset, pid from preset" {
     try testing.expectEqual(@as(?i64, 0x0ce6), out.pid);
 }
 
+test "E2E emulate: dualsense-edge preset exposes Edge identity and extra buttons" {
+    const allocator = testing.allocator;
+    const toml_str =
+        \\[device]
+        \\name = "My Device"
+        \\vid = 0x1111
+        \\pid = 0x2222
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+        \\[output]
+        \\emulate = "dualsense-edge"
+    ;
+    const parsed = try device_mod.parseString(allocator, toml_str);
+    defer parsed.deinit();
+
+    const out = parsed.value.output.?;
+    try testing.expectEqual(@as(?i64, 0x054c), out.vid);
+    try testing.expectEqual(@as(?i64, 0x0df2), out.pid);
+    try testing.expectEqualStrings("Sony DualSense Edge", out.name.?);
+
+    const axes = out.axes orelse return error.NoAxes;
+    const left_x = axes.map.get("left_x") orelse return error.NoLeftX;
+    try testing.expectEqual(@as(i64, -32768), left_x.min);
+    try testing.expectEqual(@as(i64, 32767), left_x.max);
+
+    const buttons = out.buttons orelse return error.NoButtons;
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY1", buttons.map.get("M1") orelse return error.NoM1);
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY2", buttons.map.get("M2") orelse return error.NoM2);
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY3", buttons.map.get("M3") orelse return error.NoM3);
+    try testing.expectEqualStrings("BTN_TRIGGER_HAPPY4", buttons.map.get("M4") orelse return error.NoM4);
+}
+
 test "E2E emulate: switch-pro preset axes count" {
     const allocator = testing.allocator;
     const toml_str =


### PR DESCRIPTION
Summary
- add a `dualsense-edge` output emulation preset with Sony VID/PID `054c:0df2`
- keep high-resolution `-32768..32767` stick axes in the Edge preset to avoid the stick precision regression raised in issue #471
- map Edge-style extra buttons `M1`-`M4` to `BTN_TRIGGER_HAPPY1`-`BTN_TRIGGER_HAPPY4`
- document the preset list and clarify that presets do not synthesize native Sony HIDAPI gyro/touchpad/adaptive-trigger packet formats

Testing
- reproduced current Vader 5 state: built-in config still publishes Xbox Elite Series 2 `045e:0b00` and no `dualsense-edge` preset existed
- `zig fmt src/config/presets.zig src/config/device.zig src/test/validate_e2e_test.zig src/io/uhid_descriptor.zig`
- `git diff --check`
- `/home/jim_z/.local/bin/zig build --cache-dir /tmp/padctl-zig-cache-edge2 --global-cache-dir /tmp/padctl-zig-global-edge2 test -Dtarget=x86_64-linux-musl -Dtest-filter="DualSense Edge"`
- `/home/jim_z/.local/bin/zig build --cache-dir /tmp/padctl-zig-cache-edge3 --global-cache-dir /tmp/padctl-zig-global-edge3 test -Dtarget=x86_64-linux-musl -Dtest-filter="dualsense-edge"`
- `/home/jim_z/.local/bin/zig build --cache-dir /tmp/padctl-zig-cache-vader --global-cache-dir /tmp/padctl-zig-global-vader test -Dtarget=x86_64-linux-musl -Dtest-filter="vader5"`
- `/home/jim_z/.local/bin/zig build --cache-dir /tmp/padctl-zig-cache-emu --global-cache-dir /tmp/padctl-zig-global-emu test -Dtarget=x86_64-linux-musl -Dtest-filter="emulate"`
- `/home/jim_z/.local/bin/zig build --cache-dir /tmp/padctl-zig-cache-ffb --global-cache-dir /tmp/padctl-zig-global-ffb test -Dtarget=x86_64-linux-musl -Dtest-filter="ffbUnavailableOverUhid"`
- `/home/jim_z/.local/bin/zig build --cache-dir /tmp/padctl-zig-cache-desc --global-cache-dir /tmp/padctl-zig-global-desc test -Dtarget=x86_64-linux-musl -Dtest-filter="descriptor: Vader 5"`
- `/home/jim_z/.local/bin/zig build --cache-dir /tmp/padctl-zig-cache-edgepreset --global-cache-dir /tmp/padctl-zig-global-edgepreset test -Dtarget=x86_64-linux-musl -Dtest-filter="applyPreset: dualsense-edge"`
- `PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test --summary all` passed: 1876/1887 tests passed, 11 skipped

Review
- read-only reviewer found no blocking issues
- residual boundary: this adds an output identity/profile, not a full DualSense Edge HID protocol implementation

Refs #471


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a built-in `dualsense-edge` controller profile with updated button and axis mappings, including extra buttons M1–M4.
  * Expanded output emulation options with additional preset profiles for common gamepad identities.

* **Documentation**
  * Updated device configuration guides to explain built-in emulation profiles and when to use them.
  * Clarified that emulation fills in missing output settings without overriding explicit configuration.

* **Tests**
  * Added regression coverage for `dualsense-edge` emulation and its HID button mapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->