### PR TITLE
test(rumble): add issue #65 field-trace coverage

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -354,7 +354,7 @@ pub fn build(b: *std.Build) void {
         "timeout",
         "--signal=TERM",
         "--kill-after=2s",
-        "20s",
+        "30s",
         null,
     });
     integration_step.dependOn(&b.addRunArtifact(ff_erase_int_tests).step);

--- a/build.zig
+++ b/build.zig
@@ -333,9 +333,10 @@ pub fn build(b: *std.Build) void {
     shadow_int_tests.linkLibC();
     integration_step.dependOn(&b.addRunArtifact(shadow_int_tests).step);
 
-    // uinput_ff_erase_integration: real UI_FF_ERASE wiring validation.
-    // Creates an FF_RUMBLE uinput device, EVIOCSFF-uploads then EVIOCRMFF-erases
-    // an effect (no EV_FF=0), and asserts pollFf surfaces a zero-magnitude stop.
+    // uinput FF integration: real PLAY/STOP ordering and UI_FF_ERASE wiring.
+    // Creates FF_RUMBLE uinput devices and drives them through real evdev
+    // clients. A hard process watchdog backs up the harness's bounded ioctl
+    // cancellation so a kernel handshake regression cannot hang CI forever.
     // Own test artifact like shadow_grab; skips gracefully without /dev/uinput
     // unless PADCTL_TEST_REQUIRE_UINPUT=1 (set by the privileged e2e job).
     const ff_erase_int_mod = b.createModule(.{
@@ -349,6 +350,13 @@ pub fn build(b: *std.Build) void {
     const ff_erase_int_tests = b.addTest(.{ .root_module = ff_erase_int_mod, .filters = test_filters });
     applyLibusb(b, ff_erase_int_tests, use_libusb, vendored);
     ff_erase_int_tests.linkLibC();
+    ff_erase_int_tests.setExecCmd(&.{
+        "timeout",
+        "--signal=TERM",
+        "--kill-after=2s",
+        "20s",
+        null,
+    });
     integration_step.dependOn(&b.addRunArtifact(ff_erase_int_tests).step);
 
     // Phase 13 Wave 3 T5f: Layer 1 routing tests — pure pipe2 fixture, no

--- a/src/main.zig
+++ b/src/main.zig
@@ -125,6 +125,7 @@ pub const testing_support = struct {
     pub const bugfix_regression_test = @import("test/bugfix_regression_test.zig");
     pub const doctor_accuracy_test = @import("test/doctor_accuracy_test.zig");
     pub const event_loop_rumble_test = @import("test/event_loop_rumble_test.zig");
+    pub const rumble_trace_corpus_test = @import("test/rumble_trace_corpus_test.zig");
     pub const event_loop_ff_erase_test = @import("test/event_loop_ff_erase_test.zig");
     pub const uhid_output_dispatch_test = @import("test/uhid_output_dispatch_test.zig");
     pub const uhid_t1_strict_red_green_test = @import("test/uhid_t1_strict_red_green_test.zig");

--- a/src/test/fixtures/issue65_rumble/README.md
+++ b/src/test/fixtures/issue65_rumble/README.md
@@ -1,0 +1,52 @@
+# Issue #65 rumble trace fixtures
+
+These are normalized, de-identified vectors derived from public diagnostics
+attached to issue #65. Wall time is replaced with `trace-derived`, monotonic
+time is rebased to T0 nanoseconds, and only the `FF_EVENT`/`HID_WRITE` fields
+needed by the tests are retained. Host paths, process IDs, topology, and
+unrelated log content are omitted.
+
+## `daniel_60hz_stop.log`
+
+- Issue comment: <https://github.com/BANANASJIM/padctl/issues/65#issuecomment-5013818944>
+- Attachment: <https://github.com/user-attachments/files/30159607/rumble.log>
+- Original SHA-256: `e80a47a849ef563dcaafb9da5764fc777dd84d4c2155dbde7763b8f0e8863139`
+- Derived fixture SHA-256: `10a1927af5cd6a3267fe5ff8ef97ac2e37ded0b648a099e13a26dcc38ac8aa56`
+- Reporter version: padctl 0.1.23 (`padctl-bin`); the attachment does not
+  identify an exact commit
+- Extraction: original lines 435-486, retaining only `FF_EVENT` and
+  `HID_WRITE`, then applying the de-identification transform above
+- Evidence shape: one-to-one 60 Hz decay followed by an explicit STOP and zero
+  HID frame
+
+## `daniel_strong_only_stop.log`
+
+- Source, attachment, and original SHA-256: same as `daniel_60hz_stop.log`
+- Derived fixture SHA-256: `8680694396b548f80db1dd47bdc9cbecf1df4444838c59579920546b9a10055b`
+- Extraction: original lines 359-386, retaining only `FF_EVENT` and
+  `HID_WRITE`, then applying the de-identification transform above
+- Evidence shape: strong-only decay, which independently pins the encoder's
+  strong/weak byte placement before the final STOP
+
+## `dreadtusk_throttled_stop.log`
+
+- Issue comment: <https://github.com/BANANASJIM/padctl/issues/65#issuecomment-4903267303>
+- Attachment: <https://github.com/user-attachments/files/29742918/rumble.pt1.txt>
+- Original SHA-256: `322e6ac5b5604ee511a669f7a7bee36d947c795a83f3df5a05a97477ac0b9766`
+- Derived fixture SHA-256: `f753ca29922966450d38678142e49cbbda3b010524f56b141a402b9be41a4e6b`
+- Reporter version: `padctl-git`; the attachment does not identify an exact
+  commit
+- Extraction: original lines 43214-43335, retaining only `FF_EVENT` and
+  `HID_WRITE`, then applying the de-identification transform above
+- Evidence shape: roughly 1-2 ms logical FF updates, latest-wins logged
+  `HID_WRITE` intents at the 10 ms throttle boundary, then a recorded STOP/zero
+  frame 9.18ms after the preceding non-zero logged `HID_WRITE` intent
+
+The parser accepts the same `HID_WRITE` field format used by the MIT-licensed
+[`rumble-replay`](https://github.com/shakespear-dev/vader5pro-linux-tools/tree/main/tools/rumble-replay)
+tool, but no source code from that project is copied here.
+
+These fixtures characterize the attached field traces and guard the shipped
+encoder contract. They are not a #65 hardware reproduction and do not prove USB
+transfer completion or physical motor state; those require a real-device run
+with transport capture and an external physical oracle.

--- a/src/test/fixtures/issue65_rumble/daniel_60hz_stop.log
+++ b/src/test/fixtures/issue65_rumble/daniel_60hz_stop.log
@@ -1,0 +1,16 @@
+[trace-derived] [MONO:0] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=65535 weak=65535 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:16081] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=65535 weak=65535 iface=0 len=32 frame=[5a a5 12 06 ff ff 00 00 16 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
+[trace-derived] [MONO:116532130] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=54795 weak=54795 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:116545426] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=54795 weak=54795 iface=0 len=32 frame=[5a a5 12 06 d6 d6 00 00 c4 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
+[trace-derived] [MONO:133311815] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=40236 weak=40236 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:133323858] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=40236 weak=40236 iface=0 len=32 frame=[5a a5 12 06 9d 9d 00 00 52 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
+[trace-derived] [MONO:149913912] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=26824 weak=26824 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:149926476] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=26824 weak=26824 iface=0 len=32 frame=[5a a5 12 06 68 68 00 00 e8 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
+[trace-derived] [MONO:166574089] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=15496 weak=15496 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:166587004] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=15496 weak=15496 iface=0 len=32 frame=[5a a5 12 06 3c 3c 00 00 90 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
+[trace-derived] [MONO:183170294] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=6769 weak=6769 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:183182968] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=6769 weak=6769 iface=0 len=32 frame=[5a a5 12 06 1a 1a 00 00 4c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
+[trace-derived] [MONO:199833567] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=1413 weak=1413 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:199845149] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=1413 weak=1413 iface=0 len=32 frame=[5a a5 12 06 05 05 00 00 22 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
+[trace-derived] [MONO:216530104] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=0 weak=0 dur=65535ms is_stop=true sched_on=true
+[trace-derived] [MONO:216553879] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=0 weak=0 iface=0 len=32 frame=[5a a5 12 06 00 00 00 00 18 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]

--- a/src/test/fixtures/issue65_rumble/daniel_strong_only_stop.log
+++ b/src/test/fixtures/issue65_rumble/daniel_strong_only_stop.log
@@ -1,0 +1,8 @@
+[trace-derived] [MONO:0] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=65535 weak=0 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:13115] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=65535 weak=0 iface=0 len=32 frame=[5a a5 12 06 ff 00 00 00 17 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
+[trace-derived] [MONO:152473282] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=49194 weak=0 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:152485876] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=49194 weak=0 iface=0 len=32 frame=[5a a5 12 06 c0 00 00 00 d8 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
+[trace-derived] [MONO:168741864] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=13977 weak=0 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:168753957] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=13977 weak=0 iface=0 len=32 frame=[5a a5 12 06 36 00 00 00 4e 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
+[trace-derived] [MONO:184909735] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=0 weak=0 dur=65535ms is_stop=true sched_on=true
+[trace-derived] [MONO:184924433] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=0 weak=0 iface=0 len=32 frame=[5a a5 12 06 00 00 00 00 18 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]

--- a/src/test/fixtures/issue65_rumble/dreadtusk_throttled_stop.log
+++ b/src/test/fixtures/issue65_rumble/dreadtusk_throttled_stop.log
@@ -1,0 +1,22 @@
+[trace-derived] [MONO:0] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=1228 weak=1228 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:26971] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=1228 weak=1228 iface=0 len=32 frame=[5a a5 12 06 04 04 00 00 20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
+[trace-derived] [MONO:1851700] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=1154 weak=1154 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:3733050] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=1080 weak=1080 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:5612260] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=1006 weak=1006 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:7480770] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=932 weak=932 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:9352300] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=858 weak=858 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:11225180] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=785 weak=785 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:11257802] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=785 weak=785 iface=0 len=32 frame=[5a a5 12 06 03 03 00 00 1e 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
+[trace-derived] [MONO:13079280] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=712 weak=712 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:14932549] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=639 weak=639 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:16787249] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=565 weak=565 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:18651839] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=492 weak=492 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:20485067] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=420 weak=420 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:22328726] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=347 weak=347 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:22362547] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=347 weak=347 iface=0 len=32 frame=[5a a5 12 06 01 01 00 00 1a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
+[trace-derived] [MONO:24178716] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=274 weak=274 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:26008895] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=202 weak=202 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:27851034] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=130 weak=130 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:29690203] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=58 weak=58 dur=65535ms is_stop=false sched_on=true
+[trace-derived] [MONO:31503621] debug(rumble): [Flydigi Vader 5 Pro] FF_EVENT: id=0 strong=0 weak=0 dur=65535ms is_stop=true sched_on=true
+[trace-derived] [MONO:31538762] debug(rumble): [Flydigi Vader 5 Pro] HID_WRITE: cmd=rumble strong=0 weak=0 iface=0 len=32 frame=[5a a5 12 06 00 00 00 00 18 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]

