### PR TITLE
Fix issue 65 rumble resume recovery

### DIFF
--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -169,6 +169,17 @@ pub fn openUhidDeviceForTest(
     return openUhidDevice(allocator, cfg, test_fd);
 }
 
+fn quiescePhysicalRumble(
+    loop: *EventLoop,
+    devices: []DeviceIO,
+    allocator: std.mem.Allocator,
+    cfg: *const DeviceConfig,
+) void {
+    // Best-effort physical reset for attach/rebind paths. This uses
+    // commands.rumble directly, so it does not depend on kernel FF state.
+    loop.quiesceTimersAndRumble(devices, allocator, cfg, cfg.device.name);
+}
+
 pub const DeviceInstance = struct {
     allocator: std.mem.Allocator,
     devices: []DeviceIO,
@@ -489,6 +500,7 @@ pub const DeviceInstance = struct {
         } else {
             std.log.info("device \"{s}\": passthrough (no mapping)", .{cfg.device.name});
         }
+        quiescePhysicalRumble(&loop, devices, allocator, cfg);
         std.log.info("device ready: \"{s}\"", .{cfg.device.name});
 
         return .{
@@ -673,7 +685,7 @@ pub const DeviceInstance = struct {
     }
 
     pub fn quiesceOutputs(self: *DeviceInstance, options: QuiesceOptions) void {
-        self.loop.quiesceTimersAndRumble(self.devices, self.allocator, self.device_cfg, self.device_cfg.device.name);
+        quiescePhysicalRumble(&self.loop, self.devices, self.allocator, self.device_cfg);
 
         if (self.mapper) |*m| {
             self.releaseMapperAux(m);
@@ -752,6 +764,7 @@ pub const DeviceInstance = struct {
                 };
             }
         }
+        quiescePhysicalRumble(&self.loop, self.devices, self.allocator, self.device_cfg);
     }
 
     /// Signal the event loop to stop. run() returns after the current ppoll.
@@ -885,6 +898,29 @@ const init_toml =
     \\expect = [0x01]
 ;
 
+const init_with_rumble_toml =
+    \\[device]
+    \\name = "InitRumbleDevice"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[device.init]
+    \\interface = 0
+    \\commands = ["0101"]
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 1
+    \\[report.match]
+    \\offset = 0
+    \\expect = [0x01]
+    \\[commands.rumble]
+    \\interface = 0
+    \\template = "aa {strong:u8} {weak:u8} bb"
+;
+
 const strict_init_toml =
     \\[device]
     \\name = "StrictInitDevice"
@@ -1015,6 +1051,26 @@ test "DeviceInstance.init propagates feature_report init errors" {
     });
 
     try testing.expectError(DeviceIO.WriteError.Io, result);
+}
+
+test "DeviceInstance.init quiesces physical rumble after init sequence" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, init_with_rumble_toml);
+    defer parsed.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    const devices = try allocator.alloc(DeviceIO, 1);
+    devices[0] = mock.deviceIO();
+
+    var uniq_counter: u16 = 1;
+    var inst = try DeviceInstance.init(allocator, &parsed.value, null, null, &uniq_counter, .{
+        .test_devices_override = devices,
+    });
+    defer inst.deinit();
+
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x01, 0x01, 0xaa, 0x00, 0x00, 0xbb }, mock.write_log.items);
 }
 
 const suppress_first_init_toml =
@@ -1235,6 +1291,91 @@ test "DeviceInstance: rerunInitSequence propagates feature_report errors" {
     };
 
     try testing.expectError(DeviceIO.WriteError.Io, inst.rerunInitSequence());
