### PR TITLE
Add selectable output profiles

### DIFF
--- a/devices/flydigi/vader5.toml
+++ b/devices/flydigi/vader5.toml
@@ -88,6 +88,7 @@ offset = 8
 # Masquerade as Xbox Elite Series 2 (VID 045e PID 0b00) so that Steam and
 # most games apply Xbox button mappings without additional configuration.
 [output]
+default_profile = "xbox-elite2"
 name = "Xbox Elite Series 2"
 vid = 0x045e
 pid = 0x0b00
@@ -132,5 +133,58 @@ type = "mouse"
 name = "Vader 5 Pro Virtual Mouse"
 
 [output.force_feedback]
+type = "rumble"
+max_effects = 16
+
+# Optional Steam Input profile. Select it from config.toml:
+#
+# [[device]]
+# name = "Flydigi Vader 5 Pro"
+# output_profile = "dualsense-edge"
+#
+# The profile keeps 16-bit stick ranges while publishing a DualSense Edge
+# VID/PID/name and Edge-style M1-M4 slots. Native Steam gyro still requires a
+# UHID IMU profile; this safer profile stays on the existing uinput path.
+[output.profiles.dualsense-edge]
+emulate = "dualsense-edge"
+
+[output.profiles.dualsense-edge.axes]
+left_x  = { code = "ABS_X",  min = -32768, max = 32767, fuzz = 16, flat = 128 }
+left_y  = { code = "ABS_Y",  min = -32768, max = 32767, fuzz = 16, flat = 128 }
+right_x = { code = "ABS_RX", min = -32768, max = 32767, fuzz = 16, flat = 128 }
+right_y = { code = "ABS_RY", min = -32768, max = 32767, fuzz = 16, flat = 128 }
+lt      = { code = "ABS_Z",  min = 0, max = 255 }
+rt      = { code = "ABS_RZ", min = 0, max = 255 }
+
+[output.profiles.dualsense-edge.buttons]
+A      = "BTN_SOUTH"
+B      = "BTN_EAST"
+X      = "BTN_WEST"
+Y      = "BTN_NORTH"
+LB     = "BTN_TL"
+RB     = "BTN_TR"
+Select = "BTN_SELECT"
+Start  = "BTN_START"
+Home   = "BTN_MODE"
+LS     = "BTN_THUMBL"
+RS     = "BTN_THUMBR"
+M1     = "BTN_TRIGGER_HAPPY1"
+M2     = "BTN_TRIGGER_HAPPY2"
+M3     = "BTN_TRIGGER_HAPPY3"
+M4     = "BTN_TRIGGER_HAPPY4"
+C      = "BTN_TRIGGER_HAPPY5"
+Z      = "BTN_TRIGGER_HAPPY6"
+LM     = "BTN_TRIGGER_HAPPY7"
+RM     = "BTN_TRIGGER_HAPPY8"
+O      = "BTN_TRIGGER_HAPPY9"
+
+[output.profiles.dualsense-edge.dpad]
+type = "hat"
+
+[output.profiles.dualsense-edge.aux]
+type = "mouse"
+name = "Vader 5 Pro Virtual Mouse"
+
+[output.profiles.dualsense-edge.force_feedback]
 type = "rumble"
 max_effects = 16

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -166,6 +166,7 @@ Declares the uinput device emitted by padctl.
 | Field | Type | Description |
 |-------|------|-------------|
 | `emulate` | string | Preset emulation profile |
+| `default_profile` | string | Optional name for the default `[output]` profile |
 | `name` | string | uinput device name |
 | `vid` | integer | Emulated vendor ID |
 | `pid` | integer | Emulated product ID |
@@ -195,6 +196,34 @@ it is not a complete DualSense Edge firmware clone. If a physical controller has
 higher-resolution sticks than the preset defaults, keep explicit
 `[output.axes]` entries in the device TOML; explicit axis ranges override the
 preset and prevent accidental precision loss.
+
+### Output profiles
+
+Device configs may declare named output profiles under `[output.profiles.<name>]`.
+The default `[output]` remains active unless the user selects a profile in
+`config.toml`:
+
+```toml
+# ~/.config/padctl/config.toml
+version = 1
+
+[[device]]
+name = "Flydigi Vader 5 Pro"
+default_mapping = "vader5"
+output_profile = "dualsense-edge"
+```
+
+Profiles overlay the default `[output]`: fields declared by the profile replace
+the default, and fields omitted by the profile inherit the default. When a
+profile sets `emulate`, the preset first fills that profile's missing
+VID/PID/name/buttons/axes, then the result overlays `[output]`. Unknown profile
+names are ignored with a warning and the default output stays active.
+
+For Vader 5, `output_profile = "dualsense-edge"` switches the virtual identity
+to DualSense Edge and keeps explicit `-32768..32767` stick ranges. It is still
+an output identity/layout profile, not a complete native DualSense Edge firmware
+clone. Native SDL/Steam sensor pairing requires the separate `[output.imu]`
+UHID path, which has force-feedback caveats documented below.
 
 ### `[output.axes]`
 

--- a/docs/src/devices/flydigi-flydigi-vader-5-pro.md
+++ b/docs/src/devices/flydigi-flydigi-vader-5-pro.md
@@ -8,7 +8,9 @@
 
 | ID | Class | EP IN | EP OUT |
 |----|-------|-------|--------|
-| 1 | hid | — | — |
+| 1 | vendor | 130 | 6 |
+| 2 | suppress | — | — |
+| 3 | suppress | — | — |
 
 ## Report: `extended` (32 bytes, interface 1)
 
@@ -21,9 +23,9 @@ Match: byte[0] = `0x5a`, `0xa5`, `0xef`
 | `left_y` | 5 | `i16le` | negate |
 | `right_y` | 9 | `i16le` | negate |
 | `accel_x` | 23 | `i16le` | — |
-| `gyro_z` | 21 | `i16le` | — |
+| `gyro_z` | 19 | `i16le` | — |
 | `gyro_x` | 17 | `i16le` | — |
-| `gyro_y` | 19 | `i16le` | — |
+| `gyro_y` | 21 | `i16le` | negate |
 | `accel_z` | 27 | `i16le` | — |
 | `accel_y` | 25 | `i16le` | — |
 | `left_x` | 3 | `i16le` | — |
@@ -66,7 +68,7 @@ Source: offset 11, size 4 byte(s)
 
 | Name | Interface | Template |
 |------|-----------|----------|
-| `rumble` | 1 | `5aa5 1206 {strong:u8} {weak:u8} 0000 0000...` |
+| `rumble` | 1 | `5a a5 12 06 {strong:u8} {weak:u8} 00 00 00 00 00 00 00 00 00...` |
 
 ## Output Capabilities
 
@@ -87,26 +89,34 @@ uinput device name: **Xbox Elite Series 2** | VID `0x045e` | PID `0x0b00`
 
 | Button | Event Code |
 |--------|------------|
-| `M2` | `BTN_TRIGGER_HAPPY2` |
-| `M4` | `BTN_TRIGGER_HAPPY4` |
-| `M1` | `BTN_TRIGGER_HAPPY1` |
-| `RM` | `BTN_TRIGGER_HAPPY8` |
-| `LM` | `BTN_TRIGGER_HAPPY7` |
+| `M2` | `BTN_TRIGGER_HAPPY7` |
+| `M4` | `BTN_TRIGGER_HAPPY8` |
+| `M1` | `BTN_TRIGGER_HAPPY5` |
+| `RM` | `BTN_TRIGGER_HAPPY12` |
+| `LM` | `BTN_TRIGGER_HAPPY11` |
 | `B` | `BTN_EAST` |
 | `LS` | `BTN_THUMBL` |
 | `RS` | `BTN_THUMBR` |
 | `X` | `BTN_NORTH` |
