### PR TITLE
fix(mapper): make gesture gamepad taps reliably observable

### DIFF
--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -70,6 +70,7 @@ const AuxDownTarget = union(enum) {
 };
 
 const AUX_TAP_RELEASE_DELAY_NS: i128 = 30 * std.time.ns_per_ms;
+const GAMEPAD_GESTURE_TAP_RELEASE_DELAY_NS: i128 = 120 * std.time.ns_per_ms;
 const AUX_TAP_RELEASE_TOKEN_SLOTS = BUTTON_COUNT;
 const GESTURE_TOKEN_SLOTS = gesture_mod.GESTURE_SLOTS * 2;
 
@@ -228,9 +229,6 @@ pub const Mapper = struct {
     macro_timer_tap_pending: u64,
     gesture_engine: gesture_mod.GestureEngine,
     gesture_tokens: GestureTokenTable,
-    // Same staging discipline as macro_timer_tap_pending: gamepad taps emitted
-    // from gesture timer expiry need one apply() to reach output.
-    gesture_timer_tap_pending: u64,
     // Gamepad bits held by an active gesture hold leg; re-asserted each frame
     // until the hold leg emits its release.
     gesture_held_gamepad: u64,
@@ -300,7 +298,6 @@ pub const Mapper = struct {
             .macro_timer_tap_pending = 0,
             .gesture_engine = .{},
             .gesture_tokens = .{},
-            .gesture_timer_tap_pending = 0,
             .gesture_held_gamepad = 0,
             .layer_held_gamepad = 0,
             .layer_hold_aux_down = null,
@@ -358,7 +355,6 @@ pub const Mapper = struct {
         self.macro_timer_tap_pending = 0;
         self.gesture_engine.reset();
         self.gesture_tokens.clear();
-        self.gesture_timer_tap_pending = 0;
         self.gesture_held_gamepad = 0;
         // callers must releaseMapperAux first; this only clears state, no release edge.
         self.layer_held_gamepad = 0;
@@ -473,14 +469,6 @@ pub const Mapper = struct {
             self.pending_tap_release = existing | self.macro_timer_tap_pending;
             self.macro_timer_tap_pending = 0;
             for (self.active_macros.items) |*p| p.staged_timer_taps = 0;
-        }
-
-        // Promote gesture-timer tap bits staged at last expiry.
-        if (self.gesture_timer_tap_pending != 0) {
-            self.injected_buttons |= self.gesture_timer_tap_pending;
-            const existing = self.pending_tap_release orelse 0;
-            self.pending_tap_release = existing | self.gesture_timer_tap_pending;
-            self.gesture_timer_tap_pending = 0;
         }
 
         // Suppress layer trigger buttons so they don't leak to uinput output.
@@ -684,7 +672,7 @@ pub const Mapper = struct {
                                 out.cancel_double,
                             );
                         }
-                        self.applyGestureOutcome(src_idx, out, &aux, false, now_ns);
+                        _ = self.applyGestureOutcome(src_idx, out, &aux, false, now_ns);
                     }
                 },
             }