+}
+
+test "DeviceInstance: rerunInitSequence quiesces physical rumble after re-init" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, init_with_rumble_toml);
+    defer parsed.deinit();
+
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    const devices = try allocator.alloc(DeviceIO, 1);
+    defer allocator.free(devices);
+    devices[0] = mock.deviceIO();
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+    try loop.addDevice(devices[0]);
+
+    var inst = DeviceInstance{
+        .allocator = allocator,
+        .devices = devices,
+        .loop = loop,
+        .interp = Interpreter.init(&parsed.value),
+        .mapper = null,
+        .owner = .none,
+        .primary_output = null,
+        .imu_output = null,
+        .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
+        .device_cfg = &parsed.value,
+        .pending_mapping = null,
+        .stopped = false,
+        .poll_timeout_ms = 100,
+    };
+
+    try inst.rerunInitSequence();
+
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x01, 0x01, 0xaa, 0x00, 0x00, 0xbb }, mock.write_log.items);
+}
+
+test "DeviceInstance: rebind then re-init quiesces physical rumble on fresh fd" {
+    const allocator = testing.allocator;
+
+    const parsed = try device_mod.parseString(allocator, init_with_rumble_toml);
+    defer parsed.deinit();
+
+    var old_mock = try MockDeviceIO.init(allocator, &.{});
+    defer old_mock.deinit();
+    var new_mock = try MockDeviceIO.init(allocator, &.{});
+    defer new_mock.deinit();
+    const devices = try allocator.alloc(DeviceIO, 1);
+    defer allocator.free(devices);
+    devices[0] = old_mock.deviceIO();
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+    try loop.addDevice(devices[0]);
+
+    var inst = DeviceInstance{
+        .allocator = allocator,
+        .devices = devices,
+        .loop = loop,
+        .interp = Interpreter.init(&parsed.value),
+        .mapper = null,
+        .owner = .none,
+        .primary_output = null,
+        .imu_output = null,
+        .aux_dev = null,
+        .touchpad_dev = null,
+        .generic_state = null,
+        .generic_uinput = null,
+        .device_cfg = &parsed.value,
+        .pending_mapping = null,
+        .stopped = false,
+        .poll_timeout_ms = 100,
+    };
+
+    var new_devices = [_]DeviceIO{new_mock.deviceIO()};
+    try inst.rebindDeviceIO(&new_devices);
+    try inst.rerunInitSequence();
+
+    try testing.expectEqual(@as(usize, 0), old_mock.write_log.items.len);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x01, 0x01, 0xaa, 0x00, 0x00, 0xbb }, new_mock.write_log.items);
 }
 
 test "DeviceInstance: stop() causes run() to exit" {

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -613,12 +613,10 @@ pub const EventLoop = struct {
             1;
 
         if (retry_count > RUMBLE_MAX_RETRY_ATTEMPTS) {
-            rumble_log.debug("[{s}] HID_WRITE: retry limit exceeded strong={d} weak={d}; marking disconnected", .{
+            rumble_log.warn("[{s}] HID_WRITE: retry limit exceeded strong={d} weak={d}; dropping rumble frame and keeping input loop alive", .{
                 ctx.device_tag, frame.strong, frame.weak,
             });
             self.clearPendingRumble();
-            self.disconnected = true;
-            self.running = false;
             return;
         }
 

--- a/src/test/event_loop_rumble_test.zig
+++ b/src/test/event_loop_rumble_test.zig
@@ -1395,7 +1395,7 @@ test "event_loop: disconnected rumble write exits without retry queue" {
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00 }, fail_dev.write_log.items[0..frame_size]);
 }
 
-test "event_loop: repeated rumble write failures stop retrying and mark disconnected" {
+test "event_loop: repeated rumble write failures stop retrying without disconnecting input loop" {
     const allocator = testing.allocator;
 
     var loop = try EventLoop.initManaged();
@@ -1459,11 +1459,12 @@ test "event_loop: repeated rumble write failures stop retrying and mark disconne
     try waitForAck(write_ack_pipe[0]);
     try sendFfAndWait(ff_pipe[1], ack_pipe[0]);
     try waitForNoAck(write_ack_pipe[0], 100);
+    try testing.expect(@atomicLoad(bool, &loop.running, .acquire));
     loop.stop();
     thread.join();
 
     try testing.expectEqual(@as(usize, 5), fail_dev.write_attempts);
-    try testing.expect(loop.disconnected);
+    try testing.expect(!loop.disconnected);
     try testing.expectEqual(@as(?rumble_scheduler_mod.RumbleScheduler.Frame, null), loop.pending_rumble_frame);
     try testing.expectEqual(@as(?i128, null), loop.pending_rumble_deadline_ns);
     try testing.expectEqual(@as(usize, frame_size), fail_dev.write_log.items.len);


### PR DESCRIPTION
## Summary

Fixes two issue #65 failure paths found in the latest Dreadtusk logs and code review:

- send a best-effort neutral physical rumble frame after initial device attach and after suspend/resume re-init, so a fresh physical fd does not inherit stale firmware rumble state when the old fd was already disconnected
- keep the input loop alive after non-disconnect rumble `Io` retry exhaustion; the failed rumble frame is dropped after bounded retries, but only explicit `Disconnected` still tears down the device loop

Issue #65 should remain open until hardware reporters verify the behavior.

## Evidence

Latest #65 logs show:

- `DISCONNECT: HUP/ERR` followed by detach-time zero rumble write failing with `error.Disconnected`
- subsequent resume/re-init without a fresh neutral rumble write on the new fd
- final exported log ends with a zero stop and empty scheduler, so the attachment does not prove a lost STOP in the normal scheduler path

## Tests

- `/home/jim_z/.local/bin/zig build test -Dtarget=x86_64-linux-musl -Dtest-filter=DeviceInstance --summary all`
- `/home/jim_z/.local/bin/zig build test -Dtarget=x86_64-linux-musl -Dtest-filter=rumble --summary all`
- `/home/jim_z/.local/bin/zig build test -Dtarget=x86_64-linux-musl -Dtest-filter="repeated rumble write failures" --summary all`
- `/home/jim_z/.local/bin/zig build test -Dtarget=x86_64-linux-musl -Dtest-filter="failed stop frame" --summary all`
- `PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test --summary all`
- `PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test-safe --summary all`
- `PADCTL_DOCKER_NETWORK=host ./scripts/padctl-docker build test-tsan --summary all`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved device startup behavior so rumble is reliably reset as soon as a device is ready.
  * Rumble reset now also runs again during device reinitialization and after reconnecting device input.

* **Bug Fixes**
  * Repeated rumble failures no longer cause the input loop to disconnect or stop unexpectedly.
  * Updated regression coverage to match the new rumble failure handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->