-| `Z` | `BTN_TRIGGER_HAPPY6` |
+| `Z` | `BTN_TRIGGER_HAPPY10` |
 | `LB` | `BTN_TL` |
 | `RB` | `BTN_TR` |
 | `A` | `BTN_SOUTH` |
 | `Select` | `BTN_SELECT` |
 | `Home` | `BTN_MODE` |
-| `C` | `BTN_TRIGGER_HAPPY5` |
+| `C` | `BTN_TRIGGER_HAPPY9` |
 | `Start` | `BTN_START` |
-| `O` | `BTN_TRIGGER_HAPPY9` |
+| `O` | `BTN_TRIGGER_HAPPY13` |
 | `Y` | `BTN_WEST` |
-| `M3` | `BTN_TRIGGER_HAPPY3` |
+| `M3` | `BTN_TRIGGER_HAPPY6` |
 
 **Force feedback**: type=`rumble`, max_effects=16
+
+### Output Profiles
+
+Default profile: `xbox-elite2`
+
+| Profile | Device Name | VID | PID | Axes | Buttons |
+|---------|-------------|-----|-----|------|---------|
+| `dualsense-edge` | **Sony DualSense Edge** | `0x054c` | `0x0df2` | 6 | 20 |
 

--- a/docs/src/diagnostic-logging.md
+++ b/docs/src/diagnostic-logging.md
@@ -64,7 +64,7 @@ max_log_size_mb = 100 # rotation threshold (default 100 MB)
 
 <a id="schema-rewrite"></a>
 
-> ⚠️ **Rewrite behavior.** `padctl dump enable/disable` parses `config.toml`, rewrites it from the known schema, and atomically renames the result into place. Anything outside the documented schema — unknown sections, undocumented keys, hand-written comments — is **not preserved**. If you hand-edit `config.toml` with content that matters (e.g. a forward-looking `[experimental]` block, inline comments documenting a choice), keep it in a sibling file, or drive padctl via `SIGHUP` after the edit instead of using the `dump` subcommand. The current known schema is `version`, `[diagnostics]` (`dump`, `max_log_size_mb`), `[supervisor]` (`suspend_grace_sec`), `[chord_switch]` (`modifier`, `selectors`, `hold_ms`), and `[[device]]` entries (`name`, `default_mapping`).
+> ⚠️ **Rewrite behavior.** `padctl dump enable/disable` parses `config.toml`, rewrites it from the known schema, and atomically renames the result into place. Anything outside the documented schema — unknown sections, undocumented keys, hand-written comments — is **not preserved**. If you hand-edit `config.toml` with content that matters (e.g. a forward-looking `[experimental]` block, inline comments documenting a choice), keep it in a sibling file, or drive padctl via `SIGHUP` after the edit instead of using the `dump` subcommand. The current known schema is `version`, `[diagnostics]` (`dump`, `max_log_size_mb`), `[supervisor]` (`suspend_grace_sec`), `[chord_switch]` (`modifier`, `selectors`, `hold_ms`), and `[[device]]` entries (`name`, `default_mapping`, `output_profile`).
 
 ## Supervisor tunables
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -253,9 +253,10 @@ version = 1
 [[device]]
 name = "Flydigi Vader 5 Pro"
 default_mapping = "fps"
+output_profile = "dualsense-edge"  # optional; selects a device-declared output profile
 ```
 
-On daemon start, padctl matches the connected device name (case-insensitive) and loads the named mapping profile automatically. The system path is the fallback for environments where `HOME` is not set (e.g. systemd services).
+On daemon start, padctl matches the connected device name (case-insensitive), loads the named mapping profile automatically, and applies the optional output profile before creating the virtual gamepad. `output_profile` selects a profile declared by the device TOML; do not put it in a mapping file. The system path is the fallback for environments where `HOME` is not set (e.g. systemd services).
 
 `padctl switch <name>` automatically updates the user config, so the choice is remembered for bare `padctl switch` (re-apply without a name). Bare `padctl switch` (no argument) reads `default_mapping` from the connected device's entry in `config.toml`; if no entry exists, it prints `error: no default_mapping in config.toml for device "<name>"` and exits. To make the choice survive reboots, use `padctl switch <name> --persist` which copies the mapping and config to `/etc/padctl/` via sudo.
 

--- a/docs/src/immutable-install.md
+++ b/docs/src/immutable-install.md
@@ -112,9 +112,10 @@ version = 1
 [[device]]
 name = "Flydigi Vader 5 Pro"
 default_mapping = "vader5"
+output_profile = "dualsense-edge"  # optional
 ```
 
-The daemon reads this file at startup and auto-applies the mapping — no manual `padctl switch` needed after reboot. User-level overrides in `~/.config/padctl/config.toml` take priority when available.
+The daemon reads this file at startup, auto-applies the mapping, and applies any optional output profile — no manual `padctl switch` needed after reboot. User-level overrides in `~/.config/padctl/config.toml` take priority when available.
 
 You can also persist a mapping change after switching at runtime:
 

--- a/docs/src/mapping-guide.md
+++ b/docs/src/mapping-guide.md
@@ -86,9 +86,15 @@ version = 1
 [[device]]
 name = "Flydigi Vader 5 Pro"
 default_mapping = "fps"
