### PR TITLE
chore(release): bump version to 0.1.25

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.24",
+    .version = "0.1.25",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
## Summary

- bump the package version from 0.1.24 to 0.1.25
- include the Vader 5 rumble coalescing fix from #506
- keep `build.zig.zon` as the release version source of truth

## Verification

- canonical Docker Debug suite: 2046/2057 passed, 11 skipped
- canonical Docker TSan suite: 2042/2053 passed, 11 skipped
- x86_64-linux-musl ReleaseSafe build: 12/12 steps
- x86_64 candidate: `padctl 0.1.25 (libusb)`
- aarch64-linux-musl ReleaseSafe build: 12/12 steps
- local kcov v43 coverage suite: 2046/2057 passed, 11 skipped

## Release boundary

After this PR is green and squash-merged, an annotated `v0.1.25` tag will be created on the exact merge commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `.padctl` package to version 0.1.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->