### PR TITLE
fix(mapper): preserve completed macro/gesture timer-staged taps across layer transitions

### DIFF
--- a/src/core/macro_player.zig
+++ b/src/core/macro_player.zig
@@ -44,6 +44,12 @@ pub const MacroPlayer = struct {
     // for now_ns to reach this deadline before restarting from step_index = 0.
     // Same gating mechanism as next_step_eligible_at_ns.
     awaiting_restart_at_ns: ?i128,
+    // Tap bits this still-active player contributed to the mapper's
+    // macro_timer_tap_pending at its last timer expiry (e.g. repeat restarts).
+    // Used to distinguish a completed macro's staged tap (which must survive a
+    // same-frame layer transition) from a still-live player's staged tap (which
+    // is discarded when the layer cancels the player).
+    staged_timer_taps: u64 = 0,
 
     pub fn init(m: *const Macro, token: u32, src_idx: u6) MacroPlayer {
         return .{

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -410,6 +410,7 @@ pub const Mapper = struct {
             const existing = self.pending_tap_release orelse 0;
             self.pending_tap_release = existing | self.macro_timer_tap_pending;
             self.macro_timer_tap_pending = 0;
+            for (self.active_macros.items) |*p| p.staged_timer_taps = 0;
         }
 
         // Promote gesture-timer tap bits staged at last expiry.
@@ -769,10 +770,12 @@ pub const Mapper = struct {
                     // step() didn't finish (delay after pause_for_release, etc.) — cancel.
                     self.timer_queue.cancel(p.timer_token, now_ns);
                     p.emitPendingReleases(aux, &self.injected_buttons);
+                    self.macro_timer_tap_pending &= ~p.staged_timer_taps;
                     _ = self.active_macros.swapRemove(0);
                 } else {
                     self.timer_queue.cancel(p.timer_token, now_ns);
                     p.emitPendingReleases(aux, &self.injected_buttons);
+                    self.macro_timer_tap_pending &= ~p.staged_timer_taps;
                     _ = self.active_macros.swapRemove(0);
                 }
             }
@@ -780,12 +783,11 @@ pub const Mapper = struct {
             for (self.active_macros.items) |*p| {
                 self.timer_queue.cancel(p.timer_token, now_ns);
                 p.emitPendingReleases(aux, &self.injected_buttons);
+                self.macro_timer_tap_pending &= ~p.staged_timer_taps;
             }
             self.active_macros.clearRetainingCapacity();
         }
         releasePendingAuxTapReleases(self, aux, now_ns);
-        // Discard tap bits staged from a cancelled macro's timer expiry.
-        self.macro_timer_tap_pending = 0;
         self.cancelGestureStateForLayerChange(aux, now_ns);
         self.updateLayerHold(aux);
     }
@@ -798,7 +800,6 @@ pub const Mapper = struct {
         }
         self.gesture_tokens.clear();
         self.gesture_engine.reset();
-        self.gesture_timer_tap_pending = 0;
         self.gesture_held_gamepad = 0;
         for (&self.gesture_aux_down_targets) |*target| {
             if (target.*) |down| {
@@ -1045,6 +1046,7 @@ pub const Mapper = struct {
             var idx: usize = 0;
             while (idx < self.active_macros.items.len) {
                 if (self.active_macros.items[idx].timer_token == d.token) {
+                    const before = macro_tap_release;
                     const done = self.active_macros.items[idx].step(
                         &aux,
                         &self.timer_queue,
@@ -1059,6 +1061,7 @@ pub const Mapper = struct {
                     if (done) {
                         _ = self.active_macros.swapRemove(idx);
                     } else {
+                        self.active_macros.items[idx].staged_timer_taps |= macro_tap_release & ~before;
                         idx += 1;
                     }
                     break;

--- a/src/test/macro_e2e_test.zig
+++ b/src/test/macro_e2e_test.zig
@@ -782,3 +782,110 @@ test "macro #119: non-repeat macro unaffected (single-shot completion)" {
     _ = try m.apply(.{ .buttons = c_mask }, 4, t0 + 4 * ns_per_ms);
     try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
 }
+
+// --- F-2: completed macro / resolved gesture timer-staged taps survive a
+// same-frame layer transition. A layer active-state change used to zero
+// macro_timer_tap_pending / gesture_timer_tap_pending before the apply()
+// promotion block, silently dropping a tap staged by a macro that had already
+// finished (and was removed) at its timer expiry.
+
+test "macro F-2: completed macro timer-staged tap survives same-frame layer toggle" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\X = "macro:delayed_a"
+        \\
+        \\[[macro]]
+        \\name = "delayed_a"
+        \\steps = [
+        \\  { delay = 50 },
+        \\  { tap = "A" },
+        \\]
+        \\
+        \\[[layer]]
+        \\name = "fn"
+        \\trigger = "LB"
+        \\activation = "toggle"
+        \\
+        \\[layer.remap]
+        \\Y = "KEY_F1"
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const x_mask = btnMask(.X);
+    const lb_mask = btnMask(.LB);
+    const a_bit = btnMask(.A);
+    const ns_per_ms: i128 = std.time.ns_per_ms;
+    const t0: i128 = 1_000_000_000;
+
+    // Frame 1: X rising edge spawns the macro (delay step arms the timer); LB
+    // press only arms the toggle (toggle flips on release).
+    _ = try m.apply(.{ .buttons = x_mask | lb_mask }, 16, t0);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
+
+    // Frame 2: X released, LB still held. Macro remains in-flight on its delay.
+    _ = try m.apply(.{ .buttons = lb_mask }, 4, t0 + 4 * ns_per_ms);
+
+    // Timer expiry: delay elapses, tap "A" runs, macro completes and is removed.
+    // The tap bit is staged for the next apply() promotion.
+    _ = m.onMacroTimerExpired(t0 + 60 * ns_per_ms);
+    try testing.expectEqual(a_bit, m.macro_timer_tap_pending);
+    try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
+
+    // Frame 3: LB released -> toggle flips -> layer active_changed. The staged
+    // tap from the already-completed macro must survive to the promotion block.
+    const ev = try m.apply(.{ .buttons = 0 }, 4, t0 + 61 * ns_per_ms);
+    try testing.expectEqual(a_bit, ev.gamepad.buttons & a_bit);
+}
+
+// Guard (green before and after): a still-active repeat macro's staged tap is
+// discarded when the layer transition cancels that macro. This pins the
+// cancelled-macro semantics the fix must preserve.
+test "macro F-2 guard: still-active repeat macro's staged tap discarded on layer cancel" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\C = "macro:spam_a"
+        \\
+        \\[[macro]]
+        \\name = "spam_a"
+        \\repeat_delay_ms = 50
+        \\steps = [
+        \\  { tap = "A" },
+        \\]
+        \\
+        \\[[layer]]
+        \\name = "fn"
+        \\trigger = "LB"
+        \\activation = "toggle"
+        \\
+        \\[layer.remap]
+        \\Y = "KEY_F1"
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const c_mask = btnMask(.C);
+    const lb_mask = btnMask(.LB);
+    const a_bit = btnMask(.A);
+    const ns_per_ms: i128 = std.time.ns_per_ms;
+    const t0: i128 = 1_000_000_000;
+
+    // Frame 1: C spawns the repeat macro (first tap emitted immediately); LB arms toggle.
+    _ = try m.apply(.{ .buttons = c_mask | lb_mask }, 16, t0);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
+
+    // Frame 2: first tap release; macro still active awaiting restart.
+    _ = try m.apply(.{ .buttons = c_mask | lb_mask }, 4, t0 + 4 * ns_per_ms);
+
+    // Restart timer fires: macro restarts, stages a new tap while still active.
+    _ = m.onMacroTimerExpired(t0 + 50 * ns_per_ms);
+    try testing.expectEqual(a_bit, m.macro_timer_tap_pending);
+    try testing.expectEqual(@as(usize, 1), m.active_macros.items.len);
+
+    // Frame 3: LB released -> toggle flips -> layer cancels the active macro.
+    // Its staged tap belongs to a cancelled macro and must NOT reach output.
+    const ev = try m.apply(.{ .buttons = 0 }, 4, t0 + 51 * ns_per_ms);
+    try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & a_bit);
+}

--- a/src/test/macro_e2e_test.zig
+++ b/src/test/macro_e2e_test.zig
@@ -889,3 +889,79 @@ test "macro F-2 guard: still-active repeat macro's staged tap discarded on layer
     const ev = try m.apply(.{ .buttons = 0 }, 4, t0 + 51 * ns_per_ms);
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & a_bit);
 }
+
+// Guard (green before and after): when a HOLD layer DEACTIVATES, both
+// deactivation cancel paths must subtract the cancelled player's staged taps —
+// the waiting_for_release drain-then-cancel path (delay after
+// pause_for_release) and the plain not-waiting cancel path. Two macros with
+// distinct staged bits pin both sites.
+test "macro F-2 guard: layer deactivation subtracts staged taps of cancelled waiting and repeat macros" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\X = "macro:waiter"
+        \\C = "macro:spam_b"
+        \\
+        \\[[macro]]
+        \\name = "waiter"
+        \\steps = [
+        \\  { delay = 50 },
+        \\  { tap = "A" },
+        \\  "pause_for_release",
+        \\  { delay = 60000 },
+        \\]
+        \\
+        \\[[macro]]
+        \\name = "spam_b"
+        \\repeat_delay_ms = 50
+        \\steps = [
+        \\  { tap = "B" },
+        \\]
+        \\
+        \\[[layer]]
+        \\name = "combo"
+        \\trigger = "LB"
+        \\activation = "hold"
+        \\hold_timeout = 50
+        \\
+        \\[layer.remap]
+        \\Y = "KEY_F1"
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const lb_mask = btnMask(.LB);
+    const x_mask = btnMask(.X);
+    const c_mask = btnMask(.C);
+    const a_bit = btnMask(.A);
+    const b_bit = btnMask(.B);
+    const ns_per_ms: i128 = std.time.ns_per_ms;
+    const t0: i128 = 1_000_000_000;
+
+    // LB pressed -> layer PENDING; mock timer expiry -> ACTIVE.
+    _ = try m.apply(.{ .buttons = lb_mask }, 16, t0);
+    _ = m.layer.onTimerExpired();
+    // Absorb the activation active_changed before spawning macros.
+    _ = try m.apply(.{ .buttons = lb_mask }, 4, t0 + ns_per_ms);
+
+    // Spawn both macros while the layer is active. waiter parks on its delay;
+    // spam_b taps B immediately and schedules a restart.
+    _ = try m.apply(.{ .buttons = lb_mask | x_mask | c_mask }, 4, t0 + 2 * ns_per_ms);
+    try testing.expectEqual(@as(usize, 2), m.active_macros.items.len);
+    _ = try m.apply(.{ .buttons = lb_mask | x_mask | c_mask }, 4, t0 + 3 * ns_per_ms);
+
+    // Timer expiry: waiter runs tap "A" then parks at pause_for_release
+    // (still active, waiting); spam_b restarts and stages another "B"
+    // (still active, not waiting). Both bits staged for promotion.
+    _ = m.onMacroTimerExpired(t0 + 60 * ns_per_ms);
+    try testing.expectEqual(a_bit | b_bit, m.macro_timer_tap_pending);
+    try testing.expectEqual(@as(usize, 2), m.active_macros.items.len);
+
+    // LB released -> hold layer DEACTIVATES, cancelling both macros. waiter's
+    // drain yields on the post-pause delay (waiting cancel path); spam_b takes
+    // the plain cancel path. Both staged bits must be discarded, not promoted.
+    const ev = try m.apply(.{ .buttons = 0 }, 4, t0 + 61 * ns_per_ms);
+    try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & (a_bit | b_bit));
+    try testing.expectEqual(@as(u64, 0), m.macro_timer_tap_pending);
+    try testing.expectEqual(@as(usize, 0), m.active_macros.items.len);
+}

--- a/src/test/mapper_e2e_test.zig
+++ b/src/test/mapper_e2e_test.zig
@@ -1045,3 +1045,46 @@ test "e2e gesture back-compat: chord array remap A=[KEY_LEFTMETA,KEY_1] unchange
     try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.A));
     try testing.expectEqual(@as(usize, 0), ev.aux.len);
 }
