### PR TITLE
Fix native rumble write throttling

### DIFF
--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -655,6 +655,30 @@ pub const EventLoop = struct {
         }
     }
 
+    fn handleNativeRumbleAt(self: *EventLoop, ctx: EventLoopContext, frame: RumbleScheduler.Frame, now_ns: i128) void {
+        const is_stop = frame.strong == 0 and frame.weak == 0;
+        if (is_stop) {
+            // STOP must not wait behind a throttled non-zero frame: cancel the
+            // stale frame and emit zero immediately so rumble cannot stick.
+            self.clearPendingRumble();
+            self.emitOrQueueRumble(ctx, frame, now_ns);
+        } else {
+            const elapsed = now_ns - self.last_rumble_ns;
+            if (elapsed >= RUMBLE_MIN_INTERVAL_NS) {
+                self.emitOrQueueRumble(ctx, frame, now_ns);
+            } else {
+                // The mailbox and this pending slot are both capacity one.
+                // A newer native command replaces the older throttled frame
+                // without moving the original 10ms physical-write deadline.
+                self.queuePendingRumble(frame, self.last_rumble_ns + RUMBLE_MIN_INTERVAL_NS, 0);
+                rumble_log.debug("[{s}] NATIVE_RUMBLE: THROTTLED elapsed={d}ns", .{
+                    ctx.device_tag, elapsedNsForLog(elapsed),
+                });
+            }
+        }
+        self.armRumbleTimer(null);
+    }
+
     fn flushPendingRumbleIfDue(self: *EventLoop, ctx: EventLoopContext, now_ns: i128) void {
         const deadline = self.pending_rumble_deadline_ns orelse return;
         if (deadline > now_ns) return;
@@ -851,6 +875,29 @@ pub const EventLoop = struct {
                 }
             }
 
+            // Drain native rumble before the shared timerfd. When a mailbox
+            // wake and a pending-frame deadline become ready together, the
+            // newest native command replaces the stale pending frame before
+            // the timer flushes it. EventLoop remains the only physical writer.
+            if (self.native_rumble_slot) |slot| {
+                if (self.pollfds[slot].revents & posix.POLL.IN != 0) {
+                    if (self.native_rumble_device) |device| {
+                        device.drainRumbleWake();
+                        if (device.takeRumbleCommand()) |rumble_command| {
+                            // Physical input/mapping work earlier in this poll
+                            // cycle may be expensive. Sample again at the
+                            // actual output boundary so last_rumble_ns tracks
+                            // physical-write time rather than ppoll wake time.
+                            const native_now_ns = monotonicNs();
+                            self.handleNativeRumbleAt(ctx, .{
+                                .strong = rumble_command.strong,
+                                .weak = rumble_command.weak,
+                            }, native_now_ns);
+                        }
+                    }
+                }
+            }
+
             // Check rumble auto-stop timerfd (slot 3). This may synchronously
             // write a HID rumble frame, so it follows physical input fds just
             // like the optional output-side FF drains.
