### PR TITLE
chore(release): bump version to 0.1.19

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.18",
+    .version = "0.1.19",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
## Summary

- bump `build.zig.zon` from `0.1.18` to `0.1.19`
- prepare the next annotated tag/release workflow run

## Verification

- `PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test --summary all`
  - 1876/1887 tests passed
  - 11 skipped

## Notes

- This PR intentionally only changes the version field.
- It does not close any issue.
