### PR TITLE
fix(usbraw): reject incomplete interrupt writes

### DIFF
--- a/src/io/usbraw.zig
+++ b/src/io/usbraw.zig
@@ -27,6 +27,22 @@ const c = @cImport({
     @cInclude("libusb-1.0/libusb.h");
 });
 
+// A zero libusb return code does not guarantee that the entire interrupt OUT
+// payload was transferred. Treat anything other than an exact write as I/O
+// failure so the event loop can retry the complete rumble frame.
+fn checkInterruptWriteResult(rc: c_int, transferred: c_int, expected: usize) DeviceIO.WriteError!void {
+    if (rc == c.LIBUSB_ERROR_NO_DEVICE) return DeviceIO.WriteError.Disconnected;
+    if (rc != 0) return DeviceIO.WriteError.Io;
+    if (transferred < 0 or @as(usize, @intCast(transferred)) != expected) {
+        return DeviceIO.WriteError.Io;
+    }
+}
+
+fn checkedInterruptWriteLength(requested: usize, capacity: usize) DeviceIO.WriteError!usize {
+    if (requested > capacity) return DeviceIO.WriteError.Io;
+    return requested;
+}
+
 // Fixed-size ring buffer: 64 slots x 64 bytes each.
 // Overflow drops oldest report and logs a warning.
 pub const RingBuffer = struct {
@@ -230,7 +246,13 @@ pub const UsbrawDevice = struct {
         var transferred: c_int = 0;
         // libusb wants a mutable pointer even for writes
         var buf: [RingBuffer.SLOT_SIZE]u8 = undefined;
-        const n = @min(data.len, buf.len);
+        const n = checkedInterruptWriteLength(data.len, buf.len) catch {
+            if (!is_test) std.log.warn(
+                "usbraw: refusing oversized interrupt write: endpoint=0x{x} requested={d} max={d}",
+                .{ self.ep_out, data.len, buf.len },
+            );
+            return DeviceIO.WriteError.Io;
+        };
         @memcpy(buf[0..n], data[0..n]);
 
         const rc = c.libusb_interrupt_transfer(
@@ -241,8 +263,22 @@ pub const UsbrawDevice = struct {
             &transferred,
             100,
         );
-        if (rc == c.LIBUSB_ERROR_NO_DEVICE) return DeviceIO.WriteError.Disconnected;
-        if (rc != 0) return DeviceIO.WriteError.Io;
+        checkInterruptWriteResult(rc, transferred, n) catch |err| {
+            if (!is_test) {
+                if (rc == 0) {
+                    std.log.warn(
+                        "usbraw: incomplete interrupt write: endpoint=0x{x} expected={d} transferred={d}",
+                        .{ self.ep_out, n, transferred },
+                    );
+                } else if (rc != c.LIBUSB_ERROR_NO_DEVICE) {
+                    std.log.debug(
+                        "usbraw: interrupt write failed: endpoint=0x{x} rc={d} expected={d} transferred={d}",
+                        .{ self.ep_out, rc, n, transferred },
+                    );
+                }
+            }
+            return err;
+        };
     }
 
     fn pollfd(ptr: *anyopaque) std.posix.pollfd {
@@ -308,6 +344,48 @@ pub const UsbrawSuppress = struct {
 };
 
 // --- Tests ---
+
+test "usbraw: interrupt write result accepts exact transfer" {
+    try checkInterruptWriteResult(0, 32, 32);
+    try checkInterruptWriteResult(0, 0, 0);
+}
+
+test "usbraw: interrupt write result rejects incomplete transfer" {
+    try std.testing.expectError(
+        DeviceIO.WriteError.Io,
+        checkInterruptWriteResult(0, 31, 32),
+    );
+    try std.testing.expectError(
+        DeviceIO.WriteError.Io,
+        checkInterruptWriteResult(0, 33, 32),
+    );
+    try std.testing.expectError(
+        DeviceIO.WriteError.Io,
+        checkInterruptWriteResult(0, -1, 32),
+    );
+}
+
+test "usbraw: interrupt write result classifies libusb failures" {
+    try std.testing.expectError(
+        DeviceIO.WriteError.Disconnected,
+        checkInterruptWriteResult(c.LIBUSB_ERROR_NO_DEVICE, 0, 32),
+    );
+    try std.testing.expectError(
+        DeviceIO.WriteError.Io,
+        checkInterruptWriteResult(c.LIBUSB_ERROR_TIMEOUT, 0, 32),
+    );
+}
+
+test "usbraw: oversized interrupt write is rejected instead of truncated" {
+    try std.testing.expectEqual(
+        @as(usize, RingBuffer.SLOT_SIZE),
+        try checkedInterruptWriteLength(RingBuffer.SLOT_SIZE, RingBuffer.SLOT_SIZE),
+    );
+    try std.testing.expectError(
+        DeviceIO.WriteError.Io,
+        checkedInterruptWriteLength(RingBuffer.SLOT_SIZE + 1, RingBuffer.SLOT_SIZE),
+    );
+}
 
 test "usbraw: RingBuffer push/pop basic" {
     var rb: RingBuffer = .{};


### PR DESCRIPTION
## Summary

- require libusb interrupt OUT writes to transfer the exact requested length
- map successful short writes to `DeviceIO.Io`, allowing the existing bounded rumble retry path to resend the complete frame
- log endpoint, expected length, and actual transferred length for incomplete writes
- reject reports larger than the 64-byte usbraw buffer instead of silently truncating them

## Evidence and scope

The previous usbraw path checked only the libusb return code and ignored `transferred`. A short zero-motor frame could therefore be treated as successful while `padctl dump` showed the full intended frame because that log is emitted before the physical write.

A focused regression test reproduced that transport-contract defect before the fix (`rc=0`, `transferred=31`, `expected=32` returned success) and passes after the fix.

This is a concrete failure path consistent with the symptoms in #65, but the existing reporter dumps do not contain `transferred`, so this PR does not claim that short writes are the confirmed or only hardware root cause.

## Verification

- Debug usbraw tests: 12/12 passed
- ReleaseSafe usbraw tests: 12/12 passed
- existing failed-STOP retry integration: 3/3 passed
- `zig fmt --check`: passed
- `git diff --check`: passed
- full `zig build test`: attempted, but did not complete after 6 minutes with no additional output
- TSan: native musl path blocked by non-PIC libusb/linker failures; canonical Docker path blocked by the host temporary-storage quota

Refs #65. The issue should remain open for reporter and real-hardware verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB write validation to prevent oversized or partially completed transfers from being silently accepted.
  * USB devices that disconnect during a transfer are now reported accurately.
  * Other failed or incomplete transfers now return a clear I/O error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->