### PR TITLE
fix(mapper): apply deadzones and stabilize gesture taps

### DIFF
--- a/docs/src/mapping-config.md
+++ b/docs/src/mapping-config.md
@@ -179,7 +179,7 @@ suppress_gamepad = true
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `mode` | string | `"gamepad"` | `"gamepad"`, `"mouse"`, or `"scroll"` |
-| `deadzone` | integer | — | Stick deadzone threshold |
+| `deadzone` | integer | `0` (`"gamepad"`), `128` (`"mouse"`/`"scroll"`) | Stick deadzone threshold. In `"gamepad"` mode, axis values with an absolute magnitude below this value are emitted as zero. |
 | `sensitivity` | float | — | Sensitivity multiplier |
 | `suppress_gamepad` | bool | — | Suppress gamepad axis output when in mouse/scroll mode |
 

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -51,6 +51,11 @@ pub const LayerTimerEvents = struct {
     aux: AuxEventList = .{},
 };
 
+pub const MacroTimerEvents = struct {
+    gamepad: ?GamepadState = null,
+    aux: AuxEventList = .{},
+};
+
 const BUTTON_COUNT = @typeInfo(ButtonId).@"enum".fields.len;
 
 const ResolvedRemap = struct {
@@ -110,6 +115,52 @@ const AuxTapReleaseTokenTable = struct {
     }
 };
 
