### PR TITLE
fix(mapper): evict most recent press on aux event overflow instead of dropping release

### DIFF
--- a/src/core/aux_event.zig
+++ b/src/core/aux_event.zig
@@ -10,7 +10,7 @@ var overflow_warned = std.atomic.Value(bool).init(false);
 
 fn warnOverflowOnce() void {
     if (overflow_warned.cmpxchgStrong(false, true, .monotonic, .monotonic) == null) {
-        std.log.warn("aux event buffer overflow (64 slots): shedding a press to keep key releases; check for oversized single-frame macros", .{});
+        std.log.warn("aux event buffer overflow (64 slots): some events dropped or shed; check for oversized single-frame macros", .{});
     }
 }
 

--- a/src/core/aux_event.zig
+++ b/src/core/aux_event.zig
@@ -6,14 +6,70 @@ pub const AuxEvent = union(enum) {
     rel: struct { code: u16, value: i32 },
 };
 
+var overflow_warned = std.atomic.Value(bool).init(false);
+
+fn warnOverflowOnce() void {
+    if (overflow_warned.cmpxchgStrong(false, true, .monotonic, .monotonic) == null) {
+        std.log.warn("aux event buffer overflow (64 slots): shedding a press to keep key releases; check for oversized single-frame macros", .{});
+    }
+}
+
+fn isRelease(val: AuxEvent) bool {
+    return switch (val) {
+        .key => |k| !k.pressed,
+        .mouse_button => |b| !b.pressed,
+        .rel => false,
+    };
+}
+
+fn isPress(val: AuxEvent) bool {
+    return switch (val) {
+        .key => |k| k.pressed,
+        .mouse_button => |b| b.pressed,
+        .rel => false,
+    };
+}
+
+fn isRel(val: AuxEvent) bool {
+    return switch (val) {
+        .rel => true,
+        else => false,
+    };
+}
+
 pub const AuxEventList = struct {
     buffer: [64]AuxEvent = undefined,
     len: usize = 0,
 
     pub fn append(self: *AuxEventList, val: AuxEvent) error{Overflow}!void {
-        if (self.len >= 64) return error.Overflow;
-        self.buffer[self.len] = val;
-        self.len += 1;
+        if (self.len < 64) {
+            self.buffer[self.len] = val;
+            self.len += 1;
+            return;
+        }
+
+        // A dropped release strands a key (stuck); a dropped press is benign.
+        // On overflow, evict the newest press to seat an incoming release.
+        warnOverflowOnce();
+        if (isRelease(val)) {
+            var i: usize = self.len;
+            while (i > 0) {
+                i -= 1;
+                if (isPress(self.buffer[i])) {
+                    self.buffer[i] = val;
+                    return;
+                }
+            }
+            i = self.len;
+            while (i > 0) {
+                i -= 1;
+                if (isRel(self.buffer[i])) {
+                    self.buffer[i] = val;
+                    return;
+                }
+            }
+        }
+        return error.Overflow;
     }
 
     pub fn get(self: *const AuxEventList, i: usize) AuxEvent {
@@ -25,3 +81,47 @@ pub const AuxEventList = struct {
         return self.buffer[0..self.len];
     }
 };
+
+const testing = std.testing;
+
+test "AuxEventList: release evicts most recent press on overflow (F-3)" {
+    var list = AuxEventList{};
+    for (0..64) |i| {
+        try list.append(.{ .key = .{ .code = @intCast(i), .pressed = true } });
+    }
+    try list.append(.{ .key = .{ .code = 99, .pressed = false } });
+    try testing.expectEqual(@as(usize, 64), list.len);
+
+    // The evicted slot is the last (most recent) press.
+    switch (list.buffer[63]) {
+        .key => |k| {
+            try testing.expectEqual(@as(u16, 99), k.code);
+            try testing.expect(!k.pressed);
+        },
+        else => return error.WrongType,
+    }
+    // The prior slot still holds an original press.
+    switch (list.buffer[62]) {
+        .key => |k| try testing.expect(k.pressed),
+        else => return error.WrongType,
+    }
+    // Exactly one release seated.
+    var releases: usize = 0;
+    for (list.slice()) |ev| {
+        switch (ev) {
+            .key => |k| if (!k.pressed) {
+                releases += 1;
+            },
+            else => {},
+        }
+    }
+    try testing.expectEqual(@as(usize, 1), releases);
+}
+
+test "AuxEventList: all-release buffer still overflows on release" {
+    var list = AuxEventList{};
+    for (0..64) |_| {
+        try list.append(.{ .key = .{ .code = 30, .pressed = false } });
+    }
+    try testing.expectError(error.Overflow, list.append(.{ .key = .{ .code = 30, .pressed = false } }));
+}

--- a/src/core/macro_player.zig
+++ b/src/core/macro_player.zig
@@ -492,6 +492,41 @@ test "macro_player: repeat_delay_ms — release mid-iteration completes current 
     try testing.expect(p.awaiting_restart_at_ns == null);
 }
 