--- a/src/test/rumble_trace_corpus_test.zig
+++ b/src/test/rumble_trace_corpus_test.zig
@@ -1,0 +1,404 @@
+//! Characterization tests for public issue #65 rumble traces.
+//!
+//! These tests characterize field-derived event/write shapes and guard the
+//! shipped Vader 5 encoder. They deliberately do not claim USB completion or
+//! physical motor state.
+
+const std = @import("std");
+const testing = std.testing;
+
+const command = @import("../core/command.zig");
+const device = @import("../config/device.zig");
+
+const FRAME_LEN = 32;
+const MAX_EVENT_TO_WRITE_LAG_NS = std.time.ns_per_ms;
+
+const FfEvent = struct {
+    mono_ns: u64,
+    id: u8,
+    strong: u16,
+    weak: u16,
+    duration_ms: u16,
+    is_stop: bool,
+};
+
+const HidWrite = struct {
+    mono_ns: u64,
+    strong: u16,
+    weak: u16,
+    declared_len: u8,
+    frame: [FRAME_LEN]u8,
+};
+
+const Record = union(enum) {
+    ff: FfEvent,
+    hid: HidWrite,
+};
+
+const Magnitude = struct {
+    strong: u16,
+    weak: u16,
+};
+
+fn parseUnsignedAfter(comptime T: type, line: []const u8, marker: []const u8) !T {
+    const marker_pos = std.mem.indexOf(u8, line, marker) orelse return error.MissingField;
+    const start = marker_pos + marker.len;
+    var end = start;
+    while (end < line.len and std.ascii.isDigit(line[end])) : (end += 1) {}
+    if (end == start) return error.InvalidField;
+    return std.fmt.parseUnsigned(T, line[start..end], 10);
+}
+
+fn parseBoolAfter(line: []const u8, marker: []const u8) !bool {
+    const marker_pos = std.mem.indexOf(u8, line, marker) orelse return error.MissingField;
+    const value = line[marker_pos + marker.len ..];
+    if (std.mem.startsWith(u8, value, "true")) return true;
+    if (std.mem.startsWith(u8, value, "false")) return false;
+    return error.InvalidField;
+}
+
+fn parseFfEvent(line: []const u8) !FfEvent {
+    return .{
+        .mono_ns = try parseUnsignedAfter(u64, line, "[MONO:"),
+        .id = try parseUnsignedAfter(u8, line, "FF_EVENT: id="),
+        .strong = try parseUnsignedAfter(u16, line, "strong="),
+        .weak = try parseUnsignedAfter(u16, line, "weak="),
+        .duration_ms = try parseUnsignedAfter(u16, line, "dur="),
+        .is_stop = try parseBoolAfter(line, "is_stop="),
+    };
+}
+
+fn parseHidWrite(line: []const u8) !HidWrite {
+    const declared_len = try parseUnsignedAfter(u8, line, "len=");
+    if (declared_len != FRAME_LEN) return error.UnexpectedFrameLength;
+
+    const marker = "frame=[";
+    const marker_pos = std.mem.indexOf(u8, line, marker) orelse return error.MissingFrame;
+    const start = marker_pos + marker.len;
+    const end_rel = std.mem.indexOfScalar(u8, line[start..], ']') orelse return error.UnterminatedFrame;
+    const frame_text = line[start .. start + end_rel];
+
+    var frame: [FRAME_LEN]u8 = undefined;
+    var count: usize = 0;
+    var tokens = std.mem.tokenizeScalar(u8, frame_text, ' ');
+    while (tokens.next()) |token| {
+        if (count >= frame.len) return error.UnexpectedFrameLength;
+        frame[count] = std.fmt.parseUnsigned(u8, token, 16) catch return error.InvalidFrameByte;
+        count += 1;
+    }
+    if (count != declared_len) return error.UnexpectedFrameLength;
+
+    return .{
+        .mono_ns = try parseUnsignedAfter(u64, line, "[MONO:"),
+        .strong = try parseUnsignedAfter(u16, line, "strong="),
+        .weak = try parseUnsignedAfter(u16, line, "weak="),
+        .declared_len = declared_len,
+        .frame = frame,
+    };
+}
+
+fn parseTrace(allocator: std.mem.Allocator, text: []const u8) ![]Record {
+    var records: std.ArrayList(Record) = .{};
+    errdefer records.deinit(allocator);
+
+    var lines = std.mem.tokenizeScalar(u8, text, '\n');
+    while (lines.next()) |line| {
+        if (std.mem.indexOf(u8, line, "FF_EVENT:") != null) {
+            try records.append(allocator, .{ .ff = try parseFfEvent(line) });
+        } else if (std.mem.indexOf(u8, line, "HID_WRITE:") != null) {
+            try records.append(allocator, .{ .hid = try parseHidWrite(line) });
+        }
+    }
+    if (records.items.len == 0) return error.EmptyTrace;
+    return records.toOwnedSlice(allocator);
+}
+
+fn validateHidFrame(hid: HidWrite) !void {
+    if (hid.declared_len != FRAME_LEN) return error.UnexpectedFrameLength;
+    if (!std.mem.eql(u8, hid.frame[0..4], &.{ 0x5a, 0xa5, 0x12, 0x06 })) return error.BadHeader;
+    if (hid.frame[4] != @as(u8, @intCast(hid.strong >> 8))) return error.StrongMismatch;
+    if (hid.frame[5] != @as(u8, @intCast(hid.weak >> 8))) return error.WeakMismatch;
+    for (hid.frame[6..8]) |byte| if (byte != 0) return error.BadReservedByte;
+
+    var checksum: u8 = 0;
+    for (hid.frame[2..8]) |byte| checksum +%= byte;
+    if (hid.frame[8] != checksum) return error.BadChecksum;
+    for (hid.frame[9..]) |byte| if (byte != 0) return error.BadReservedByte;
+}
+
+fn validateAllFrames(records: []const Record) !void {
+    for (records) |record| switch (record) {
+        .ff => {},
+        .hid => |hid| try validateHidFrame(hid),
+    };
+}
+
+fn expectParsedMagnitudes(
+    records: []const Record,
+    expected_ff: []const Magnitude,
+    expected_hid: []const Magnitude,
+) !void {
+    var ff_index: usize = 0;
+    var hid_index: usize = 0;
+    for (records) |record| switch (record) {
+        .ff => |ff| {
+            if (ff_index >= expected_ff.len) return error.UnexpectedFfEvent;
+            try testing.expectEqual(expected_ff[ff_index].strong, ff.strong);
+            try testing.expectEqual(expected_ff[ff_index].weak, ff.weak);
+            try testing.expectEqual(@as(u16, 65535), ff.duration_ms);
+            try testing.expectEqual(ff.strong == 0 and ff.weak == 0, ff.is_stop);
+            ff_index += 1;
+        },
+        .hid => |hid| {
+            if (hid_index >= expected_hid.len) return error.UnexpectedHidWrite;
+            try testing.expectEqual(expected_hid[hid_index].strong, hid.strong);
+            try testing.expectEqual(expected_hid[hid_index].weak, hid.weak);
+            hid_index += 1;
+        },
+    };
+    try testing.expectEqual(expected_ff.len, ff_index);
+    try testing.expectEqual(expected_hid.len, hid_index);
+}
+
+fn validateTerminalStop(records: []const Record) !void {
+    var last_ff: ?FfEvent = null;
+    var last_hid: ?HidWrite = null;
+    for (records) |record| switch (record) {
+        .ff => |ff| last_ff = ff,
+        .hid => |hid| last_hid = hid,
+    };
+
+    const ff = last_ff orelse return error.MissingTerminalStop;
+    const hid = last_hid orelse return error.MissingTerminalStop;
+    if (!ff.is_stop or ff.strong != 0 or ff.weak != 0) return error.MissingTerminalStop;
+    if (hid.strong != 0 or hid.weak != 0) return error.MissingTerminalStop;
+    if (hid.mono_ns < ff.mono_ns or hid.mono_ns - ff.mono_ns > MAX_EVENT_TO_WRITE_LAG_NS)
+        return error.StopWriteLag;
+}
+
+fn validateOneToOne(records: []const Record) !void {
+    var pending: ?FfEvent = null;
+    for (records) |record| switch (record) {
+        .ff => |ff| {
+            if (pending != null) return error.UnpairedFfEvent;
+            pending = ff;
+        },
+        .hid => |hid| {
+            const ff = pending orelse return error.UnpairedHidWrite;
+            if (ff.strong != hid.strong or ff.weak != hid.weak) return error.EventWriteMismatch;
+            if (hid.mono_ns < ff.mono_ns or hid.mono_ns - ff.mono_ns > MAX_EVENT_TO_WRITE_LAG_NS)
+                return error.EventWriteLag;
+            pending = null;
+        },
+    };
+    if (pending != null) return error.UnpairedFfEvent;
+}
+
+fn expectSixtyHzCadence(records: []const Record) !void {
+    var previous: ?u64 = null;
+    var sixty_hz_deltas: usize = 0;
+    for (records) |record| switch (record) {
+        .ff => {},
+        .hid => |hid| {
+            if (previous) |prev| {
+                const delta = hid.mono_ns - prev;
+                if (delta >= 15 * std.time.ns_per_ms and delta <= 18 * std.time.ns_per_ms)
+                    sixty_hz_deltas += 1;
+            }
+            previous = hid.mono_ns;
+        },
+    };
+    try testing.expect(sixty_hz_deltas >= 5);
+}
+
+fn validateLatestWinsThrottle(records: []const Record) !void {
+    var latest_ff: ?FfEvent = null;
+    var previous_ff_ns: ?u64 = null;
+    var previous_nonzero_hid_ns: ?u64 = null;
+    var fast_ff_deltas: usize = 0;
+    var throttled_hid_deltas: usize = 0;
+    var stop_inside_throttle_window = false;
+    var ff_count: usize = 0;
+    var hid_count: usize = 0;
+
+    for (records) |record| switch (record) {
+        .ff => |ff| {
+            if (previous_ff_ns) |prev| {
+                if (ff.mono_ns - prev < 3 * std.time.ns_per_ms) fast_ff_deltas += 1;
+            }
+            previous_ff_ns = ff.mono_ns;
+            latest_ff = ff;
+            ff_count += 1;
+        },
+        .hid => |hid| {
+            const ff = latest_ff orelse return error.UnpairedHidWrite;
+            if (hid.mono_ns < ff.mono_ns) return error.EventWriteLag;
+            if (ff.strong != hid.strong or ff.weak != hid.weak) return error.LatestEventNotWritten;
+            if (hid.strong != 0 or hid.weak != 0) {
+                if (previous_nonzero_hid_ns) |prev| {
+                    const delta = hid.mono_ns - prev;
+                    if (delta < 10 * std.time.ns_per_ms) return error.NonzeroWriteInsideThrottleWindow;
+                    if (delta >= 10 * std.time.ns_per_ms and delta <= 12 * std.time.ns_per_ms)
+                        throttled_hid_deltas += 1;
+                }
+                previous_nonzero_hid_ns = hid.mono_ns;
+            } else if (previous_nonzero_hid_ns) |prev| {
+                if (hid.mono_ns - prev < 10 * std.time.ns_per_ms)
+                    stop_inside_throttle_window = true;
+            }
+            hid_count += 1;
+        },
+    };
+
+    try testing.expect(ff_count > hid_count);
+    try testing.expect(fast_ff_deltas >= 16);
+    try testing.expect(throttled_hid_deltas >= 2);
+    try testing.expect(stop_inside_throttle_window);
+}
+
+fn expectShippedVaderEncoder(records: []const Record) !void {
+    const allocator = testing.allocator;
+    var parsed = try device.parseFile(allocator, "devices/flydigi/vader5.toml");
+    defer parsed.deinit();
+
+    const commands = parsed.value.commands orelse return error.MissingCommands;
+    const rumble = commands.map.get("rumble") orelse return error.MissingRumbleCommand;
+    for (records) |record| switch (record) {
+        .ff => {},
+        .hid => |hid| {
+            const encoded = try command.fillTemplate(allocator, rumble.template, &.{
+                .{ .name = "strong", .value = hid.strong },
+                .{ .name = "weak", .value = hid.weak },
+            });
+            defer allocator.free(encoded);
+            if (rumble.checksum) |*checksum| command.applyChecksum(encoded, checksum);
+            try testing.expectEqualSlices(u8, &hid.frame, encoded);
+        },
+    };
+}
+
+test "issue65 field characterization: 60 Hz events map one-to-one to valid Vader frames and terminal stop" {
+    const records = try parseTrace(testing.allocator, @embedFile("fixtures/issue65_rumble/daniel_60hz_stop.log"));
+    defer testing.allocator.free(records);
+
+    const expected = [_]Magnitude{
+        .{ .strong = 65535, .weak = 65535 },
+        .{ .strong = 54795, .weak = 54795 },
+        .{ .strong = 40236, .weak = 40236 },
+        .{ .strong = 26824, .weak = 26824 },
+        .{ .strong = 15496, .weak = 15496 },
+        .{ .strong = 6769, .weak = 6769 },
+        .{ .strong = 1413, .weak = 1413 },
+        .{ .strong = 0, .weak = 0 },
+    };
+    try testing.expectEqual(@as(usize, 16), records.len);
+    try expectParsedMagnitudes(records, &expected, &expected);
+    try validateAllFrames(records);
+    try validateOneToOne(records);
+    try validateTerminalStop(records);
+    try expectSixtyHzCadence(records);
+    try expectShippedVaderEncoder(records);
+}
+
+test "issue65 field characterization: strong-only events pin encoder byte placement" {
+    const records = try parseTrace(testing.allocator, @embedFile("fixtures/issue65_rumble/daniel_strong_only_stop.log"));
+    defer testing.allocator.free(records);
+
+    const expected = [_]Magnitude{
+        .{ .strong = 65535, .weak = 0 },
+        .{ .strong = 49194, .weak = 0 },
+        .{ .strong = 13977, .weak = 0 },
+        .{ .strong = 0, .weak = 0 },
+    };
+    try testing.expectEqual(@as(usize, 8), records.len);
+    try expectParsedMagnitudes(records, &expected, &expected);
+    try validateAllFrames(records);
+    try validateOneToOne(records);
+    try validateTerminalStop(records);
+    try expectShippedVaderEncoder(records);
+}
+
+test "issue65 field characterization: dense events show latest-wins writes and stop inside throttle window" {
+    const records = try parseTrace(testing.allocator, @embedFile("fixtures/issue65_rumble/dreadtusk_throttled_stop.log"));
+    defer testing.allocator.free(records);
+
+    const expected_ff = [_]Magnitude{
+        .{ .strong = 1228, .weak = 1228 },
+        .{ .strong = 1154, .weak = 1154 },
+        .{ .strong = 1080, .weak = 1080 },
+        .{ .strong = 1006, .weak = 1006 },
+        .{ .strong = 932, .weak = 932 },
+        .{ .strong = 858, .weak = 858 },
+        .{ .strong = 785, .weak = 785 },
+        .{ .strong = 712, .weak = 712 },
+        .{ .strong = 639, .weak = 639 },
+        .{ .strong = 565, .weak = 565 },
+        .{ .strong = 492, .weak = 492 },
+        .{ .strong = 420, .weak = 420 },
+        .{ .strong = 347, .weak = 347 },
+        .{ .strong = 274, .weak = 274 },
+        .{ .strong = 202, .weak = 202 },
+        .{ .strong = 130, .weak = 130 },
+        .{ .strong = 58, .weak = 58 },
+        .{ .strong = 0, .weak = 0 },
+    };
+    const expected_hid = [_]Magnitude{
+        .{ .strong = 1228, .weak = 1228 },
+        .{ .strong = 785, .weak = 785 },
+        .{ .strong = 347, .weak = 347 },
+        .{ .strong = 0, .weak = 0 },
+    };
+    try testing.expectEqual(@as(usize, 22), records.len);
+    try expectParsedMagnitudes(records, &expected_ff, &expected_hid);
+    try validateAllFrames(records);
+    try validateLatestWinsThrottle(records);
+    try validateTerminalStop(records);
+    try expectShippedVaderEncoder(records);
+}
+
+test "issue65 trace oracle rejects a corrupted checksum" {
+    const records = try parseTrace(testing.allocator, @embedFile("fixtures/issue65_rumble/daniel_60hz_stop.log"));
+    defer testing.allocator.free(records);
+
+    var corrupted: ?HidWrite = null;
+    for (records) |record| switch (record) {
+        .ff => {},
+        .hid => |hid| {
+            corrupted = hid;
+            break;
+        },
+    };
+    var hid = corrupted orelse return error.MissingFrame;
+    hid.frame[8] ^= 0x01;
+    try testing.expectError(error.BadChecksum, validateHidFrame(hid));
+}
+
+test "issue65 trace parser rejects a truncated declared frame" {
+    const truncated =
+        "[trace-derived] [MONO:1] debug(rumble): [Flydigi Vader 5 Pro] " ++
+        "HID_WRITE: cmd=rumble strong=0 weak=0 iface=0 len=32 " ++
+        "frame=[5a a5 12 06 00 00 00 00 18 ]\n";
+    try testing.expectError(error.UnexpectedFrameLength, parseTrace(testing.allocator, truncated));
+}
+
+test "issue65 trace oracle rejects a missing terminal stop" {
+    const records = try parseTrace(testing.allocator, @embedFile("fixtures/issue65_rumble/daniel_60hz_stop.log"));
+    defer testing.allocator.free(records);
+    const copy = try testing.allocator.dupe(Record, records);
+    defer testing.allocator.free(copy);
+
+    var index = copy.len;
+    while (index > 0) {
+        index -= 1;
+        switch (copy[index]) {
+            .ff => |ff| {
+                var changed = ff;
+                changed.is_stop = false;
+                copy[index] = .{ .ff = changed };
+                break;
+            },
+            .hid => {},
+        }
+    }
+    try testing.expectError(error.MissingTerminalStop, validateTerminalStop(copy));
+}

