### PR TITLE
fix(vader5): correlate init replies with command opcodes

### DIFF
--- a/devices/flydigi/vader5.toml
+++ b/devices/flydigi/vader5.toml
@@ -34,6 +34,9 @@ commands = [
     "5aa5 0402 06",
 ]
 response_prefix = [0x5a, 0xa5]
+# Correlate each ACK with the command opcode. Extended input reports also
+# begin with 5a a5 (5a a5 ef), so the broad prefix alone is not an ACK.
+response_command_prefix_len = 3
 require_response = true
 enable  = "5aa5 1107 ff01 ffff ff15 00"
 disable = "5aa5 1107 ff00 ffff ff14 00"

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -27,13 +27,14 @@ Optional initialization sequence sent after device open.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `commands` | string[] | yes | Hex byte strings sent in order |
-| `response_prefix` | integer[] | yes | Expected response prefix bytes |
+| `commands` | string[] | no | Hex byte strings sent in order |
+| `response_prefix` | integer[] | no | Expected response prefix bytes. It may be omitted when command-prefix correlation alone identifies replies. |
+| `response_command_prefix_len` | integer | no | Also require the response to match the first N bytes of the command just sent. Before each correlated command, a bounded best-effort drain reduces stale-response risk; this is not a transport transaction barrier. Use this when unsolicited input reports share `response_prefix` with command replies. |
 | `enable` | string | no | Hex byte string sent to activate extended mode (e.g. BT mode switch) |
-| `disable` | string | no | Hex byte string sent on shutdown |
+| `disable` | string | no | Reserved shutdown hex command. It is parsed but the current runtime does not send it yet. |
 | `interface` | integer | no | Interface to send init commands on |
 | `report_size` | integer | no | Expected report size after init |
-| `require_response` | bool | no | When `true`, a missing `response_prefix` ACK fails init/re-init instead of continuing. Use for devices whose input reports are valid only after an acknowledged mode switch. |
+| `require_response` | bool | no | When `true`, `commands` or `enable` and at least one ACK criterion are required; failure to receive a response matching every configured criterion fails init/re-init instead of continuing. Use for devices whose input reports are valid only after an acknowledged mode switch. |
 | `feature_report` | integer[] | no | HID feature report sent via `HIDIOCSFEATURE` immediately after `commands`. Encoded as a list of byte values (0–255); `byte[0]` is the report ID. |
 
 ## `[[report]]`

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -15,6 +15,7 @@ pub const ButtonId = state.ButtonId;
 // every report with no diagnostic. Reject at validate time instead.
 pub const MAX_REPORT_SIZE: i64 = 512;
 pub const LIBUSB_SLOT_SIZE: i64 = 64;
