### PR TITLE
feat(diagnostics): trace input gesture output edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ padctl is a userspace daemon that maps vendor-specific USB/HID gamepad reports t
 - **Runtime mapping switch** — `padctl switch <name>` changes profiles without restart
 - **Persistent mapping** — `padctl install --mapping <name>` writes a device binding to `/etc/padctl/config.toml` that auto-applies on every boot
 - **User config** — `~/.config/padctl/config.toml` for per-device default mappings (system fallback: `/etc/padctl/config.toml`)
-- **Opt-in diagnostic logging** — `padctl dump enable` turns on a general-purpose, togglable file logger so users can produce a structured log for any class of bug report (force-feedback, input, mapping, hotplug, …). Today it is wired deepest into the rumble/HID path; more subsystems will be instrumented over time. Rotated, bounded on disk, and zero overhead when disabled (default)
+- **Opt-in diagnostic logging** — `padctl dump enable` turns on a general-purpose, togglable file logger so users can produce a structured log for any class of bug report (force-feedback, input, mapping, hotplug, …). It covers the rumble/HID path plus button input edges, gesture decisions, and virtual button output edges; more subsystems will be instrumented over time. Rotated, bounded on disk, and no hot-path formatting when disabled (default)
 - **CLI tools** — `padctl status`, `padctl devices`, `padctl list-mappings`, `padctl output-profile list/select/reset`, `padctl config init/edit/test`, `padctl dump enable/disable/status/export/clear`
 
 ## Architecture

--- a/docs/src/diagnostic-logging.md
+++ b/docs/src/diagnostic-logging.md
@@ -2,7 +2,12 @@
 
 padctl ships with a general-purpose, togglable file logger. It is designed to be the single mechanism you reach for when diagnosing **any** class of bug — stuck rumble, input drops, mapping misses, hotplug oddities, daemon crashes — so that reports come with structured evidence instead of guesswork.
 
-It is **off by default** and has no hot-path cost when disabled. The current build already emits a very detailed trace of the force-feedback pipeline; other subsystems (input routing, layer/remap decisions, hotplug, config reload, …) will be instrumented behind the same switch over time. The user-facing contract — enable, reproduce, export, attach — stays the same as more coverage is added.
+It is **off by default** and has no hot-path formatting cost when disabled. The
+current build emits a detailed trace of the force-feedback pipeline plus button
+input edges, gesture decisions, and virtual button output edges; other
+subsystems (non-gesture layer/remap decisions, hotplug, config reload, …) will
+be instrumented behind the same switch over time. The user-facing contract —
+enable, reproduce, export, attach — stays the same as more coverage is added.
 
 ## Quick workflow
 
@@ -111,6 +116,15 @@ When `dump = false` (the default), only warnings and errors are written, and onl
 When `dump = true`, padctl adds verbose tracing on top. The coverage today is deepest in the force-feedback pipeline — that is the area where the logger was needed first — and is being expanded to other subsystems as issues surface. Current coverage:
 
 - **Session lifecycle** — daemon start, config loaded, devices attached/detached
+- **Button input edges** — the changed decoded button mask and the bounded raw
+  controller report that produced it (`INPUT_EDGE`); axis/IMU-only frames are
+  intentionally omitted so high-rate devices do not flood the dump
+- **Gesture decisions** — physical source edge and press duration, timer
+  arm/cancel, emitted action and target, and hold/double timer expiry
+  (`GESTURE_EDGE`, `GESTURE_EMIT`, `GESTURE_TIMER`)
+- **Virtual button output edges** — the changed mapped button mask and whether
+  it came from physical input, the layer timer, or the shared macro/gesture
+  timer (`OUTPUT_EDGE`)
 - **FF_UPLOAD / FF_ERASE** kernel requests with effect IDs, rumble magnitudes, and replay durations
 - **EV_FF PLAY / STOP** events with scheduler decisions (forwarded, throttled, auto-stop timer armed, etc.)
 - **HID rumble frames** written to the physical device, with the first 16 bytes hex-dumped so post-checksum data can be inspected
@@ -118,7 +132,9 @@ When `dump = true`, padctl adds verbose tracing on top. The coverage today is de
 - **Rumble write recovery** — retry attempts, retry-limit exhaustion, and whether the input loop stayed alive after a non-disconnect write failure
 - **Hotplug/rebind rumble quiesce** — detach, init, re-init, and neutral rumble frames emitted after a fresh physical fd is bound
 
-Planned areas (no promised order): input-report parsing, layer/remap resolution, hotplug/netlink events, config reload, IPC commands. You can track progress on these in the repo issue tracker.
+Planned areas (no promised order): axis/IMU input tracing, non-gesture layer/remap
+resolution, hotplug/netlink events, config reload, IPC commands. You can track
+progress on these in the repo issue tracker.
 
 ## Reporting issues
 