--- a/src/test/uinput_ff_erase_integration_test.zig
+++ b/src/test/uinput_ff_erase_integration_test.zig
@@ -1,4 +1,4 @@
-//! Real-uinput integration test for the pollFf UI_FF_ERASE wiring.
+//! Real-uinput integration tests for the pollFf FF event wiring.
 //!
 //! The production stop-on-erase plumbing lives in `UinputDevice.pollFf`'s
 //! UI_FF_ERASE branch (`result = eraseStopEvent(...); break;`). That branch only
@@ -6,12 +6,10 @@
 //! the kernel — which the Layer-0 `event_loop_ff_erase_test.zig` can't reach
 //! because it feeds pollFf's output to the event loop via a canned FfEvent.
 //!
-//! This test drives the actual ioctl path: padctl creates an FF_RUMBLE uinput
-//! device, a client opens the matching evdev node, EVIOCSFF-uploads an infinite
-//! effect, then EVIOCRMFF-erases it WITHOUT writing EV_FF value=0. The kernel
-//! turns that into UI_FF_UPLOAD / UI_FF_ERASE requests on padctl's fd; we pump
-//! the real `pollFf()` and assert it surfaces a zero-magnitude stop FfEvent for
-//! the erased slot — the exact emulation that stops the motor on erase.
+//! These tests drive the actual ioctl path: padctl creates an FF_RUMBLE uinput
+//! device and a client opens the matching evdev node. One scenario uploads an
+//! effect and writes rapid EV_FF PLAY+STOP events; the other erases an effect
+//! without EV_FF=0. Both kernel handshakes are pumped through real `pollFf()`.
 //!
 //! ## Runtime behaviour (mirrors shadow_grab_integration_test.zig)
 //!