+test "macro_player: burst overflow keeps final KEY_A release (F-3)" {
+    const allocator = testing.allocator;
+    // down KEY_B + 32× tap KEY_A = 1 + 64 = 65 aux events in a single frame,
+    // one past the 64-slot AuxEventList. The final KEY_A release must survive
+    // (dropping it would leave KEY_A stuck at the OS level).
+    var steps: [33]MacroStep = undefined;
+    steps[0] = .{ .down = "KEY_B" };
+    for (1..33) |i| steps[i] = .{ .tap = "KEY_A" };
+    const m = Macro{ .name = "burst", .steps = &steps };
+    var player = makePlayer(&m);
+    var ctx = StepCtx.init(allocator);
+    defer ctx.deinit();
+
+    const done = try ctx.step(&player);
+    try testing.expect(done);
+    try testing.expectEqual(@as(usize, 64), ctx.aux.len);
+
+    const a_target = remap.resolveTarget("KEY_A") catch unreachable;
+    const a_code: u16 = switch (a_target) {
+        .key => |c| c,
+        else => unreachable,
+    };
+    var last_a_pressed: ?bool = null;
+    for (ctx.aux.slice()) |ev| {
+        switch (ev) {
+            .key => |k| if (k.code == a_code) {
+                last_a_pressed = k.pressed;
+            },
+            else => {},
+        }
+    }
+    try testing.expect(last_a_pressed != null);
+    try testing.expect(!last_a_pressed.?);
+}
+
 test "macro_player: repeat_delay_ms absent — legacy single-shot completion" {
     const allocator = testing.allocator;
     const steps = [_]MacroStep{.{ .tap = "KEY_A" }};

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -564,27 +564,8 @@ pub const AuxDevice = struct {
     }
 
     pub fn emitAux(self: *AuxDevice, events: []const AuxEvent) !void {
-        var buf: [MAX_EVENTS]c.input_event = undefined;
-        var n: usize = 0;
-        for (events) |ev| {
-            if (n >= MAX_EVENTS - 1) break;
-            switch (ev) {
-                .key => |k| {
-                    buf[n] = .{ .type = c.EV_KEY, .code = k.code, .value = if (k.pressed) @as(i32, 1) else 0, .time = std.mem.zeroes(c.timeval) };
-                    n += 1;
-                },
-                .mouse_button => |mb| {
-                    buf[n] = .{ .type = c.EV_KEY, .code = mb.code, .value = if (mb.pressed) @as(i32, 1) else 0, .time = std.mem.zeroes(c.timeval) };
-                    n += 1;
-                },
-                .rel => |r| {
-                    if (r.value != 0) {
-                        buf[n] = .{ .type = c.EV_REL, .code = r.code, .value = r.value, .time = std.mem.zeroes(c.timeval) };
-                        n += 1;
-                    }
-                },
-            }
-        }
+        var buf: [MAX_EVENTS + 1]c.input_event = undefined;
+        var n = convertAuxEvents(events, buf[0..MAX_EVENTS]);
         if (n > 0) {
             buf[n] = .{ .type = c.EV_SYN, .code = c.SYN_REPORT, .value = 0, .time = std.mem.zeroes(c.timeval) };
             n += 1;
@@ -597,6 +578,30 @@ pub const AuxDevice = struct {
         std.posix.close(self.fd);
     }
 };
+
+fn convertAuxEvents(events: []const AuxEvent, buf: []c.input_event) usize {
+    var n: usize = 0;
+    for (events) |ev| {
+        if (n >= buf.len) break;
+        switch (ev) {
+            .key => |k| {
+                buf[n] = .{ .type = c.EV_KEY, .code = k.code, .value = if (k.pressed) @as(i32, 1) else 0, .time = std.mem.zeroes(c.timeval) };
+                n += 1;
+            },
+            .mouse_button => |mb| {
+                buf[n] = .{ .type = c.EV_KEY, .code = mb.code, .value = if (mb.pressed) @as(i32, 1) else 0, .time = std.mem.zeroes(c.timeval) };
+                n += 1;
+            },
+            .rel => |r| {
+                if (r.value != 0) {
+                    buf[n] = .{ .type = c.EV_REL, .code = r.code, .value = r.value, .time = std.mem.zeroes(c.timeval) };
+                    n += 1;
+                }
+            },
+        }
+    }
+    return n;
+}
 
 pub const TouchpadOutputDevice = struct {
     ptr: *anyopaque,
@@ -1465,6 +1470,40 @@ test "uinput: UinputDevice.emit: axis diff writes correct input_events via pipe"
     try std.testing.expectEqual(@as(i32, -300), events[1].value);
     try std.testing.expectEqual(@as(u16, c.EV_SYN), events[2].type);
     try std.testing.expectEqual(@as(u16, c.SYN_REPORT), events[2].code);
+}
+
+test "uinput: convertAuxEvents converts all 64 events including slot 63" {
+    var aux: [64]AuxEvent = undefined;
+    for (0..63) |i| aux[i] = .{ .key = .{ .code = @intCast(i), .pressed = true } };
+    aux[63] = .{ .key = .{ .code = 99, .pressed = false } };
+
+    var buf: [MAX_EVENTS]c.input_event = undefined;
+    const n = convertAuxEvents(&aux, &buf);
+    try std.testing.expectEqual(@as(usize, 64), n);
+    try std.testing.expectEqual(@as(u16, c.EV_KEY), buf[63].type);
+    try std.testing.expectEqual(@as(u16, 99), buf[63].code);
+    try std.testing.expectEqual(@as(i32, 0), buf[63].value);
+}
+
+test "uinput: AuxDevice.emitAux writes 64 events plus SYN via pipe" {
+    const pfds = try std.posix.pipe2(.{});
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = AuxDevice{ .fd = pfds[1] };
+    var aux: [64]AuxEvent = undefined;
+    for (0..63) |i| aux[i] = .{ .key = .{ .code = @intCast(i), .pressed = true } };
+    aux[63] = .{ .key = .{ .code = 99, .pressed = false } };
+    try dev.emitAux(&aux);
+
+    var events: [66]c.input_event = undefined;
+    const n = readEvents(pfds[0], &events);
+    try std.testing.expectEqual(@as(usize, 65), n);
+    try std.testing.expectEqual(@as(u16, c.EV_KEY), events[63].type);
+    try std.testing.expectEqual(@as(u16, 99), events[63].code);
+    try std.testing.expectEqual(@as(i32, 0), events[63].value);
+    try std.testing.expectEqual(@as(u16, c.EV_SYN), events[64].type);
+    try std.testing.expectEqual(@as(u16, c.SYN_REPORT), events[64].code);
 }
 
 test "uinput: UinputDevice.emit: no change produces no write" {


### PR DESCRIPTION
- `AuxEventList.append` on a full 64-slot buffer silently swallowed `error.Overflow` at all release-capable call sites — an oversized single-frame macro burst (e.g. `down` + 32 taps = 65 events) emitted the final press but dropped its release, leaving an OS-level stuck key with zero log output
- On overflow of a key/button release: overwrite the most recent press (else newest `rel` motion) — a shed press means one lost keystroke instead of one stuck key; all-release buffer still returns `error.Overflow`
- Warn once globally on first overflow (atomic flag, tsan-safe); never `log.err`

Test plan:
- Unit test (release evicts most recent press) and burst-macro regression (final KEY_A release survives) are red on main, green here
- Pre-existing intentional `.rel` overflow test untouched and green
- Docker 0.15.2 oracle: `zig build test` exit 0 and `zig build test-tsan` exit 0 (dispatcher re-ran test independently)