### PR TITLE
fix(mapper): preserve rapid gesture tap edges

### DIFF
--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -148,6 +148,12 @@ const GestureGamepadTapReleaseTokenTable = struct {
         return null;
     }
 
+    fn takeSource(self: *GestureGamepadTapReleaseTokenTable, src_idx: u6) ?GestureGamepadTapReleaseTokenEntry {
+        const prior = self.entries[src_idx];
+        self.entries[src_idx] = null;
+        return prior;
+    }
+
     fn activeMask(self: *const GestureGamepadTapReleaseTokenTable) u64 {
         var mask: u64 = 0;
         for (self.entries) |entry| {
@@ -649,6 +655,15 @@ pub const Mapper = struct {
                 .chord => {},
                 .gesture => |node| {
                     if (pressed != prev_pressed) {
+                        // A delayed virtual tap from this source may still be
+                        // active when a rapid second physical press arrives.
+                        // End it now so the next tap gets its own release/press
+                        // edges instead of merging both clicks into one hold.
+                        if (pressed) {
+                            if (self.gesture_gamepad_tap_release_tokens.takeSource(@intCast(i))) |prior| {
+                                self.timer_queue.cancel(prior.token, now_ns);
+                            }
+                        }
                         const out = self.gesture_engine.onButtonEdge(@intCast(i), node, pressed, now_ns);
                         self.applyGestureOutcome(@intCast(i), out, &aux, false, now_ns);
                     }

--- a/src/test/mapper_e2e_test.zig
+++ b/src/test/mapper_e2e_test.zig
@@ -1010,6 +1010,45 @@ test "e2e gesture: timer-context gamepad tap stages full press one frame before 
     try testing.expectEqual(@as(u64, 0), ev2.gamepad.buttons & btnMask(.B));
 }
 
+test "e2e gesture issue 492: rapid repeated stick-click taps keep distinct edges" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\LS = { tap = "LS", hold = "KEY_Z" }
+        \\RS = { tap = "RS", hold = "KEY_Z" }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    for ([_]ButtonId{ .LS, .RS }, 0..) |button, iteration| {
+        const t0: i128 = 1_000_000_000 + @as(i128, @intCast(iteration)) * 100 * std.time.ns_per_ms;
+        const mask = btnMask(button);
+
+        // First physical click resolves to a virtual stick-click press.
+        _ = try m.apply(.{ .buttons = mask }, 16, t0);
+        const first_tap = try m.apply(.{ .buttons = 0 }, 16, t0 + 10 * std.time.ns_per_ms);
+        try testing.expectEqual(mask, first_tap.gamepad.buttons & mask);
+
+        // A second physical click starts before the first tap's minimum pulse
+        // has elapsed. It must end the first virtual click so consumers observe
+        // a release edge before the second virtual press; otherwise both
+        // physical clicks collapse into one long virtual press.
+        const second_press = try m.apply(.{ .buttons = mask }, 16, t0 + 20 * std.time.ns_per_ms);
+        try testing.expectEqual(@as(u64, 0), second_press.gamepad.buttons & mask);
+
+        const second_tap = try m.apply(.{ .buttons = 0 }, 16, t0 + 25 * std.time.ns_per_ms);
+        try testing.expectEqual(mask, second_tap.gamepad.buttons & mask);
+
+        // The cancelled first deadline must not release the second tap early.
+        const stale_release = m.onMacroTimerExpiredEvents(t0 + 41 * std.time.ns_per_ms);
+        try testing.expect(stale_release.gamepad == null);
+
+        const final_release = m.onMacroTimerExpiredEvents(t0 + 60 * std.time.ns_per_ms);
+        try testing.expect(final_release.gamepad != null);
+        try testing.expectEqual(@as(u64, 0), final_release.gamepad.?.buttons & mask);
+    }
+}
+
 test "e2e gesture back-compat: plain string remap A=KEY_F13 unchanged (immediate edge)" {
     const allocator = testing.allocator;
     var ctx = try makeMapper(


### PR DESCRIPTION
## Summary

- end an active delayed gamepad tap when the same physical gesture source starts a new press
- preserve a release edge between rapid LS/RS taps instead of merging them into one virtual hold
- cancel the replaced timer token so its stale deadline cannot release the newer tap

## Reproduction

On current `main`, two taps from the same stick-click source within the delayed tap window produce this virtual sequence:

`press -> pressed -> release`

The new regression test requires distinct edges:

`press -> release -> press -> release`

Before the implementation change, the test failed with virtual LS still set (`expected 0, found 4096`) on the second physical press.

## Review evidence

- behavior review: both LS and RS preserve distinct virtual edges
- timer/state review: the first release token is cancelled and its stale deadline is inert
- compatibility review: tap/hold/double and layer gesture coverage remains green

## Verification

- focused #492 regression: 4/4 passed
- all gesture tests: 42/42 passed
- full Docker suite: 1988/1999 passed, 11 environment-gated skipped
- Docker TSAN suite: 1984/1995 passed, 11 environment-gated skipped
- `zig fmt --check` and `git diff --check` passed

Related issue: #492. Keep the issue open for reporter verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rapid repeated gesture taps so each physical press is handled as a distinct tap.
  * Prevented overlapping tap-release timers from merging inputs or generating stray gamepad events.
  * Ensured canceled tap deadlines no longer produce unexpected releases or leave buttons stuck.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->