@@ -23,7 +21,7 @@
 //!       `error.UinputAccessRequired` — a hard failure, so an environment meant
 //!       to have /dev/uinput but lacking it surfaces the breakage. The
 //!       privileged `e2e` job sets it when /dev/uinput is accessible, which is
-//!       the only place this UI_FF_ERASE wiring runs against the real kernel.
+//!       where these FF wiring scenarios run against the real kernel.
 
 const std = @import("std");
 const posix = std.posix;
@@ -39,12 +37,21 @@ const c = @cImport({
     @cInclude("linux/input.h");
 });
 
+extern "c" fn pthread_kill(thread: std.c.pthread_t, signal: c_int) c_int;
+
 const gate = src.testing_support.uhid_gate;
 
 const FF_VID: u16 = 0xFAD7;
-const FF_PID: u16 = 0x2401;
+const FF_ERASE_PID: u16 = 0x2401;
+const FF_PLAY_STOP_PID: u16 = 0x2402;
+const FF_ERASE_NAME = "padctl-ff-erase-itest";
+const FF_PLAY_STOP_NAME = "padctl-ff-play-stop-itest";
+const EVIOCGNAME_256 = linux.IOCTL.IOR('E', 0x06, [256]u8);
+const CLIENT_TIMEOUT_NS = 5 * std.time.ns_per_s;
+const CLIENT_POLL_MS: i32 = 50;
+const CANCEL_TIMEOUT_MS: i32 = 500;
 