@@ -132,6 +148,11 @@ padctl dump disable
 ```
 
 Attach `issue.log`. Sensitive information in the logs is limited to device names, USB identifiers, and input report bytes — there is no keystroke capture or payload from other applications.
+
+For button or gesture reports, the most useful lines are `INPUT_EDGE`,
+`GESTURE_EDGE`, `GESTURE_EMIT`, `GESTURE_TIMER`, and `OUTPUT_EDGE`. Their
+monotonic timestamps let maintainers follow one physical edge through the
+gesture decision and into the virtual device.
 
 For stuck-rumble reports, also attach `padctl doctor` output and note the game
 action that produced the rumble. The most useful lines are `FF_PLAY`,

--- a/src/core/gesture.zig
+++ b/src/core/gesture.zig
@@ -70,6 +70,14 @@ pub const GestureEngine = struct {
         return null;
     }
 
+    /// Diagnostic-only timing lookup. The mapper samples this immediately
+    /// before a release edge so dump logs can show the physical press length
+    /// that selected tap versus hold.
+    pub fn pressStartedAt(self: *GestureEngine, src_idx: u6) ?i128 {
+        const slot = self.findSlot(src_idx) orelse return null;
+        return if (slot.phase == .idle) null else slot.press_ns;
+    }
+
     fn acquireSlot(self: *GestureEngine, src_idx: u6, gesture: *const ResolvedGesture) ?*Slot {
         if (self.findSlot(src_idx)) |s| return s;
         for (&self.slots) |*maybe| {
@@ -222,6 +230,23 @@ test "gesture: tap-only emits tap on release" {
     try testing.expectEqual(@as(usize, 1), o_rel.emit_len);
     try testing.expectEqual(EmitAction.tap, o_rel.slice()[0].action);
     try testing.expectEqual(key("KEY_X").key, o_rel.slice()[0].target.key);
+}
+
+test "gesture: diagnostic press start is present only while a gesture is active" {
+    var g = ResolvedGesture{
+        .tap = key("KEY_X"),
+        .hold = null,
+        .double = null,
+        .hold_ns = 300 * ns_ms,
+        .double_ns = 250 * ns_ms,
+        .has_double = false,
+    };
+    var e = GestureEngine{};
+    try testing.expectEqual(@as(?i128, null), e.pressStartedAt(0));
+    _ = e.onButtonEdge(0, &g, true, 123 * ns_ms);
+    try testing.expectEqual(@as(?i128, 123 * ns_ms), e.pressStartedAt(0));
+    _ = e.onButtonEdge(0, &g, false, 180 * ns_ms);
+    try testing.expectEqual(@as(?i128, null), e.pressStartedAt(0));
 }
 
 test "gesture: hold fires at deadline while still held, then release on button up" {

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -20,6 +20,7 @@ const REL_HWHEEL: u16 = c.REL_HWHEEL;
 const remap_mod = @import("remap.zig");
 const gesture_mod = @import("gesture.zig");
 const chord_detector_mod = @import("chord_detector.zig");
+const input_trace = @import("../diagnostics/input_trace.zig");
 pub const RemapTargetResolved = remap_mod.RemapTargetResolved;
 pub const resolveTarget = remap_mod.resolveTarget;
 pub const AuxEvent = aux_event_mod.AuxEvent;
@@ -664,8 +665,26 @@ pub const Mapper = struct {
                                 self.timer_queue.cancel(prior.token, now_ns);
                             }
                         }
-                        const out = self.gesture_engine.onButtonEdge(@intCast(i), node, pressed, now_ns);
-                        self.applyGestureOutcome(@intCast(i), out, &aux, false, now_ns);
+                        const src_idx: u6 = @intCast(i);
+                        const trace_enabled = input_trace.enabled();
+                        const press_started_ns = if (trace_enabled and !pressed) self.gesture_engine.pressStartedAt(src_idx) else null;
+                        const out = self.gesture_engine.onButtonEdge(src_idx, node, pressed, now_ns);
+                        if (trace_enabled) {
+                            const arm_leg = if (out.arm) |a| @tagName(a.leg) else "none";
+                            const arm_deadline_ns = if (out.arm) |a| a.deadline_ns else @as(i128, 0);
+                            input_trace.logGestureEdge(
+                                buttonNameFromIndex(@intCast(i)),
+                                pressed,
+                                now_ns,
+                                if (press_started_ns) |start| @max(now_ns - start, 0) else 0,
+                                out.emit_len,
+                                arm_leg,
+                                arm_deadline_ns,
+                                out.cancel_hold,
+                                out.cancel_double,
+                            );
+                        }
+                        self.applyGestureOutcome(src_idx, out, &aux, false, now_ns);
                     }
                 },
             }
@@ -1059,6 +1078,16 @@ pub const Mapper = struct {
             }
         }
         for (out.slice()) |em| {
+            if (input_trace.enabled()) {
+                var target_buf: [64]u8 = undefined;
+                input_trace.logGestureEmit(
+                    buttonNameFromIndex(src_idx),
+                    @tagName(em.action),
+                    gestureTargetTraceLabel(em.target, &target_buf),
+                    from_timer,
+                    now_ns,
+                );
+            }
             switch (em.target) {
                 .gamepad_button => |dst| {
                     const mask = @as(u64, 1) << @as(u6, @intCast(@intFromEnum(dst)));
@@ -1135,6 +1164,13 @@ pub const Mapper = struct {
                 const src_bit = @as(u64, 1) << ge.src_idx;
                 const held = (self.state.buttons & src_bit) != 0;
                 const out = self.gesture_engine.onTimerExpired(ge.src_idx, ge.leg, held, now_ns);
+                input_trace.logGestureTimer(
+                    buttonNameFromIndex(ge.src_idx),
+                    @tagName(ge.leg),
+                    held,
+                    out.emit_len,
+                    now_ns,
+                );
                 self.applyGestureOutcome(ge.src_idx, out, &events.aux, true, now_ns);
                 continue;
             }
@@ -1267,6 +1303,23 @@ fn resolveStickConfig(mc: *const mapping.StickConfig) stick.StickConfig {
         .deadzone = if (mc.deadzone) |v| @intCast(v) else if (std.mem.eql(u8, mode, "gamepad")) 0 else 128,
         .sensitivity = if (mc.sensitivity) |v| @floatCast(v) else 1.0,
         .suppress_gamepad = mc.suppress_gamepad orelse false,
+    };
+}
+
+fn buttonNameFromIndex(idx: u6) []const u8 {
+    const button: ButtonId = @enumFromInt(idx);
+    return @tagName(button);
+}
+
+fn gestureTargetTraceLabel(target: RemapTargetResolved, buf: *[64]u8) []const u8 {
+    return switch (target) {
+        .gamepad_button => |button| std.fmt.bufPrint(buf, "gamepad:{s}", .{@tagName(button)}) catch "gamepad:?",
+        .key => |code| std.fmt.bufPrint(buf, "key:{d}", .{code}) catch "key:?",
+        .mouse_button => |code| std.fmt.bufPrint(buf, "mouse:{d}", .{code}) catch "mouse:?",
+        .disabled => "disabled",
+        .macro => |name| std.fmt.bufPrint(buf, "macro:{s}", .{name}) catch "macro:?",
+        .chord => "chord",
+        .gesture => "gesture",
     };
 }
 

--- a/src/diagnostics/input_trace.zig
+++ b/src/diagnostics/input_trace.zig
@@ -1,0 +1,133 @@
+const std = @import("std");
+const padctl_log = @import("../log.zig");
+
+const input_log = std.log.scoped(.input);
+const gesture_log = std.log.scoped(.gesture);
+
+/// Button reports are the useful unit for mapping diagnostics. Logging every
+/// axis/IMU report would rotate a 100 MiB dump in minutes on high-rate pads.
+pub const MAX_RAW_BYTES: usize = 64;
+
+pub fn enabled() bool {
+    return padctl_log.shouldWriteToFile(.debug);
+}
+
+pub fn isButtonEdge(before: u64, after: u64) bool {
+    return before != after;
+}
+
+fn rawHex(raw: []const u8, buf: *[MAX_RAW_BYTES * 2]u8) []const u8 {
+    const hex = "0123456789abcdef";
+    const n: usize = @min(raw.len, MAX_RAW_BYTES);
+    for (raw[0..n], 0..) |byte, i| {
+        buf[i * 2] = hex[byte >> 4];
+        buf[i * 2 + 1] = hex[byte & 0x0f];
+    }
+    return buf[0 .. n * 2];
+}
+
+/// Physical layer: raw report bytes plus the decoded button transition. This
+/// deliberately fires only when the decoded button mask changes.
+pub fn logInputEdge(
+    device_tag: []const u8,
+    interface_id: u8,
+    before: u64,
+    after: u64,
+    raw: []const u8,
+    now_ns: i128,
+) void {
+    if (!isButtonEdge(before, after) or !enabled()) return;
+    var hex_buf: [MAX_RAW_BYTES * 2]u8 = undefined;
+    const encoded = rawHex(raw, &hex_buf);
+    input_log.debug(
+        "[{s}] INPUT_EDGE now_ns={d} iface={d} changed=0x{x:0>16} buttons=0x{x:0>16} raw={s}{s}",
+        .{ device_tag, now_ns, interface_id, before ^ after, after, encoded, if (raw.len > MAX_RAW_BYTES) "..." else "" },
+    );
+}
+
+/// Virtual layer: log only output button transitions, not axis-only frames.
+pub fn logOutputEdge(
+    device_tag: []const u8,
+    cause: []const u8,
+    before: u64,
+    after: u64,
+    now_ns: i128,
+) void {
+    if (!isButtonEdge(before, after) or !enabled()) return;
+    input_log.debug(
+        "[{s}] OUTPUT_EDGE now_ns={d} cause={s} changed=0x{x:0>16} buttons=0x{x:0>16}",
+        .{ device_tag, now_ns, cause, before ^ after, after },
+    );
+}
+
+/// Gesture layer: one line for each physical edge and the state-machine result.
+pub fn logGestureEdge(
+    source: []const u8,
+    pressed: bool,
+    now_ns: i128,
+    elapsed_ns: i128,
+    emit_len: usize,
+    arm_leg: []const u8,
+    arm_deadline_ns: i128,
+    cancel_hold: bool,
+    cancel_double: bool,
+) void {
+    if (!enabled()) return;
+    gesture_log.debug(
+        "GESTURE_EDGE source={s} edge={s} now_ns={d} elapsed_ns={d} emits={d} arm={s} deadline_ns={d} cancel_hold={} cancel_double={}",
+        .{ source, if (pressed) "down" else "up", now_ns, elapsed_ns, emit_len, arm_leg, arm_deadline_ns, cancel_hold, cancel_double },
+    );
+}
+
+pub fn logGestureEmit(
+    source: []const u8,
+    action: []const u8,
+    target: []const u8,
+    from_timer: bool,
+    now_ns: i128,
+) void {
+    if (!enabled()) return;
+    gesture_log.debug(
+        "GESTURE_EMIT source={s} action={s} target={s} origin={s} now_ns={d}",
+        .{ source, action, target, if (from_timer) "timer" else "edge", now_ns },
+    );
+}
+
+pub fn logGestureTimer(
+    source: []const u8,
+    leg: []const u8,
+    held: bool,
+    emit_len: usize,
+    now_ns: i128,
+) void {
+    if (!enabled()) return;
+    gesture_log.debug(
+        "GESTURE_TIMER source={s} leg={s} held={} emits={d} now_ns={d}",
+        .{ source, leg, held, emit_len, now_ns },
+    );
+}
+
+test "input trace: button-edge filter ignores axis-only reports" {
+    try std.testing.expect(!isButtonEdge(0, 0));
+    try std.testing.expect(isButtonEdge(0, @as(u64, 1) << 14));
+    try std.testing.expect(isButtonEdge(@as(u64, 1) << 15, 0));
+}
+
+test "input trace: raw hex is exact and bounded" {
+    var buf: [MAX_RAW_BYTES * 2]u8 = undefined;
+    try std.testing.expectEqualStrings("5aa5ef00", rawHex(&.{ 0x5a, 0xa5, 0xef, 0x00 }, &buf));
+
+    var oversized: [MAX_RAW_BYTES + 7]u8 = undefined;
+    @memset(&oversized, 0xab);
+    const got = rawHex(&oversized, &buf);
+    try std.testing.expectEqual(MAX_RAW_BYTES * 2, got.len);
+    try std.testing.expectEqualStrings("ab", got[got.len - 2 ..]);
+}
+
+test "input trace: debug diagnostics are gated by dump" {
+    padctl_log.setEnabled(false);
+    try std.testing.expect(!enabled());
+    padctl_log.setEnabled(true);
+    defer padctl_log.setEnabled(false);
+    try std.testing.expect(enabled());
+}

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -6,6 +6,7 @@ const DeviceIO = @import("io/device_io.zig").DeviceIO;
 const interpreter_mod = @import("core/interpreter.zig");
 const Interpreter = interpreter_mod.Interpreter;
 const OutputDevice = @import("io/uinput.zig").OutputDevice;
+const OutputEmitError = @import("io/uinput.zig").EmitError;
 const AuxOutputDevice = @import("io/uinput.zig").AuxOutputDevice;
 const TouchpadOutputDevice = @import("io/uinput.zig").TouchpadOutputDevice;
 const generic = @import("core/generic.zig");
@@ -28,6 +29,7 @@ const rumble_scheduler_mod = @import("core/rumble_scheduler.zig");
 const RumbleScheduler = rumble_scheduler_mod.RumbleScheduler;
 const rumble_log = std.log.scoped(.rumble);
 const padctl_log = @import("log.zig");
+const input_trace = @import("diagnostics/input_trace.zig");
 const socket_client = @import("cli/socket_client.zig");
 const uhid_mod = @import("io/uhid.zig");
 pub const UhidDevice = uhid_mod.UhidDevice;
@@ -441,6 +443,9 @@ pub const EventLoop = struct {
     pending_rumble_deadline_ns: ?i128,
     pending_rumble_retry_count: u8,
     last_heartbeat_ns: i128 = 0,
+    /// Last successfully emitted virtual button mask. Diagnostic tracing uses
+    /// it to log output edges without flooding dumps with axis-only frames.
+    diagnostic_output_buttons: u64 = 0,
 
     pub fn init() !EventLoop {
         var mask = posix.sigemptyset();
@@ -528,6 +533,24 @@ pub const EventLoop = struct {
         self.pollfds[slot] = device.pollfd();
         self.device_count += 1;
         self.fd_count += 1;
+    }
+
+    fn emitGamepadOutput(
+        self: *EventLoop,
+        ctx: EventLoopContext,
+        gamepad: state.GamepadState,
+        now_ns: i128,
+        cause: []const u8,
+    ) OutputEmitError!void {
+        try ctx.output.emit(gamepad);
+        input_trace.logOutputEdge(
+            ctx.device_tag,
+            cause,
+            self.diagnostic_output_buttons,
+            gamepad.buttons,
+            now_ns,
+        );
+        self.diagnostic_output_buttons = gamepad.buttons;
     }
 
     /// Replace pollfd entries for device slots with fds from new DeviceIO
@@ -832,7 +855,16 @@ pub const EventLoop = struct {
                             break :blk ctx.interpreter.processReport(interface_id, buf[0..n]) catch null;
                         };
                         if (maybe_delta) |delta| {
+                            const input_buttons_before = self.gamepad_state.buttons;
                             self.gamepad_state.applyDelta(delta);
+                            input_trace.logInputEdge(
+                                ctx.device_tag,
+                                interface_id,
+                                input_buttons_before,
+                                self.gamepad_state.buttons,
+                                buf[0..n],
+                                now,
+                            );
 
                             if (ctx.mapper) |m| {
                                 const events = m.apply(delta, dt_ms, now) catch |err| {
@@ -844,7 +876,7 @@ pub const EventLoop = struct {
                                     .disarm => disarmTimer(self.timer_fd),
                                 };
                                 if (events.chord_switch_request) |idx| dispatchChordSwitch(idx);
-                                ctx.output.emit(events.gamepad) catch |err| {
+                                self.emitGamepadOutput(ctx, events.gamepad, now, "input") catch |err| {
                                     std.log.err("output.emit failed: {}", .{err});
                                     continue;
                                 };
@@ -859,7 +891,7 @@ pub const EventLoop = struct {
                                 }
                             } else {
                                 self.gamepad_state.synthesizeDpadAxes();
-                                ctx.output.emit(self.gamepad_state) catch |err| {
+                                self.emitGamepadOutput(ctx, self.gamepad_state, now, "input") catch |err| {
                                     std.log.err("output.emit failed: {}", .{err});
                                     continue;
                                 };
@@ -1043,7 +1075,7 @@ pub const EventLoop = struct {
                 if (ctx.mapper) |m| {
                     const events = m.onLayerTimerExpiredAt(now);
                     if (events.gamepad) |gamepad| {
-                        ctx.output.emit(gamepad) catch |err| {
+                        self.emitGamepadOutput(ctx, gamepad, now, "layer_timer") catch |err| {
                             std.log.err("output.emit failed: {}", .{err});
                         };
                     }
@@ -1063,7 +1095,7 @@ pub const EventLoop = struct {
                 if (ctx.mapper) |m| {
                     const events = m.onMacroTimerExpiredEvents(now);
                     if (events.gamepad) |gamepad| {
-                        ctx.output.emit(gamepad) catch |err| {
+                        self.emitGamepadOutput(ctx, gamepad, now, "macro_timer") catch |err| {
                             std.log.err("output.emit failed: {}", .{err});
                         };
                     }

--- a/src/test/interpreter_e2e_test.zig
+++ b/src/test/interpreter_e2e_test.zig
@@ -148,6 +148,7 @@ fn makeVader5ButtonFrame(buttons: u32) [32]u8 {
 const StreamingDeviceIO = struct {
     read_fd: std.posix.fd_t,
     write_fd: std.posix.fd_t,
+    read_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
 
     fn init() !StreamingDeviceIO {
         var fds: [2]std.posix.fd_t = undefined;
@@ -175,6 +176,10 @@ const StreamingDeviceIO = struct {
         return .{ .ptr = self, .vtable = &vtable };
     }
 
+    fn framesRead(self: *const StreamingDeviceIO) usize {
+        return self.read_count.load(.acquire);
+    }
+
     const vtable = DeviceIO.VTable{
         .read = read,
         .write = write,
@@ -185,11 +190,13 @@ const StreamingDeviceIO = struct {
 
     fn read(ptr: *anyopaque, buf: []u8) DeviceIO.ReadError!usize {
         const self: *StreamingDeviceIO = @ptrCast(@alignCast(ptr));
-        return std.posix.read(self.read_fd, buf) catch |err| switch (err) {
-            error.WouldBlock => DeviceIO.ReadError.Again,
-            error.ConnectionResetByPeer => DeviceIO.ReadError.Disconnected,
-            else => DeviceIO.ReadError.Io,
+        const n = std.posix.read(self.read_fd, buf) catch |err| switch (err) {
+            error.WouldBlock => return DeviceIO.ReadError.Again,
+            error.ConnectionResetByPeer => return DeviceIO.ReadError.Disconnected,
+            else => return DeviceIO.ReadError.Io,
         };
+        if (n != 0) _ = self.read_count.fetchAdd(1, .release);
+        return n;
     }
 
     fn write(_: *anyopaque, _: []const u8) DeviceIO.WriteError!void {}
@@ -200,6 +207,68 @@ const StreamingDeviceIO = struct {
     }
     fn close(_: *anyopaque) void {}
 };
+
+const GestureEdgeOutput = struct {
+    allocator: std.mem.Allocator,
+    emitted: std.ArrayList(GamepadState),
+    prev: GamepadState = .{},
+    rises: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    falls: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    fn init(allocator: std.mem.Allocator) GestureEdgeOutput {
+        return .{ .allocator = allocator, .emitted = .{} };
+    }
+
+    fn deinit(self: *GestureEdgeOutput) void {
+        self.emitted.deinit(self.allocator);
+    }
+
+    fn outputDevice(self: *GestureEdgeOutput) uinput.OutputDevice {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    fn observed(self: *const GestureEdgeOutput, mask: u64) bool {
+        return self.rises.load(.acquire) & mask != 0 and
+            self.falls.load(.acquire) & mask != 0;
+    }
+
+    const vtable = uinput.OutputDevice.VTable{
+        .emit = emit,
+        .poll_ff = pollFf,
+        .close = close,
+    };
+
+    fn emit(ptr: *anyopaque, current: GamepadState) uinput.EmitError!void {
+        const self: *GestureEdgeOutput = @ptrCast(@alignCast(ptr));
+        const previous_buttons = self.prev.buttons;
+        self.emitted.append(self.allocator, current) catch return error.WriteFailed;
+        self.prev = current;
+        _ = self.rises.fetchOr(~previous_buttons & current.buttons, .release);
+        _ = self.falls.fetchOr(previous_buttons & ~current.buttons, .release);
+    }
+
+    fn pollFf(_: *anyopaque) uinput.PollFfError!?uinput.FfEvent {
+        return null;
+    }
+
+    fn close(_: *anyopaque) void {}
+};
+
+fn waitForFrames(stream: *const StreamingDeviceIO, expected: usize) !void {
+    for (0..1000) |_| {
+        if (stream.framesRead() >= expected) return;
+        std.Thread.sleep(std.time.ns_per_ms);
+    }
+    return error.Timeout;
+}
+
+fn waitForGestureEdges(output: *const GestureEdgeOutput, mask: u64) !void {
+    for (0..1000) |_| {
+        if (output.observed(mask)) return;
+        std.Thread.sleep(std.time.ns_per_ms);
+    }
+    return error.Timeout;
+}
 
 test "EventLoop pipeline: A press then release" {
     const allocator = testing.allocator;
@@ -277,14 +346,14 @@ test "EventLoop diagnostics issue 492: Vader5 LS and RS gesture taps keep full o
 
     const parsed_mapping = try mapping_mod.parseString(allocator,
         \\[remap]
-        \\LS = { tap = "LS", hold = "KEY_Z" }
-        \\RS = { tap = "RS", hold = "KEY_Z" }
+        \\LS = { tap = "LS", hold = "KEY_Z", hold_ms = 1000 }
+        \\RS = { tap = "RS", hold = "KEY_Z", hold_ms = 1000 }
     );
     defer parsed_mapping.deinit();
     var mapper = try Mapper.init(&parsed_mapping.value, loop.macro_timer_fd, allocator);
     defer mapper.deinit();
 
-    var out = MockOutput.init(allocator);
+    var out = GestureEdgeOutput.init(allocator);
     defer out.deinit();
 
     var devs = [_]DeviceIO{dev};
@@ -328,22 +397,24 @@ test "EventLoop diagnostics issue 492: Vader5 LS and RS gesture taps keep full o
     const idle = makeVader5ButtonFrame(0);
     const ls_down = makeVader5ButtonFrame(ls_raw_bit);
     const rs_down = makeVader5ButtonFrame(rs_raw_bit);
+    const ls_mask = @as(u64, 1) << @intFromEnum(ButtonId.LS);
+    const rs_mask = @as(u64, 1) << @intFromEnum(ButtonId.RS);
 
     try stream.send(&ls_down);
-    std.Thread.sleep(10 * std.time.ns_per_ms);
+    try waitForFrames(&stream, 1);
     try stream.send(&idle);
-    std.Thread.sleep(100 * std.time.ns_per_ms);
+    try waitForFrames(&stream, 2);
+    try waitForGestureEdges(&out, ls_mask);
     try stream.send(&rs_down);
-    std.Thread.sleep(10 * std.time.ns_per_ms);
+    try waitForFrames(&stream, 3);
     try stream.send(&idle);
-    std.Thread.sleep(100 * std.time.ns_per_ms);
+    try waitForFrames(&stream, 4);
+    try waitForGestureEdges(&out, rs_mask);
 
     loop.stop();
     thread.join();
     thread_joined = true;
 
-    const ls_mask = @as(u64, 1) << @intFromEnum(ButtonId.LS);
-    const rs_mask = @as(u64, 1) << @intFromEnum(ButtonId.RS);
     var ls_rises: usize = 0;
     var ls_falls: usize = 0;
     var rs_rises: usize = 0;

--- a/src/test/interpreter_e2e_test.zig
+++ b/src/test/interpreter_e2e_test.zig
@@ -9,6 +9,9 @@ const MockDeviceIO = @import("mock_device_io.zig").MockDeviceIO;
 const EventLoop = @import("../event_loop.zig").EventLoop;
 const EventLoopContext = @import("../event_loop.zig").EventLoopContext;
 const DeviceIO = @import("../io/device_io.zig").DeviceIO;
+const mapping_mod = @import("../config/mapping.zig");
+const Mapper = @import("../core/mapper.zig").Mapper;
+const padctl_log = @import("../log.zig");
 
 const Interpreter = interpreter_mod.Interpreter;
 const GamepadState = state_mod.GamepadState;
@@ -133,6 +136,71 @@ fn makeFrame(left_x: i16, left_y_raw: i16, buttons_byte: u8, lt: u8) [32]u8 {
     return raw;
 }
 
+fn makeVader5ButtonFrame(buttons: u32) [32]u8 {
+    var raw = [_]u8{0} ** 32;
+    raw[0] = 0x5a;
+    raw[1] = 0xa5;
+    raw[2] = 0xef;
+    std.mem.writeInt(u32, raw[11..15], buttons, .little);
+    return raw;
+}
+
+const StreamingDeviceIO = struct {
+    read_fd: std.posix.fd_t,
+    write_fd: std.posix.fd_t,
+
+    fn init() !StreamingDeviceIO {
+        var fds: [2]std.posix.fd_t = undefined;
+        const rc = std.os.linux.socketpair(
+            std.os.linux.AF.UNIX,
+            std.os.linux.SOCK.SEQPACKET | std.os.linux.SOCK.NONBLOCK,
+            0,
+            &fds,
+        );
+        if (rc != 0) return error.SocketPairFailed;
+        return .{ .read_fd = fds[0], .write_fd = fds[1] };
+    }
+
+    fn deinit(self: *StreamingDeviceIO) void {
+        std.posix.close(self.read_fd);
+        std.posix.close(self.write_fd);
+    }
+
+    fn send(self: *StreamingDeviceIO, frame: []const u8) !void {
+        const written = try std.posix.write(self.write_fd, frame);
+        if (written != frame.len) return error.ShortWrite;
+    }
+
+    fn deviceIO(self: *StreamingDeviceIO) DeviceIO {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = DeviceIO.VTable{
+        .read = read,
+        .write = write,
+        .feature_report = featureReport,
+        .pollfd = pollfd,
+        .close = close,
+    };
+
+    fn read(ptr: *anyopaque, buf: []u8) DeviceIO.ReadError!usize {
+        const self: *StreamingDeviceIO = @ptrCast(@alignCast(ptr));
+        return std.posix.read(self.read_fd, buf) catch |err| switch (err) {
+            error.WouldBlock => DeviceIO.ReadError.Again,
+            error.ConnectionResetByPeer => DeviceIO.ReadError.Disconnected,
+            else => DeviceIO.ReadError.Io,
+        };
+    }
+
+    fn write(_: *anyopaque, _: []const u8) DeviceIO.WriteError!void {}
+    fn featureReport(_: *anyopaque, _: []const u8) DeviceIO.WriteError!void {}
+    fn pollfd(ptr: *anyopaque) std.posix.pollfd {
+        const self: *StreamingDeviceIO = @ptrCast(@alignCast(ptr));
+        return .{ .fd = self.read_fd, .events = std.posix.POLL.IN, .revents = 0 };
+    }
+    fn close(_: *anyopaque) void {}
+};
+
 test "EventLoop pipeline: A press then release" {
     const allocator = testing.allocator;
 
@@ -188,6 +256,111 @@ test "EventLoop pipeline: A press then release" {
     // Second diff: buttons changed, A released
     const d1_btns = out.diffs.items[1].buttons orelse return error.NoDiff;
     try testing.expect(d1_btns & a_mask == 0);
+}
+
+test "EventLoop diagnostics issue 492: Vader5 LS and RS gesture taps keep full output edges" {
+    const allocator = testing.allocator;
+    padctl_log.setEnabled(true);
+    defer padctl_log.setEnabled(false);
+
+    var stream = try StreamingDeviceIO.init();
+    defer stream.deinit();
+    const dev = stream.deviceIO();
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+    try loop.addDevice(dev);
+
+    const parsed_device = try device_mod.parseFile(allocator, "devices/flydigi/vader5.toml");
+    defer parsed_device.deinit();
+    const interp = Interpreter.init(&parsed_device.value);
+
+    const parsed_mapping = try mapping_mod.parseString(allocator,
+        \\[remap]
+        \\LS = { tap = "LS", hold = "KEY_Z" }
+        \\RS = { tap = "RS", hold = "KEY_Z" }
+    );
+    defer parsed_mapping.deinit();
+    var mapper = try Mapper.init(&parsed_mapping.value, loop.macro_timer_fd, allocator);
+    defer mapper.deinit();
+
+    var out = MockOutput.init(allocator);
+    defer out.deinit();
+
+    var devs = [_]DeviceIO{dev};
+    const RunCtx = struct {
+        loop: *EventLoop,
+        elc: EventLoopContext,
+    };
+    var ctx = RunCtx{
+        .loop = &loop,
+        .elc = .{
+            .devices = &devs,
+            .interpreter = &interp,
+            .output = out.outputDevice(),
+            .mapper = &mapper,
+            .device_config = &parsed_device.value,
+            .mapping_config = &parsed_mapping.value,
+            .poll_timeout_ms = 100,
+            .device_tag = "Vader5 diagnostics test",
+        },
+    };
+    const Runner = struct {
+        fn run(c: *RunCtx) !void {
+            try c.loop.run(c.elc);
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, Runner.run, .{&ctx});
+    var thread_joined = false;
+    defer if (!thread_joined) {
+        loop.stop();
+        thread.join();
+    };
+
+    var wait_count: usize = 0;
+    while (!@atomicLoad(bool, &loop.running, .acquire) and wait_count < 200) : (wait_count += 1) {
+        std.Thread.sleep(std.time.ns_per_ms);
+    }
+    try testing.expect(@atomicLoad(bool, &loop.running, .acquire));
+
+    const ls_raw_bit: u32 = @as(u32, 1) << 14;
+    const rs_raw_bit: u32 = @as(u32, 1) << 15;
+    const idle = makeVader5ButtonFrame(0);
+    const ls_down = makeVader5ButtonFrame(ls_raw_bit);
+    const rs_down = makeVader5ButtonFrame(rs_raw_bit);
+
+    try stream.send(&ls_down);
+    std.Thread.sleep(10 * std.time.ns_per_ms);
+    try stream.send(&idle);
+    std.Thread.sleep(100 * std.time.ns_per_ms);
+    try stream.send(&rs_down);
+    std.Thread.sleep(10 * std.time.ns_per_ms);
+    try stream.send(&idle);
+    std.Thread.sleep(100 * std.time.ns_per_ms);
+
+    loop.stop();
+    thread.join();
+    thread_joined = true;
+
+    const ls_mask = @as(u64, 1) << @intFromEnum(ButtonId.LS);
+    const rs_mask = @as(u64, 1) << @intFromEnum(ButtonId.RS);
+    var ls_rises: usize = 0;
+    var ls_falls: usize = 0;
+    var rs_rises: usize = 0;
+    var rs_falls: usize = 0;
+    var prev_buttons: u64 = 0;
+    for (out.emitted.items) |frame| {
+        if (prev_buttons & ls_mask == 0 and frame.buttons & ls_mask != 0) ls_rises += 1;
+        if (prev_buttons & ls_mask != 0 and frame.buttons & ls_mask == 0) ls_falls += 1;
+        if (prev_buttons & rs_mask == 0 and frame.buttons & rs_mask != 0) rs_rises += 1;
+        if (prev_buttons & rs_mask != 0 and frame.buttons & rs_mask == 0) rs_falls += 1;
+        prev_buttons = frame.buttons;
+    }
+
+    try testing.expectEqual(@as(usize, 1), ls_rises);
+    try testing.expectEqual(@as(usize, 1), ls_falls);
+    try testing.expectEqual(@as(usize, 1), rs_rises);
+    try testing.expectEqual(@as(usize, 1), rs_falls);
 }
 
 // --- Layer 2 (manual) ---

--- a/src/test/mapper_e2e_test.zig
+++ b/src/test/mapper_e2e_test.zig
@@ -1049,6 +1049,67 @@ test "e2e gesture issue 492: rapid repeated stick-click taps keep distinct edges
     }
 }
 
+test "e2e gesture issue 492: LS and RS duration sweep classifies every sub-threshold press as tap" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\LS = { tap = "LS", hold = "KEY_Z", hold_ms = 300 }
+        \\RS = { tap = "RS", hold = "KEY_Z", hold_ms = 300 }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    var now_ns: i128 = std.time.ns_per_s;
+    for ([_]ButtonId{ .LS, .RS }) |button| {
+        const mask = btnMask(button);
+        var duration_ms: u32 = 1;
+        while (duration_ms < 300) : (duration_ms += 1) {
+            const press = try m.apply(.{ .buttons = mask }, 16, now_ns);
+            try testing.expectEqual(@as(u64, 0), press.gamepad.buttons & mask);
+
+            const release_ns = now_ns + @as(i128, duration_ms) * std.time.ns_per_ms;
+            const release = try m.apply(.{ .buttons = 0 }, 16, release_ns);
+            try testing.expectEqual(mask, release.gamepad.buttons & mask);
+            try testing.expect(!auxHasAnyKey(release, keyCode("KEY_Z")));
+
+            const timer = m.onMacroTimerExpiredEvents(release_ns + 31 * std.time.ns_per_ms);
+            try testing.expect(timer.gamepad != null);
+            try testing.expectEqual(@as(u64, 0), timer.gamepad.?.buttons & mask);
+            try testing.expect(!auxListHasAnyKey(&timer.aux, keyCode("KEY_Z")));
+
+            now_ns = release_ns + 40 * std.time.ns_per_ms;
+        }
+    }
+}
+
+test "e2e gesture issue 492: LS and RS at hold deadline select KEY_Z and never tap" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\LS = { tap = "LS", hold = "KEY_Z", hold_ms = 300 }
+        \\RS = { tap = "RS", hold = "KEY_Z", hold_ms = 300 }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    var now_ns: i128 = std.time.ns_per_s;
+    for ([_]ButtonId{ .LS, .RS }) |button| {
+        const mask = btnMask(button);
+        _ = try m.apply(.{ .buttons = mask }, 16, now_ns);
+
+        const hold = m.onMacroTimerExpiredEvents(now_ns + 300 * std.time.ns_per_ms);
+        try testing.expect(hold.gamepad == null);
+        try testing.expect(auxListHasKey(&hold.aux, keyCode("KEY_Z"), true));
+
+        const release = try m.apply(.{ .buttons = 0 }, 16, now_ns + 301 * std.time.ns_per_ms);
+        try testing.expectEqual(@as(u64, 0), release.gamepad.buttons & mask);
+        try testing.expect(auxHasKey(release, keyCode("KEY_Z"), false));
+        try testing.expect(!auxHasKey(release, keyCode("KEY_Z"), true));
+
+        now_ns += 500 * std.time.ns_per_ms;
+    }
+}
+
 test "e2e gesture back-compat: plain string remap A=KEY_F13 unchanged (immediate edge)" {
     const allocator = testing.allocator;
     var ctx = try makeMapper(


### PR DESCRIPTION
## Summary

- add opt-in `INPUT_EDGE` traces with decoded button masks and bounded raw reports
- add `GESTURE_EDGE`, `GESTURE_EMIT`, and `GESTURE_TIMER` traces, including physical press duration
- add `OUTPUT_EDGE` traces after successful virtual button emission
- keep disabled-path formatting off and omit axis/IMU-only frames to bound overhead and log volume
- add a paced Vader 5 raw-report → interpreter → mapper → real timerfd → virtual-output regression
- sweep LS/RS press durations from 1–299 ms and pin the 300 ms hold boundary

## Context

This supplies the missing three-layer evidence needed to diagnose #492. It does not claim that the reporter's remaining ~40% registration issue is fixed; that issue should remain open while we collect a dump from affected hardware.

## Validation

- `test -Dtest-filter=gesture`: 44/44 passed
- `test -Dtest-filter="issue 492"`: 7/7 passed
- full `test`: 1993 passed, 11 environment-dependent skips
- focused `test-tsan -Dtest-filter=diagnostic`: 12/12 passed
- focused `test-safe -Dtest-filter=diagnostic`: 12/12 passed
- `zig fmt --check`, `git diff --check`, and `mdbook build`: passed

The full TSAN run reached 1980 passes and 11 skips, then an unrelated install test hit `DiskQuota` because the host `/tmp` tmpfs was full. No ThreadSanitizer report was emitted before that environmental failure; the changed diagnostic paths pass the focused TSAN suite.

Related: #492


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed diagnostic tracing for button inputs, gesture decisions, force-feedback processing, and virtual button outputs.
  - Diagnostic logs include bounded raw input data and timestamps to help trace events end to end.
  - Logging remains disabled by default and supports bounded, rotated disk output.

- **Bug Fixes**
  - Improved LS/RS gesture tap and hold handling, preserving complete button press and release output edges.

- **Documentation**
  - Expanded diagnostic logging guidance, coverage details, and troubleshooting recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->