+output_profile = "dualsense-edge"  # optional output identity/layout profile
 ```
 
 If you installed with `padctl install --mapping vader5`, the system config is already written for you.
+
+`output_profile` belongs in `config.toml` next to `default_mapping`, not in a
+mapping file. Mapping files control remaps, gyro processing, layers, and macros;
+device output identity such as VID/PID/name/buttons/axes is selected from
+profiles declared by the device config.
 
 ### Manual run
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -135,6 +135,55 @@ Reference: issue #470.
 
 ---
 
+## Vader 5 still appears as Xbox Elite 2 after adding `output.emulate`
+
+**Symptoms:**
+
+- You copied `devices/flydigi/vader5.toml` from `/usr/share` or
+  `/usr/local/share` into `~/.config/padctl/devices/` and added
+  `emulate = "dualsense-edge"`, but Steam Input still shows Xbox Elite 2.
+- You added `output.emulate` or `output_profile` to a mapping file and nothing
+  changed.
+
+**Fix:** select the device-declared profile from `config.toml`:
+
+```toml
+# ~/.config/padctl/config.toml
+version = 1
+
+[[device]]
+name = "Flydigi Vader 5 Pro"
+default_mapping = "vader5"
+output_profile = "dualsense-edge"
+```
+
+Then restart or reload the daemon:
+
+```sh
+padctl reload
+# or
+systemctl --user restart padctl.service
+```
+
+`output_profile` is a per-device startup choice, not a mapping option. The
+Vader 5 builtin device config keeps Xbox Elite 2 as the default and exposes
+`dualsense-edge` as an opt-in profile. Do not create a second Vader 5 device
+TOML with the same physical VID/PID unless you are intentionally replacing the
+installed config; duplicate matches make scan order decide which config wins.
+
+If your service was installed with a system fallback and has no `HOME`, put the
+same `[[device]]` entry in `/etc/padctl/config.toml` or use the documented
+persist flow. `padctl doctor` shows which config paths the daemon can read.
+
+The DualSense Edge profile changes the virtual identity and button layout while
+keeping high-resolution stick ranges. Native SDL/Steam gyro sensor pairing uses
+the separate `[output.imu]` UHID path and has force-feedback caveats; a profile
+name alone is not a full DualSense Edge firmware clone.
+
+Reference: issue #471.
+
+---
+
 ## Vader 5 rumble stays on, disconnects, or controls lag during vibration
 
 **Symptoms:**

--- a/src/cli/install/mappings.zig
+++ b/src/cli/install/mappings.zig
@@ -247,7 +247,7 @@ pub fn writeBinding(
     if (devices) |devs| {
         for (devs) |d| {
             if (std.ascii.eqlIgnoreCase(d.name, device_name)) {
-                new_devices[idx] = .{ .name = device_name, .default_mapping = mapping_name };
+                new_devices[idx] = .{ .name = device_name, .default_mapping = mapping_name, .output_profile = d.output_profile };
             } else {
                 new_devices[idx] = d;
             }

--- a/src/cli/install/tests.zig
+++ b/src/cli/install/tests.zig
@@ -2523,6 +2523,40 @@ test "install: writeBinding conflict with force - backup + overwrite" {
     try std.testing.expect(found_bak);
 }
 
+test "install: writeBinding force overwrite preserves output_profile" {
+    const testing_alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const destdir = try tmp.dir.realpathAlloc(testing_alloc, ".");
+    defer testing_alloc.free(destdir);
+
+    const etc_dir = try std.fmt.allocPrint(testing_alloc, "{s}/etc/padctl", .{destdir});
+    defer testing_alloc.free(etc_dir);
+    try ensureDirAll(testing_alloc, etc_dir);
+    const config_path = try std.fmt.allocPrint(testing_alloc, "{s}/config.toml", .{etc_dir});
+    defer testing_alloc.free(config_path);
+    {
+        const f = try std.fs.createFileAbsolute(config_path, .{});
+        defer f.close();
+        try f.writeAll(
+            \\version = 1
+            \\
+            \\[[device]]
+            \\name = "Vader"
+            \\default_mapping = "old_map"
+            \\output_profile = "dualsense-edge"
+        );
+    }
+
+    try writeBinding(testing_alloc, destdir, "Vader", "new_map", .force, mockPromptKeep);
+
+    const content = try std.fs.cwd().readFileAlloc(testing_alloc, config_path, 64 * 1024);
+    defer testing_alloc.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "default_mapping = \"new_map\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "output_profile = \"dualsense-edge\"") != null);
+}
+
 test "install: writeBinding force pure-add does not create backup" {
     const testing_alloc = std.testing.allocator;
 

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -175,6 +175,23 @@ pub const MappingEntry = struct {
 
 pub const OutputConfig = struct {
     emulate: ?[]const u8 = null,
+    default_profile: ?[]const u8 = null,
+    name: ?[]const u8 = null,
+    vid: ?i64 = null,
+    pid: ?i64 = null,
+    axes: ?toml.HashMap(AxisConfig) = null,
+    buttons: ?toml.HashMap([]const u8) = null,
+    dpad: ?DpadOutputConfig = null,
+    force_feedback: ?ForceFeedbackConfig = null,
+    aux: ?AuxConfig = null,
+    touchpad: ?TouchpadConfig = null,
+    mapping: ?toml.HashMap(MappingEntry) = null,
+    imu: ?ImuConfig = null,
+    profiles: ?toml.HashMap(OutputProfileConfig) = null,
+};
+
+pub const OutputProfileConfig = struct {
+    emulate: ?[]const u8 = null,
     name: ?[]const u8 = null,
     vid: ?i64 = null,
     pid: ?i64 = null,
@@ -204,6 +221,71 @@ pub const DeviceConfig = struct {
     output: ?OutputConfig = null,
     wasm: ?WasmConfig = null,
 };
+
+fn outputFromProfile(profile: OutputProfileConfig) OutputConfig {
+    return .{
+        .emulate = profile.emulate,
+        .name = profile.name,
+        .vid = profile.vid,
+        .pid = profile.pid,
+        .axes = profile.axes,
+        .buttons = profile.buttons,
+        .dpad = profile.dpad,
+        .force_feedback = profile.force_feedback,
+        .aux = profile.aux,
+        .touchpad = profile.touchpad,
+        .mapping = profile.mapping,
+        .imu = profile.imu,
+    };
+}
+
+fn profileFromOutput(out: OutputConfig) OutputProfileConfig {
+    return .{
+        .emulate = out.emulate,
+        .name = out.name,
+        .vid = out.vid,
+        .pid = out.pid,
+        .axes = out.axes,
+        .buttons = out.buttons,
+        .dpad = out.dpad,
+        .force_feedback = out.force_feedback,
+        .aux = out.aux,
+        .touchpad = out.touchpad,
+        .mapping = out.mapping,
+        .imu = out.imu,
+    };
+}
+
+fn overlayOutputProfile(base: OutputConfig, profile: OutputProfileConfig) OutputConfig {
+    var out = base;
+    if (profile.emulate) |v| out.emulate = v;
+    if (profile.name) |v| out.name = v;
+    if (profile.vid) |v| out.vid = v;
+    if (profile.pid) |v| out.pid = v;
+    if (profile.axes) |v| out.axes = v;
+    if (profile.buttons) |v| out.buttons = v;
+    if (profile.dpad) |v| out.dpad = v;
+    if (profile.force_feedback) |v| out.force_feedback = v;
+    if (profile.aux) |v| out.aux = v;
+    if (profile.touchpad) |v| out.touchpad = v;
+    if (profile.mapping) |v| out.mapping = v;
+    if (profile.imu) |v| out.imu = v;
+    out.default_profile = null;
+    out.profiles = null;
+    return out;
+}
+
+pub fn selectOutputProfile(cfg: *DeviceConfig, profile_name: []const u8) bool {
+    var out = cfg.output orelse return false;
+    if (out.default_profile) |default_profile| {
+        if (std.mem.eql(u8, default_profile, profile_name)) return true;
+    }
+    const profiles = out.profiles orelse return false;
+    const profile = profiles.map.get(profile_name) orelse return false;
+    out = overlayOutputProfile(out, profile);
+    cfg.output = out;
+    return true;
+}
 
 const valid_transforms = [_][]const u8{ "negate", "abs", "scale", "clamp", "deadzone" };
 
@@ -438,17 +520,7 @@ pub fn validate(cfg: *const DeviceConfig) !void {
     if (cfg.device.mode) |m| {
         if (std.mem.eql(u8, m, "generic")) {
             const out = cfg.output orelse return error.InvalidConfig;
-            const mapping = out.mapping orelse return error.InvalidConfig;
-            var it = mapping.map.iterator();
-            while (it.next()) |entry| {
-                const me = entry.value_ptr.*;
-                _ = input_codes.resolveEventCode(me.event) catch return error.InvalidConfig;
-                // ABS events require range
-                if (std.mem.startsWith(u8, me.event, "ABS_")) {
-                    const range = me.range orelse return error.InvalidConfig;
-                    if (range.len != 2) return error.InvalidConfig;
-                }
-            }
+            _ = out.mapping orelse return error.InvalidConfig;
         }
     }
 
@@ -459,38 +531,66 @@ pub fn validate(cfg: *const DeviceConfig) !void {
         }
     }
 
+    if (cfg.output) |out| {
+        try validateOutputConfig(cfg, &out);
+        if (out.profiles) |profiles| {
+            var it = profiles.map.iterator();
+            while (it.next()) |entry| {
+                var profile_out = overlayOutputProfile(out, entry.value_ptr.*);
+                try validateOutputConfig(cfg, &profile_out);
+            }
+        }
+    }
+}
+
+fn validateMappingEntries(mapping: toml.HashMap(MappingEntry)) !void {
+    var it = mapping.map.iterator();
+    while (it.next()) |entry| {
+        const me = entry.value_ptr.*;
+        _ = input_codes.resolveEventCode(me.event) catch return error.InvalidConfig;
+        // ABS events require range
+        if (std.mem.startsWith(u8, me.event, "ABS_")) {
+            const range = me.range orelse return error.InvalidConfig;
+            if (range.len != 2) return error.InvalidConfig;
+        }
+    }
+}
+
+fn validateOutputConfig(cfg: *const DeviceConfig, out: *const OutputConfig) !void {
+    if (cfg.device.mode) |m| {
+        if (std.mem.eql(u8, m, "generic") and out.mapping == null) return error.InvalidConfig;
+    }
+
+    if (out.mapping) |mapping| try validateMappingEntries(mapping);
+
     // IMU backend validation: uinput's EVIOCGUNIQ always returns -ENOENT,
     // so SDL's uniq-based pairing fails. Only "uhid" is legal when
     // [output.imu] is declared; unknown strings fail closed.
-    if (cfg.output) |out| {
-        if (out.imu) |imu| {
-            if (!std.mem.eql(u8, imu.backend, "uhid")) return error.InvalidConfig;
-        }
+    if (out.imu) |imu| {
+        if (!std.mem.eql(u8, imu.backend, "uhid")) return error.InvalidConfig;
     }
 
     // Force feedback backend/kind matrix. Absent force_feedback is always legal.
-    if (cfg.output) |out| {
-        if (out.force_feedback) |ffb| {
-            const is_uinput = std.mem.eql(u8, ffb.backend, "uinput");
-            const is_uhid = std.mem.eql(u8, ffb.backend, "uhid");
-            const is_rumble = std.mem.eql(u8, ffb.kind, "rumble");
-            const is_pid = std.mem.eql(u8, ffb.kind, "pid");
+    if (out.force_feedback) |ffb| {
+        const is_uinput = std.mem.eql(u8, ffb.backend, "uinput");
+        const is_uhid = std.mem.eql(u8, ffb.backend, "uhid");
+        const is_rumble = std.mem.eql(u8, ffb.kind, "rumble");
+        const is_pid = std.mem.eql(u8, ffb.kind, "pid");
 
-            if (!is_uinput and !is_uhid) return error.InvalidConfig;
-            if (!is_rumble and !is_pid) return error.InvalidConfig;
+        if (!is_uinput and !is_uhid) return error.InvalidConfig;
+        if (!is_rumble and !is_pid) return error.InvalidConfig;
 
-            if (is_uinput and is_pid) return error.InvalidConfig;
-            if (is_uhid and is_rumble) return error.InvalidConfig;
+        if (is_uinput and is_pid) return error.InvalidConfig;
+        if (is_uhid and is_rumble) return error.InvalidConfig;
 
-            // uhid+pid requires [output.imu] as the UHID routing gate.
-            if (is_uhid and is_pid) {
-                if (out.imu == null) return error.InvalidConfig;
-            }
+        // uhid+pid requires [output.imu] as the UHID routing gate.
+        if (is_uhid and is_pid) {
+            if (out.imu == null) return error.InvalidConfig;
+        }
 
-            // clone_vid_pid=true is meaningless without a real VID/PID to clone.
-            if (ffb.clone_vid_pid) {
-                if (cfg.device.vid == 0 or cfg.device.pid == 0) return error.InvalidConfig;
-            }
+        // clone_vid_pid=true is meaningless without a real VID/PID to clone.
+        if (ffb.clone_vid_pid) {
+            if (cfg.device.vid == 0 or cfg.device.pid == 0) return error.InvalidConfig;
         }
     }
 }
@@ -530,6 +630,22 @@ fn lintAllowlistFor(header: []const u8) ?[]const []const u8 {
         std.mem.eql(u8, header, "output.mapping") or
         std.mem.eql(u8, header, "output.aux.buttons")) return null; // free-form
 
+    if (std.mem.startsWith(u8, header, "output.profiles.")) {
+        const rest = header["output.profiles.".len..];
+        const dot = std.mem.indexOfScalar(u8, rest, '.');
+        if (dot == null) return sf(OutputProfileConfig);
+        const child = rest[dot.? + 1 ..];
+        if (std.mem.eql(u8, child, "dpad")) return sf(DpadOutputConfig);
+        if (std.mem.eql(u8, child, "force_feedback")) return sf(ForceFeedbackConfig);
+        if (std.mem.eql(u8, child, "aux")) return sf(AuxConfig);
+        if (std.mem.eql(u8, child, "touchpad")) return sf(TouchpadConfig);
+        if (std.mem.eql(u8, child, "imu")) return sf(ImuConfig);
+        if (std.mem.eql(u8, child, "axes") or
+            std.mem.eql(u8, child, "buttons") or
+            std.mem.eql(u8, child, "mapping") or
+            std.mem.eql(u8, child, "aux.buttons")) return null; // free-form
+    }
+
     if (std.mem.eql(u8, header, "wasm")) return sf(WasmConfig);
     if (std.mem.eql(u8, header, "wasm.overrides")) return sf(WasmOverridesConfig);
 
@@ -566,6 +682,19 @@ pub fn parseStringRaw(allocator: std.mem.Allocator, content: []const u8) !ParseR
                 result.deinit();
                 return err;
             };
+        }
+        if (out.profiles) |*profiles| {
+            var it = profiles.map.iterator();
+            while (it.next()) |entry| {
+                var profile_out = outputFromProfile(entry.value_ptr.*);
+                if (profile_out.emulate) |preset_name| {
+                    presets.applyPreset(result.arena.allocator(), &profile_out, preset_name) catch |err| {
+                        result.deinit();
+                        return err;
+                    };
+                    entry.value_ptr.* = profileFromOutput(profile_out);
+                }
+            }
         }
     }
     if (lintUnknownFields(allocator, content)) |findings| {
@@ -699,6 +828,111 @@ test "device: load flydigi/vader5.toml succeeds" {
     try std.testing.expectEqual(@as(i64, 0x2401), cfg.device.pid);
     try std.testing.expectEqual(@as(usize, 1), cfg.report.len);
     try std.testing.expectEqualStrings("extended", cfg.report[0].name);
+}
+
+test "device: output profile overlays default output and preset identity" {
+    const allocator = std.testing.allocator;
+    const toml_with_profile =
+        \\[device]
+        \\name = "Profile Test"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\
+        \\[[report]]
+        \\name = "main"
+        \\interface = 0
+        \\size = 4
+        \\
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x00]
+        \\
+        \\[report.fields]
+        \\left_x = { offset = 1, type = "i16le" }
+        \\
+        \\[output]
+        \\name = "Base Output"
+        \\vid = 0x1111
+        \\pid = 0x2222
+        \\
+        \\[output.axes]
+        \\left_x = { code = "ABS_X", min = -32768, max = 32767 }
+        \\
+        \\[output.buttons]
+        \\A = "BTN_SOUTH"
+        \\
+        \\[output.dpad]
+        \\type = "hat"
+        \\
+        \\[output.force_feedback]
+        \\type = "rumble"
+        \\max_effects = 16
+        \\
+        \\[output.profiles.dualsense-edge]
+        \\emulate = "dualsense-edge"
+    ;
+    var result = try parseString(allocator, toml_with_profile);
+    defer result.deinit();
+
+    try std.testing.expect(selectOutputProfile(&result.value, "dualsense-edge"));
+    const out = result.value.output orelse return error.MissingOutput;
+    try std.testing.expectEqual(@as(?i64, 0x054c), out.vid);
+    try std.testing.expectEqual(@as(?i64, 0x0df2), out.pid);
+    try std.testing.expectEqualStrings("Sony DualSense Edge", out.name.?);
+    try std.testing.expectEqualStrings("hat", out.dpad.?.type);
+    try std.testing.expectEqual(@as(?i64, 16), out.force_feedback.?.max_effects);
+
+    const buttons = out.buttons orelse return error.MissingButtons;
+    try std.testing.expectEqualStrings("BTN_TRIGGER_HAPPY1", buttons.map.get("M1") orelse return error.MissingM1);
+    const axes = out.axes orelse return error.MissingAxes;
+    const left_x = axes.map.get("left_x") orelse return error.MissingLeftX;
+    try std.testing.expectEqual(@as(i64, -32768), left_x.min);
+    try std.testing.expectEqual(@as(i64, 32767), left_x.max);
+}
+
+test "device: unknown output profile leaves default output unchanged" {
+    const allocator = std.testing.allocator;
+    var result = try parseFile(allocator, "devices/flydigi/vader5.toml");
+    defer result.deinit();
+
+    try std.testing.expect(!selectOutputProfile(&result.value, "not-a-profile"));
+    const out = result.value.output orelse return error.MissingOutput;
+    try std.testing.expectEqual(@as(?i64, 0x045e), out.vid);
+    try std.testing.expectEqual(@as(?i64, 0x0b00), out.pid);
+    try std.testing.expectEqualStrings("Xbox Elite Series 2", out.name.?);
+}
+
+test "device: vader5 dualsense-edge output profile preserves high resolution controls" {
+    const allocator = std.testing.allocator;
+    var result = try parseFile(allocator, "devices/flydigi/vader5.toml");
+    defer result.deinit();
+
+    try std.testing.expect(selectOutputProfile(&result.value, "dualsense-edge"));
+    const out = result.value.output orelse return error.MissingOutput;
+    try std.testing.expectEqual(@as(?i64, 0x054c), out.vid);
+    try std.testing.expectEqual(@as(?i64, 0x0df2), out.pid);
+    try std.testing.expectEqualStrings("Sony DualSense Edge", out.name.?);
+
+    const axes = out.axes orelse return error.MissingAxes;
+    const left_x = axes.map.get("left_x") orelse return error.MissingLeftX;
+    try std.testing.expectEqual(@as(i64, -32768), left_x.min);
+    try std.testing.expectEqual(@as(i64, 32767), left_x.max);
+
+    const buttons = out.buttons orelse return error.MissingButtons;
+    try std.testing.expectEqualStrings("BTN_TRIGGER_HAPPY1", buttons.map.get("M1") orelse return error.MissingM1);
+    try std.testing.expectEqualStrings("BTN_TRIGGER_HAPPY2", buttons.map.get("M2") orelse return error.MissingM2);
+    try std.testing.expectEqualStrings("BTN_TRIGGER_HAPPY3", buttons.map.get("M3") orelse return error.MissingM3);
+    try std.testing.expectEqualStrings("BTN_TRIGGER_HAPPY4", buttons.map.get("M4") orelse return error.MissingM4);
+    try std.testing.expectEqualStrings("BTN_TRIGGER_HAPPY5", buttons.map.get("C") orelse return error.MissingC);
+    try std.testing.expectEqualStrings("BTN_TRIGGER_HAPPY9", buttons.map.get("O") orelse return error.MissingO);
+
+    try std.testing.expectEqualStrings("hat", out.dpad.?.type);
+    try std.testing.expectEqual(@as(?i64, 16), out.force_feedback.?.max_effects);
+    try std.testing.expectEqualStrings("mouse", out.aux.?.type.?);
 }
 
 test "device: vader5 IF1 is claimed via libusb (vendor transport)" {

--- a/src/config/user_config.zig
+++ b/src/config/user_config.zig
@@ -10,6 +10,7 @@ pub const CURRENT_VERSION: i64 = 1;
 pub const DeviceEntry = struct {
     name: []const u8,
     default_mapping: ?[]const u8 = null,
+    output_profile: ?[]const u8 = null,
 };
 
 pub const DiagnosticsConfig = struct {
@@ -170,6 +171,14 @@ pub fn findDefaultMapping(result: *const ParseResult, device_name: []const u8) ?
     return null;
 }
 
+pub fn findOutputProfile(result: *const ParseResult, device_name: []const u8) ?[]const u8 {
+    const entries = result.value.device orelse return null;
+    for (entries) |e| {
+        if (std.ascii.eqlIgnoreCase(e.name, device_name)) return e.output_profile;
+    }
+    return null;
+}
+
 /// Atomically rewrite `config_path` from `cfg`, preserving every section.
 ///
 /// Writes `version`, then `[diagnostics]` and `[supervisor]` (each emitted
@@ -251,6 +260,11 @@ pub fn emitToml(writer: anytype, cfg: *const UserConfig) !void {
             if (d.default_mapping) |m| {
                 try writer.writeAll("default_mapping = \"");
                 try escapeTomlString(writer, m);
+                try writer.writeAll("\"\n");
+            }
+            if (d.output_profile) |p| {
+                try writer.writeAll("output_profile = \"");
+                try escapeTomlString(writer, p);
                 try writer.writeAll("\"\n");
             }
         }
@@ -427,6 +441,25 @@ test "findDefaultMapping: case-insensitive match" {
     // Different casing must still match.
     try std.testing.expectEqualStrings("fps", findDefaultMapping(&result, "flydigi vader 5 pro").?);
     try std.testing.expectEqualStrings("fps", findDefaultMapping(&result, "FLYDIGI VADER 5 PRO").?);
+}
+
+test "findOutputProfile: parses and matches device name case-insensitively" {
+    const allocator = std.testing.allocator;
+
+    const toml_str =
+        \\[[device]]
+        \\name = "Flydigi Vader 5 Pro"
+        \\default_mapping = "fps"
+        \\output_profile = "dualsense-edge"
+    ;
+
+    var parser = toml.Parser(UserConfig).init(allocator);
+    defer parser.deinit();
+    var result = try parser.parseString(toml_str);
+    defer result.deinit();
+
+    try std.testing.expectEqualStrings("dualsense-edge", findOutputProfile(&result, "flydigi vader 5 pro").?);
+    try std.testing.expectEqual(@as(?[]const u8, null), findOutputProfile(&result, "Unknown Device"));
 }
 
 test "findDefaultMapping: no match returns null" {
@@ -654,6 +687,7 @@ test "writeAtomic preserves all sections through device-mutation flow" {
         \\[[device]]
         \\name = "Vader 5 Pro"
         \\default_mapping = "fps"
+        \\output_profile = "dualsense-edge"
     ;
     {
         const f = try tmp.dir.createFile("config.toml", .{});
@@ -667,7 +701,11 @@ test "writeAtomic preserves all sections through device-mutation flow" {
 
     const new_devices = try allocator.alloc(DeviceEntry, 1);
     defer allocator.free(new_devices);
-    new_devices[0] = .{ .name = "Vader 5 Pro", .default_mapping = "racing" };
+    new_devices[0] = .{
+        .name = "Vader 5 Pro",
+        .default_mapping = "racing",
+        .output_profile = loaded.value.device.?[0].output_profile,
+    };
 
     const mutated = UserConfig{
         .version = loaded.value.version,
@@ -683,6 +721,7 @@ test "writeAtomic preserves all sections through device-mutation flow" {
     try std.testing.expectEqual(@as(i64, 50), reloaded.value.diagnostics.max_log_size_mb);
     try std.testing.expectEqual(@as(i64, 30), reloaded.value.supervisor.suspend_grace_sec);
     try std.testing.expectEqualStrings("racing", findDefaultMapping(&reloaded, "Vader 5 Pro").?);
+    try std.testing.expectEqualStrings("dualsense-edge", findOutputProfile(&reloaded, "Vader 5 Pro").?);
 }
 
 test "writeAtomic leaves no .tmp sidecar after success" {
@@ -821,6 +860,7 @@ test "lintUnknownFields: clean user config returns no findings" {
         \\[[device]]
         \\name = "Vader 5 Pro"
         \\default_mapping = "fps"
+        \\output_profile = "dualsense-edge"
     ;
     var findings = try lintUnknownFields(allocator, toml_str);
     defer findings.deinit(allocator);
@@ -899,6 +939,7 @@ test "user_config: switch-style full rewrite preserves [chord_switch]" {
         \\[[device]]
         \\name = "Vader 5 Pro"
         \\default_mapping = "fps"
+        \\output_profile = "dualsense-edge"
     ;
 
     var parser = toml.Parser(UserConfig).init(allocator);
@@ -908,7 +949,11 @@ test "user_config: switch-style full rewrite preserves [chord_switch]" {
 
     // Mirror writeConfigToml: rebuild the config preserving every section
     // except the changed device mapping (here: "fps" -> "racing").
-    var new_devices = [_]DeviceEntry{.{ .name = "Vader 5 Pro", .default_mapping = "racing" }};
+    var new_devices = [_]DeviceEntry{.{
+        .name = "Vader 5 Pro",
+        .default_mapping = "racing",
+        .output_profile = parsed.value.device.?[0].output_profile,
+    }};
     const rewritten = UserConfig{
         .version = parsed.value.version,
         .device = &new_devices,
@@ -930,6 +975,7 @@ test "user_config: switch-style full rewrite preserves [chord_switch]" {
     const devs = roundtripped.value.device orelse return error.TestUnexpectedResult;
     try std.testing.expectEqual(@as(usize, 1), devs.len);
     try std.testing.expectEqualStrings("racing", devs[0].default_mapping.?);
+    try std.testing.expectEqualStrings("dualsense-edge", devs[0].output_profile.?);
 
     // [chord_switch] survived the rewrite, byte-for-byte intact.
     const cs = roundtripped.value.chord_switch orelse return error.TestUnexpectedResult;

--- a/src/main.zig
+++ b/src/main.zig
@@ -626,7 +626,7 @@ fn isHelpFlag(arg: []const u8) bool {
 fn printConfigHelp(sub: ?[]const u8) void {
     const text = if (sub) |s| blk: {
         if (std.mem.eql(u8, s, "init"))
-            break :blk 
+            break :blk
             \\Usage: padctl config init [--device <name>]
             \\
             \\Interactively create a mapping in ~/.config/padctl/mappings/.
@@ -634,7 +634,7 @@ fn printConfigHelp(sub: ?[]const u8) void {
             \\
         ;
         if (std.mem.eql(u8, s, "edit"))
-            break :blk 
+            break :blk
             \\Usage: padctl config edit [name]
             \\
             \\Open a mapping in $VISUAL/$EDITOR; validate on exit.
@@ -642,7 +642,7 @@ fn printConfigHelp(sub: ?[]const u8) void {
             \\
         ;
         if (std.mem.eql(u8, s, "test"))
-            break :blk 
+            break :blk
             \\Usage: padctl config test [--config <path>] [--mapping <path>] [--raw]
             \\
             \\Live input preview decoded into named button/axis events (Ctrl-C to exit).
@@ -1265,7 +1265,7 @@ pub fn main() !void {
 
     const config_path = parsed.config_path.?;
 
-    const device_cfg = config.device.parseFile(allocator, config_path) catch |err| {
+    var device_cfg = config.device.parseFile(allocator, config_path) catch |err| {
         std.log.err("failed to load config '{s}': {}", .{ config_path, err });
         std.process.exit(1);
     };
@@ -1274,6 +1274,15 @@ pub fn main() !void {
     const user_cfg_mod = @import("config/user_config.zig");
     var user_cfg_pr = user_cfg_mod.load(allocator);
     defer if (user_cfg_pr) |*pr| pr.deinit();
+    if (user_cfg_pr) |*ucpr| {
+        if (user_cfg_mod.findOutputProfile(ucpr, device_cfg.value.device.name)) |profile_name| {
+            if (config.device.selectOutputProfile(&device_cfg.value, profile_name)) {
+                std.log.info("output profile: device \"{s}\" profile \"{s}\"", .{ device_cfg.value.device.name, profile_name });
+            } else {
+                std.log.warn("output profile \"{s}\" for device \"{s}\" not found; using default output", .{ profile_name, device_cfg.value.device.name });
+            }
+        }
+    }
 
     var mapping_pr: ?config.mapping.ParseResult = null;
     defer if (mapping_pr) |*pr| pr.deinit();
@@ -1652,7 +1661,7 @@ fn writeConfigToml(
     if (old_devices) |devs| {
         for (devs) |d| {
             if (std.ascii.eqlIgnoreCase(d.name, device_name)) {
-                new_devices[idx] = .{ .name = device_name, .default_mapping = mapping_name };
+                new_devices[idx] = .{ .name = device_name, .default_mapping = mapping_name, .output_profile = d.output_profile };
             } else {
                 new_devices[idx] = d;
             }
@@ -1819,7 +1828,7 @@ fn writeDefaultFromParsedDevices(
     defer allocator.free(new_devices);
 
     for (devs, 0..) |d, i| {
-        new_devices[i] = .{ .name = d.name, .default_mapping = mapping_name };
+        new_devices[i] = .{ .name = d.name, .default_mapping = mapping_name, .output_profile = d.output_profile };
     }
 
     const cfg = user_config_mod.UserConfig{
@@ -2243,6 +2252,7 @@ test "writeDefaultForAllDevices: updates all devices, preserves other sections" 
         \\[[device]]
         \\name = "Vader 5 Pro"
         \\default_mapping = "fps"
+        \\output_profile = "dualsense-edge"
         \\
         \\[[device]]
         \\name = "Sony DualSense"
@@ -2264,10 +2274,46 @@ test "writeDefaultForAllDevices: updates all devices, preserves other sections" 
     try testing.expectEqual(@as(usize, 2), devs.len);
     for (devs) |d| {
         try testing.expectEqualStrings("nioh", d.default_mapping.?);
+        if (std.ascii.eqlIgnoreCase(d.name, "Vader 5 Pro")) {
+            try testing.expectEqualStrings("dualsense-edge", d.output_profile.?);
+        }
     }
     // Other sections must survive.
     try testing.expectEqual(true, result.value.diagnostics.dump);
     try testing.expectEqual(@as(i64, 30), result.value.supervisor.suspend_grace_sec);
+}
+
+test "writeConfigToml: updates mapping while preserving output_profile" {
+    const allocator = testing.allocator;
+    const user_config_mod = @import("config/user_config.zig");
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    const seed =
+        \\version = 1
+        \\
+        \\[[device]]
+        \\name = "Vader 5 Pro"
+        \\default_mapping = "fps"
+        \\output_profile = "dualsense-edge"
+    ;
+    {
+        const f = try tmp.dir.createFile("config.toml", .{});
+        defer f.close();
+        try f.writeAll(seed);
+    }
+
+    try writeConfigToml(allocator, dir_path, "Vader 5 Pro", "racing");
+
+    var result = (try user_config_mod.loadFromDir(allocator, dir_path)).?;
+    defer result.deinit();
+    const devs = result.value.device orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(@as(usize, 1), devs.len);
+    try testing.expectEqualStrings("racing", devs[0].default_mapping.?);
+    try testing.expectEqualStrings("dualsense-edge", devs[0].output_profile.?);
 }
 
 test "writeDefaultForAllDevices: zero [[device]] entries returns 0" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -626,35 +626,41 @@ fn isHelpFlag(arg: []const u8) bool {
 fn printConfigHelp(sub: ?[]const u8) void {
     const text = if (sub) |s| blk: {
         if (std.mem.eql(u8, s, "init"))
-            break :blk
-            \\Usage: padctl config init [--device <name>]
-            \\
-            \\Interactively create a mapping in ~/.config/padctl/mappings/.
-            \\  --device <name>   Skip the device selection prompt
-            \\
-        ;
+            break :blk config_init_help;
         if (std.mem.eql(u8, s, "edit"))
-            break :blk
-            \\Usage: padctl config edit [name]
-            \\
-            \\Open a mapping in $VISUAL/$EDITOR; validate on exit.
-            \\Omit the name to pick from discovered mappings.
-            \\
-        ;
+            break :blk config_edit_help;
         if (std.mem.eql(u8, s, "test"))
-            break :blk
-            \\Usage: padctl config test [--config <path>] [--mapping <path>] [--raw]
-            \\
-            \\Live input preview decoded into named button/axis events (Ctrl-C to exit).
-            \\  --config <path>    Device config to decode input (default: auto-detect)
-            \\  --mapping <path>   Mapping to apply for display
-            \\  --raw              Show raw report bytes instead of decoded events
-            \\
-        ;
+            break :blk config_test_help;
         break :blk config_group_help;
     } else config_group_help;
     _ = std.posix.write(std.posix.STDOUT_FILENO, text) catch 0;
 }
+
+const config_init_help =
+    \\Usage: padctl config init [--device <name>]
+    \\
+    \\Interactively create a mapping in ~/.config/padctl/mappings/.
+    \\  --device <name>   Skip the device selection prompt
+    \\
+;
+
+const config_edit_help =
+    \\Usage: padctl config edit [name]
+    \\
+    \\Open a mapping in $VISUAL/$EDITOR; validate on exit.
+    \\Omit the name to pick from discovered mappings.
+    \\
+;
+
+const config_test_help =
+    \\Usage: padctl config test [--config <path>] [--mapping <path>] [--raw]
+    \\
+    \\Live input preview decoded into named button/axis events (Ctrl-C to exit).
+    \\  --config <path>    Device config to decode input (default: auto-detect)
+    \\  --mapping <path>   Mapping to apply for display
+    \\  --raw              Show raw report bytes instead of decoded events
+    \\
+;
 
 const config_group_help =
     \\Usage: padctl config <list|init|edit|test>

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -2378,6 +2378,16 @@ pub const Supervisor = struct {
         return .{ .pr = p, .stem = dm.stem };
     }
 
+    fn applyUserOutputProfile(self: *Supervisor, cfg: *DeviceConfig) void {
+        const ucfg = &(self.user_cfg orelse return);
+        const profile_name = user_config_mod.findOutputProfile(ucfg, cfg.device.name) orelse return;
+        if (config_device.selectOutputProfile(cfg, profile_name)) {
+            std.log.info("output profile: device \"{s}\" profile \"{s}\"", .{ cfg.device.name, profile_name });
+        } else {
+            std.log.warn("output profile \"{s}\" for device \"{s}\" not found; using default output", .{ profile_name, cfg.device.name });
+        }
+    }
+
     /// Glob *.toml in dir_path, discover devices by VID/PID, dedup by physical path, spawn threads.
     pub fn startFromDir(self: *Supervisor, dir_path: []const u8) !void {
         return self.startFromDirWithRoot(dir_path, "/dev");
@@ -2411,6 +2421,7 @@ pub const Supervisor = struct {
             };
             const cfg_ptr = try self.allocator.create(config_device.ParseResult);
             cfg_ptr.* = parsed;
+            self.applyUserOutputProfile(&cfg_ptr.value);
 
             const vid: u16 = @intCast(cfg_ptr.value.device.vid);
             const pid: u16 = @intCast(cfg_ptr.value.device.pid);
@@ -4494,6 +4505,63 @@ test "supervisor: hotplug: config retained when no device online, attach finds i
     try sup.startFromDirWithRoot(tmp_path, "/nonexistent_dev_root_xyz");
     try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
     try testing.expectEqual(@as(usize, 1), sup.configs.items.len);
+}
+
+test "supervisor: user output_profile applies before config is cached for hotplug" {
+    const allocator = testing.allocator;
+    const profile_device_toml =
+        \\[device]
+        \\name = "T"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 3
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x01]
+        \\[report.fields]
+        \\left_x = { offset = 1, type = "i16le" }
+        \\[output]
+        \\name = "Base Output"
+        \\vid = 0x1111
+        \\pid = 0x2222
+        \\[output.buttons]
+        \\A = "BTN_SOUTH"
+        \\[output.profiles.dualsense-edge]
+        \\emulate = "dualsense-edge"
+    ;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "profile.toml", .data = profile_device_toml });
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    var sup = try Supervisor.initForTest(allocator);
+    defer sup.deinit();
+
+    const cfg_str =
+        \\[[device]]
+        \\name = "T"
+        \\output_profile = "dualsense-edge"
+    ;
+    var ucfg_parser = @import("toml").Parser(user_config_mod.UserConfig).init(allocator);
+    defer ucfg_parser.deinit();
+    sup.user_cfg = try ucfg_parser.parseString(cfg_str);
+
+    try sup.startFromDirWithRoot(tmp_path, "/nonexistent_dev_root_xyz");
+    try testing.expectEqual(@as(usize, 0), sup.managed.items.len);
+    try testing.expectEqual(@as(usize, 1), sup.configs.items.len);
+
+    const out = sup.configs.items[0].value.output orelse return error.MissingOutput;
+    try testing.expectEqual(@as(?i64, 0x054c), out.vid);
+    try testing.expectEqual(@as(?i64, 0x0df2), out.pid);
+    try testing.expectEqualStrings("Sony DualSense Edge", out.name.?);
 }
 
 test "supervisor: Supervisor: duplicate attach devname — only one instance created" {

--- a/src/test/validate_e2e_test.zig
+++ b/src/test/validate_e2e_test.zig
@@ -191,6 +191,8 @@ test "E2E docgen: vader5 output contains required sections" {
     try testing.expect(std.mem.indexOf(u8, out, "## Report:") != null);
     try testing.expect(std.mem.indexOf(u8, out, "## Commands") != null);
     try testing.expect(std.mem.indexOf(u8, out, "## Output Capabilities") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "### Output Profiles") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "dualsense-edge") != null);
 }
 
 // --- 4. parseFile: all 5 device configs load correctly ---

--- a/src/tools/docgen.zig
+++ b/src/tools/docgen.zig
@@ -26,7 +26,8 @@ pub fn generateDevicePage(
                     const s = try std.fmt.bufPrint(&buf, "{d}", .{ep});
                     break :blk s;
                 } else "—",
-                if (iface.ep_out) |ep| blk: {
+                if (iface.ep_out) |ep|
+                blk: {
                     var buf: [8]u8 = undefined;
                     const s = try std.fmt.bufPrint(&buf, "{d}", .{ep});
                     break :blk s;

--- a/src/tools/docgen.zig
+++ b/src/tools/docgen.zig
@@ -26,8 +26,7 @@ pub fn generateDevicePage(
                     const s = try std.fmt.bufPrint(&buf, "{d}", .{ep});
                     break :blk s;
                 } else "—",
-                if (iface.ep_out) |ep|
-                blk: {
+                if (iface.ep_out) |ep| blk: {
                     var buf: [8]u8 = undefined;
                     const s = try std.fmt.bufPrint(&buf, "{d}", .{ep});
                     break :blk s;
@@ -163,6 +162,49 @@ pub fn generateDevicePage(
             if (ff.max_effects) |me| try writer.print(", max_effects={d}", .{me});
             try writer.writeAll("\n\n");
         }
+
+        if (out.default_profile != null or out.profiles != null) {
+            try writer.writeAll("### Output Profiles\n\n");
+            if (out.default_profile) |name| {
+                try writer.print("Default profile: `{s}`\n\n", .{name});
+            }
+            if (out.profiles) |profiles| {
+                try writer.writeAll("| Profile | Device Name | VID | PID | Axes | Buttons |\n");
+                try writer.writeAll("|---------|-------------|-----|-----|------|---------|\n");
+                var it = profiles.map.iterator();
+                while (it.next()) |entry| {
+                    const p = entry.value_ptr.*;
+                    const profile_name = p.name orelse out.name orelse "";
+                    const axes_count: usize = if (p.axes) |axes|
+                        axes.map.count()
+                    else if (out.axes) |axes|
+                        axes.map.count()
+                    else
+                        0;
+                    const button_count: usize = if (p.buttons) |buttons|
+                        buttons.map.count()
+                    else if (out.buttons) |buttons|
+                        buttons.map.count()
+                    else
+                        0;
+
+                    try writer.print("| `{s}` | **{s}** | ", .{ entry.key_ptr.*, profile_name });
+                    try writeOptionalHex(writer, p.vid orelse out.vid);
+                    try writer.writeAll(" | ");
+                    try writeOptionalHex(writer, p.pid orelse out.pid);
+                    try writer.print(" | {d} | {d} |\n", .{ axes_count, button_count });
+                }
+                try writer.writeByte('\n');
+            }
+        }
+    }
+}
+
+fn writeOptionalHex(writer: anytype, value: ?i64) !void {
+    if (value) |v| {
+        try writer.print("`0x{x:0>4}`", .{@as(u64, @intCast(v))});
+    } else {
+        try writer.writeAll("—");
     }
 }
 
@@ -171,7 +213,6 @@ fn outputFilename(
     toml_path: []const u8,
     dev_name: []const u8,
 ) ![]u8 {
-    _ = dev_name;
     // derive vendor from directory: devices/<vendor>/model.toml -> vendor
     var vendor: []const u8 = "unknown";
     const basename = std.fs.path.basename(toml_path);
@@ -184,13 +225,36 @@ fn outputFilename(
         vendor = grandparent_base;
     }
 
-    // strip .toml from basename
-    const stem = if (std.mem.endsWith(u8, basename, ".toml"))
+    const fallback_stem = if (std.mem.endsWith(u8, basename, ".toml"))
         basename[0 .. basename.len - 5]
     else
         basename;
+    const stem_source = if (dev_name.len != 0) dev_name else fallback_stem;
+    const stem = try slugify(allocator, stem_source);
+    defer allocator.free(stem);
 
     return std.fmt.allocPrint(allocator, "{s}-{s}.md", .{ vendor, stem });
+}
+
+fn slugify(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
+    var out: std.ArrayList(u8) = .{};
+    errdefer out.deinit(allocator);
+
+    var last_dash = true;
+    for (s) |c| {
+        if (std.ascii.isAlphanumeric(c)) {
+            try out.append(allocator, std.ascii.toLower(c));
+            last_dash = false;
+        } else if (!last_dash) {
+            try out.append(allocator, '-');
+            last_dash = true;
+        }
+    }
+    if (out.items.len > 0 and out.items[out.items.len - 1] == '-') {
+        _ = out.pop();
+    }
+    if (out.items.len == 0) try out.appendSlice(allocator, "unknown");
+    return out.toOwnedSlice(allocator);
 }
 
 pub fn runDocGen(
@@ -383,5 +447,12 @@ test "docgen: outputFilename derives vendor-slug" {
     const allocator = std.testing.allocator;
     const fname = try outputFilename(allocator, "devices/sony/dualsense.toml", "Sony DualSense");
     defer allocator.free(fname);
-    try std.testing.expectEqualStrings("sony-dualsense.md", fname);
+    try std.testing.expectEqualStrings("sony-sony-dualsense.md", fname);
+}
+
+test "docgen: outputFilename uses device name instead of terse TOML stem" {
+    const allocator = std.testing.allocator;
+    const fname = try outputFilename(allocator, "devices/flydigi/vader5.toml", "Flydigi Vader 5 Pro");
+    defer allocator.free(fname);
+    try std.testing.expectEqualStrings("flydigi-flydigi-vader-5-pro.md", fname);
 }


### PR DESCRIPTION
## Summary
- add device output profiles and user config `output_profile` selection
- add an opt-in Vader 5 `dualsense-edge` profile while keeping Xbox Elite 2 default
- preserve `output_profile` across config rewrites and document where users set it

Refs #471

## Tests
- `/home/jim_z/.local/bin/zig build test -Dtarget=x86_64-linux-musl -Dtest-filter=\"output profile\" --summary all`
- `/home/jim_z/.local/bin/zig build test -Dtarget=x86_64-linux-musl -Dtest-filter=\"output_profile\" --summary all`
- `/home/jim_z/.local/bin/zig build test -Dtarget=x86_64-linux-musl -Dtest-filter=\"vader5\" --summary all`
- `/home/jim_z/.local/bin/zig build test -Dtarget=x86_64-linux-musl -Dtest-filter=\"writeBinding\" --summary all`
- `/home/jim_z/.local/bin/zig build test -Dtarget=x86_64-linux-musl -Dtest-filter=\"docgen\" --summary all`
- `/home/jim_z/.local/bin/zig build test -Dtarget=x86_64-linux-musl -Dtest-filter=\"E2E validate\" --summary all`
- `./zig-out/bin/padctl --validate devices/flydigi/vader5.toml`
- `mdbook build docs`
- `git diff --check`

Note: a full unfiltered `zig build test -Dtarget=x86_64-linux-musl` run produced no new output for several minutes after the bazzite fixture logs, so I interrupted it and used the focused coverage above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting per-device output profiles, letting users switch a device’s virtual identity/layout without changing the mapping itself.
  * Device documentation now includes an “Output Profiles” section where available profiles and their details are listed.

* **Bug Fixes**
  * Preserved configured output profiles when updating or rewriting device settings.
  * Improved profile application so the selected output profile is applied before cached device configs are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->