### PR TITLE
fix: coalesce Vader 5 rumble commands

### DIFF
--- a/devices/flydigi/vader5.toml
+++ b/devices/flydigi/vader5.toml
@@ -81,6 +81,9 @@ map = { DPadUp = 0, DPadRight = 1, DPadDown = 2, DPadLeft = 3, A = 4, B = 5, Sel
 [commands.rumble]
 interface = 1
 template = "5a a5 12 06 {strong:u8} {weak:u8} 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00"
+# Each command makes the receiver pause every input endpoint for about 16ms.
+# Coalesce at 10Hz to keep input responsive while retaining the latest strength.
+min_interval_ms = 100
 
 [commands.rumble.checksum]
 algo = "sum8"

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -138,6 +138,16 @@ interface = 3
 template = "02 01 00 {weak:u8} {strong:u8} 00 ..."
 ```
 
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `interface` | integer | required | Physical interface used for the command |
+| `template` | string | required | Output bytes with typed placeholders |
+| `min_interval_ms` | integer | `10` | Minimum interval between physical PLAY writes (`1`–`1000` ms); newer queued states replace older ones |
+
+STOP commands remain immediate so a throttled PLAY cannot leave a motor
+running. Once the last successful physical state is already identical,
+including zero, padctl suppresses the redundant write.
+
 ### Adaptive Trigger Commands
 
 DualSense-style adaptive triggers use a naming convention of `adaptive_trigger_<mode>`:

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -105,6 +105,7 @@ pub const CommandChecksumConfig = struct {
 pub const CommandConfig = struct {
     interface: i64,
     template: []const u8,
+    min_interval_ms: ?i64 = null,
     checksum: ?CommandChecksumConfig = null,
 };
 
@@ -472,6 +473,9 @@ pub fn validate(cfg: *const DeviceConfig) !void {
         while (it.next()) |entry| {
             if (!interfaceExists(cfg, entry.value_ptr.interface)) return error.InvalidConfig;
             if (isSuppressInterface(cfg, entry.value_ptr.interface)) return error.InvalidConfig;
+            if (entry.value_ptr.min_interval_ms) |interval_ms| {
+                if (interval_ms <= 0 or interval_ms > 1000) return error.InvalidConfig;
+            }
         }
     }
     if (cfg.device.init) |init_cfg| {
@@ -1031,6 +1035,10 @@ test "device: load flydigi/vader5.toml succeeds" {
     try std.testing.expectEqual(
         @as(?i64, 3),
         cfg.device.init.?.response_command_prefix_len,
+    );
+    try std.testing.expectEqual(
+        @as(?i64, 100),
+        cfg.commands.?.map.get("rumble").?.min_interval_ms,
     );
 }
 
@@ -3247,6 +3255,32 @@ test "device: command referencing nonexistent interface id is rejected" {
         \\template = "00 {strong} {weak}"
     ;
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad_cmd_toml));
+}
+
+test "device: command min_interval_ms outside 1 to 1000 is rejected" {
+    const allocator = std.testing.allocator;
+    const prefix =
+        \\[device]
+        \\name = "Bad Command Cadence"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "main"
+        \\interface = 0
+        \\size = 1
+        \\[commands.rumble]
+        \\interface = 0
+        \\template = "00 {strong:u8} {weak:u8}"
+        \\min_interval_ms =
+    ;
+    inline for (.{ 0, -1, 1001 }) |interval_ms| {
+        const input = try std.fmt.allocPrint(allocator, "{s} {d}", .{ prefix, interval_ms });
+        defer allocator.free(input);
+        try std.testing.expectError(error.InvalidConfig, parseString(allocator, input));
+    }
 }
 
 test "device: init referencing nonexistent interface id is rejected" {

--- a/src/core/rumble_writer.zig
+++ b/src/core/rumble_writer.zig
@@ -190,10 +190,7 @@ pub const RumbleWriter = struct {
             const result = writeRequest(request);
             const completed_ns = monotonicNs();
             if (result == .written) {
-                last_success = .{
-                    .frame = request.frame,
-                    .completed_ns = completed_ns,
-                };
+                last_success = successfulWrite(request, completed_ns);
             }
 
             if (self.shutting_down.load(.acquire)) {
@@ -254,12 +251,28 @@ pub const RumbleWriter = struct {
     };
 
     const SuccessfulWrite = struct {
-        frame: Frame,
+        device: DeviceIO,
         completed_ns: i128,
+        len: usize,
+        bytes: [MAX_FRAME_BYTES]u8,
     };
 
-    fn framesEqual(a: Frame, b: Frame) bool {
-        return a.strong == b.strong and a.weak == b.weak;
+    fn successfulWrite(request: Request, completed_ns: i128) SuccessfulWrite {
+        var success = SuccessfulWrite{
+            .device = request.device,
+            .completed_ns = completed_ns,
+            .len = request.len,
+            .bytes = undefined,
+        };
+        @memcpy(success.bytes[0..request.len], request.bytes[0..request.len]);
+        return success;
+    }
+
+    fn payloadsEqual(request: Request, success: SuccessfulWrite) bool {
+        return request.device.ptr == success.device.ptr and
+            request.device.vtable == success.device.vtable and
+            request.len == success.len and
+            std.mem.eql(u8, request.bytes[0..request.len], success.bytes[0..success.len]);
     }
 
     fn takeReadyRequest(self: *RumbleWriter, last_success: ?SuccessfulWrite) Selection {
@@ -269,13 +282,13 @@ pub const RumbleWriter = struct {
         while (self.pending_stop) |request| {
             self.pending_stop = null;
             if (last_success) |success| {
-                if (framesEqual(request.frame, success.frame)) continue;
+                if (payloadsEqual(request, success)) continue;
             }
             return .{ .request = request };
         }
         while (self.pending) |request| {
             if (last_success) |success| {
-                if (framesEqual(request.frame, success.frame)) {
+                if (payloadsEqual(request, success)) {
                     self.pending = null;
                     continue;
                 }

--- a/src/core/rumble_writer.zig
+++ b/src/core/rumble_writer.zig
@@ -8,7 +8,7 @@ const DeviceIO = @import("../io/device_io.zig").DeviceIO;
 // configured input reports. Keeping the mailbox inline avoids allocator use
 // across the EventLoop and writer threads.
 pub const MAX_FRAME_BYTES: usize = 512;
-const MIN_WRITE_INTERVAL_NS: i128 = 10 * std.time.ns_per_ms;
+pub const DEFAULT_MIN_WRITE_INTERVAL_NS: u64 = 10 * std.time.ns_per_ms;
 
 const Mutex = if (builtin.sanitize_thread) struct {
     m: std.c.pthread_mutex_t = .{},
@@ -48,6 +48,7 @@ const Request = struct {
     frame: Frame,
     retry_count: u8,
     generation: u64,
+    min_interval_ns: u64,
     len: usize,
     bytes: [MAX_FRAME_BYTES]u8,
 
@@ -122,6 +123,7 @@ pub const RumbleWriter = struct {
         frame: Frame,
         retry_count: u8,
         generation: u64,
+        min_interval_ns: u64,
     ) error{ NotRunning, FrameTooLarge }!void {
         if (self.thread == null) return error.NotRunning;
         if (bytes.len > MAX_FRAME_BYTES) return error.FrameTooLarge;
@@ -131,6 +133,7 @@ pub const RumbleWriter = struct {
             .frame = frame,
             .retry_count = retry_count,
             .generation = generation,
+            .min_interval_ns = min_interval_ns,
             .len = bytes.len,
             .bytes = undefined,
         };
@@ -164,21 +167,21 @@ pub const RumbleWriter = struct {
     }
 
     fn workerMain(self: *RumbleWriter) void {
-        var last_success_ns: i128 = 0;
+        var last_success: ?SuccessfulWrite = null;
         while (true) {
-            const selection = self.takeReadyRequest(last_success_ns);
+            const selection = self.takeReadyRequest(last_success);
             const request = switch (selection) {
                 .request => |request| request,
                 .wait => |wait_ns| {
                     if (!self.waitForWake(wait_ns)) {
-                        self.writePendingOnShutdown(last_success_ns);
+                        self.writePendingOnShutdown(last_success);
                         return;
                     }
                     continue;
                 },
                 .empty => {
                     if (!self.waitForWake(null)) {
-                        self.writePendingOnShutdown(last_success_ns);
+                        self.writePendingOnShutdown(last_success);
                         return;
                     }
                     continue;
@@ -186,10 +189,15 @@ pub const RumbleWriter = struct {
             };
             const result = writeRequest(request);
             const completed_ns = monotonicNs();
-            if (result == .written) last_success_ns = completed_ns;
+            if (result == .written) {
+                last_success = .{
+                    .frame = request.frame,
+                    .completed_ns = completed_ns,
+                };
+            }
 
             if (self.shutting_down.load(.acquire)) {
-                self.writePendingOnShutdown(last_success_ns);
+                self.writePendingOnShutdown(last_success);
                 return;
             }
 
@@ -206,7 +214,7 @@ pub const RumbleWriter = struct {
             signal(self.completion_w);
 
             if (!self.waitForCompletionAck()) {
-                self.writePendingOnShutdown(last_success_ns);
+                self.writePendingOnShutdown(last_success);
                 return;
             }
         }
@@ -222,9 +230,9 @@ pub const RumbleWriter = struct {
         return .written;
     }
 
-    fn writePendingOnShutdown(self: *RumbleWriter, last_success_ns: i128) void {
+    fn writePendingOnShutdown(self: *RumbleWriter, last_success: ?SuccessfulWrite) void {
         while (true) {
-            switch (self.takeReadyRequest(last_success_ns)) {
+            switch (self.takeReadyRequest(last_success)) {
                 .request => |request| {
                     self.mutex.lock();
                     self.pending = null;
@@ -245,21 +253,40 @@ pub const RumbleWriter = struct {
         empty,
     };
 
-    fn takeReadyRequest(self: *RumbleWriter, last_success_ns: i128) Selection {
+    const SuccessfulWrite = struct {
+        frame: Frame,
+        completed_ns: i128,
+    };
+
+    fn framesEqual(a: Frame, b: Frame) bool {
+        return a.strong == b.strong and a.weak == b.weak;
+    }
+
+    fn takeReadyRequest(self: *RumbleWriter, last_success: ?SuccessfulWrite) Selection {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        if (self.pending_stop) |request| {
+        while (self.pending_stop) |request| {
             self.pending_stop = null;
+            if (last_success) |success| {
+                if (framesEqual(request.frame, success.frame)) continue;
+            }
             return .{ .request = request };
         }
-        const request = self.pending orelse return .empty;
-        if (last_success_ns != 0) {
-            const remaining = last_success_ns + MIN_WRITE_INTERVAL_NS - monotonicNs();
-            if (remaining > 0) return .{ .wait = remaining };
+        while (self.pending) |request| {
+            if (last_success) |success| {
+                if (framesEqual(request.frame, success.frame)) {
+                    self.pending = null;
+                    continue;
+                }
+                const interval_ns: i128 = @intCast(request.min_interval_ns);
+                const remaining = success.completed_ns + interval_ns - monotonicNs();
+                if (remaining > 0) return .{ .wait = remaining };
+            }
+            self.pending = null;
+            return .{ .request = request };
         }
-        self.pending = null;
-        return .{ .request = request };
+        return .empty;
     }
 
     fn waitForWake(self: *RumbleWriter, wait_ns: ?i128) bool {

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -187,9 +187,23 @@ fn slotStr(buf: *const [256]u8) []const u8 {
 /// Returns whether a rumble frame was written, skipped as permanently
 /// unconfigured, or failed on the HID write path. Callers only retry write
 /// failures; scheduler accounting advances independently of emit.
-const RUMBLE_MIN_INTERVAL_NS: i128 = 10_000_000; // 10ms
+const RUMBLE_MIN_INTERVAL_NS: i128 = rumble_writer_mod.DEFAULT_MIN_WRITE_INTERVAL_NS;
 const RUMBLE_RETRY_INTERVAL_NS: i128 = 10_000_000; // 10ms
 const RUMBLE_MAX_RETRY_ATTEMPTS: u8 = 3;
+
+fn commandMinIntervalNs(cmd: *const device_cfg.CommandConfig) u64 {
+    return if (cmd.min_interval_ms) |interval_ms|
+        @intCast(interval_ms * std.time.ns_per_ms)
+    else
+        rumble_writer_mod.DEFAULT_MIN_WRITE_INTERVAL_NS;
+}
+
+fn rumbleMinIntervalNs(dcfg: ?*const DeviceConfig) i128 {
+    const cfg = dcfg orelse return RUMBLE_MIN_INTERVAL_NS;
+    const commands = cfg.commands orelse return RUMBLE_MIN_INTERVAL_NS;
+    const cmd = commands.map.get(ffTypeFor(cfg)) orelse return RUMBLE_MIN_INTERVAL_NS;
+    return @intCast(commandMinIntervalNs(&cmd));
+}
 
 const RumbleEmitResult = enum {
     written,
@@ -277,10 +291,7 @@ fn emitRumbleFrame(
             .{ .strong = strong, .weak = weak },
             retry_count,
             generation,
-            if (cmd.min_interval_ms) |interval_ms|
-                @intCast(interval_ms * std.time.ns_per_ms)
-            else
-                rumble_writer_mod.DEFAULT_MIN_WRITE_INTERVAL_NS,
+            commandMinIntervalNs(&cmd),
         ) catch |err| {
             if (err == error.FrameTooLarge) {
                 rumble_log.warn("[{s}] HID_WRITE: frame too large cmd={s} strong={d} weak={d} len={d} max={d}; dropping without retry", .{
@@ -780,6 +791,7 @@ pub const EventLoop = struct {
     fn handleNativeRumbleAt(self: *EventLoop, ctx: EventLoopContext, frame: RumbleScheduler.Frame, now_ns: i128) void {
         const generation = self.nextRumbleGeneration();
         const is_stop = frame.strong == 0 and frame.weak == 0;
+        const min_interval_ns = rumbleMinIntervalNs(ctx.device_config);
         if (is_stop) {
             // STOP must not wait behind a throttled non-zero frame: cancel the
             // stale frame and emit zero immediately so rumble cannot stick.
@@ -787,13 +799,13 @@ pub const EventLoop = struct {
             self.emitOrQueueRumble(ctx, frame, now_ns, generation);
         } else {
             const elapsed = now_ns - self.last_rumble_ns;
-            if (elapsed >= RUMBLE_MIN_INTERVAL_NS) {
+            if (elapsed >= min_interval_ns) {
                 self.emitOrQueueRumble(ctx, frame, now_ns, generation);
             } else {
                 // The mailbox and this pending slot are both capacity one.
                 // A newer native command replaces the older throttled frame
-                // without moving the original 10ms physical-write deadline.
-                self.queuePendingRumble(frame, self.last_rumble_ns + RUMBLE_MIN_INTERVAL_NS, 0, generation);
+                // without moving the configured physical-write deadline.
+                self.queuePendingRumble(frame, self.last_rumble_ns + min_interval_ns, 0, generation);
                 rumble_log.debug("[{s}] NATIVE_RUMBLE: THROTTLED elapsed={d}ns", .{
                     ctx.device_tag, elapsedNsForLog(elapsed),
                 });
@@ -1118,7 +1130,7 @@ pub const EventLoop = struct {
                     };
                     if (ff_result) |ff_ev| {
                         const now_ns = monotonicNs();
-                        const min_interval_ns = RUMBLE_MIN_INTERVAL_NS;
+                        const min_interval_ns = rumbleMinIntervalNs(ctx.device_config);
                         const is_stop = ff_ev.strong == 0 and ff_ev.weak == 0;
                         const scheduler_on = autoStopEnabled(ctx.device_config);
 
@@ -1807,7 +1819,7 @@ test "event_loop: oversized rumble frame is permanent and does not queue retry" 
     try testing.expectEqual(@as(usize, 0), mock_dev.write_log.items.len);
 }
 
-test "event_loop: native throttle keeps latest while stop cancels pending" {
+test "event_loop: native throttle honors command cadence while stop cancels pending" {
     const allocator = testing.allocator;
     const rumble_toml =
         \\[device]
@@ -1824,6 +1836,7 @@ test "event_loop: native throttle keeps latest while stop cancels pending" {
         \\[commands.rumble]
         \\interface = 0
         \\template = "00 08 00 {strong:u8} {weak:u8} 00 00 00"
+        \\min_interval_ms = 100
     ;
     const parsed = try device_mod.parseString(allocator, rumble_toml);
     defer parsed.deinit();
@@ -1855,7 +1868,7 @@ test "event_loop: native throttle keeps latest while stop cancels pending" {
 
     try testing.expectEqual(@as(usize, 0), mock_dev.write_log.items.len);
     try testing.expectEqual(latest, loop.pending_rumble_frame.?);
-    try testing.expectEqual(@as(?i128, base + RUMBLE_MIN_INTERVAL_NS), loop.pending_rumble_deadline_ns);
+    try testing.expectEqual(@as(?i128, base + 100 * std.time.ns_per_ms), loop.pending_rumble_deadline_ns);
 
     // A zero frame is a safety command: it cancels the stale non-zero frame
     // and writes immediately. Its successful completion starts the next
@@ -1869,6 +1882,8 @@ test "event_loop: native throttle keeps latest while stop cancels pending" {
     loop.handleNativeRumbleAt(ctx, latest, base + 4 * std.time.ns_per_ms);
     try testing.expectEqual(latest, loop.pending_rumble_frame.?);
     loop.flushPendingRumbleIfDue(ctx, base + 13 * std.time.ns_per_ms);
+    try testing.expectEqual(@as(usize, 8), mock_dev.write_log.items.len);
+    loop.flushPendingRumbleIfDue(ctx, base + 103 * std.time.ns_per_ms);
     try testing.expectEqual(@as(usize, 16), mock_dev.write_log.items.len);
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x66, 0x99, 0x00, 0x00, 0x00 }, mock_dev.write_log.items[8..16]);
 }

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -277,6 +277,10 @@ fn emitRumbleFrame(
             .{ .strong = strong, .weak = weak },
             retry_count,
             generation,
+            if (cmd.min_interval_ms) |interval_ms|
+                @intCast(interval_ms * std.time.ns_per_ms)
+            else
+                rumble_writer_mod.DEFAULT_MIN_WRITE_INTERVAL_NS,
         ) catch |err| {
             if (err == error.FrameTooLarge) {
                 rumble_log.warn("[{s}] HID_WRITE: frame too large cmd={s} strong={d} weak={d} len={d} max={d}; dropping without retry", .{

--- a/src/test/event_loop_rumble_test.zig
+++ b/src/test/event_loop_rumble_test.zig
@@ -1242,6 +1242,30 @@ test "issue 503: repeated physical stop is suppressed after hardware is zero" {
     }, harness.write_dev.write_log.items);
 }
 
+test "issue 503: logically different frames with identical payload are suppressed" {
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x4000, .weak = 0x2000, .duration_ms = 500 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x40ff, .weak = 0x20ff, .duration_ms = 500 },
+        null,
+    };
+    var harness = try AsyncRumbleHarness.init(testing.allocator, 1, 0);
+    defer harness.deinit();
+    try harness.start(&seq);
+
+    try harness.send();
+    try waitForAck(harness.attempt_ack[0]);
+    try harness.send();
+    try harness.releaseWrite();
+    try waitForAck(harness.write_ack[0]);
+    try waitForNoAck(harness.attempt_ack[0], 50);
+    harness.finish();
+
+    try testing.expectEqual(@as(usize, 1), harness.write_dev.write_attempts);
+    try testing.expectEqualSlices(u8, &[_]u8{
+        0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00,
+    }, harness.write_dev.write_log.items);
+}
+
 test "issue 503: weaker no-frame play does not suppress aggregate retry" {
     const seq = [_]?uinput.FfEvent{
         .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 0 },

--- a/src/test/event_loop_rumble_test.zig
+++ b/src/test/event_loop_rumble_test.zig
@@ -1187,6 +1187,61 @@ test "issue 503: newer stop supersedes an older failed play retry" {
     try testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, harness.write_dev.write_log.items);
 }
 
+test "issue 503: command cadence bounds physical writes while keeping latest play" {
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x4000, .weak = 0x2000, .duration_ms = 500 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x6000, .weak = 0x3000, .duration_ms = 500 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 500 },
+        null,
+    };
+    var harness = try AsyncRumbleHarness.init(testing.allocator, 1, 0);
+    defer harness.deinit();
+    harness.parsed.value.commands.?.map.getPtr("rumble").?.min_interval_ms = 100;
+    try harness.start(&seq);
+
+    try harness.send();
+    try waitForAck(harness.attempt_ack[0]);
+    try harness.send();
+    try harness.send();
+    try harness.releaseWrite();
+    try waitForAck(harness.write_ack[0]);
+    try waitForNoAck(harness.attempt_ack[0], 50);
+    try waitForAck(harness.attempt_ack[0]);
+    try waitForAck(harness.write_ack[0]);
+    harness.finish();
+
+    try testing.expectEqual(@as(usize, 2), harness.write_dev.write_attempts);
+    try testing.expect(harness.write_dev.attempt_times.items[1] - harness.write_dev.write_times.items[0] >= 90 * std.time.ns_per_ms);
+    try testing.expectEqualSlices(u8, &[_]u8{
+        0x00, 0x08, 0x00, 0x40, 0x20, 0x00, 0x00, 0x00,
+        0x00, 0x08, 0x00, 0x80, 0x40, 0x00, 0x00, 0x00,
+    }, harness.write_dev.write_log.items);
+}
+
+test "issue 503: repeated physical stop is suppressed after hardware is zero" {
+    const seq = [_]?uinput.FfEvent{
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0, .weak = 0, .duration_ms = 0 },
+        .{ .effect_type = 0x50, .effect_id = 0, .strong = 0, .weak = 0, .duration_ms = 0 },
+        null,
+    };
+    var harness = try AsyncRumbleHarness.init(testing.allocator, 1, 0);
+    defer harness.deinit();
+    try harness.start(&seq);
+
+    try harness.send();
+    try waitForAck(harness.attempt_ack[0]);
+    try harness.send();
+    try harness.releaseWrite();
+    try waitForAck(harness.write_ack[0]);
+    try waitForNoAck(harness.attempt_ack[0], 50);
+    harness.finish();
+
+    try testing.expectEqual(@as(usize, 1), harness.write_dev.write_attempts);
+    try testing.expectEqualSlices(u8, &[_]u8{
+        0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    }, harness.write_dev.write_log.items);
+}
+
 test "issue 503: weaker no-frame play does not suppress aggregate retry" {
     const seq = [_]?uinput.FfEvent{
         .{ .effect_type = 0x50, .effect_id = 0, .strong = 0x8000, .weak = 0x4000, .duration_ms = 0 },


### PR DESCRIPTION
## Summary

- add an optional per-command `min_interval_ms` physical-write cadence (10ms default)
- set Vader 5 rumble to 100ms, keeping the latest queued strength instead of forwarding every game update
- suppress a physical write when the last successful hardware state is already identical, especially repeated STOP frames
- keep STOP as an immediate safety barrier; it still cancels a queued PLAY and never waits for cadence

## Root cause

PR #505 removed synchronous USB writes from the input EventLoop, but it did not reduce physical USB OUT traffic. Hardware tracing on a `37d7:2401` Vader 5 Pro shows that **every** `5a a5 12 06` command causes all receiver input endpoints to go silent for about 16–18ms:

- zero-strength STOP frames reproduce it with the motors stationary
- IF0 and IF1 OUT endpoints both reproduce it
- IF0 and IF1 input endpoints pause together
- an async/persistent IN URB prototype still reproduces it

This is receiver behavior, not EventLoop blocking, pipe backlog, motor interference, or libusb event-lock starvation. The practical fix therefore has to bound and coalesce physical rumble commands.

## Hardware evidence

| Scenario | Physical input rate | Long gaps |
|---|---:|---:|
| Baseline | ~493Hz | 0 |
| `main`: 40 zero STOP writes/s | ~222Hz | 200 in 5s |
| `main`: 40 short PLAY/STOP pulses/s | ~63Hz | output storm |
| This PR: 40 varying PLAY updates/s | ~436Hz | 40 in 5s (~8 writes/s) |
| This PR: 40 short PLAY/STOP pulses/s | ~383Hz | 80 in 5s (~16 writes/s; STOP remains immediate) |
| After each test | ~489–490Hz | 0 |

The remaining individual ~18ms gaps are the receiver's irreducible per-command pause; the sustained input starvation is removed by bounding command count.

## Tests

- regression test is RED on `origin/main`: the old writer performs the second physical write within 50ms (`UnexpectedAck`)
- regression is GREEN here: configured 100ms cadence holds the write and emits only the newest queued strength
- repeated STOP regression proves hardware-zero deduplication
- full canonical Docker suite: 2045 passed, 11 skipped
- full canonical Docker ThreadSanitizer suite: 2041 passed, 11 skipped
- Issue 503 filtered ReleaseSafe: 13/13 passed
- canonical ReleaseSafe build and format check passed
- live Vader 5 A/B tests above

Fixes #503
Addresses #65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable rumble command intervals to control how frequently physical rumble updates are sent.
  * Rumble updates are coalesced to preserve responsiveness while applying the latest strength.
  * Added validation for interval values between 1 and 1,000 milliseconds.

* **Bug Fixes**
  * Prevented redundant stop commands when the device is already stopped.
  * Ensured the latest rumble state is applied after throttling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->