@@ -981,25 +1028,6 @@ pub const EventLoop = struct {
                             if (uhid_dev.output_cb) |cb| {
                                 cb(uhid_dev.output_ctx.?, r);
                             }
-                        }
-                    }
-                }
-            }
-
-            // Native UHID fd traffic is consumed exclusively by its pump.
-            // EventLoop sees only a coalesced wake and atomically takes the
-            // latest normalized command before using the existing physical
-            // `[commands.rumble]` formatter/writer.
-            if (self.native_rumble_slot) |slot| {
-                if (self.pollfds[slot].revents & posix.POLL.IN != 0) {
-                    if (self.native_rumble_device) |device| {
-                        device.drainRumbleWake();
-                        if (device.takeRumbleCommand()) |rumble_command| {
-                            self.emitOrQueueRumble(ctx, .{
-                                .strong = rumble_command.strong,
-                                .weak = rumble_command.weak,
-                            }, now);
-                            self.armRumbleTimer(null);
                         }
                     }
                 }
@@ -1527,6 +1555,69 @@ test "event_loop: rumble template OOM queues retry as write failure" {
 
     try testing.expectEqual(RumbleEmitResult.write_failed, result);
     try testing.expectEqual(@as(usize, 0), mock_dev.write_log.items.len);
+}
+
+test "event_loop: native throttle keeps latest while stop cancels pending" {
+    const allocator = testing.allocator;
+    const rumble_toml =
+        \\[device]
+        \\name = "T"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 1
+        \\[commands.rumble]
+        \\interface = 0
+        \\template = "00 08 00 {strong:u8} {weak:u8} 00 00 00"
+    ;
+    const parsed = try device_mod.parseString(allocator, rumble_toml);
+    defer parsed.deinit();
+    const interpreter = Interpreter.init(&parsed.value);
+
+    var mock_dev = try MockDeviceIO.init(allocator, &.{});
+    defer mock_dev.deinit();
+    var devices = [_]DeviceIO{mock_dev.deviceIO()};
+    var output = MockOutput.init(allocator);
+    defer output.deinit();
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+    const ctx = EventLoopContext{
+        .devices = &devices,
+        .interpreter = &interpreter,
+        .output = output.outputDevice(),
+        .allocator = allocator,
+        .device_config = &parsed.value,
+        .device_tag = "native-throttle-test",
+    };
+
+    const base = monotonicNs();
+    loop.last_rumble_ns = base;
+    const first = RumbleScheduler.Frame{ .strong = 0x1100, .weak = 0x2200 };
+    const latest = RumbleScheduler.Frame{ .strong = 0x6600, .weak = 0x9900 };
+    loop.handleNativeRumbleAt(ctx, first, base + std.time.ns_per_ms);
+    loop.handleNativeRumbleAt(ctx, latest, base + 2 * std.time.ns_per_ms);
+
+    try testing.expectEqual(@as(usize, 0), mock_dev.write_log.items.len);
+    try testing.expectEqual(latest, loop.pending_rumble_frame.?);
+    try testing.expectEqual(@as(?i128, base + RUMBLE_MIN_INTERVAL_NS), loop.pending_rumble_deadline_ns);
+
+    // A zero frame is a safety command: it cancels the stale non-zero frame,
+    // writes immediately, and resets the throttle clock so replay is immediate.
+    loop.handleNativeRumbleAt(ctx, .{ .strong = 0, .weak = 0 }, base + 3 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(?RumbleScheduler.Frame, null), loop.pending_rumble_frame);
+    try testing.expectEqual(@as(?i128, null), loop.pending_rumble_deadline_ns);
+    try testing.expectEqual(@as(i128, 0), loop.last_rumble_ns);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, mock_dev.write_log.items);
+
+    loop.handleNativeRumbleAt(ctx, latest, base + 4 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 16), mock_dev.write_log.items.len);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x66, 0x99, 0x00, 0x00, 0x00 }, mock_dev.write_log.items[8..16]);
 }
 
 test "event_loop: EventLoop mini: device frame dispatched to interpreter and output" {

--- a/src/io/uhid.zig
+++ b/src/io/uhid.zig
@@ -538,7 +538,6 @@ pub const UhidDevice = struct {
 
         if (cfg.native_pump) |pump_cfg| {
             self.startNativePump(pump_cfg) catch return error.UhidCreateFailed;
-            errdefer self.abortNativePump();
         }
 
         try self.sendCreateOwned(cfg);

--- a/src/test/uhid_native_pump_test.zig
+++ b/src/test/uhid_native_pump_test.zig
@@ -11,7 +11,8 @@ const posix = std.posix;
 const testing = std.testing;
 
 const uhid = @import("../io/uhid.zig");
-const EventLoop = @import("../event_loop.zig").EventLoop;
+const event_loop = @import("../event_loop.zig");
+const EventLoop = event_loop.EventLoop;
 const Interpreter = @import("../core/interpreter.zig").Interpreter;
 const device_config = @import("../config/device.zig");
 const DeviceIO = @import("../io/device_io.zig").DeviceIO;
@@ -116,6 +117,14 @@ fn waitForPublishes(dev: *uhid.UhidDevice, expected: u64) !void {
     try testing.expectEqual(expected, dev.rumbleMailboxSnapshot().publish_count);
 }
 
+fn waitForPhysicalWrites(physical: *const PhysicalWriteMock, expected: usize) !void {
+    var attempts: usize = 0;
+    while (physical.write_count.load(.acquire) < expected and attempts < 1000) : (attempts += 1) {
+        std.Thread.sleep(std.time.ns_per_ms);
+    }
+    try testing.expectEqual(expected, physical.write_count.load(.acquire));
+}
+
 fn waitReadable(fd: posix.fd_t, timeout_ms: i32) !void {
     var pfd = [_]posix.pollfd{.{ .fd = fd, .events = posix.POLL.IN, .revents = 0 }};
     const ready = try posix.poll(&pfd, timeout_ms);
@@ -136,6 +145,11 @@ const PhysicalWriteMock = struct {
     poll_w: posix.fd_t,
     bytes: [32]u8 = undefined,
     write_len: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    write_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    write_times_ns: [8]i128 = [_]i128{0} ** 8,
+    next_read_delay_ns: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    publish_after_first: ?*uhid.UhidDevice = null,
+    publish_after_first_command: uhid.RumbleCommand = .{ .strong = 0, .weak = 0 },
 
     fn init() !PhysicalWriteMock {
         const fds = try posix.pipe2(.{ .NONBLOCK = true, .CLOEXEC = true });
@@ -151,15 +165,36 @@ const PhysicalWriteMock = struct {
         return .{ .ptr = self, .vtable = &vtable };
     }
 
-    fn read(_: *anyopaque, _: []u8) DeviceIO.ReadError!usize {
+    fn delayNextRead(self: *PhysicalWriteMock, delay_ns: u64) !void {
+        self.next_read_delay_ns.store(delay_ns, .release);
+        _ = try posix.write(self.poll_w, &[_]u8{1});
+    }
+
+    fn read(context: *anyopaque, _: []u8) DeviceIO.ReadError!usize {
+        const self: *PhysicalWriteMock = @ptrCast(@alignCast(context));
+        var wake: [1]u8 = undefined;
+        _ = posix.read(self.poll_r, &wake) catch {};
+        const delay_ns = self.next_read_delay_ns.swap(0, .acq_rel);
+        if (delay_ns != 0) {
+            std.Thread.sleep(delay_ns);
+        }
         return DeviceIO.ReadError.Again;
     }
 
     fn write(context: *anyopaque, data: []const u8) DeviceIO.WriteError!void {
         const self: *PhysicalWriteMock = @ptrCast(@alignCast(context));
         if (data.len > self.bytes.len) return DeviceIO.WriteError.Io;
+        const write_index = self.write_count.load(.monotonic);
+        if (write_index >= self.write_times_ns.len) return DeviceIO.WriteError.Io;
         @memcpy(self.bytes[0..data.len], data);
+        self.write_times_ns[write_index] = event_loop.monotonicNs();
         self.write_len.store(data.len, .release);
+        _ = self.write_count.fetchAdd(1, .release);
+        if (write_index == 0) {
+            if (self.publish_after_first) |dev| {
+                dev.publishRumbleCommand(self.publish_after_first_command) catch return DeviceIO.WriteError.Io;
+            }
+        }
     }
 
     fn featureReport(_: *anyopaque, _: []const u8) DeviceIO.WriteError!void {}
@@ -554,7 +589,7 @@ test "uhid_native_t4: failed CREATE2 after pump start joins thread and releases 
     dev.close();
 }
 
-test "uhid_native_t4: pump never writes physical device and EventLoop drains mailbox" {
+test "uhid_native_t4: EventLoop throttles native mailbox writes and keeps latest command" {
     if (builtin.os.tag != .linux) return error.SkipZigTest;
 
     const config_toml =
@@ -607,11 +642,21 @@ test "uhid_native_t4: pump never writes physical device and EventLoop drains mai
     defer dev.close();
     try loop.addNativeUhidRumble(dev);
 
+    try sendStubOutput(fds[1], 0x11);
     try sendStubOutput(fds[1], 0x66);
-    try waitForPublishes(dev, 1);
+    try waitForPublishes(dev, 2);
     // The pump has decoded and published, but has no DeviceIO and therefore
     // cannot perform the physical command write itself.
     try testing.expectEqual(@as(usize, 0), physical.write_len.load(.acquire));
+
+    // Make both the physical fd and native mailbox readable before ppoll. The
+    // physical read deliberately consumes 30ms before native output handling.
+    // The first physical write publishes another native command from inside
+    // the writer, guaranteeing that the follow-up wake occurs immediately
+    // after the first write rather than depending on test-thread scheduling.
+    try physical.delayNextRead(30 * std.time.ns_per_ms);
+    physical.publish_after_first = dev;
+    physical.publish_after_first_command = .{ .strong = 0x3333, .weak = 0xCCCC };
 
     var output = MockOutput.init(testing.allocator);
     defer output.deinit();
@@ -642,16 +687,17 @@ test "uhid_native_t4: pump never writes physical device and EventLoop drains mai
         .config = &parsed.value,
     };
     const event_thread = try std.Thread.spawn(.{}, RunCtx.run, .{&run_ctx});
-    var attempts: usize = 0;
-    while (physical.write_len.load(.acquire) == 0 and attempts < 500) : (attempts += 1) {
-        std.Thread.sleep(std.time.ns_per_ms);
-    }
+    try waitForPhysicalWrites(&physical, 2);
+
     loop.stop();
     event_thread.join();
 
     const write_len = physical.write_len.load(.acquire);
+    try testing.expectEqual(@as(u64, 3), dev.rumbleMailboxSnapshot().publish_count);
+    try testing.expectEqual(@as(usize, 2), physical.write_count.load(.acquire));
     try testing.expectEqual(@as(usize, 5), write_len);
-    try testing.expectEqualSlices(u8, &[_]u8{ 0xA5, 0x66, 0x66, 0x99, 0x99 }, physical.bytes[0..write_len]);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0xA5, 0x33, 0x33, 0xCC, 0xCC }, physical.bytes[0..write_len]);
+    try testing.expect(physical.write_times_ns[1] - physical.write_times_ns[0] >= 8 * std.time.ns_per_ms);
 
     var stop = fullEvent(uhid.UHID_STOP);
     try sendEvent(fds[1], stop[0..4]);


### PR DESCRIPTION
## Summary

- apply the existing 10ms physical rumble write limit to native UHID mailbox commands
- keep native commands latest-wins while preserving the original pending deadline
- send STOP immediately, cancel stale pending rumble, and allow immediate replay after STOP
- process the native wake before a simultaneously-ready rumble timer so the timer flushes the newest frame
- sample monotonic time at the physical output boundary instead of reusing the pre-input ppoll timestamp
- remove the redundant native-pump `errdefer` identified in the review of #478

## Why

CodeRabbit completed just after #478 merged and correctly identified that mailbox coalescing did not enforce the EventLoop's 100Hz physical HID write limit. Under a fast native output stream, EventLoop could consume each wake and write faster than 10ms. A follow-up review also found that a ppoll-cycle timestamp could be stale after expensive physical input work and backdate the write.

## Verification

- regression test before the throttle fix: RED (`expected 0, found 1` physical write)
- delayed-input timestamp regression with the old ppoll timestamp: RED
- both regressions with this patch: PASS
- focused ReleaseSafe native throttle tests: PASS
- `test-safe` native pump and rumble filters: PASS
- canonical Docker full test: 17/17 steps; 1961/1972 passed, 11 skipped
- canonical Docker full TSan: 10/10 steps; 1957/1968 passed, 11 skipped
- pre-push Docker TSan: PASS
- `zig fmt --check` and `git diff --check`: PASS
- independent final review: PASS, no P1/P2

The host-native TSan link remains unavailable because Zig 0.15.2 cannot consume this host GCC 16 `.sframe` startup objects; the repository's canonical Docker fallback passed.

Follow-up to #478 and [CodeRabbit discussion](https://github.com/BANANASJIM/padctl/pull/478#discussion_r3563975420).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rumble command handling to prevent outdated effects from being played.
  - Ensured the latest rumble command takes precedence when commands arrive rapidly.
  - STOP commands now immediately cancel pending rumble effects and reliably reset throttling.
  - Improved timing consistency between consecutive rumble updates.

- **Tests**
  - Added coverage for rapid rumble updates, STOP behavior, command replacement, and write timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->