### PR TITLE
chore(release): bump version to 0.1.24

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.23",
+    .version = "0.1.24",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
## Summary

- bump the package version from 0.1.23 to 0.1.24 after PR #500 landed
- keep `build.zig.zon` as the release version source of truth
- prepare the tag-gated release workflow without changing runtime behavior

Refs #65. #65 and #481 remain OPEN.

## Verification

- `git diff --check`
- canonical Docker Debug suite: 2032/2043 passed, 11 skipped
- canonical Docker TSan suite: 2028/2039 passed, 11 skipped
- x86_64-linux-musl ReleaseSafe build: 12/12 steps
- x86_64 candidate: `padctl 0.1.24 (libusb)`
- aarch64-linux-musl ReleaseSafe build: 12/12 steps
- aarch64 candidate contains `padctl 0.1.24 (libusb)`; independently executed under QEMU

## Release boundary

After this PR is reviewed, green, and squash-merged, an annotated `v0.1.24`
tag will be created on the exact merge commit. No tag is created by this PR.