+const GestureGamepadTapReleaseTokenEntry = struct {
+    token: u32,
+    mask: u64,
+};
+
+const GestureGamepadTapReleaseTokenTable = struct {
+    // One live tap per physical source.  Indexing by source preserves overlapping
+    // taps that happen to target the same virtual button.
+    entries: [BUTTON_COUNT]?GestureGamepadTapReleaseTokenEntry =
+        [_]?GestureGamepadTapReleaseTokenEntry{null} ** BUTTON_COUNT,
+
+    fn replaceSource(
+        self: *GestureGamepadTapReleaseTokenTable,
+        src_idx: u6,
+        entry: GestureGamepadTapReleaseTokenEntry,
+    ) ?GestureGamepadTapReleaseTokenEntry {
+        const prior = self.entries[src_idx];
+        self.entries[src_idx] = entry;
+        return prior;
+    }
+
+    fn take(self: *GestureGamepadTapReleaseTokenTable, token: u32) ?GestureGamepadTapReleaseTokenEntry {
+        for (&self.entries) |*e| {
+            if (e.*) |v| {
+                if (v.token == token) {
+                    e.* = null;
+                    return v;
+                }
+            }
+        }
+        return null;
+    }
+
+    fn activeMask(self: *const GestureGamepadTapReleaseTokenTable) u64 {
+        var mask: u64 = 0;
+        for (self.entries) |entry| {
+            if (entry) |e| mask |= e.mask;
+        }
+        return mask;
+    }
+
+    fn clear(self: *GestureGamepadTapReleaseTokenTable) void {
+        self.entries = [_]?GestureGamepadTapReleaseTokenEntry{null} ** BUTTON_COUNT;
+    }
+};
+
 const GestureTokenEntry = struct {
     token: u32,
     src_idx: u6,
@@ -163,6 +214,7 @@ pub const Mapper = struct {
     gesture_aux_down_targets: [BUTTON_COUNT]?AuxDownTarget,
     pending_tap_release: ?u64,
     aux_tap_release_tokens: AuxTapReleaseTokenTable,
+    gesture_gamepad_tap_release_tokens: GestureGamepadTapReleaseTokenTable,
     // Gamepad-button taps emitted by macro timer expiry need one apply() cycle
     // to reach output before pending_tap_release fires; staged here, promoted
     // to injected+pending_tap_release at the next apply.
@@ -237,6 +289,7 @@ pub const Mapper = struct {
             .gesture_aux_down_targets = [_]?AuxDownTarget{null} ** BUTTON_COUNT,
             .pending_tap_release = null,
             .aux_tap_release_tokens = .{},
+            .gesture_gamepad_tap_release_tokens = .{},
             .macro_timer_tap_pending = 0,
             .gesture_engine = .{},
             .gesture_tokens = .{},
@@ -294,6 +347,7 @@ pub const Mapper = struct {
         self.gesture_aux_down_targets = [_]?AuxDownTarget{null} ** BUTTON_COUNT;
         self.pending_tap_release = null;
         self.aux_tap_release_tokens = .{};
+        self.gesture_gamepad_tap_release_tokens = .{};
         self.macro_timer_tap_pending = 0;
         self.gesture_engine.reset();
         self.gesture_tokens.clear();
@@ -354,6 +408,7 @@ pub const Mapper = struct {
             }
         }
         releasePendingAuxTapReleases(self, &aux, null);
+        self.gesture_gamepad_tap_release_tokens.clear();
         return aux;
     }
 
@@ -605,12 +660,18 @@ pub const Mapper = struct {
         // emits press once, so the bit must persist across frames until release.
         self.injected_buttons |= self.gesture_held_gamepad;
 
+        // Gamepad taps need a minimum observable duration just like key/mouse
+        // taps.  Re-assert them until their timer emits an explicit release.
+        self.injected_buttons |= self.gesture_gamepad_tap_release_tokens.activeMask();
+
         // Re-assert the active layer's `hold` passthrough gamepad bit each frame.
         self.injected_buttons |= self.layer_held_gamepad;
 
         // Gesture hold legs and layer hold passthrough drive LT/RT via these
         // masks rather than per_src_inject; give them the same analog floor.
-        const held_gamepad = self.gesture_held_gamepad | self.layer_held_gamepad;
+        const held_gamepad = self.gesture_held_gamepad |
+            self.layer_held_gamepad |
+            self.gesture_gamepad_tap_release_tokens.activeMask();
         if (held_gamepad & buttonBit("LT") != 0) inject_axes.lt = 255;
         if (held_gamepad & buttonBit("RT") != 0) inject_axes.rt = 255;
 
@@ -804,6 +865,10 @@ pub const Mapper = struct {
         self.gesture_tokens.clear();
         self.gesture_engine.reset();
         self.gesture_held_gamepad = 0;
+        for (self.gesture_gamepad_tap_release_tokens.entries) |maybe| {
+            if (maybe) |e| self.timer_queue.cancel(e.token, now_ns);
+        }
+        self.gesture_gamepad_tap_release_tokens.clear();
         for (&self.gesture_aux_down_targets) |*target| {
             if (target.*) |down| {
                 emitAuxDownRelease(down, aux);
@@ -853,13 +918,14 @@ pub const Mapper = struct {
     fn currentMappedGamepadFrame(self: *Mapper) GamepadState {
         const configs = self.config.layer orelse &.{};
         var suppressed: u64 = 0;
-        var injected: u64 = self.gesture_held_gamepad | self.layer_held_gamepad;
+        const gesture_tap_mask = self.gesture_gamepad_tap_release_tokens.activeMask();
+        var injected: u64 = self.gesture_held_gamepad | self.layer_held_gamepad | gesture_tap_mask;
         var per_src_inject: [BUTTON_COUNT]?RemapTargetResolved = [_]?RemapTargetResolved{null} ** BUTTON_COUNT;
         var inject_axes: remap_mod.AxisFloor = .{};
 
         // Mirror apply(): hold masks and macro holds driving LT/RT raise the
         // analog axis floor so timer-emitted frames match regular frames.
-        const held_gamepad = self.gesture_held_gamepad | self.layer_held_gamepad;
+        const held_gamepad = self.gesture_held_gamepad | self.layer_held_gamepad | gesture_tap_mask;
         if (held_gamepad & buttonBit("LT") != 0) inject_axes.lt = 255;
         if (held_gamepad & buttonBit("RT") != 0) inject_axes.rt = 255;
 
@@ -993,9 +1059,11 @@ pub const Mapper = struct {
                         .tap => if (from_timer) {
                             self.gesture_timer_tap_pending |= mask;
                         } else {
-                            self.injected_buttons |= mask;
-                            const existing = self.pending_tap_release orelse 0;
-                            self.pending_tap_release = existing | mask;
+                            if (!emitDelayedGestureGamepadTap(self, src_idx, mask, now_ns)) {
+                                self.injected_buttons |= mask;
+                                const existing = self.pending_tap_release orelse 0;
+                                self.pending_tap_release = existing | mask;
+                            }
                         },
                     }
                 },
@@ -1028,7 +1096,11 @@ pub const Mapper = struct {
 
     // Macro timerfd (slot 4) expiry only — must NOT call onLayerTimerExpired().
     pub fn onMacroTimerExpired(self: *Mapper, now_ns: i128) AuxEventList {
-        var aux = AuxEventList{};
+        return self.onMacroTimerExpiredEvents(now_ns).aux;
+    }
+
+    pub fn onMacroTimerExpiredEvents(self: *Mapper, now_ns: i128) MacroTimerEvents {
+        var events = MacroTimerEvents{};
         var macro_tap_release: u64 = 0;
         // Axis floor on timer-driven resume is discarded; the next Mapper.apply()
         // frame re-walks active macros and recomputes from held_axis_*.
@@ -1037,14 +1109,18 @@ pub const Mapper = struct {
         const expired = self.timer_queue.drainExpired(now_ns, &buf);
         for (expired) |d| {
             if (self.aux_tap_release_tokens.take(d.token)) |target| {
-                emitAuxDownRelease(target, &aux);
+                emitAuxDownRelease(target, &events.aux);
+                continue;
+            }
+            if (self.gesture_gamepad_tap_release_tokens.take(d.token) != null) {
+                events.gamepad = self.currentMappedGamepadFrame();
                 continue;
             }
             if (self.gesture_tokens.take(d.token)) |ge| {
                 const src_bit = @as(u64, 1) << ge.src_idx;
                 const held = (self.state.buttons & src_bit) != 0;
                 const out = self.gesture_engine.onTimerExpired(ge.src_idx, ge.leg, held, now_ns);
-                self.applyGestureOutcome(ge.src_idx, out, &aux, true, now_ns);
+                self.applyGestureOutcome(ge.src_idx, out, &events.aux, true, now_ns);
                 continue;
             }
             var idx: usize = 0;
@@ -1052,7 +1128,7 @@ pub const Mapper = struct {
                 if (self.active_macros.items[idx].timer_token == d.token) {
                     const before = macro_tap_release;
                     const done = self.active_macros.items[idx].step(
-                        &aux,
+                        &events.aux,
                         &self.timer_queue,
                         &self.injected_buttons,
                         &macro_tap_release,
@@ -1080,7 +1156,7 @@ pub const Mapper = struct {
             // before the gamepad output is ever emitted.
             self.macro_timer_tap_pending |= macro_tap_release;
         }
-        return aux;
+        return events;
     }
 
     fn findMacro(self: *const Mapper, name: []const u8) ?*const mapping.Macro {
@@ -1268,6 +1344,22 @@ fn emitDelayedAuxTap(self: *Mapper, target: RemapTargetResolved, aux: *AuxEventL
         _ = self.aux_tap_release_tokens.take(token);
         std.log.warn("aux tap release timer arm failed: {}", .{err});
         emitAuxDownRelease(down, aux);
+    };
+    return true;
+}
+
+fn emitDelayedGestureGamepadTap(self: *Mapper, src_idx: u6, mask: u64, now_ns: i128) bool {
+    const token = self.next_token;
+    self.next_token +%= 1;
+    if (self.gesture_gamepad_tap_release_tokens.replaceSource(src_idx, .{
+        .token = token,
+        .mask = mask,
+    })) |prior| self.timer_queue.cancel(prior.token, now_ns);
+
+    self.timer_queue.arm(now_ns + AUX_TAP_RELEASE_DELAY_NS, token, now_ns) catch |err| {
+        _ = self.gesture_gamepad_tap_release_tokens.take(token);
+        std.log.warn("gamepad tap release timer arm failed: {}", .{err});
+        return false;
     };
     return true;
 }
@@ -1473,6 +1565,43 @@ test "mapper: gesture tap remap emits tap key through apply" {
         },
         else => return error.WrongEventType,
     }
+}
+
+test "mapper: issue 492 stick-click tap remains observable until release timer" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[remap]
+        \\LS = { tap = "LS", hold = "KEY_Z" }
+        \\RS = { tap = "RS", hold = "KEY_Z" }
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const ls_mask = buttonBit("LS");
+    const stick_clicks = ls_mask | buttonBit("RS");
+    const t0: i128 = std.time.ns_per_s;
+
+    // The gesture consumes the physical press while it waits to distinguish tap/hold.
+    const press = try m.apply(.{ .buttons = stick_clicks }, 16, t0);
+    try testing.expectEqual(@as(u64, 0), press.gamepad.buttons & stick_clicks);
+
+    // Releasing before hold_ms chooses the tap leg and emits the virtual stick-click presses.
+    const tap = try m.apply(.{ .buttons = 0 }, 16, t0 + 10 * std.time.ns_per_ms);
+    try testing.expectEqual(stick_clicks, tap.gamepad.buttons & stick_clicks);
+
+    // A high-poll-rate controller reports again almost immediately.  The virtual
+    // press must remain visible for the same 30 ms minimum used by key/mouse taps;
+    // a one-report pulse is too short for consumers to observe reliably.
+    const early = try m.apply(.{ .buttons = 0 }, 1, t0 + 11 * std.time.ns_per_ms);
+    try testing.expectEqual(stick_clicks, early.gamepad.buttons & stick_clicks);
+
+    // Release comes from the timer itself; it must not depend on another physical
+    // controller report after the stick click.
+    const release = m.onMacroTimerExpiredEvents(t0 + 40 * std.time.ns_per_ms);
+    try testing.expect(release.gamepad != null);
+    try testing.expectEqual(@as(u64, 0), release.gamepad.?.buttons & stick_clicks);
 }
 
 test "mapper: gesture hold gamepad bit persists then clears on release" {

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -667,6 +667,8 @@ pub const Mapper = struct {
             emit_state.dpad_y = 0;
         }
 
+        applyGamepadStickDeadzones(&emit_state, &left_cfg, &right_cfg);
+
         // gyro joystick mode: override or blend stick axes, suppress originals
         if (suppress_right_stick_gyro) {
             if (gyro_joy_x) |jx| emit_state.rx = if (gyro_blend_stick)
@@ -707,6 +709,7 @@ pub const Mapper = struct {
             masked_prev.dpad_x = 0;
             masked_prev.dpad_y = 0;
         }
+        applyGamepadStickDeadzones(&masked_prev, &left_cfg, &right_cfg);
 
         self.prev = self.state;
 
@@ -922,6 +925,7 @@ pub const Mapper = struct {
 
         const left_cfg = self.effectiveStickConfig(.left);
         const right_cfg = self.effectiveStickConfig(.right);
+        applyGamepadStickDeadzones(&emit_state, &left_cfg, &right_cfg);
         if (left_cfg.suppress_gamepad or !std.mem.eql(u8, left_cfg.mode, "gamepad")) {
             emit_state.ax = 0;
             emit_state.ay = 0;
@@ -1166,12 +1170,24 @@ fn resolveGyroAxis(axis: ?[]const u8, default: gyro.GyroAxis) gyro.GyroAxis {
 }
 
 fn resolveStickConfig(mc: *const mapping.StickConfig) stick.StickConfig {
+    const mode = mc.mode;
     return .{
-        .mode = mc.mode,
-        .deadzone = if (mc.deadzone) |v| @intCast(v) else 128,
+        .mode = mode,
+        .deadzone = if (mc.deadzone) |v| @intCast(v) else if (std.mem.eql(u8, mode, "gamepad")) 0 else 128,
         .sensitivity = if (mc.sensitivity) |v| @floatCast(v) else 1.0,
         .suppress_gamepad = mc.suppress_gamepad orelse false,
     };
+}
+
+fn applyGamepadStickDeadzones(gs: *GamepadState, left_cfg: *const stick.StickConfig, right_cfg: *const stick.StickConfig) void {
+    if (std.mem.eql(u8, left_cfg.mode, "gamepad")) {
+        gs.ax = stick.applyAxisDeadzone(gs.ax, left_cfg.deadzone);
+        gs.ay = stick.applyAxisDeadzone(gs.ay, left_cfg.deadzone);
+    }
+    if (std.mem.eql(u8, right_cfg.mode, "gamepad")) {
+        gs.rx = stick.applyAxisDeadzone(gs.rx, right_cfg.deadzone);
+        gs.ry = stick.applyAxisDeadzone(gs.ry, right_cfg.deadzone);
+    }
 }
 
 fn freeResolvedRemap(allocator: std.mem.Allocator, r: ResolvedRemap) void {
@@ -3035,6 +3051,57 @@ test "mapper: dt_ms propagation: stick mouse output scales with dt" {
     // 4 frames × dt=4 ≡ 1 frame × dt=16 in total motion budget
     const diff = @abs(total4 - total16);
     try testing.expect(diff <= 2);
+}
+
+test "mapper: issue 491 gamepad stick deadzone suppresses in-zone axes" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[stick.left]
+        \\mode = "gamepad"
+        \\deadzone = 32767
+        \\sensitivity = 1.0
+        \\
+        \\[stick.right]
+        \\mode = "gamepad"
+        \\deadzone = 32767
+        \\sensitivity = 1.0
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    _ = try m.apply(.{ .ax = 100, .ay = -100, .rx = 100, .ry = -100 }, 16, 0);
+    const in_zone = try m.apply(.{ .ax = 200, .ay = -200, .rx = 200, .ry = -200 }, 16, 0);
+    try testing.expectEqual(@as(i16, 0), in_zone.gamepad.ax);
+    try testing.expectEqual(@as(i16, 0), in_zone.gamepad.ay);
+    try testing.expectEqual(@as(i16, 0), in_zone.gamepad.rx);
+    try testing.expectEqual(@as(i16, 0), in_zone.gamepad.ry);
+    try testing.expectEqual(@as(i16, 0), in_zone.prev.ax);
+    try testing.expectEqual(@as(i16, 0), in_zone.prev.ay);
+    try testing.expectEqual(@as(i16, 0), in_zone.prev.rx);
+    try testing.expectEqual(@as(i16, 0), in_zone.prev.ry);
+
+    const boundary = try m.apply(.{ .ax = 32767, .ay = -32768, .rx = 32767, .ry = -32768 }, 16, 0);
+    try testing.expectEqual(@as(i16, 32767), boundary.gamepad.ax);
+    try testing.expectEqual(@as(i16, -32768), boundary.gamepad.ay);
+    try testing.expectEqual(@as(i16, 32767), boundary.gamepad.rx);
+    try testing.expectEqual(@as(i16, -32768), boundary.gamepad.ry);
+}
+
+test "mapper: issue 491 omitted gamepad deadzone preserves passthrough" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping("", allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    const ev = try m.apply(.{ .ax = 100, .ay = -100, .rx = 100, .ry = -100 }, 16, 0);
+    try testing.expectEqual(@as(i16, 100), ev.gamepad.ax);
+    try testing.expectEqual(@as(i16, -100), ev.gamepad.ay);
+    try testing.expectEqual(@as(i16, 100), ev.gamepad.rx);
+    try testing.expectEqual(@as(i16, -100), ev.gamepad.ry);
 }
 
 test "mapper: dpad prev mask: suppress_dpad_hat applied to masked_prev" {

--- a/src/core/stick.zig
+++ b/src/core/stick.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub const StickConfig = struct {
     mode: []const u8 = "gamepad", // "gamepad" | "mouse" | "scroll"
-    deadzone: i16 = 128,
+    deadzone: i16 = 0,
     sensitivity: f32 = 1.0,
     suppress_gamepad: bool = false,
 };
@@ -77,8 +77,12 @@ pub const StickProcessor = struct {
 };
 
 fn applyDeadzone(val: i16, deadzone: i16) f32 {
+    return @floatFromInt(applyAxisDeadzone(val, deadzone));
+}
+
+pub fn applyAxisDeadzone(val: i16, deadzone: i16) i16 {
     if (@abs(@as(i32, val)) < deadzone) return 0;
-    return @floatFromInt(val);
+    return val;
 }
 
 // --- tests ---

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -1061,9 +1061,14 @@ pub const EventLoop = struct {
                 var expiry: [8]u8 = undefined;
                 _ = posix.read(self.macro_timer_fd, &expiry) catch {};
                 if (ctx.mapper) |m| {
-                    const macro_aux = m.onMacroTimerExpired(now);
-                    if (macro_aux.len > 0) {
-                        if (ctx.aux_output) |ao| ao.emitAux(macro_aux.slice()) catch {};
+                    const events = m.onMacroTimerExpiredEvents(now);
+                    if (events.gamepad) |gamepad| {
+                        ctx.output.emit(gamepad) catch |err| {
+                            std.log.err("output.emit failed: {}", .{err});
+                        };
+                    }
+                    if (events.aux.len > 0) {
+                        if (ctx.aux_output) |ao| ao.emitAux(events.aux.slice()) catch {};
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- apply configured stick deadzones to gamepad-mode output while preserving zero-deadzone passthrough by default
- keep gesture gamepad taps observable for 30 ms and emit their release from the timer path without requiring another physical report
- add regression coverage for both stick sides, deadzone boundaries, omitted defaults, and LS/RS tap timing

## Reproduction

- #491: an in-deadzone axis value of 100 was emitted unchanged instead of 0
- #492: an LS/RS gesture tap disappeared on the next 1 ms controller report

## Verification

- `./scripts/padctl-docker test -Dtest-filter='issue 49' --summary all` — 5/5 passed
- `./scripts/padctl-docker test --summary all` — 1976 passed, 11 environment-gated skipped
- pre-push `test-tsan` in the canonical Zig 0.15.2 Docker image — 1972 passed, 11 environment-gated skipped

Closes #491
Closes #492


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gesture-triggered gamepad taps so press and release events remain observable for the required tap duration.
  * Corrected timer-driven output to deliver both gamepad and auxiliary events.
  * Improved stick deadzone suppression and passthrough behavior when no deadzone is configured.

* **Documentation**
  * Clarified default deadzone values and zero-output behavior for gamepad, mouse, and scroll stick modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->