+
+// --- F-2: a resolved gesture's timer-staged gamepad tap survives a same-frame
+// layer transition. The double-tap window expiring to a single tap stages the
+// tap bit; a layer active-state change on the next frame used to zero
+// gesture_timer_tap_pending before the apply() promotion block, dropping it.
+
+test "gesture F-2: resolved single-tap gamepad bit survives same-frame layer toggle" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "B", double = "X", double_ms = 250 }
+        \\
+        \\[[layer]]
+        \\name = "fn"
+        \\trigger = "LB"
+        \\activation = "toggle"
+        \\
+        \\[layer.remap]
+        \\Y = "KEY_F1"
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const lb_mask = btnMask(.LB);
+    const b_bit = btnMask(.B);
+    const ns_per_ms: i128 = std.time.ns_per_ms;
+    const t0: i128 = 1_000_000_000;
+
+    // Frame 1: A press (gesture wait_decide); LB press arms toggle.
+    _ = try m.apply(.{ .buttons = btnMask(.A) | lb_mask }, 16, t0);
+
+    // Frame 2: A release opens the double window; LB still held.
+    _ = try m.apply(.{ .buttons = lb_mask }, 16, t0 + 40 * ns_per_ms);
+
+    // Double window expires with no second press -> single tap "B" staged.
+    _ = m.onMacroTimerExpired(t0 + 300 * ns_per_ms);
+    try testing.expectEqual(b_bit, m.gesture_timer_tap_pending);
+
+    // Frame 3: LB released -> toggle flips -> layer active_changed. The resolved
+    // gesture's staged tap must survive to the promotion block.
+    const ev = try m.apply(.{ .buttons = 0 }, 16, t0 + 301 * ns_per_ms);
+    try testing.expectEqual(b_bit, ev.gamepad.buttons & b_bit);
+}


### PR DESCRIPTION
- `handleLayerActiveChanged` unconditionally zeroed `macro_timer_tap_pending`, and `cancelGestureStateForLayerChange` zeroed `gesture_timer_tap_pending`, before the apply() promotion block — a COMPLETED macro's (or resolved gesture's) timer-staged gamepad tap was silently dropped when any layer transition landed on the next frame
- Add `MacroPlayer.staged_timer_taps` attribution: bits staged by still-active players (repeat restarts) are recorded at timer expiry and subtracted only when that player is actually cancelled — cancelled-macro semantics preserved, completed-macro taps survive
- Delete the unconditional gesture-side zeroing: staging happens only at gesture resolution (`gesture.zig` onTimerExpired `.double` leg resolves and frees the slot before staging), so no in-flight gesture can own a staged tap

Test plan:
- Test A (macro) and Test B (gesture) are red on main (`expected 1, found 0` / `expected 2, found 0` at the output assertions), green here
- Test C guard pins cancelled-macro discard semantics (green on main and here)
- Docker 0.15.2 oracle: full `zig build test` exit 0 incl. property/generative suites (dispatcher re-ran independently)