+pub const MAX_INIT_COMMAND_SIZE: i64 = 64;
 
 pub const InterfaceConfig = struct {
     id: i64,
@@ -26,6 +27,10 @@ pub const InterfaceConfig = struct {
 pub const InitConfig = struct {
     commands: ?[]const []const u8 = null,
     response_prefix: ?[]const i64 = null,
+    /// When set, an init response must also begin with the first N bytes of
+    /// the command it acknowledges. This disambiguates command ACKs from
+    /// unsolicited input reports that share response_prefix.
+    response_command_prefix_len: ?i64 = null,
     enable: ?[]const u8 = null,
     disable: ?[]const u8 = null,
     require_response: bool = false,
@@ -362,6 +367,23 @@ fn fieldTypeSize(type_str: []const u8) ?i64 {
     return null;
 }
 
+fn initCommandByteLen(command: []const u8) !usize {
+    var i: usize = 0;
+    var byte_len: usize = 0;
+    while (i < command.len) {
+        if (command[i] == ' ') {
+            i += 1;
+            continue;
+        }
+        if (i + 1 >= command.len) return error.InvalidConfig;
+        _ = std.fmt.charToDigit(command[i], 16) catch return error.InvalidConfig;
+        _ = std.fmt.charToDigit(command[i + 1], 16) catch return error.InvalidConfig;
+        byte_len += 1;
+        i += 2;
+    }
+    return byte_len;
+}
+
 pub fn isSuppressClass(class: []const u8) bool {
     return std.mem.eql(u8, class, "suppress");
 }
@@ -456,6 +478,37 @@ pub fn validate(cfg: *const DeviceConfig) !void {
         if (init_cfg.interface) |iface_id| {
             if (!interfaceExists(cfg, iface_id)) return error.InvalidConfig;
             if (isSuppressInterface(cfg, iface_id)) return error.InvalidConfig;
+        }
+        const has_response_prefix = if (init_cfg.response_prefix) |prefix|
+            prefix.len > 0
+        else
+            false;
+        const has_command_correlation = init_cfg.response_command_prefix_len != null;
+        const has_command = if (init_cfg.commands) |commands| commands.len > 0 else false;
+        const has_response_step = has_command or init_cfg.enable != null;
+        if (init_cfg.require_response and
+            (!has_response_step or (!has_response_prefix and !has_command_correlation)))
+        {
+            return error.InvalidConfig;
+        }
+        if (init_cfg.response_prefix) |prefix| {
+            if (prefix.len > MAX_INIT_COMMAND_SIZE) return error.InvalidConfig;
+        }
+        if (init_cfg.response_command_prefix_len) |raw_prefix_len| {
+            if (raw_prefix_len <= 0 or raw_prefix_len > MAX_INIT_COMMAND_SIZE)
+                return error.InvalidConfig;
+            if (!has_command and init_cfg.enable == null) return error.InvalidConfig;
+            const prefix_len: usize = @intCast(raw_prefix_len);
+            if (init_cfg.commands) |commands| {
+                for (commands) |command| {
+                    if (try initCommandByteLen(command) < prefix_len)
+                        return error.InvalidConfig;
+                }
+            }
+            if (init_cfg.enable) |enable| {
+                if (try initCommandByteLen(enable) < prefix_len)
+                    return error.InvalidConfig;
+            }
         }
     }
 
@@ -554,6 +607,9 @@ pub fn validate(cfg: *const DeviceConfig) !void {
     if (cfg.device.init) |init_cfg| {
         if (init_cfg.feature_report) |fr| {
             for (fr) |b| if (b < 0 or b > 255) return error.InvalidConfig;
+        }
+        if (init_cfg.response_prefix) |prefix| {
+            for (prefix) |b| if (b < 0 or b > 255) return error.InvalidConfig;
         }
     }
 
@@ -972,6 +1028,10 @@ test "device: load flydigi/vader5.toml succeeds" {
     try std.testing.expectEqual(@as(i64, 0x2401), cfg.device.pid);
     try std.testing.expectEqual(@as(usize, 1), cfg.report.len);
     try std.testing.expectEqualStrings("extended", cfg.report[0].name);
+    try std.testing.expectEqual(
+        @as(?i64, 3),
+        cfg.device.init.?.response_command_prefix_len,
+    );
 }
 
 test "device: output profile overlays default output and preset identity" {
@@ -2529,6 +2589,241 @@ test "device: feature_report rejects byte < 0" {
         \\size = 4
     ;
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad));
+}
+
+test "device: response_command_prefix_len parses and validates" {
+    const allocator = std.testing.allocator;
+    const valid =
+        \\[device]
+        \\name = "Test"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[device.init]
+        \\commands = ["5aa5 0102 03"]
+        \\response_prefix = [0x5a, 0xa5]
+        \\response_command_prefix_len = 3
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+    ;
+    const result = try parseString(allocator, valid);
+    defer result.deinit();
+    try std.testing.expectEqual(
+        @as(?i64, 3),
+        result.value.device.init.?.response_command_prefix_len,
+    );
+}
+
+test "device: response_command_prefix_len rejects zero and values above 64" {
+    const allocator = std.testing.allocator;
+    const zero =
+        \\[device]
+        \\name = "Test"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[device.init]
+        \\commands = ["5aa5 01"]
+        \\response_command_prefix_len = 0
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, zero));
+
+    const too_large =
+        \\[device]
+        \\name = "Test"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[device.init]
+        \\commands = ["5aa5 01"]
+        \\response_command_prefix_len = 65
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, too_large));
+}
+
+test "device: response_command_prefix_len cannot exceed command byte length" {
+    const allocator = std.testing.allocator;
+    const bad =
+        \\[device]
+        \\name = "Test"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[device.init]
+        \\commands = ["5aa5"]
+        \\response_command_prefix_len = 3
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad));
+}
+
+test "device: response_command_prefix_len cannot exceed enable byte length" {
+    const allocator = std.testing.allocator;
+    const bad =
+        \\[device]
+        \\name = "Test"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[device.init]
+        \\enable = "5aa5"
+        \\response_command_prefix_len = 3
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad));
+}
+
+test "device: response_command_prefix_len requires a command or enable step" {
+    const allocator = std.testing.allocator;
+    const bad =
+        \\[device]
+        \\name = "Test"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[device.init]
+        \\response_command_prefix_len = 3
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad));
+}
+
+test "device: response_prefix rejects values outside the byte range" {
+    const allocator = std.testing.allocator;
+    const too_large =
+        \\[device]
+        \\name = "Test"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[device.init]
+        \\commands = ["01"]
+        \\response_prefix = [256]
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, too_large));
+
+    const negative =
+        \\[device]
+        \\name = "Test"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[device.init]
+        \\commands = ["01"]
+        \\response_prefix = [-1]
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, negative));
+}
+
+test "device: required init response needs a bounded match criterion" {
+    const allocator = std.testing.allocator;
+    const missing =
+        \\[device]
+        \\name = "Test"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[device.init]
+        \\commands = ["01"]
+        \\require_response = true
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, missing));
+
+    const empty =
+        \\[device]
+        \\name = "Test"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[device.init]
+        \\commands = ["01"]
+        \\response_prefix = []
+        \\require_response = true
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, empty));
+
+    const no_response_step =
+        \\[device]
+        \\name = "Test"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[device.init]
+        \\response_prefix = [0x5a]
+        \\require_response = true
+        \\feature_report = [1]
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, no_response_step));
+
+    const prefix_values: [MAX_INIT_COMMAND_SIZE + 1]i64 = @splat(0x5a);
+    var result = try parseString(allocator, test_toml);
+    defer result.deinit();
+    result.value.device.init = .{
+        .commands = &.{"01"},
+        .response_prefix = &prefix_values,
+    };
+    try std.testing.expectError(error.InvalidConfig, validate(&result.value));
 }
 
 test "device: fuzz parseString: no panic on arbitrary input" {

--- a/src/init.zig
+++ b/src/init.zig
@@ -22,7 +22,51 @@ pub fn parseHexBytes(allocator: std.mem.Allocator, hex: []const u8) ![]u8 {
     return out.toOwnedSlice(allocator);
 }
 
-fn sendAndWaitPrefix(device: DeviceIO, bytes: []const u8, prefix: []const u8, retries: u16, report_size: usize) !void {
+const init_poll_interval_ns = 10 * std.time.ns_per_ms;
+const init_drain_limit = 64;
+
+fn drainPendingReports(device: DeviceIO) !usize {
+    var read_buf: [64]u8 = undefined;
+    var drained: usize = 0;
+    while (drained < init_drain_limit) {
+        _ = device.read(&read_buf) catch |err| switch (err) {
+            error.Again => return drained,
+            else => return err,
+        };
+        drained += 1;
+    }
+    return drained;
+}
+
+fn responseMatches(
+    response: []const u8,
+    response_prefix: []const u8,
+    command_prefix: []const u8,
+) bool {
+    return std.mem.startsWith(u8, response, response_prefix) and
+        std.mem.startsWith(u8, response, command_prefix);
+}
+
+fn sendAndWaitPrefix(
+    device: DeviceIO,
+    bytes: []const u8,
+    prefix: []const u8,
+    command_prefix_len: usize,
+    retries: u16,
+    report_size: usize,
+) !void {
+    if (command_prefix_len > bytes.len or
+        command_prefix_len > device_mod.MAX_INIT_COMMAND_SIZE)
+        return error.InvalidConfig;
+
+    // Reduce the chance that a queued response is mistaken for this command's
+    // ACK. This is deliberately bounded and is not a transport-level barrier:
+    // a concurrent producer can still enqueue a frame between drain and write.
+    const pre_drain_count = if (command_prefix_len > 0)
+        try drainPendingReports(device)
+    else
+        0;
+
     // Zero-pad to report_size to match HID output report length
     var pad_buf: [64]u8 = .{0} ** 64;
     if (bytes.len > pad_buf.len)
@@ -33,28 +77,53 @@ fn sendAndWaitPrefix(device: DeviceIO, bytes: []const u8, prefix: []const u8, re
     const copy_len = @min(bytes.len, pad_buf.len);
     @memcpy(pad_buf[0..copy_len], bytes[0..copy_len]);
     try device.write(pad_buf[0..@min(send_len, pad_buf.len)]);
-    if (prefix.len == 0) {
+    if (prefix.len == 0 and command_prefix_len == 0) {
         std.Thread.sleep(20 * std.time.ns_per_ms);
         return;
     }
+
+    if (retries == 0) return error.InitFailed;
+
+    const command_prefix = bytes[0..command_prefix_len];
+    const logged_command_prefix = command_prefix[0..@min(command_prefix.len, 8)];
     var read_buf: [64]u8 = undefined;
-    var attempt: u16 = 0;
-    while (attempt < retries) : (attempt += 1) {
+    var timer = try std.time.Timer.start();
+    const timeout_ns = @as(u64, retries) * init_poll_interval_ns;
+    var ignored_count: usize = 0;
+    while (timer.read() < timeout_ns) {
         const n = device.read(&read_buf) catch |err| switch (err) {
             error.Again => {
-                std.Thread.sleep(10 * std.time.ns_per_ms);
+                const elapsed_ns = timer.read();
+                if (elapsed_ns >= timeout_ns) break;
+                std.Thread.sleep(@min(init_poll_interval_ns, timeout_ns - elapsed_ns));
                 continue;
             },
             else => return err,
         };
-        if (std.mem.startsWith(u8, read_buf[0..n], prefix)) return;
-        std.Thread.sleep(10 * std.time.ns_per_ms);
+        if (responseMatches(read_buf[0..n], prefix, command_prefix)) {
+            if (command_prefix_len > 0) {
+                std.log.debug(
+                    "init: strict ACK command_prefix={x} command_prefix_len={d} response_prefix={x} pre_drain={d} ignored={d}",
+                    .{ logged_command_prefix, command_prefix.len, prefix, pre_drain_count, ignored_count },
+                );
+            }
+            return;
+        }
+        ignored_count += 1;
+        if (ignored_count % init_drain_limit == 0) std.Thread.yield() catch {};
+    }
+    if (command_prefix_len > 0) {
+        std.log.debug(
+            "init: strict ACK timeout command_prefix={x} command_prefix_len={d} response_prefix={x} pre_drain={d} ignored={d}",
+            .{ logged_command_prefix, command_prefix.len, prefix, pre_drain_count, ignored_count },
+        );
     }
     return error.InitFailed;
 }
 
 /// Run device init handshake for a single DeviceIO.
-/// For each command hex string: write bytes, then retry waiting for response_prefix.
+/// For each command hex string: write bytes, then wait for all configured
+/// response criteria (static prefix and optional command-prefix correlation).
 /// If feature_report is set, send it via HIDIOCSFEATURE after all commands.
 pub fn runInitSequence(
     allocator: std.mem.Allocator,
@@ -63,14 +132,28 @@ pub fn runInitSequence(
 ) !void {
     const prefix: []const u8 = blk: {
         const raw = init_config.response_prefix orelse break :blk &[_]u8{};
-        var buf = try allocator.alloc(u8, raw.len);
+        if (raw.len > device_mod.MAX_INIT_COMMAND_SIZE) return error.InvalidConfig;
+        for (raw) |b| if (b < 0 or b > 255) return error.InvalidConfig;
+        const buf = try allocator.alloc(u8, raw.len);
         for (raw, 0..) |b, j| buf[j] = @intCast(b);
         break :blk buf;
     };
     defer if (init_config.response_prefix != null) allocator.free(prefix);
 
     const report_size: usize = if (init_config.report_size) |rs| @intCast(rs) else 0;
+    const command_prefix_len: usize = if (init_config.response_command_prefix_len) |len| blk: {
+        if (len <= 0 or len > device_mod.MAX_INIT_COMMAND_SIZE)
+            return error.InvalidConfig;
+        break :blk @intCast(len);
+    } else 0;
     const require_response = init_config.require_response;
+    const has_command = if (init_config.commands) |commands| commands.len > 0 else false;
+    const has_response_step = has_command or init_config.enable != null;
+    if (require_response and
+        (!has_response_step or (prefix.len == 0 and command_prefix_len == 0)))
+    {
+        return error.InvalidConfig;
+    }
 
     var total: usize = 0;
 
@@ -78,7 +161,7 @@ pub fn runInitSequence(
         for (cmds) |cmd| {
             const bytes = try parseHexBytes(allocator, cmd);
             defer allocator.free(bytes);
-            sendAndWaitPrefix(device, bytes, prefix, 50, report_size) catch |err| {
+            sendAndWaitPrefix(device, bytes, prefix, command_prefix_len, 50, report_size) catch |err| {
                 if (err == error.InitFailed) {
                     if (require_response) return err;
                     std.log.debug("init command got no ack, continuing", .{});
@@ -91,7 +174,7 @@ pub fn runInitSequence(
     if (init_config.enable) |enable_cmd| {
         const bytes = try parseHexBytes(allocator, enable_cmd);
         defer allocator.free(bytes);
-        sendAndWaitPrefix(device, bytes, prefix, 50, report_size) catch |err| {
+        sendAndWaitPrefix(device, bytes, prefix, command_prefix_len, 50, report_size) catch |err| {
             if (err == error.InitFailed) {
                 if (require_response) return err;
                 std.log.debug("enable command got no ack, continuing", .{});
@@ -148,6 +231,242 @@ test "init: parseHexBytes odd length returns error" {
 }
 
 const MockDeviceIO = @import("test/mock_device_io.zig").MockDeviceIO;
+
+/// Test-only DeviceIO that exposes one queue before the first write and either
+/// a single response queue or one queue per write afterwards. This models
+/// asynchronous traffic closely enough to distinguish stale reports from
+/// responses produced by a particular command.
+const WriteTriggeredDeviceIO = struct {
+    allocator: std.mem.Allocator,
+    before_write: []const []const u8,
+    after_write: []const []const u8,
+    response_stages: ?[]const []const []const u8 = null,
+    before_idx: usize = 0,
+    response_idx: usize = 0,
+    total_response_reads: usize = 0,
+    write_count: usize = 0,
+    write_log: std.ArrayList(u8) = .{},
+
+    fn init(
+        allocator: std.mem.Allocator,
+        before_write: []const []const u8,
+        after_write: []const []const u8,
+    ) WriteTriggeredDeviceIO {
+        return .{
+            .allocator = allocator,
+            .before_write = before_write,
+            .after_write = after_write,
+        };
+    }
+
+    fn initStaged(
+        allocator: std.mem.Allocator,
+        before_write: []const []const u8,
+        response_stages: []const []const []const u8,
+    ) WriteTriggeredDeviceIO {
+        return .{
+            .allocator = allocator,
+            .before_write = before_write,
+            .after_write = &.{},
+            .response_stages = response_stages,
+        };
+    }
+
+    fn deinit(self: *WriteTriggeredDeviceIO) void {
+        self.write_log.deinit(self.allocator);
+    }
+
+    fn deviceIO(self: *WriteTriggeredDeviceIO) DeviceIO {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = DeviceIO.VTable{
+        .read = read,
+        .write = write,
+        .feature_report = featureReport,
+        .pollfd = pollfd,
+        .close = close,
+    };
+
+    fn read(ptr: *anyopaque, buf: []u8) DeviceIO.ReadError!usize {
+        const self: *WriteTriggeredDeviceIO = @ptrCast(@alignCast(ptr));
+        const frame = if (self.write_count == 0) blk: {
+            if (self.before_idx >= self.before_write.len) return error.Again;
+            defer self.before_idx += 1;
+            break :blk self.before_write[self.before_idx];
+        } else blk: {
+            const responses = if (self.response_stages) |stages| stage: {
+                const stage_idx = self.write_count - 1;
+                if (stage_idx >= stages.len) return error.Again;
+                break :stage stages[stage_idx];
+            } else self.after_write;
+            if (self.response_idx >= responses.len) return error.Again;
+            defer {
+                self.response_idx += 1;
+                self.total_response_reads += 1;
+            }
+            break :blk responses[self.response_idx];
+        };
+        const n = @min(buf.len, frame.len);
+        @memcpy(buf[0..n], frame[0..n]);
+        return n;
+    }
+
+    fn write(ptr: *anyopaque, data: []const u8) DeviceIO.WriteError!void {
+        const self: *WriteTriggeredDeviceIO = @ptrCast(@alignCast(ptr));
+        self.write_log.appendSlice(self.allocator, data) catch return error.Io;
+        self.write_count += 1;
+        self.response_idx = 0;
+    }
+
+    fn featureReport(_: *anyopaque, _: []const u8) DeviceIO.WriteError!void {}
+
+    fn pollfd(_: *anyopaque) std.posix.pollfd {
+        return .{ .fd = -1, .events = 0, .revents = 0 };
+    }
+
+    fn close(_: *anyopaque) void {}
+};
+
+test "init: Vader input report does not acknowledge init command" {
+    const allocator = std.testing.allocator;
+
+    // Vader 5 extended input reports share the broad 5a a5 prefix with
+    // command acknowledgements, but 0xef is input data rather than the
+    // response to command 0x01.
+    const input_report = [_]u8{ 0x5a, 0xa5, 0xef, 0x00 };
+    const command = [_]u8{ 0x5a, 0xa5, 0x01, 0x02, 0x03 };
+    var mock = WriteTriggeredDeviceIO.init(allocator, &.{}, &.{&input_report});
+    defer mock.deinit();
+
+    try std.testing.expectError(
+        error.InitFailed,
+        sendAndWaitPrefix(mock.deviceIO(), &command, &.{ 0x5a, 0xa5 }, 3, 1, 0),
+    );
+}
+
+test "init: strict response rejects a late ACK for another opcode" {
+    const allocator = std.testing.allocator;
+    const command = [_]u8{ 0x5a, 0xa5, 0x01, 0x02, 0x03 };
+    const late_serial_ack = [_]u8{ 0x5a, 0xa5, 0xa1, 0x01 };
+    var mock = WriteTriggeredDeviceIO.init(allocator, &.{}, &.{&late_serial_ack});
+    defer mock.deinit();
+
+    try std.testing.expectError(
+        error.InitFailed,
+        sendAndWaitPrefix(mock.deviceIO(), &command, &.{ 0x5a, 0xa5 }, 3, 1, 0),
+    );
+}
+
+test "init: strict response drains an ACK queued before write" {
+    const allocator = std.testing.allocator;
+    const command = [_]u8{ 0x5a, 0xa5, 0x01, 0x02, 0x03 };
+    const stale_ack = [_]u8{ 0x5a, 0xa5, 0x01, 0x01 };
+    var mock = WriteTriggeredDeviceIO.init(allocator, &.{&stale_ack}, &.{});
+    defer mock.deinit();
+
+    try std.testing.expectError(
+        error.InitFailed,
+        sendAndWaitPrefix(mock.deviceIO(), &command, &.{ 0x5a, 0xa5 }, 3, 1, 0),
+    );
+    try std.testing.expectEqual(@as(usize, 1), mock.before_idx);
+    try std.testing.expectEqual(@as(usize, 1), mock.write_count);
+}
+
+test "init: strict response accepts matching ACK produced after write" {
+    const allocator = std.testing.allocator;
+    const command = [_]u8{ 0x5a, 0xa5, 0x01, 0x02, 0x03 };
+    const ack = [_]u8{ 0x5a, 0xa5, 0x01, 0x01 };
+    var mock = WriteTriggeredDeviceIO.init(allocator, &.{}, &.{&ack});
+    defer mock.deinit();
+
+    try sendAndWaitPrefix(mock.deviceIO(), &command, &.{ 0x5a, 0xa5 }, 3, 1, 0);
+    try std.testing.expectEqualSlices(u8, &command, mock.write_log.items);
+}
+
+test "init: command correlation works without a static response prefix" {
+    const allocator = std.testing.allocator;
+    const command = [_]u8{ 0x5a, 0xa5, 0x01, 0x02, 0x03 };
+    const ack = [_]u8{ 0x5a, 0xa5, 0x01, 0x01 };
+    var mock = WriteTriggeredDeviceIO.init(allocator, &.{}, &.{&ack});
+    defer mock.deinit();
+
+    try sendAndWaitPrefix(mock.deviceIO(), &command, &.{}, 3, 1, 0);
+}
+
+test "init: strict response skips input reports until matching ACK" {
+    const allocator = std.testing.allocator;
+    const command = [_]u8{ 0x5a, 0xa5, 0x01, 0x02, 0x03 };
+    const input_report = [_]u8{ 0x5a, 0xa5, 0xef, 0x00 };
+    const ack = [_]u8{ 0x5a, 0xa5, 0x01, 0x01 };
+    var mock = WriteTriggeredDeviceIO.init(allocator, &.{}, &.{
+        &input_report, &input_report, &input_report, &input_report, &input_report,
+        &input_report, &input_report, &input_report, &input_report, &input_report,
+        &input_report, &input_report, &input_report, &input_report, &input_report,
+        &input_report, &input_report, &input_report, &input_report, &input_report,
+        &input_report, &input_report, &input_report, &input_report, &ack,
+    });
+    defer mock.deinit();
+
+    try sendAndWaitPrefix(mock.deviceIO(), &command, &.{ 0x5a, 0xa5 }, 3, 1, 0);
+    try std.testing.expectEqual(@as(usize, 25), mock.total_response_reads);
+}
+
+test "init: unconfigured command correlation preserves prefix-only matching" {
+    const allocator = std.testing.allocator;
+    const command = [_]u8{ 0x5a, 0xa5, 0x01, 0x02, 0x03 };
+    const input_report = [_]u8{ 0x5a, 0xa5, 0xef, 0x00 };
+    var mock = try MockDeviceIO.init(allocator, &.{&input_report});
+    defer mock.deinit();
+
+    try sendAndWaitPrefix(mock.deviceIO(), &command, &.{ 0x5a, 0xa5 }, 0, 1, 0);
+}
+
+test "init: strict Vader handshake correlates all commands and enable ACKs" {
+    const allocator = std.testing.allocator;
+    const input_report = [_]u8{ 0x5a, 0xa5, 0xef, 0x00 };
+    const ident_ack = [_]u8{ 0x5a, 0xa5, 0x01, 0x01 };
+    const serial_ack = [_]u8{ 0x5a, 0xa5, 0xa1, 0x01 };
+    const config_read_ack = [_]u8{ 0x5a, 0xa5, 0x02, 0x01 };
+    const config_data_ack = [_]u8{ 0x5a, 0xa5, 0x04, 0x01 };
+    const enable_ack = [_]u8{ 0x5a, 0xa5, 0x11, 0x01 };
+    const ident_responses = [_][]const u8{ &input_report, &ident_ack };
+    const serial_responses = [_][]const u8{ &input_report, &serial_ack };
+    const config_read_responses = [_][]const u8{ &input_report, &config_read_ack };
+    const config_data_responses = [_][]const u8{ &input_report, &config_data_ack };
+    const enable_responses = [_][]const u8{ &input_report, &enable_ack };
+    const response_stages = [_][]const []const u8{
+        &ident_responses,
+        &serial_responses,
+        &config_read_responses,
+        &config_data_responses,
+        &enable_responses,
+    };
+    var mock = WriteTriggeredDeviceIO.initStaged(allocator, &.{}, &response_stages);
+    defer mock.deinit();
+
+    const parsed = try device_mod.parseFile(allocator, "devices/flydigi/vader5.toml");
+    defer parsed.deinit();
+    const init_cfg = parsed.value.device.init orelse return error.MissingInit;
+
+    try runInitSequence(allocator, mock.deviceIO(), init_cfg);
+    try std.testing.expectEqual(@as(usize, 5), mock.write_count);
+    try std.testing.expectEqual(@as(usize, 10), mock.total_response_reads);
+    try std.testing.expectEqual(@as(usize, 5 * 32), mock.write_log.items.len);
+
+    const expected_commands = [_][]const u8{
+        &.{ 0x5a, 0xa5, 0x01, 0x02, 0x03 },
+        &.{ 0x5a, 0xa5, 0xa1, 0x02, 0xa3 },
+        &.{ 0x5a, 0xa5, 0x02, 0x02, 0x04 },
+        &.{ 0x5a, 0xa5, 0x04, 0x02, 0x06 },
+        &.{ 0x5a, 0xa5, 0x11, 0x07, 0xff, 0x01, 0xff, 0xff, 0xff, 0x15, 0x00 },
+    };
+    for (expected_commands, 0..) |expected, i| {
+        const report = mock.write_log.items[i * 32 ..][0..32];
+        try std.testing.expectEqualSlices(u8, expected, report[0..expected.len]);
+        for (report[expected.len..]) |byte| try std.testing.expectEqual(@as(u8, 0), byte);
+    }
+}
 
 const FailFeatureReportDeviceIO = struct {
     pub fn deviceIO(self: *FailFeatureReportDeviceIO) DeviceIO {
@@ -223,12 +542,79 @@ test "init: runInitSequence: require_response fails on missing ack" {
     const dev = mock.deviceIO();
 
     const init_cfg = device_mod.InitConfig{
-        .commands = &[_][]const u8{"0101"},
+        .commands = &[_][]const u8{"5a01"},
         .response_prefix = &[_]i64{0x5a},
+        .response_command_prefix_len = 1,
         .require_response = true,
     };
 
     try std.testing.expectError(error.InitFailed, runInitSequence(allocator, dev, init_cfg));
+}
+
+test "init: runInitSequence rejects an out-of-range response prefix" {
+    const allocator = std.testing.allocator;
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    const init_cfg = device_mod.InitConfig{
+        .commands = &.{"01"},
+        .response_prefix = &.{ 0x5a, 256 },
+    };
+
+    try std.testing.expectError(
+        error.InvalidConfig,
+        runInitSequence(allocator, mock.deviceIO(), init_cfg),
+    );
+    try std.testing.expectEqual(@as(usize, 0), mock.write_log.items.len);
+}
+
+test "init: runInitSequence rejects required response without match criteria" {
+    const allocator = std.testing.allocator;
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    const init_cfg = device_mod.InitConfig{
+        .commands = &.{"01"},
+        .require_response = true,
+    };
+
+    try std.testing.expectError(
+        error.InvalidConfig,
+        runInitSequence(allocator, mock.deviceIO(), init_cfg),
+    );
+    try std.testing.expectEqual(@as(usize, 0), mock.write_log.items.len);
+}
+
+test "init: runInitSequence rejects required response without a response step" {
+    const allocator = std.testing.allocator;
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    const init_cfg = device_mod.InitConfig{
+        .response_prefix = &.{0x5a},
+        .require_response = true,
+        .feature_report = &.{1},
+    };
+
+    try std.testing.expectError(
+        error.InvalidConfig,
+        runInitSequence(allocator, mock.deviceIO(), init_cfg),
+    );
+    try std.testing.expectEqual(@as(usize, 0), mock.feature_report_log.items.len);
+}
+
+test "init: runInitSequence rejects response prefix larger than read buffer" {
+    const allocator = std.testing.allocator;
+    var mock = try MockDeviceIO.init(allocator, &.{});
+    defer mock.deinit();
+    const prefix_values: [device_mod.MAX_INIT_COMMAND_SIZE + 1]i64 = @splat(0x5a);
+    const init_cfg = device_mod.InitConfig{
+        .commands = &.{"01"},
+        .response_prefix = &prefix_values,
+    };
+
+    try std.testing.expectError(
+        error.InvalidConfig,
+        runInitSequence(allocator, mock.deviceIO(), init_cfg),
+    );
+    try std.testing.expectEqual(@as(usize, 0), mock.write_log.items.len);
 }
 
 test "init: runInitSequence: enable command sent after commands" {


### PR DESCRIPTION
## Summary

Vader 5 extended input reports begin with `5a a5 ef`, while init replies begin with `5a a5 <command-opcode>`. The previous prefix-only matcher accepted ordinary input as an ACK and advanced the five-step handshake in roughly 2 ms instead of waiting for the real replies.

This patch:

- adds optional command-prefix correlation for init responses while preserving existing prefix-only device behavior
- configures Vader 5 to require the first three response bytes to match the command just sent
- bounds stale-report draining and ACK waiting, and rejects invalid/vacuous response configurations before device I/O
- adds canonical five-command Vader coverage, negative input/wrong-opcode/stale-ACK cases, and configuration boundary tests
- documents the matcher and clarifies that `disable` is currently parsed/reserved rather than sent at shutdown

Refs #65. This PR intentionally does not close the issue.

## Reproduction and hardware evidence

- Baseline regression test on the old matcher failed with `expected error.InitFailed, found void` when only a `5a a5 ef` input report was supplied.
- Real Vader 5 traces show the expected reply order `5aa501`, `5aa5a1`, `5aa502`, `5aa504`, `5aa511`, with about 22 ms between replies.
- Final musl artifact SHA-256 `1d0385e21cf013204b9b9b1e67d703bf1c6ebad73a07f02bed31b675ebfd6391`: 5/5 daemon restart cycles reached all five strict ACKs and `device ready` (25/25 ACKs).
- Earlier fixed-artifact stress: 30/30 restart cycles succeeded. A dense 300-cycle force-feedback run produced 5,100 PLAY updates, 900 STOP events, valid 32-byte HID frames, a final zero frame with empty scheduler slots, and no logged error/warn/disconnect.
- The original user-managed `padctl.service` was restored to `active/running` after hardware testing.

## Tests

- Init target: 43/43 passed
- Canonical Docker Debug: 20/20 build steps; 2032/2043 passed, 11 device/environment skips
- Canonical Docker ReleaseSafe: 10/10 build steps; 2028/2039 passed, 11 skips
- Canonical Docker ThreadSanitizer: 10/10 build steps; 2028/2039 passed, 11 skips
- Production x86_64-linux-musl build: 12/12 steps
- Pre-push Docker ThreadSanitizer fallback: passed
- `zig fmt --check` and `git diff --check`: passed

## Remaining issue #65 scope

This proves the init ACK misclassification and short high-density rumble control path on one connected Vader 5. It does not yet prove controller-before-boot cold-start behavior, dongle re-enumeration, long-duration RF/input liveness, other firmware revisions, or physical motor state over hours. Those paths remain follow-up work, so issue #65 should remain open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter initialization response matching to distinguish acknowledgments from unrelated device reports.
  * Added configuration support for matching responses to command prefixes.
  * Improved handling of stale reports before initialization commands.

* **Bug Fixes**
  * Initialization now ignores unrelated responses and fails promptly when valid acknowledgments are not received.
  * Added validation for response-matching settings and invalid initialization configurations.
  * Improved timeout handling during device initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->