@@ -899,10 +887,6 @@ pub const Mapper = struct {
         self.gesture_tokens.clear();
         self.gesture_engine.reset();
         self.gesture_held_gamepad = 0;
-        for (self.gesture_gamepad_tap_release_tokens.entries) |maybe| {
-            if (maybe) |e| self.timer_queue.cancel(e.token, now_ns);
-        }
-        self.gesture_gamepad_tap_release_tokens.clear();
         for (&self.gesture_aux_down_targets) |*target| {
             if (target.*) |down| {
                 emitAuxDownRelease(down, aux);
@@ -1050,10 +1034,9 @@ pub const Mapper = struct {
         return suppress;
     }
 
-    // Translate one gesture-engine Outcome into output. `from_timer` selects
-    // the gamepad-tap staging path: timer-context taps stage into
-    // gesture_timer_tap_pending so a full press is visible one frame before the
-    // release; apply-context taps use pending_tap_release directly.
+    // Translate one gesture-engine Outcome into output. Returns whether it
+    // changed gamepad state so timer-origin outcomes can emit a frame without
+    // waiting for another physical input report.
     fn applyGestureOutcome(
         self: *Mapper,
         src_idx: u6,
@@ -1061,7 +1044,8 @@ pub const Mapper = struct {
         aux: *AuxEventList,
         from_timer: bool,
         now_ns: i128,
-    ) void {
+    ) bool {
+        var gamepad_changed = false;
         if (out.cancel_hold or out.cancel_double) {
             // Tokens are matched by value at expiry; cancel both the queue
             // entry and the routing record so a stale expiry is inert.
@@ -1095,18 +1079,26 @@ pub const Mapper = struct {
                         .press => {
                             self.injected_buttons |= mask;
                             self.gesture_held_gamepad |= mask;
+                            gamepad_changed = true;
                         },
                         .release => {
                             self.injected_buttons &= ~mask;
                             self.gesture_held_gamepad &= ~mask;
+                            gamepad_changed = true;
                         },
-                        .tap => if (from_timer) {
-                            self.gesture_timer_tap_pending |= mask;
-                        } else {
-                            if (!emitDelayedGestureGamepadTap(self, src_idx, mask, now_ns)) {
+                        .tap => {
+                            if (emitDelayedGestureGamepadTap(self, src_idx, mask, now_ns)) {
+                                gamepad_changed = true;
+                            } else if (!from_timer) {
+                                // Preserve the existing one-frame fallback for
+                                // edge-origin taps if the release timer cannot
+                                // be armed. Timer-origin taps cannot safely use
+                                // that fallback because no later report is
+                                // guaranteed to emit their release.
                                 self.injected_buttons |= mask;
                                 const existing = self.pending_tap_release orelse 0;
                                 self.pending_tap_release = existing | mask;
+                                gamepad_changed = true;
                             }
                         },
                     }
@@ -1132,10 +1124,11 @@ pub const Mapper = struct {
         if (out.arm) |a| {
             const token = self.next_token;
             self.next_token +%= 1;
-            self.timer_queue.arm(a.deadline_ns, token, now_ns) catch return;
+            self.timer_queue.arm(a.deadline_ns, token, now_ns) catch return gamepad_changed;
             self.gesture_tokens.put(token, src_idx, a.leg);
             self.gesture_engine.setArmToken(src_idx, a.leg, token);
         }
+        return gamepad_changed;
     }
 
     // Macro timerfd (slot 4) expiry only — must NOT call onLayerTimerExpired().
@@ -1171,7 +1164,9 @@ pub const Mapper = struct {
                     out.emit_len,
                     now_ns,
                 );
-                self.applyGestureOutcome(ge.src_idx, out, &events.aux, true, now_ns);
+                if (self.applyGestureOutcome(ge.src_idx, out, &events.aux, true, now_ns)) {
+                    events.gamepad = self.currentMappedGamepadFrame();
+                }
                 continue;
             }
             var idx: usize = 0;
@@ -1424,7 +1419,7 @@ fn emitDelayedGestureGamepadTap(self: *Mapper, src_idx: u6, mask: u64, now_ns: i
         .mask = mask,
     })) |prior| self.timer_queue.cancel(prior.token, now_ns);
 
-    self.timer_queue.arm(now_ns + AUX_TAP_RELEASE_DELAY_NS, token, now_ns) catch |err| {
+    self.timer_queue.arm(now_ns + GAMEPAD_GESTURE_TAP_RELEASE_DELAY_NS, token, now_ns) catch |err| {
         _ = self.gesture_gamepad_tap_release_tokens.take(token);
         std.log.warn("gamepad tap release timer arm failed: {}", .{err});
         return false;
@@ -1533,7 +1528,6 @@ test "mapper: resetRuntimeState clears transient layer timer and input state" {
     m.seeded_buttons = buttonBit("A");
     m.pending_tap_release = buttonBit("B");
     m.macro_timer_tap_pending = buttonBit("X");
-    m.gesture_timer_tap_pending = buttonBit("Y");
     m.gesture_held_gamepad = buttonBit("RB");
     m.aux_down_targets[@intFromEnum(ButtonId.A)] = .{ .key = 30 };
     try m.timer_queue.arm(2_000, 99, 1_000);
@@ -1547,7 +1541,6 @@ test "mapper: resetRuntimeState clears transient layer timer and input state" {
     try testing.expectEqual(@as(u64, 0), m.seeded_buttons);
     try testing.expectEqual(@as(?u64, null), m.pending_tap_release);
     try testing.expectEqual(@as(u64, 0), m.macro_timer_tap_pending);
-    try testing.expectEqual(@as(u64, 0), m.gesture_timer_tap_pending);
     try testing.expectEqual(@as(u64, 0), m.gesture_held_gamepad);
     try testing.expect(m.aux_down_targets[@intFromEnum(ButtonId.A)] == null);
     try testing.expectEqual(@as(usize, 0), m.timer_queue.heap.count());
@@ -1659,15 +1652,15 @@ test "mapper: issue 492 stick-click tap remains observable until release timer" 
     const tap = try m.apply(.{ .buttons = 0 }, 16, t0 + 10 * std.time.ns_per_ms);
     try testing.expectEqual(stick_clicks, tap.gamepad.buttons & stick_clicks);
 
-    // A high-poll-rate controller reports again almost immediately.  The virtual
-    // press must remain visible for the same 30 ms minimum used by key/mouse taps;
-    // a one-report pulse is too short for consumers to observe reliably.
+    // A high-poll-rate controller reports again almost immediately. The virtual
+    // press must remain visible for the dedicated gamepad tap lifetime; a
+    // one-report pulse is too short for consumers to observe reliably.
     const early = try m.apply(.{ .buttons = 0 }, 1, t0 + 11 * std.time.ns_per_ms);
     try testing.expectEqual(stick_clicks, early.gamepad.buttons & stick_clicks);
 
     // Release comes from the timer itself; it must not depend on another physical
     // controller report after the stick click.
-    const release = m.onMacroTimerExpiredEvents(t0 + 40 * std.time.ns_per_ms);
+    const release = m.onMacroTimerExpiredEvents(t0 + 130 * std.time.ns_per_ms);
     try testing.expect(release.gamepad != null);
     try testing.expectEqual(@as(u64, 0), release.gamepad.?.buttons & stick_clicks);
 }
@@ -1689,8 +1682,11 @@ test "mapper: gesture hold gamepad bit persists then clears on release" {
     // Press arms the hold timer.
     _ = try m.apply(.{ .buttons = a_mask }, 16, 0);
 
-    // Hold deadline fires while button still held -> gamepad press staged.
-    _ = m.onMacroTimerExpired(100 * std.time.ns_per_ms + 1);
+    // Hold deadline fires while button is still held -> gamepad press is
+    // returned immediately by the timer wakeup and remains asserted.
+    const hold = m.onMacroTimerExpiredEvents(100 * std.time.ns_per_ms + 1);
+    try testing.expect(hold.gamepad != null);
+    try testing.expect((hold.gamepad.?.buttons & rb_mask) != 0);
     try testing.expect((m.gesture_held_gamepad & rb_mask) != 0);
 
     // Next frame re-asserts the held bit into output.

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -175,6 +175,16 @@ const GestureTokenEntry = struct {
     leg: gesture_mod.GestureLeg,
 };
 
+// Gyro joystick processing is stateful and runs only on physical input
+// frames. Timer-origin output frames reuse the last axes it produced instead
+// of recomputing motion or briefly exposing the underlying physical sticks.
+const GyroJoystickAxes = struct {
+    ax: ?i16 = null,
+    ay: ?i16 = null,
+    rx: ?i16 = null,
+    ry: ?i16 = null,
+};
+
 // Maps live timer tokens armed by the gesture engine back to (slot, leg) so
 // onMacroTimerExpired can route expiry. Bounded by concurrent gesture timers.
 const GestureTokenTable = struct {
@@ -212,6 +222,7 @@ pub const Mapper = struct {
     state: GamepadState,
     prev: GamepadState,
     gyro_proc: gyro.GyroProcessor,
+    last_gyro_joystick_axes: GyroJoystickAxes,
     stick_left: stick.StickProcessor,
     stick_right: stick.StickProcessor,
     suppressed_buttons: u64,
@@ -285,6 +296,7 @@ pub const Mapper = struct {
             .state = .{},
             .prev = .{},
             .gyro_proc = .{},
+            .last_gyro_joystick_axes = .{},
             .stick_left = .{},
             .stick_right = .{},
             .suppressed_buttons = 0,
@@ -334,6 +346,7 @@ pub const Mapper = struct {
         self.state = seeded;
         self.prev = seeded;
         self.seeded_buttons = seeded.buttons;
+        self.last_gyro_joystick_axes = .{};
     }
 
     pub fn resetRuntimeState(self: *Mapper) void {
@@ -342,6 +355,7 @@ pub const Mapper = struct {
         self.state = .{};
         self.prev = .{};
         self.gyro_proc.reset();
+        self.last_gyro_joystick_axes = .{};
         self.stick_left.reset();
         self.stick_right.reset();
         self.suppressed_buttons = 0;
@@ -603,6 +617,15 @@ pub const Mapper = struct {
             }
 
             const target = per_src_inject[i] orelse continue;
+            // A new press ends any timer-owned tap from this physical source
+            // before dispatching the source's current target. This must live at
+            // the common mapping entry because a layer may have changed the
+            // source from a gesture to any other target kind since the tap.
+            if (pressed and !prev_pressed) {
+                if (self.gesture_gamepad_tap_release_tokens.takeSource(@intCast(i))) |prior| {
+                    self.timer_queue.cancel(prior.token, now_ns);
+                }
+            }
             switch (target) {
                 .macro => |name| {
                     if (pressed and !prev_pressed) {
@@ -644,15 +667,6 @@ pub const Mapper = struct {
                 .chord => {},
                 .gesture => |node| {
                     if (pressed != prev_pressed) {
-                        // A delayed virtual tap from this source may still be
-                        // active when a rapid second physical press arrives.
-                        // End it now so the next tap gets its own release/press
-                        // edges instead of merging both clicks into one hold.
-                        if (pressed) {
-                            if (self.gesture_gamepad_tap_release_tokens.takeSource(@intCast(i))) |prior| {
-                                self.timer_queue.cancel(prior.token, now_ns);
-                            }
-                        }
                         const src_idx: u6 = @intCast(i);
                         const trace_enabled = input_trace.enabled();
                         const press_started_ns = if (trace_enabled and !pressed) self.gesture_engine.pressStartedAt(src_idx) else null;
@@ -774,6 +788,16 @@ pub const Mapper = struct {
                 jy;
         }
 
+        // Cache only axes actually controlled by gyro joystick mode. Physical
+        // input frames replace this snapshot atomically; timer frames can then
+        // reuse it without advancing the stateful gyro processor.
+        self.last_gyro_joystick_axes = .{
+            .ax = if (suppress_left_stick_gyro and gyro_joy_x != null) emit_state.ax else null,
+            .ay = if (suppress_left_stick_gyro and gyro_joy_y != null) emit_state.ay else null,
+            .rx = if (suppress_right_stick_gyro and gyro_joy_x != null) emit_state.rx else null,
+            .ry = if (suppress_right_stick_gyro and gyro_joy_y != null) emit_state.ry else null,
+        };
+
         // suppress stick axes when mode != gamepad
         if (!suppress_left_stick_gyro and (left_cfg.suppress_gamepad or !std.mem.eql(u8, left_cfg.mode, "gamepad"))) {
             emit_state.ax = 0;
@@ -820,6 +844,7 @@ pub const Mapper = struct {
             // Plain hold activation has no active_changed apply() chokepoint, so
             // perform the gesture/layer-hold cleanup here without touching the
             // macro queue; layer-timer expiry is not the macro timerfd.
+            self.last_gyro_joystick_axes = .{};
             self.prev.dpad_x = 0;
             self.prev.dpad_y = 0;
             self.cancelGestureStateForLayerChange(&events.aux, now_ns);
@@ -831,6 +856,7 @@ pub const Mapper = struct {
 
     fn handleLayerActiveChanged(self: *Mapper, aux: *AuxEventList, now_ns: i128) void {
         self.gyro_proc.reset();
+        self.last_gyro_joystick_axes = .{};
         self.stick_left.reset();
         self.stick_right.reset();
         // Reset dpad prev so edge detection fires on the next frame.
@@ -1018,6 +1044,10 @@ pub const Mapper = struct {
             emit_state.rx = 0;
             emit_state.ry = 0;
         }
+        if (self.last_gyro_joystick_axes.ax) |v| emit_state.ax = v;
+        if (self.last_gyro_joystick_axes.ay) |v| emit_state.ay = v;
+        if (self.last_gyro_joystick_axes.rx) |v| emit_state.rx = v;
+        if (self.last_gyro_joystick_axes.ry) |v| emit_state.ry = v;
         return emit_state;
     }
 
@@ -1529,6 +1559,7 @@ test "mapper: resetRuntimeState clears transient layer timer and input state" {
     m.pending_tap_release = buttonBit("B");
     m.macro_timer_tap_pending = buttonBit("X");
     m.gesture_held_gamepad = buttonBit("RB");
+    m.last_gyro_joystick_axes = .{ .rx = 1234, .ry = -2345 };
     m.aux_down_targets[@intFromEnum(ButtonId.A)] = .{ .key = 30 };
     try m.timer_queue.arm(2_000, 99, 1_000);
 
@@ -1542,6 +1573,8 @@ test "mapper: resetRuntimeState clears transient layer timer and input state" {
     try testing.expectEqual(@as(?u64, null), m.pending_tap_release);
     try testing.expectEqual(@as(u64, 0), m.macro_timer_tap_pending);
     try testing.expectEqual(@as(u64, 0), m.gesture_held_gamepad);
+    try testing.expect(m.last_gyro_joystick_axes.rx == null);
+    try testing.expect(m.last_gyro_joystick_axes.ry == null);
     try testing.expect(m.aux_down_targets[@intFromEnum(ButtonId.A)] == null);
     try testing.expectEqual(@as(usize, 0), m.timer_queue.heap.count());
 }
@@ -2201,9 +2234,11 @@ test "mapper: hold_toggle timer transition resets processors" {
     m.stick_right.scroll_accum = -0.5;
 
     _ = try m.apply(.{ .buttons = lt_mask }, 16, 0);
+    m.last_gyro_joystick_axes.rx = 1234;
     _ = m.onLayerTimerExpired();
 
     try testing.expectEqual(@as(f32, 0), m.gyro_proc.ema_x);
+    try testing.expect(m.last_gyro_joystick_axes.rx == null);
     try testing.expectEqual(@as(f32, 0), m.stick_left.mouse_accum_x);
     try testing.expectEqual(@as(f32, 0), m.stick_right.scroll_accum);
 }
@@ -3959,12 +3994,14 @@ test "mapper: toggle layer switch resets processors" {
 
     // Dirty processor state to simulate residual accumulation
     m.gyro_proc.ema_y = -200.0;
+    m.last_gyro_joystick_axes.ry = -2345;
     m.stick_right.mouse_accum_y = 0.8;
 
     // Frame 2: Select released → toggle fires → active_changed = true → reset
     _ = try m.apply(.{ .buttons = 0 }, 16, 0);
 
     try testing.expectEqual(@as(f32, 0), m.gyro_proc.ema_y);
+    try testing.expect(m.last_gyro_joystick_axes.ry == null);
     try testing.expectEqual(@as(f32, 0), m.stick_right.mouse_accum_y);
 }
 

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -616,16 +616,17 @@ pub const Mapper = struct {
                 }
             }
 
-            const target = per_src_inject[i] orelse continue;
             // A new press ends any timer-owned tap from this physical source
             // before dispatching the source's current target. This must live at
             // the common mapping entry because a layer may have changed the
-            // source from a gesture to any other target kind since the tap.
+            // source from a gesture to another target kind, or to no mapping,
+            // since the tap.
             if (pressed and !prev_pressed) {
                 if (self.gesture_gamepad_tap_release_tokens.takeSource(@intCast(i))) |prior| {
                     self.timer_queue.cancel(prior.token, now_ns);
                 }
             }
+            const target = per_src_inject[i] orelse continue;
             switch (target) {
                 .macro => |name| {
                     if (pressed and !prev_pressed) {

--- a/src/test/mapper_e2e_test.zig
+++ b/src/test/mapper_e2e_test.zig
@@ -1183,6 +1183,42 @@ test "e2e gesture issue 492: rising edge cancels old tap after layer changes tar
     try testing.expect(stale_release.gamepad == null);
 }
 
+test "e2e gesture issue 492: unmapped rising edge cancels tap emitted by old layer" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[[layer]]
+        \\name = "fn"
+        \\trigger = "LB"
+        \\activation = "toggle"
+        \\
+        \\[layer.remap]
+        \\A = { tap = "B", hold = "KEY_Z", hold_ms = 1000 }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const t0: i128 = std.time.ns_per_s;
+
+    // Enable the layer, emit its A -> B gesture tap, then disable the layer
+    // while the timer-owned B pulse remains active.
+    _ = try m.apply(.{ .buttons = btnMask(.LB) }, 16, t0);
+    _ = try m.apply(.{ .buttons = 0 }, 16, t0 + 10 * std.time.ns_per_ms);
+    _ = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0 + 20 * std.time.ns_per_ms);
+    const tap = try m.apply(.{ .buttons = 0 }, 16, t0 + 30 * std.time.ns_per_ms);
+    try testing.expectEqual(btnMask(.B), tap.gamepad.buttons & btnMask(.B));
+    _ = try m.apply(.{ .buttons = btnMask(.LB) }, 16, t0 + 40 * std.time.ns_per_ms);
+    const layer_off = try m.apply(.{ .buttons = 0 }, 16, t0 + 50 * std.time.ns_per_ms);
+    try testing.expectEqual(btnMask(.B), layer_off.gamepad.buttons & btnMask(.B));
+
+    // Base has no A mapping. The physical rising edge still owns this source
+    // and must end its old layer-emitted pulse before target lookup returns null.
+    const unmapped_press = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0 + 60 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(u64, 0), unmapped_press.gamepad.buttons & btnMask(.B));
+
+    const stale_release = m.onMacroTimerExpiredEvents(t0 + 150 * std.time.ns_per_ms);
+    try testing.expect(stale_release.gamepad == null);
+}
+
 test "e2e gesture issue 492: different sources sharing a target retain independent releases" {
     const allocator = testing.allocator;
     var ctx = try makeMapper(

--- a/src/test/mapper_e2e_test.zig
+++ b/src/test/mapper_e2e_test.zig
@@ -16,6 +16,7 @@ const Mapper = mapper_mod.Mapper;
 const AuxEvent = mapper_mod.AuxEvent;
 const AuxEventList = mapper_mod.AuxEventList;
 const ButtonId = state_mod.ButtonId;
+const GamepadState = state_mod.GamepadState;
 const GamepadStateDelta = state_mod.GamepadStateDelta;
 
 const REL_X = h.REL_X;
@@ -1012,12 +1013,17 @@ test "e2e gesture issue 492: timer-origin tap is independent of physical report 
             try testing.expectEqual(btnMask(.B), press.gamepad.?.buttons & btnMask(.B));
 
             if (with_followup) {
-                const followup = try m.apply(
-                    .{ .buttons = 0 },
-                    cadence_ms,
-                    press_ns + @as(i128, cadence_ms) * std.time.ns_per_ms,
-                );
-                try testing.expectEqual(btnMask(.B), followup.gamepad.buttons & btnMask(.B));
+                var elapsed_ms = cadence_ms;
+                while (elapsed_ms < 119) : (elapsed_ms += cadence_ms) {
+                    const followup = try m.apply(
+                        .{ .buttons = 0 },
+                        cadence_ms,
+                        press_ns + @as(i128, elapsed_ms) * std.time.ns_per_ms,
+                    );
+                    try testing.expectEqual(btnMask(.B), followup.gamepad.buttons & btnMask(.B));
+                }
+                const at_119 = try m.apply(.{ .buttons = 0 }, 1, press_ns + 119 * std.time.ns_per_ms);
+                try testing.expectEqual(btnMask(.B), at_119.gamepad.buttons & btnMask(.B));
             }
 
             const before_release = m.onMacroTimerExpiredEvents(press_ns + 119 * std.time.ns_per_ms);
@@ -1029,15 +1035,27 @@ test "e2e gesture issue 492: timer-origin tap is independent of physical report 
     }
 }
 
-fn periodicSamplerObservesPulse(
-    press_ms: u32,
-    release_ms: u32,
+const TimedGamepadFrame = struct {
+    at_ms: u32,
+    gamepad: GamepadState,
+};
+
+fn periodicSamplerObservesMapperPulse(
+    frames: []const TimedGamepadFrame,
+    mask: u64,
     period_ms: u32,
     phase_ms: u32,
 ) bool {
+    std.debug.assert(frames.len > 0);
     var sample_ms = phase_ms;
-    while (sample_ms < release_ms) : (sample_ms += period_ms) {
-        if (sample_ms >= press_ms) return true;
+    const end_ms = frames[frames.len - 1].at_ms;
+    while (sample_ms <= end_ms) : (sample_ms += period_ms) {
+        var last = frames[0].gamepad;
+        for (frames[1..]) |frame| {
+            if (frame.at_ms > sample_ms) break;
+            last = frame.gamepad;
+        }
+        if ((last.buttons & mask) != 0) return true;
     }
     return false;
 }
@@ -1057,6 +1075,8 @@ test "e2e gesture issue 492: edge-origin gamepad tap remains pressed for 120ms" 
     const press_ns = t0 + 333 * std.time.ns_per_ms;
     const tap = try m.apply(.{ .buttons = 0 }, 16, press_ns);
     try testing.expectEqual(ls, tap.gamepad.buttons & ls);
+    const followup = try m.apply(.{ .buttons = 0 }, 1, press_ns + std.time.ns_per_ms);
+    try testing.expectEqual(ls, followup.gamepad.buttons & ls);
 
     // The old 30 ms auxiliary-tap lifetime expires here. A gamepad tap needs a
     // dedicated lifetime long enough to cross slower consumer polling phases.
@@ -1067,13 +1087,20 @@ test "e2e gesture issue 492: edge-origin gamepad tap remains pressed for 120ms" 
     try testing.expect(release.gamepad != null);
     try testing.expectEqual(@as(u64, 0), release.gamepad.?.buttons & ls);
 
-    // A 120 ms state lifetime crosses every phase of the consumer polling
-    // periods exercised here, including the 100 ms slow-poll boundary.
+    const frames = [_]TimedGamepadFrame{
+        .{ .at_ms = 0, .gamepad = .{} },
+        .{ .at_ms = 333, .gamepad = tap.gamepad },
+        .{ .at_ms = 334, .gamepad = followup.gamepad },
+        .{ .at_ms = 453, .gamepad = release.gamepad.? },
+    };
+
+    // Sample the last real Mapper output frame at each consumer tick. A 120 ms
+    // state lifetime crosses every phase, including the 100 ms boundary.
     for ([_]u32{ 8, 16, 33, 50, 100 }) |period_ms| {
         for (0..period_ms) |phase_ms| {
-            try testing.expect(periodicSamplerObservesPulse(
-                333,
-                453,
+            try testing.expect(periodicSamplerObservesMapperPulse(
+                &frames,
+                ls,
                 period_ms,
                 @intCast(phase_ms),
             ));
@@ -1118,6 +1145,42 @@ test "e2e gesture issue 492: rapid repeated stick-click taps keep distinct edges
         try testing.expect(final_release.gamepad != null);
         try testing.expectEqual(@as(u64, 0), final_release.gamepad.?.buttons & mask);
     }
+}
+
+test "e2e gesture issue 492: rising edge cancels old tap after layer changes target kind" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "B", hold = "KEY_Z", hold_ms = 1000 }
+        \\
+        \\[[layer]]
+        \\name = "fn"
+        \\trigger = "LB"
+        \\activation = "toggle"
+        \\
+        \\[layer.remap]
+        \\A = "X"
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const t0: i128 = std.time.ns_per_s;
+    _ = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0);
+    const old_tap = try m.apply(.{ .buttons = 0 }, 16, t0 + 10 * std.time.ns_per_ms);
+    try testing.expectEqual(btnMask(.B), old_tap.gamepad.buttons & btnMask(.B));
+
+    _ = try m.apply(.{ .buttons = btnMask(.LB) }, 16, t0 + 20 * std.time.ns_per_ms);
+    const layer_on = try m.apply(.{ .buttons = 0 }, 16, t0 + 30 * std.time.ns_per_ms);
+    try testing.expectEqual(btnMask(.B), layer_on.gamepad.buttons & btnMask(.B));
+
+    // A is now a plain gamepad remap. Its rising edge must still terminate the
+    // old gesture-owned B pulse before emitting X.
+    const remapped_press = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0 + 40 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(u64, 0), remapped_press.gamepad.buttons & btnMask(.B));
+    try testing.expectEqual(btnMask(.X), remapped_press.gamepad.buttons & btnMask(.X));
+
+    const stale_release = m.onMacroTimerExpiredEvents(t0 + 130 * std.time.ns_per_ms);
+    try testing.expect(stale_release.gamepad == null);
 }
 
 test "e2e gesture issue 492: different sources sharing a target retain independent releases" {
@@ -1187,6 +1250,53 @@ test "e2e gesture issue 492: timer-origin LT and RT taps include analog floors" 
     }
 }
 
+test "e2e gesture issue 492: edge-origin LT and RT taps keep bit and analog floor for 120ms" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "LT", hold = "KEY_Z", hold_ms = 1000 }
+        \\B = { tap = "RT", hold = "KEY_Z", hold_ms = 1000 }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    for ([_]struct { src: ButtonId, dst: ButtonId, use_lt: bool }{
+        .{ .src = .A, .dst = .LT, .use_lt = true },
+        .{ .src = .B, .dst = .RT, .use_lt = false },
+    }, 0..) |case, index| {
+        const t0 = std.time.ns_per_s + @as(i128, @intCast(index)) * std.time.ns_per_s;
+        _ = try m.apply(.{ .buttons = btnMask(case.src) }, 16, t0);
+        const press_ns = t0 + 10 * std.time.ns_per_ms;
+        const press = try m.apply(.{ .buttons = 0 }, 16, press_ns);
+        try testing.expectEqual(btnMask(case.dst), press.gamepad.buttons & btnMask(case.dst));
+        if (case.use_lt) {
+            try testing.expectEqual(@as(u8, 255), press.gamepad.lt);
+        } else {
+            try testing.expectEqual(@as(u8, 255), press.gamepad.rt);
+        }
+
+        const early = try m.apply(.{ .buttons = 0 }, 1, press_ns + std.time.ns_per_ms);
+        const at_119 = try m.apply(.{ .buttons = 0 }, 118, press_ns + 119 * std.time.ns_per_ms);
+        for ([_]GamepadState{ early.gamepad, at_119.gamepad }) |frame| {
+            try testing.expectEqual(btnMask(case.dst), frame.buttons & btnMask(case.dst));
+            if (case.use_lt) {
+                try testing.expectEqual(@as(u8, 255), frame.lt);
+            } else {
+                try testing.expectEqual(@as(u8, 255), frame.rt);
+            }
+        }
+
+        const release = m.onMacroTimerExpiredEvents(press_ns + 120 * std.time.ns_per_ms);
+        try testing.expect(release.gamepad != null);
+        try testing.expectEqual(@as(u64, 0), release.gamepad.?.buttons & btnMask(case.dst));
+        if (case.use_lt) {
+            try testing.expectEqual(@as(u8, 0), release.gamepad.?.lt);
+        } else {
+            try testing.expectEqual(@as(u8, 0), release.gamepad.?.rt);
+        }
+    }
+}
+
 test "e2e gesture issue 492: timer-origin gamepad hold emits without a followup report" {
     const allocator = testing.allocator;
     var ctx = try makeMapper(
@@ -1201,9 +1311,51 @@ test "e2e gesture issue 492: timer-origin gamepad hold emits without a followup 
     const hold = m.onMacroTimerExpiredEvents(t0 + 100 * std.time.ns_per_ms);
     try testing.expect(hold.gamepad != null);
     try testing.expectEqual(btnMask(.RB), hold.gamepad.?.buttons & btnMask(.RB));
+    try testing.expectEqual(@as(u64, 0), hold.gamepad.?.buttons & btnMask(.A));
 
     const release = try m.apply(.{ .buttons = 0 }, 16, t0 + 200 * std.time.ns_per_ms);
     try testing.expectEqual(@as(u64, 0), release.gamepad.buttons & btnMask(.RB));
+}
+
+test "e2e gesture issue 492: timer tap frames preserve last gyro joystick axes" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[gyro]
+        \\mode = "joystick"
+        \\sensitivity_x = 1.0
+        \\sensitivity_y = 1.0
+        \\smoothing = 0.0
+        \\
+        \\[remap]
+        \\A = { tap = "B", double = "Y", double_ms = 250 }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const t0: i128 = std.time.ns_per_s;
+    const physical_rx: i16 = 1234;
+    const physical_ry: i16 = -2345;
+    _ = try m.apply(.{
+        .buttons = btnMask(.A),
+        .gyro_x = 10000,
+        .gyro_y = -12000,
+        .rx = physical_rx,
+        .ry = physical_ry,
+    }, 16, t0);
+    const last_apply = try m.apply(.{ .buttons = 0 }, 16, t0 + 40 * std.time.ns_per_ms);
+    try testing.expect(last_apply.gamepad.rx != physical_rx);
+    try testing.expect(last_apply.gamepad.ry != physical_ry);
+
+    const tap_press = m.onMacroTimerExpiredEvents(t0 + 300 * std.time.ns_per_ms);
+    try testing.expect(tap_press.gamepad != null);
+    try testing.expectEqual(btnMask(.B), tap_press.gamepad.?.buttons & btnMask(.B));
+    try testing.expectEqual(last_apply.gamepad.rx, tap_press.gamepad.?.rx);
+    try testing.expectEqual(last_apply.gamepad.ry, tap_press.gamepad.?.ry);
+
+    const tap_release = m.onMacroTimerExpiredEvents(t0 + 420 * std.time.ns_per_ms);
+    try testing.expect(tap_release.gamepad != null);
+    try testing.expectEqual(last_apply.gamepad.rx, tap_release.gamepad.?.rx);
+    try testing.expectEqual(last_apply.gamepad.ry, tap_release.gamepad.?.ry);
 }
 
 test "e2e gesture issue 492: LS and RS duration sweep classifies every sub-threshold press as tap" {

--- a/src/test/mapper_e2e_test.zig
+++ b/src/test/mapper_e2e_test.zig
@@ -987,27 +987,98 @@ test "e2e gesture regression: tap+double KEY_J timeout release is delayed to tim
     try testing.expect(!auxListHasAnyKey(&aux_release, key_k));
 }
 
-test "e2e gesture: timer-context gamepad tap stages full press one frame before release" {
+test "e2e gesture issue 492: timer-origin tap is independent of physical report cadence" {
+    const allocator = testing.allocator;
+
+    for ([_]u32{ 2, 4, 8, 16 }) |cadence_ms| {
+        for ([_]bool{ false, true }) |with_followup| {
+            var ctx = try makeMapper(
+                \\[remap]
+                \\A = { tap = "B", double = "Y", double_ms = 250 }
+            , allocator);
+            defer ctx.deinit();
+            var m = &ctx.mapper;
+
+            const t0: i128 = 1_000_000_000;
+            _ = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0);
+            _ = try m.apply(.{ .buttons = 0 }, 16, t0 + 40 * std.time.ns_per_ms);
+
+            // The double window timeout resolves the single tap. The virtual
+            // press must be emitted by this timer wakeup, even with no later
+            // physical input report.
+            const press_ns = t0 + 300 * std.time.ns_per_ms;
+            const press = m.onMacroTimerExpiredEvents(press_ns);
+            try testing.expect(press.gamepad != null);
+            try testing.expectEqual(btnMask(.B), press.gamepad.?.buttons & btnMask(.B));
+
+            if (with_followup) {
+                const followup = try m.apply(
+                    .{ .buttons = 0 },
+                    cadence_ms,
+                    press_ns + @as(i128, cadence_ms) * std.time.ns_per_ms,
+                );
+                try testing.expectEqual(btnMask(.B), followup.gamepad.buttons & btnMask(.B));
+            }
+
+            const before_release = m.onMacroTimerExpiredEvents(press_ns + 119 * std.time.ns_per_ms);
+            try testing.expect(before_release.gamepad == null);
+            const release = m.onMacroTimerExpiredEvents(press_ns + 120 * std.time.ns_per_ms);
+            try testing.expect(release.gamepad != null);
+            try testing.expectEqual(@as(u64, 0), release.gamepad.?.buttons & btnMask(.B));
+        }
+    }
+}
+
+fn periodicSamplerObservesPulse(
+    press_ms: u32,
+    release_ms: u32,
+    period_ms: u32,
+    phase_ms: u32,
+) bool {
+    var sample_ms = phase_ms;
+    while (sample_ms < release_ms) : (sample_ms += period_ms) {
+        if (sample_ms >= press_ms) return true;
+    }
+    return false;
+}
+
+test "e2e gesture issue 492: edge-origin gamepad tap remains pressed for 120ms" {
     const allocator = testing.allocator;
     var ctx = try makeMapper(
         \\[remap]
-        \\A = { tap = "B", double = "Y", double_ms = 250 }
+        \\LS = { tap = "LS", hold = "KEY_Z", hold_ms = 1000 }
     , allocator);
     defer ctx.deinit();
     var m = &ctx.mapper;
 
+    const ls = btnMask(.LS);
     const t0: i128 = 1_000_000_000;
-    _ = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0);
-    _ = try m.apply(.{ .buttons = 0 }, 16, t0 + 40 * std.time.ns_per_ms);
-    // double window times out -> single tap of gamepad B, staged for next apply
-    _ = m.onMacroTimerExpired(t0 + 300 * std.time.ns_per_ms);
+    _ = try m.apply(.{ .buttons = ls }, 16, t0);
+    const press_ns = t0 + 333 * std.time.ns_per_ms;
+    const tap = try m.apply(.{ .buttons = 0 }, 16, press_ns);
+    try testing.expectEqual(ls, tap.gamepad.buttons & ls);
 
-    // frame N: B pressed (staged tap promoted)
-    const ev1 = try m.apply(.{ .buttons = 0 }, 16, t0 + 310 * std.time.ns_per_ms);
-    try testing.expect((ev1.gamepad.buttons & btnMask(.B)) != 0);
-    // frame N+1: B released (pending_tap_release)
-    const ev2 = try m.apply(.{ .buttons = 0 }, 16, t0 + 320 * std.time.ns_per_ms);
-    try testing.expectEqual(@as(u64, 0), ev2.gamepad.buttons & btnMask(.B));
+    // The old 30 ms auxiliary-tap lifetime expires here. A gamepad tap needs a
+    // dedicated lifetime long enough to cross slower consumer polling phases.
+    const before_release = m.onMacroTimerExpiredEvents(press_ns + 119 * std.time.ns_per_ms);
+    try testing.expect(before_release.gamepad == null);
+
+    const release = m.onMacroTimerExpiredEvents(press_ns + 120 * std.time.ns_per_ms);
+    try testing.expect(release.gamepad != null);
+    try testing.expectEqual(@as(u64, 0), release.gamepad.?.buttons & ls);
+
+    // A 120 ms state lifetime crosses every phase of the consumer polling
+    // periods exercised here, including the 100 ms slow-poll boundary.
+    for ([_]u32{ 8, 16, 33, 50, 100 }) |period_ms| {
+        for (0..period_ms) |phase_ms| {
+            try testing.expect(periodicSamplerObservesPulse(
+                333,
+                453,
+                period_ms,
+                @intCast(phase_ms),
+            ));
+        }
+    }
 }
 
 test "e2e gesture issue 492: rapid repeated stick-click taps keep distinct edges" {
@@ -1021,7 +1092,7 @@ test "e2e gesture issue 492: rapid repeated stick-click taps keep distinct edges
     var m = &ctx.mapper;
 
     for ([_]ButtonId{ .LS, .RS }, 0..) |button, iteration| {
-        const t0: i128 = 1_000_000_000 + @as(i128, @intCast(iteration)) * 100 * std.time.ns_per_ms;
+        const t0: i128 = 1_000_000_000 + @as(i128, @intCast(iteration)) * 200 * std.time.ns_per_ms;
         const mask = btnMask(button);
 
         // First physical click resolves to a virtual stick-click press.
@@ -1040,13 +1111,99 @@ test "e2e gesture issue 492: rapid repeated stick-click taps keep distinct edges
         try testing.expectEqual(mask, second_tap.gamepad.buttons & mask);
 
         // The cancelled first deadline must not release the second tap early.
-        const stale_release = m.onMacroTimerExpiredEvents(t0 + 41 * std.time.ns_per_ms);
+        const stale_release = m.onMacroTimerExpiredEvents(t0 + 131 * std.time.ns_per_ms);
         try testing.expect(stale_release.gamepad == null);
 
-        const final_release = m.onMacroTimerExpiredEvents(t0 + 60 * std.time.ns_per_ms);
+        const final_release = m.onMacroTimerExpiredEvents(t0 + 145 * std.time.ns_per_ms);
         try testing.expect(final_release.gamepad != null);
         try testing.expectEqual(@as(u64, 0), final_release.gamepad.?.buttons & mask);
     }
+}
+
+test "e2e gesture issue 492: different sources sharing a target retain independent releases" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\LS = { tap = "A", hold = "KEY_Z" }
+        \\RS = { tap = "A", hold = "KEY_Z" }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const t0: i128 = std.time.ns_per_s;
+    _ = try m.apply(.{ .buttons = btnMask(.LS) }, 16, t0);
+    const first = try m.apply(.{ .buttons = 0 }, 16, t0 + 10 * std.time.ns_per_ms);
+    try testing.expectEqual(btnMask(.A), first.gamepad.buttons & btnMask(.A));
+
+    _ = try m.apply(.{ .buttons = btnMask(.RS) }, 16, t0 + 20 * std.time.ns_per_ms);
+    const second = try m.apply(.{ .buttons = 0 }, 16, t0 + 30 * std.time.ns_per_ms);
+    try testing.expectEqual(btnMask(.A), second.gamepad.buttons & btnMask(.A));
+
+    // LS expires first, but RS still owns the same virtual A target.
+    const first_release = m.onMacroTimerExpiredEvents(t0 + 130 * std.time.ns_per_ms);
+    try testing.expect(first_release.gamepad != null);
+    try testing.expectEqual(btnMask(.A), first_release.gamepad.?.buttons & btnMask(.A));
+
+    const final_release = m.onMacroTimerExpiredEvents(t0 + 150 * std.time.ns_per_ms);
+    try testing.expect(final_release.gamepad != null);
+    try testing.expectEqual(@as(u64, 0), final_release.gamepad.?.buttons & btnMask(.A));
+}
+
+test "e2e gesture issue 492: timer-origin LT and RT taps include analog floors" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "LT", double = "X", double_ms = 250 }
+        \\B = { tap = "RT", double = "Y", double_ms = 250 }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    for ([_]struct { src: ButtonId, dst: ButtonId, use_lt: bool }{
+        .{ .src = .A, .dst = .LT, .use_lt = true },
+        .{ .src = .B, .dst = .RT, .use_lt = false },
+    }, 0..) |case, index| {
+        const t0 = std.time.ns_per_s + @as(i128, @intCast(index)) * std.time.ns_per_s;
+        _ = try m.apply(.{ .buttons = btnMask(case.src) }, 16, t0);
+        _ = try m.apply(.{ .buttons = 0 }, 16, t0 + 40 * std.time.ns_per_ms);
+
+        const press = m.onMacroTimerExpiredEvents(t0 + 300 * std.time.ns_per_ms);
+        try testing.expect(press.gamepad != null);
+        try testing.expectEqual(btnMask(case.dst), press.gamepad.?.buttons & btnMask(case.dst));
+        if (case.use_lt) {
+            try testing.expectEqual(@as(u8, 255), press.gamepad.?.lt);
+        } else {
+            try testing.expectEqual(@as(u8, 255), press.gamepad.?.rt);
+        }
+
+        const release = m.onMacroTimerExpiredEvents(t0 + 420 * std.time.ns_per_ms);
+        try testing.expect(release.gamepad != null);
+        try testing.expectEqual(@as(u64, 0), release.gamepad.?.buttons & btnMask(case.dst));
+        if (case.use_lt) {
+            try testing.expectEqual(@as(u8, 0), release.gamepad.?.lt);
+        } else {
+            try testing.expectEqual(@as(u8, 0), release.gamepad.?.rt);
+        }
+    }
+}
+
+test "e2e gesture issue 492: timer-origin gamepad hold emits without a followup report" {
+    const allocator = testing.allocator;
+    var ctx = try makeMapper(
+        \\[remap]
+        \\A = { tap = "X", hold = "RB", hold_ms = 100 }
+    , allocator);
+    defer ctx.deinit();
+    var m = &ctx.mapper;
+
+    const t0: i128 = std.time.ns_per_s;
+    _ = try m.apply(.{ .buttons = btnMask(.A) }, 16, t0);
+    const hold = m.onMacroTimerExpiredEvents(t0 + 100 * std.time.ns_per_ms);
+    try testing.expect(hold.gamepad != null);
+    try testing.expectEqual(btnMask(.RB), hold.gamepad.?.buttons & btnMask(.RB));
+
+    const release = try m.apply(.{ .buttons = 0 }, 16, t0 + 200 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(u64, 0), release.gamepad.buttons & btnMask(.RB));
 }
 
 test "e2e gesture issue 492: LS and RS duration sweep classifies every sub-threshold press as tap" {
@@ -1072,12 +1229,15 @@ test "e2e gesture issue 492: LS and RS duration sweep classifies every sub-thres
             try testing.expectEqual(mask, release.gamepad.buttons & mask);
             try testing.expect(!auxHasAnyKey(release, keyCode("KEY_Z")));
 
-            const timer = m.onMacroTimerExpiredEvents(release_ns + 31 * std.time.ns_per_ms);
+            const before_timer = m.onMacroTimerExpiredEvents(release_ns + 119 * std.time.ns_per_ms);
+            try testing.expect(before_timer.gamepad == null);
+
+            const timer = m.onMacroTimerExpiredEvents(release_ns + 120 * std.time.ns_per_ms);
             try testing.expect(timer.gamepad != null);
             try testing.expectEqual(@as(u64, 0), timer.gamepad.?.buttons & mask);
             try testing.expect(!auxListHasAnyKey(&timer.aux, keyCode("KEY_Z")));
 
-            now_ns = release_ns + 40 * std.time.ns_per_ms;
+            now_ns = release_ns + 130 * std.time.ns_per_ms;
         }
     }
 }
@@ -1146,10 +1306,9 @@ test "e2e gesture back-compat: chord array remap A=[KEY_LEFTMETA,KEY_1] unchange
     try testing.expectEqual(@as(usize, 0), ev.aux.len);
 }
 
-// --- F-2: a resolved gesture's timer-staged gamepad tap survives a same-frame
-// layer transition. The double-tap window expiring to a single tap stages the
-// tap bit; a layer active-state change on the next frame used to zero
-// gesture_timer_tap_pending before the apply() promotion block, dropping it.
+// --- F-2: a resolved timer-origin gamepad tap survives a same-frame layer
+// transition. Once emitted, its release token owns the lifetime independently
+// of the gesture engine state reset caused by the layer transition.
 
 test "gesture F-2: resolved single-tap gamepad bit survives same-frame layer toggle" {
     const allocator = testing.allocator;
@@ -1179,12 +1338,17 @@ test "gesture F-2: resolved single-tap gamepad bit survives same-frame layer tog
     // Frame 2: A release opens the double window; LB still held.
     _ = try m.apply(.{ .buttons = lb_mask }, 16, t0 + 40 * ns_per_ms);
 
-    // Double window expires with no second press -> single tap "B" staged.
-    _ = m.onMacroTimerExpired(t0 + 300 * ns_per_ms);
-    try testing.expectEqual(b_bit, m.gesture_timer_tap_pending);
+    // Double window expires with no second press -> single tap "B" emitted.
+    const tap = m.onMacroTimerExpiredEvents(t0 + 300 * ns_per_ms);
+    try testing.expect(tap.gamepad != null);
+    try testing.expectEqual(b_bit, tap.gamepad.?.buttons & b_bit);
 
     // Frame 3: LB released -> toggle flips -> layer active_changed. The resolved
-    // gesture's staged tap must survive to the promotion block.
+    // tap must remain active for the rest of its timer-owned lifetime.
     const ev = try m.apply(.{ .buttons = 0 }, 16, t0 + 301 * ns_per_ms);
     try testing.expectEqual(b_bit, ev.gamepad.buttons & b_bit);
+
+    const release = m.onMacroTimerExpiredEvents(t0 + 420 * ns_per_ms);
+    try testing.expect(release.gamepad != null);
+    try testing.expectEqual(@as(u64, 0), release.gamepad.?.buttons & b_bit);
 }


### PR DESCRIPTION
## Summary

- give gesture-generated gamepad taps a dedicated 120 ms timer-owned lifetime
- emit timer-origin gesture tap and hold frames immediately, without waiting for another physical report
- preserve gyro-joystick axes on timer frames and keep per-source tap ownership correct across layer changes

## Root cause

There were two independent output-lifetime bugs:

1. Edge-origin gamepad taps reused the 30 ms auxiliary tap delay, which was too short for slower consumers.
2. Timer-origin single taps were staged until the next physical report and released on the report after that, reducing the virtual pulse to the controller report interval (about 2–4 ms in the reporter trace).

Both paths now use a per-source release token and the same dedicated timer path. Press and release no longer depend on a future physical input report.

## Verification

- reproduced both original failures with test-only changes before production edits
- issue 492 regression matrix: 16/16 Debug and 16/16 ReleaseSafe
- gesture tests: 54/54
- gyro joystick tests: 16/16
- layer tests: 165/165
- pre-push Docker TSAN: 1999 passed, 11 skipped
- three independent review passes covering state ownership, timer/event-loop integration, gyro axes, and test oracles

The regression matrix includes 2/4/8/16 ms physical report cadences, no and repeated follow-up reports, 8/16/33/50/100 ms consumer phases, rapid repeated LS/RS taps, shared targets, LT/RT digital and analog state, layer target changes, and timer-origin holds.

Related to #492. This PR intentionally does not close the issue; real Vader5/KDE validation is still required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gesture-to-gamepad timing for more consistent tap and hold behavior.
  * Fixed rapid repeated presses so virtual taps no longer overlap or release late.
  * Ensured gesture actions remain reliable during layer changes.
  * Improved gyro-joystick output consistency across physical input and timer updates.
  * Corrected tap emission behavior when input reports arrive at varying intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->