-const ff_toml =
+const ff_erase_toml =
     \\[device]
     \\name = "ff-erase-itest"
     \\vid = 1
@@ -67,7 +74,30 @@ const ff_toml =
     \\max_effects = 16
 ;
 
-fn findEventNode(vid: u16, pid: u16, name_buf: *[40]u8) ?[]const u8 {
+const ff_play_stop_toml =
+    \\[device]
+    \\name = "ff-play-stop-itest"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 1
+    \\[output]
+    \\name = "padctl-ff-play-stop-itest"
+    \\vid = 0xFAD7
+    \\pid = 0x2402
+    \\[output.buttons]
+    \\A = "BTN_SOUTH"
+    \\[output.force_feedback]
+    \\type = "rumble"
+    \\max_effects = 16
+;
+
+fn findEventNode(vid: u16, pid: u16, expected_name: []const u8, path_buf_out: *[40]u8) ?[]const u8 {
     var attempt: usize = 0;
     while (attempt < 20) : (attempt += 1) {
         var i: u16 = 0;
@@ -79,26 +109,90 @@ fn findEventNode(vid: u16, pid: u16, name_buf: *[40]u8) ?[]const u8 {
             var id: ioctl.InputId = undefined;
             if (linux.E.init(linux.ioctl(fd, ioctl.EVIOCGID, @intFromPtr(&id))) != .SUCCESS) continue;
             if (id.vendor != vid or id.product != pid) continue;
-            return std.fmt.bufPrint(name_buf, "/dev/input/event{d}", .{i}) catch null;
+            var actual_name: [256]u8 = @splat(0);
+            if (linux.E.init(linux.ioctl(fd, EVIOCGNAME_256, @intFromPtr(&actual_name))) != .SUCCESS) continue;
+            const name_len = std.mem.indexOfScalar(u8, &actual_name, 0) orelse actual_name.len;
+            if (!std.mem.eql(u8, expected_name, actual_name[0..name_len])) continue;
+            return std.fmt.bufPrint(path_buf_out, "/dev/input/event{d}", .{i}) catch null;
         }
         std.Thread.sleep(50 * std.time.ns_per_ms);
     }
     return null;
 }
 
-// Client side, run on its own thread: EVIOCSFF an infinite rumble effect, then
-// EVIOCRMFF-erase it without writing EV_FF=0. Both ioctls block until padctl's
-// pollFf services the matching kernel request, which is why this can't run
-// inline with the pump loop.
+const ClientAction = enum {
+    erase,
+    play_stop,
+};
+
+fn interruptHandler(_: i32) callconv(.c) void {}
+
+fn terminateTestProcess() noreturn {
+    // Returning while a worker still borrows stack state is unsafe. The build
+    // target also has a hard `timeout` watchdog, but terminate immediately if
+    // SIGUSR1 failed to interrupt the blocking evdev ioctl.
+    _ = linux.kill(linux.getpid(), posix.SIG.TERM);
+    unreachable;
+}
+
+fn cancelAndJoin(thread: std.Thread, done_fd: posix.fd_t, completed: *const std.atomic.Value(bool)) void {
+    if (completed.load(.acquire)) {
+        thread.join();
+        return;
+    }
+
+    // Even when pthread_kill reports that the target already exited, allow the
+    // same bounded completion window: the worker may be between returning from
+    // its body and publishing `completed`.
+    _ = pthread_kill(thread.getHandle(), posix.SIG.USR1);
+    var done_poll = [_]posix.pollfd{.{ .fd = done_fd, .events = posix.POLL.IN, .revents = 0 }};
+    _ = posix.poll(&done_poll, CANCEL_TIMEOUT_MS) catch terminateTestProcess();
+    if (!completed.load(.acquire)) terminateTestProcess();
+    thread.join();
+}
+
+fn finishAfterPumpError(
+    thread: std.Thread,
+    done_fd: posix.fd_t,
+    completed: *const std.atomic.Value(bool),
+    client_done: bool,
+) void {
+    if (client_done or completed.load(.acquire)) {
+        thread.join();
+    } else {
+        cancelAndJoin(thread, done_fd, completed);
+    }
+}
+
+fn writeFfEvent(fd: posix.fd_t, effect_id: i16, value: i32) !void {
+    if (effect_id < 0) return error.InvalidEffectId;
+    const event = c.input_event{
+        .type = c.EV_FF,
+        .code = @intCast(effect_id),
+        .value = value,
+        .time = std.mem.zeroes(c.timeval),
+    };
+    const bytes = std.mem.asBytes(&event);
+    const written = try posix.write(fd, bytes);
+    if (written != bytes.len) return error.ShortEventWrite;
+}
+
+// Client side, run on its own thread. EVIOCSFF and EVIOCRMFF block until
+// padctl's pollFf services the corresponding kernel requests, so the main
+// thread pumps /dev/uinput while this worker uses the evdev side.
 const Client = struct {
     node: []const u8,
+    action: ClientAction,
+    done_fd: posix.fd_t,
+    completed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     result: anyerror!void = {},
-    erased_id: i16 = -1,
-    done: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    effect_id: i16 = -1,
 
     fn run(self: *Client) void {
         self.result = self.body();
-        self.done.store(true, .release);
+        self.completed.store(true, .release);
+        var one: u64 = 1;
+        _ = posix.write(self.done_fd, std.mem.asBytes(&one)) catch {};
     }
 
     fn body(self: *Client) !void {
@@ -108,23 +202,45 @@ const Client = struct {
         var effect = std.mem.zeroes(c.ff_effect);
         effect.type = c.FF_RUMBLE;
         effect.id = -1; // kernel assigns the slot
-        effect.replay.length = 0; // infinite — only ever stopped by erase
-        effect.u.rumble.strong_magnitude = 0x8000;
-        effect.u.rumble.weak_magnitude = 0x4000;
+        effect.replay.length = if (self.action == .erase) 0 else 65535;
+        effect.u.rumble.strong_magnitude = 0xf000;
+        effect.u.rumble.weak_magnitude = 0x0f00;
         if (linux.E.init(linux.ioctl(fd, ioctl.EVIOCSFF, @intFromPtr(&effect))) != .SUCCESS)
             return error.UploadFailed;
-        self.erased_id = effect.id;
+        self.effect_id = effect.id;
 
-        const id: c_int = effect.id;
-        if (linux.E.init(linux.ioctl(fd, ioctl.EVIOCRMFF, @as(usize, @bitCast(@as(isize, id))))) != .SUCCESS)
-            return error.EraseFailed;
+        switch (self.action) {
+            .erase => {
+                const id: c_int = effect.id;
+                if (linux.E.init(linux.ioctl(fd, ioctl.EVIOCRMFF, @as(usize, @bitCast(@as(isize, id))))) != .SUCCESS)
+                    return error.EraseFailed;
+            },
+            .play_stop => {
+                // Deliberately no sleep: this is the real-kernel counterpart
+                // to the rapid same-slot PLAY+STOP FIFO regression test.
+                try writeFfEvent(fd, effect.id, 1);
+                try writeFfEvent(fd, effect.id, 0);
+            },
+        }
     }
 };
 
-test "uinput: pollFf turns a real UI_FF_ERASE into a zero-magnitude stop frame" {
+const ScenarioResult = struct {
+    events: [8]uinput.FfEvent = undefined,
+    event_count: usize = 0,
+    effect_id: i16,
+};
+
+fn runScenario(
+    toml: []const u8,
+    pid: u16,
+    expected_name: []const u8,
+    action: ClientAction,
+    expected_events: usize,
+) !ScenarioResult {
     const allocator = testing.allocator;
 
-    const parsed = device_cfg.parseString(allocator, ff_toml) catch return error.ConfigParseFailed;
+    const parsed = device_cfg.parseString(allocator, toml) catch return error.ConfigParseFailed;
     defer parsed.deinit();
     const out_cfg = parsed.value.output orelse return error.NoOutput;
 
@@ -136,35 +252,144 @@ test "uinput: pollFf turns a real UI_FF_ERASE into a zero-magnitude stop frame" 
     defer dev.close();
 
     var name_buf: [40]u8 = undefined;
-    const node = findEventNode(FF_VID, FF_PID, &name_buf) orelse
+    const node = findEventNode(FF_VID, pid, expected_name, &name_buf) orelse
         return gate.reportMissingUinput("created uinput node did not appear under /dev/input");
 
-    var client = Client{ .node = node };
-    const thread = try std.Thread.spawn(.{}, Client.run, .{&client});
+    var previous_usr1: posix.Sigaction = undefined;
+    posix.sigaction(posix.SIG.USR1, &.{
+        .handler = .{ .handler = interruptHandler },
+        .mask = posix.sigemptyset(),
+        .flags = 0,
+    }, &previous_usr1);
+    defer posix.sigaction(posix.SIG.USR1, &previous_usr1, null);
 
-    // Pump the real pollFf to drive the upload + erase handshake. The client's
-    // EVIOCSFF/EVIOCRMFF block until pollFf services the matching UI_FF_UPLOAD /
-    // UI_FF_ERASE request, so we keep pumping until the client thread finishes
-    // (so its erase ioctl returns rather than timing out) while capturing the
-    // first zero-magnitude stop the erase surfaces. Deadline-bounded so a
-    // regression that drops the stop fails instead of hanging.
-    var stop: ?uinput.FfEvent = null;
-    const deadline = std.time.milliTimestamp() + 5000;
-    while (std.time.milliTimestamp() < deadline) {
-        if (try dev.pollFf()) |ev| {
-            if (stop == null and ev.strong == 0 and ev.weak == 0) stop = ev;
+    const done_fd = try posix.eventfd(0, ioctl.EFD_CLOEXEC | ioctl.EFD_NONBLOCK);
+    defer posix.close(done_fd);
+    var client = Client{ .node = node, .action = action, .done_fd = done_fd };
+    const thread = try std.Thread.spawn(.{}, Client.run, .{&client});
+    var joined = false;
+    defer if (!joined) cancelAndJoin(thread, done_fd, &client.completed);
+
+    var timer = try std.time.Timer.start();
+    var result = ScenarioResult{ .effect_id = -1 };
+    var client_done = false;
+    while (timer.read() < CLIENT_TIMEOUT_NS) {
+        var pollfds = [_]posix.pollfd{
+            .{ .fd = dev.pollFfFd(), .events = posix.POLL.IN, .revents = 0 },
+            .{ .fd = done_fd, .events = posix.POLL.IN, .revents = 0 },
+        };
+        const ready = posix.poll(&pollfds, CLIENT_POLL_MS) catch |err| {
+            finishAfterPumpError(thread, done_fd, &client.completed, client_done);
+            joined = true;
+            return err;
+        };
+        if (ready == 0) {
+            client_done = client.completed.load(.acquire);
+            if (client_done and result.event_count >= expected_events) break;
+            continue;
         }
-        if (client.done.load(.acquire) and stop != null) break;
-        std.Thread.sleep(1 * std.time.ns_per_ms);
+
+        const fatal_poll_events = posix.POLL.ERR | posix.POLL.HUP | posix.POLL.NVAL;
+        if (pollfds[0].revents & fatal_poll_events != 0 or
+            pollfds[1].revents & fatal_poll_events != 0)
+        {
+            finishAfterPumpError(thread, done_fd, &client.completed, client_done);
+            joined = true;
+            return error.PollDescriptorFailed;
+        }
+
+        if (pollfds[0].revents & posix.POLL.IN != 0) {
+            const maybe_event = dev.pollFf() catch |err| {
+                finishAfterPumpError(thread, done_fd, &client.completed, client_done);
+                joined = true;
+                return err;
+            };
+            if (maybe_event) |event| {
+                if (result.event_count >= result.events.len) {
+                    finishAfterPumpError(thread, done_fd, &client.completed, client_done);
+                    joined = true;
+                    return error.TooManyFfEvents;
+                }
+                result.events[result.event_count] = event;
+                result.event_count += 1;
+            }
+        }
+        if (pollfds[1].revents & posix.POLL.IN != 0) {
+            var completed_count: u64 = 0;
+            const read_len = posix.read(done_fd, std.mem.asBytes(&completed_count)) catch |err| {
+                finishAfterPumpError(thread, done_fd, &client.completed, client_done);
+                joined = true;
+                return err;
+            };
+            if (read_len != @sizeOf(u64) or completed_count == 0) {
+                finishAfterPumpError(thread, done_fd, &client.completed, client_done);
+                joined = true;
+                return error.InvalidCompletionSignal;
+            }
+        }
+        client_done = client.completed.load(.acquire);
+        if (client_done and result.event_count >= expected_events) break;
     }
 
+    if (!client_done) {
+        cancelAndJoin(thread, done_fd, &client.completed);
+        joined = true;
+        return error.ClientTimeout;
+    }
     thread.join();
+    joined = true;
     try client.result;
 
-    const ev = stop orelse return error.NoStopFrameFromErase;
+    // The worker only marks completion after all evdev writes/ioctls return,
+    // so any additional FF event is already queued. Drain without waiting to
+    // make the event-count assertions exact rather than prefix-only.
+    var drain_attempts: usize = 0;
+    while (drain_attempts < result.events.len) : (drain_attempts += 1) {
+        var pollfds = [_]posix.pollfd{.{ .fd = dev.pollFfFd(), .events = posix.POLL.IN, .revents = 0 }};
+        const ready = try posix.poll(&pollfds, 0);
+        if (ready == 0) break;
+        if (pollfds[0].revents & (posix.POLL.ERR | posix.POLL.HUP | posix.POLL.NVAL) != 0)
+            return error.PollDescriptorFailed;
+        if (pollfds[0].revents & posix.POLL.IN == 0) break;
+        if (try dev.pollFf()) |event| {
+            if (result.event_count >= result.events.len) return error.TooManyFfEvents;
+            result.events[result.event_count] = event;
+            result.event_count += 1;
+        }
+    }
+    if (drain_attempts == result.events.len) return error.FfQueueDidNotDrain;
+
+    result.effect_id = client.effect_id;
+    return result;
+}
+
+test "uinput: pollFf preserves real-kernel rapid PLAY then explicit STOP" {
+    const result = try runScenario(ff_play_stop_toml, FF_PLAY_STOP_PID, FF_PLAY_STOP_NAME, .play_stop, 2);
+
+    try testing.expect(result.effect_id >= 0);
+    try testing.expectEqual(@as(usize, 2), result.event_count);
+    const play = result.events[0];
+    const stop = result.events[1];
+    try testing.expectEqual(@as(u16, c.FF_RUMBLE), play.effect_type);
+    try testing.expectEqual(@as(u8, @intCast(result.effect_id)), play.effect_id);
+    try testing.expectEqual(@as(u16, 0xf000), play.strong);
+    try testing.expectEqual(@as(u16, 0x0f00), play.weak);
+    try testing.expectEqual(@as(u16, 65535), play.duration_ms);
+    try testing.expectEqual(@as(u16, c.FF_RUMBLE), stop.effect_type);
+    try testing.expectEqual(play.effect_id, stop.effect_id);
+    try testing.expectEqual(@as(u16, 0), stop.strong);
+    try testing.expectEqual(@as(u16, 0), stop.weak);
+    try testing.expectEqual(@as(u16, 0), stop.duration_ms);
+}
+
+test "uinput: pollFf turns a real UI_FF_ERASE into a zero-magnitude stop frame" {
+    const result = try runScenario(ff_erase_toml, FF_ERASE_PID, FF_ERASE_NAME, .erase, 1);
+
+    try testing.expectEqual(@as(usize, 1), result.event_count);
+    const ev = result.events[0];
     try testing.expectEqual(@as(u16, c.FF_RUMBLE), ev.effect_type);
     try testing.expectEqual(@as(u16, 0), ev.strong);
     try testing.expectEqual(@as(u16, 0), ev.weak);
-    try testing.expect(client.erased_id >= 0);
-    try testing.expectEqual(@as(u8, @intCast(client.erased_id)), ev.effect_id);
+    try testing.expect(result.effect_id >= 0);
+    try testing.expectEqual(@as(u8, @intCast(result.effect_id)), ev.effect_id);
 }

--- a/src/test/uinput_ff_erase_integration_test.zig
+++ b/src/test/uinput_ff_erase_integration_test.zig
@@ -50,6 +50,8 @@ const EVIOCGNAME_256 = linux.IOCTL.IOR('E', 0x06, [256]u8);
 const CLIENT_TIMEOUT_NS = 5 * std.time.ns_per_s;
 const CLIENT_POLL_MS: i32 = 50;
 const CANCEL_TIMEOUT_MS: i32 = 500;
+const CLEANUP_DRAIN_MS: i32 = 50;
+const MAX_DRAIN_POLLS: usize = 32;
 
 const ff_erase_toml =
     \\[device]
@@ -187,6 +189,7 @@ const Client = struct {
     completed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     result: anyerror!void = {},
     effect_id: i16 = -1,
+    fd: posix.fd_t = -1,
 
     fn run(self: *Client) void {
         self.result = self.body();
@@ -197,7 +200,10 @@ const Client = struct {
 
     fn body(self: *Client) !void {
         const fd = try posix.open(self.node, .{ .ACCMODE = .RDWR }, 0);
-        defer posix.close(fd);
+        // The harness closes this fd only after it verifies the explicit
+        // action. Keeping it open prevents kernel close-cleanup STOPs from
+        // masquerading as the PLAY/STOP or ERASE event under test.
+        self.fd = fd;
 
         var effect = std.mem.zeroes(c.ff_effect);
         effect.type = c.FF_RUMBLE;
@@ -228,8 +234,126 @@ const Client = struct {
 const ScenarioResult = struct {
     events: [8]uinput.FfEvent = undefined,
     event_count: usize = 0,
+    target_event_count: usize = 0,
     effect_id: i16,
 };
+
+fn drainQueuedEvents(dev: *uinput.UinputDevice, result: *ScenarioResult, initial_timeout_ms: i32) !void {
+    var timeout_ms = initial_timeout_ms;
+    var poll_count: usize = 0;
+    while (poll_count < MAX_DRAIN_POLLS) : (poll_count += 1) {
+        var pollfds = [_]posix.pollfd{.{ .fd = dev.pollFfFd(), .events = posix.POLL.IN, .revents = 0 }};
+        const ready = try posix.poll(&pollfds, timeout_ms);
+        timeout_ms = 0;
+        if (ready == 0) return;
+        if (pollfds[0].revents & (posix.POLL.ERR | posix.POLL.HUP | posix.POLL.NVAL) != 0)
+            return error.PollDescriptorFailed;
+        if (pollfds[0].revents & posix.POLL.IN == 0) return error.UnexpectedPollEvent;
+        if (try dev.pollFf()) |event| {
+            if (result.event_count >= result.events.len) return error.TooManyFfEvents;
+            result.events[result.event_count] = event;
+            result.event_count += 1;
+        }
+    }
+    return error.FfQueueDidNotDrain;
+}
+
+const ClientCloser = struct {
+    fd: posix.fd_t,
+    done_fd: posix.fd_t,
+    completed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    fn run(self: *ClientCloser) void {
+        posix.close(self.fd);
+        self.completed.store(true, .release);
+        var one: u64 = 1;
+        _ = posix.write(self.done_fd, std.mem.asBytes(&one)) catch {};
+    }
+};
+
+fn closeClientWithPump(dev: *uinput.UinputDevice, fd: posix.fd_t, result: *ScenarioResult) !void {
+    // Once ownership reaches this helper, failing to start the closer would
+    // leave an fd that may require a pumped UI_FF_ERASE handshake. Terminate
+    // instead of returning with an unsafe synchronous-close fallback.
+    const done_fd = posix.eventfd(0, ioctl.EFD_CLOEXEC | ioctl.EFD_NONBLOCK) catch terminateTestProcess();
+    defer posix.close(done_fd);
+
+    var closer = ClientCloser{ .fd = fd, .done_fd = done_fd };
+    const thread = std.Thread.spawn(.{}, ClientCloser.run, .{&closer}) catch terminateTestProcess();
+    var joined = false;
+    defer if (!joined) cancelAndJoin(thread, done_fd, &closer.completed);
+
+    var timer = try std.time.Timer.start();
+    var close_done = false;
+    while (timer.read() < CLIENT_TIMEOUT_NS) {
+        var pollfds = [_]posix.pollfd{
+            .{ .fd = dev.pollFfFd(), .events = posix.POLL.IN, .revents = 0 },
+            .{ .fd = done_fd, .events = posix.POLL.IN, .revents = 0 },
+        };
+        const ready = posix.poll(&pollfds, CLIENT_POLL_MS) catch |err| {
+            cancelAndJoin(thread, done_fd, &closer.completed);
+            joined = true;
+            return err;
+        };
+        if (ready == 0) {
+            close_done = closer.completed.load(.acquire);
+            if (close_done) break;
+            continue;
+        }
+
+        const fatal_poll_events = posix.POLL.ERR | posix.POLL.HUP | posix.POLL.NVAL;
+        if (pollfds[0].revents & fatal_poll_events != 0 or
+            pollfds[1].revents & fatal_poll_events != 0)
+        {
+            cancelAndJoin(thread, done_fd, &closer.completed);
+            joined = true;
+            return error.PollDescriptorFailed;
+        }
+
+        if (pollfds[0].revents & posix.POLL.IN != 0) {
+            const maybe_event = dev.pollFf() catch |err| {
+                cancelAndJoin(thread, done_fd, &closer.completed);
+                joined = true;
+                return err;
+            };
+            if (maybe_event) |event| {
+                if (result.event_count >= result.events.len) {
+                    cancelAndJoin(thread, done_fd, &closer.completed);
+                    joined = true;
+                    return error.TooManyFfEvents;
+                }
+                result.events[result.event_count] = event;
+                result.event_count += 1;
+            }
+        }
+        if (pollfds[1].revents & posix.POLL.IN != 0) {
+            var completed_count: u64 = 0;
+            const read_len = posix.read(done_fd, std.mem.asBytes(&completed_count)) catch |err| {
+                cancelAndJoin(thread, done_fd, &closer.completed);
+                joined = true;
+                return err;
+            };
+            if (read_len != @sizeOf(u64) or completed_count == 0) {
+                cancelAndJoin(thread, done_fd, &closer.completed);
+                joined = true;
+                return error.InvalidCompletionSignal;
+            }
+        }
+        close_done = closer.completed.load(.acquire);
+        if (close_done) break;
+    }
+
+    if (!close_done) {
+        cancelAndJoin(thread, done_fd, &closer.completed);
+        joined = true;
+        return error.ClientCloseTimeout;
+    }
+    thread.join();
+    joined = true;
+
+    // Catch any cleanup event queued immediately after close published done.
+    try drainQueuedEvents(dev, result, CLEANUP_DRAIN_MS);
+}
 
 fn runScenario(
     toml: []const u8,
@@ -266,12 +390,18 @@ fn runScenario(
     const done_fd = try posix.eventfd(0, ioctl.EFD_CLOEXEC | ioctl.EFD_NONBLOCK);
     defer posix.close(done_fd);
     var client = Client{ .node = node, .action = action, .done_fd = done_fd };
+    var result = ScenarioResult{ .effect_id = -1 };
     const thread = try std.Thread.spawn(.{}, Client.run, .{&client});
+    errdefer if (client.fd >= 0) {
+        const client_fd = client.fd;
+        client.fd = -1;
+        var discarded = ScenarioResult{ .effect_id = -1 };
+        closeClientWithPump(&dev, client_fd, &discarded) catch terminateTestProcess();
+    };
     var joined = false;
     defer if (!joined) cancelAndJoin(thread, done_fd, &client.completed);
 
     var timer = try std.time.Timer.start();
-    var result = ScenarioResult{ .effect_id = -1 };
     var client_done = false;
     while (timer.read() < CLIENT_TIMEOUT_NS) {
         var pollfds = [_]posix.pollfd{
@@ -285,7 +415,7 @@ fn runScenario(
         };
         if (ready == 0) {
             client_done = client.completed.load(.acquire);
-            if (client_done and result.event_count >= expected_events) break;
+            if (client_done) break;
             continue;
         }
 
@@ -328,7 +458,7 @@ fn runScenario(
             }
         }
         client_done = client.completed.load(.acquire);
-        if (client_done and result.event_count >= expected_events) break;
+        if (client_done) break;
     }
 
     if (!client_done) {
@@ -340,34 +470,40 @@ fn runScenario(
     joined = true;
     try client.result;
 
-    // The worker only marks completion after all evdev writes/ioctls return,
-    // so any additional FF event is already queued. Drain without waiting to
-    // make the event-count assertions exact rather than prefix-only.
-    var drain_attempts: usize = 0;
-    while (drain_attempts < result.events.len) : (drain_attempts += 1) {
-        var pollfds = [_]posix.pollfd{.{ .fd = dev.pollFfFd(), .events = posix.POLL.IN, .revents = 0 }};
-        const ready = try posix.poll(&pollfds, 0);
-        if (ready == 0) break;
-        if (pollfds[0].revents & (posix.POLL.ERR | posix.POLL.HUP | posix.POLL.NVAL) != 0)
-            return error.PollDescriptorFailed;
-        if (pollfds[0].revents & posix.POLL.IN == 0) break;
-        if (try dev.pollFf()) |event| {
-            if (result.event_count >= result.events.len) return error.TooManyFfEvents;
-            result.events[result.event_count] = event;
-            result.event_count += 1;
-        }
-    }
-    if (drain_attempts == result.events.len) return error.FfQueueDidNotDrain;
+    // All explicit writes/ioctls have returned, but the evdev fd remains open.
+    // Drain now and pin the target event count before close-generated cleanup
+    // can enter the uinput queue.
+    try drainQueuedEvents(&dev, &result, 0);
+    if (result.event_count != expected_events) return error.UnexpectedTargetEventCount;
+    result.target_event_count = result.event_count;
+
+    if (client.fd < 0) return error.MissingClientFd;
+    const client_fd = client.fd;
+    client.fd = -1;
+
+    // Closing the FF client can legitimately append STOP/ERASE cleanup events.
+    // A dedicated closer owns the potentially blocking close while this thread
+    // continues pumping UI_FF_ERASE. Capture cleanup separately so callers can
+    // enforce that it stays zero without letting it substitute for the target.
+    try closeClientWithPump(&dev, client_fd, &result);
 
     result.effect_id = client.effect_id;
     return result;
+}
+
+fn expectStopEvent(event: uinput.FfEvent, effect_id: u8) !void {
+    try testing.expectEqual(@as(u16, c.FF_RUMBLE), event.effect_type);
+    try testing.expectEqual(effect_id, event.effect_id);
+    try testing.expectEqual(@as(u16, 0), event.strong);
+    try testing.expectEqual(@as(u16, 0), event.weak);
+    try testing.expectEqual(@as(u16, 0), event.duration_ms);
 }
 
 test "uinput: pollFf preserves real-kernel rapid PLAY then explicit STOP" {
     const result = try runScenario(ff_play_stop_toml, FF_PLAY_STOP_PID, FF_PLAY_STOP_NAME, .play_stop, 2);
 
     try testing.expect(result.effect_id >= 0);
-    try testing.expectEqual(@as(usize, 2), result.event_count);
+    try testing.expectEqual(@as(usize, 2), result.target_event_count);
     const play = result.events[0];
     const stop = result.events[1];
     try testing.expectEqual(@as(u16, c.FF_RUMBLE), play.effect_type);
@@ -375,21 +511,24 @@ test "uinput: pollFf preserves real-kernel rapid PLAY then explicit STOP" {
     try testing.expectEqual(@as(u16, 0xf000), play.strong);
     try testing.expectEqual(@as(u16, 0x0f00), play.weak);
     try testing.expectEqual(@as(u16, 65535), play.duration_ms);
-    try testing.expectEqual(@as(u16, c.FF_RUMBLE), stop.effect_type);
-    try testing.expectEqual(play.effect_id, stop.effect_id);
-    try testing.expectEqual(@as(u16, 0), stop.strong);
-    try testing.expectEqual(@as(u16, 0), stop.weak);
-    try testing.expectEqual(@as(u16, 0), stop.duration_ms);
+    try expectStopEvent(stop, play.effect_id);
+
+    // Closing an evdev FF client may emit additional kernel cleanup STOP/ERASE
+    // notifications. They are valid only if they remain zero for this slot;
+    // a late non-zero frame would re-arm rumble after the explicit STOP.
+    for (result.events[result.target_event_count..result.event_count]) |event|
+        try expectStopEvent(event, play.effect_id);
 }
 
 test "uinput: pollFf turns a real UI_FF_ERASE into a zero-magnitude stop frame" {
-    const result = try runScenario(ff_erase_toml, FF_ERASE_PID, FF_ERASE_NAME, .erase, 1);
+    // Linux ff-core stops the effect with EV_FF=0 before issuing UI_FF_ERASE.
+    // pollFf must preserve that kernel stop and surface its own erase stop, so
+    // the pre-close target phase contains exactly two zero events.
+    const result = try runScenario(ff_erase_toml, FF_ERASE_PID, FF_ERASE_NAME, .erase, 2);
 
-    try testing.expectEqual(@as(usize, 1), result.event_count);
-    const ev = result.events[0];
-    try testing.expectEqual(@as(u16, c.FF_RUMBLE), ev.effect_type);
-    try testing.expectEqual(@as(u16, 0), ev.strong);
-    try testing.expectEqual(@as(u16, 0), ev.weak);
+    try testing.expectEqual(@as(usize, 2), result.target_event_count);
     try testing.expect(result.effect_id >= 0);
-    try testing.expectEqual(@as(u8, @intCast(result.effect_id)), ev.effect_id);
+    const effect_id: u8 = @intCast(result.effect_id);
+    for (result.events[0..result.event_count]) |event|
+        try expectStopEvent(event, effect_id);
 }


### PR DESCRIPTION
## Summary

- add a normalized, de-identified corpus derived from public issue #65 rumble diagnostics, with source links, extraction ranges, and SHA-256 provenance
- characterize the 60 Hz, strong-only, and dense/throttled STOP shapes with an independent Vader 5 frame/header/high-byte/checksum oracle, then compare them with the shipped encoder
- add negative controls for corrupt checksums, truncated frames, and missing terminal STOPs
- extend the real-uinput boundary test with immediate same-slot PLAY -> STOP ordering while retaining UI_FF_ERASE coverage
- isolate exact pre-close target events from kernel close cleanup, and close on a dedicated worker while the harness continues pumping `UI_FF_ERASE`
- bound the threaded ioctl harness with atomic completion, eventfd wakeup validation, SIGUSR1 cancellation, and a 30-second process watchdog

## Evidence boundary

This is a test-infrastructure change, not a claim that issue #65 is reproduced or fixed. `HID_WRITE` is logged before `DeviceIO.write`, so the corpus characterizes encoded write intent; it does not prove USB transfer completion or physical motor state. Those require a real Vader run with transport capture and an external physical oracle.

## Test evidence

- `./scripts/padctl-docker build test --summary all`: 20/20 steps, 2013/2024 passed, 11 skipped
- pre-push `test-tsan` in the canonical Docker image: 10/10 steps, 2009/2020 passed, 11 skipped
- `./scripts/padctl-docker build test-integration --summary all`: 18/18 steps, 7/23 passed, 16 skipped
  - the two real-uinput PLAY/STOP and ERASE scenarios compiled but skipped locally because this environment has no `/dev/uinput`
- GitHub privileged e2e with `PADCTL_TEST_REQUIRE_UINPUT=1`: both latest push and PR workflow runs passed
  - the first privileged run failed on the observed 4/2 kernel event sequences; that regression evidence drove target/cleanup phase isolation before the passing runs
- Zig 0.15.2 `zig fmt --check src/ tools/` and `git diff --check`
- three independent read-only reviews: blocker 0, major 0, minor 0 after follow-up fixes

Refs #65
