### PR TITLE
chore(release): bump version to 0.1.23

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.22",
+    .version = "0.1.23",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
- build.zig.zon .version 0.1.22 -> 0.1.23 (only file; release.yml tag gate compares the tag against build.zig.zon)

Test plan:
- Docker 0.15.2: ReleaseSafe build + `padctl --version` prints `padctl 0.1.23 (libusb)`; `zig build test` exit 0

Release delta over v0.1.22: #478 native DualSense Edge USB output (issue #471), #479 native rumble throttle fix, #480 Flydigi Apex 4 config, #484 OpenRC docs (issue #483), #486 portable hotplug reconnect launcher (issue #485), #487/#488 mapper stuck-key/aux-overflow + emitAux fixes, #489 UHID test gates. First release containing the complete #65 rumble fix wave.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.1.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->