### PR TITLE
fix: send Vader 5 rumble on the native XInput endpoint

### DIFF
--- a/devices/flydigi/vader5.toml
+++ b/devices/flydigi/vader5.toml
@@ -4,17 +4,27 @@ vid = 0x37d7
 pid = 0x2401
 block_kernel_drivers = ["xpad"]
 
-# The pad exposes a vendor interface (IF0, no driver) plus three HID interfaces
-# (IF1 input, IF2 mouse, IF3 vendor HID). padctl claims IF1 via libusb (read EP
-# 0x82 / write EP 0x06) and IF2/IF3 suppress-only; libusb_claim detaches the
-# kernel HID driver, so their hidraw nodes vanish and Steam sees only the
-# virtual Elite pad. Only xpad is blocked at udev — hid_generic/usbhid must keep
-# binding so a hidraw node exists for discovery before padctl claims it.
+# The pad exposes an XInput-signature vendor interface (IF0, class ff/93/01)
+# plus three HID interfaces (IF1 input, IF2 mouse, IF3 vendor HID). padctl
+# claims IF1 via libusb (read EP 0x82 / write EP 0x06) for extended input and
+# init, IF0 write-only for rumble, and IF2/IF3 suppress-only; libusb_claim
+# detaches the kernel HID driver, so their hidraw nodes vanish and Steam sees
+# only the virtual Elite pad. Only xpad is blocked at udev — hid_generic/usbhid
+# must keep binding so a hidraw node exists for discovery before padctl claims
+# it.
 [[device.interface]]
 id = 1
 class = "vendor"   # EP2 IN 32B extended input, EP6 OUT 32B config commands
 ep_in = 0x82
 ep_out = 0x06
+
+# Rumble only. Declared after IF1 so IF1 keeps devices[] index 0. Omitting
+# ep_in leaves EP 0x81 unpolled: its 20-byte standard report carries no IMU,
+# paddles or extra buttons, all of which come from the IF1 extended report.
+[[device.interface]]
+id = 0
+class = "vendor"
+ep_out = 0x05
 
 [[device.interface]]
 id = 2
@@ -78,17 +88,14 @@ source = { offset = 11, size = 4 }
 map = { DPadUp = 0, DPadRight = 1, DPadDown = 2, DPadLeft = 3, A = 4, B = 5, Select = 6, X = 7, Y = 8, Start = 9, LB = 10, RB = 11, LS = 14, RS = 15, C = 16, Z = 17, M1 = 18, M2 = 19, M3 = 20, M4 = 21, LM = 22, RM = 23, O = 24, Home = 27 }
 
 # --- Commands ---
+# Rumble goes to the XInput endpoint on IF0, not the IF1 vendor channel. The
+# receiver handles a vendor command synchronously and pauses every input
+# endpoint for ~18ms per command; the XInput endpoint has no such cost, so no
+# coalescing is needed. The packet is the standard 8-byte XInput frame, which
+# carries no checksum.
 [commands.rumble]
-interface = 1
-template = "5a a5 12 06 {strong:u8} {weak:u8} 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00"
-# Each command makes the receiver pause every input endpoint for about 16ms.
-# Coalesce at 10Hz to keep input responsive while retaining the latest strength.
-min_interval_ms = 100
-
-[commands.rumble.checksum]
-algo = "sum8"
-range = [2, 8]
-offset = 8
+interface = 0
+template = "00 08 00 {strong:u8} {weak:u8} 00 00 00"
 
 # --- Output device ---
 # Masquerade as Xbox Elite Series 2 (VID 045e PID 0b00) so that Steam and

--- a/devices/flydigi/vader5.toml
+++ b/devices/flydigi/vader5.toml
@@ -90,9 +90,9 @@ map = { DPadUp = 0, DPadRight = 1, DPadDown = 2, DPadLeft = 3, A = 4, B = 5, Sel
 # --- Commands ---
 # Rumble goes to the XInput endpoint on IF0, not the IF1 vendor channel. The
 # receiver handles a vendor command synchronously and pauses every input
-# endpoint for ~18ms per command; the XInput endpoint has no such cost, so no
-# coalescing is needed. The packet is the standard 8-byte XInput frame, which
-# carries no checksum.
+# endpoint for ~18ms per command; the XInput endpoint has no such cost, so this
+# device needs no extra coalescing on top of the writer's default 10ms cadence.
+# The packet is the standard 8-byte XInput frame, which carries no checksum.
 [commands.rumble]
 interface = 0
 template = "00 08 00 {strong:u8} {weak:u8} 00 00 00"

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -1036,10 +1036,12 @@ test "device: load flydigi/vader5.toml succeeds" {
         @as(?i64, 3),
         cfg.device.init.?.response_command_prefix_len,
     );
-    try std.testing.expectEqual(
-        @as(?i64, 100),
-        cfg.commands.?.map.get("rumble").?.min_interval_ms,
-    );
+    // Rumble goes to the IF0 XInput endpoint, which costs no input time, so
+    // it needs neither the vendor checksum nor coalescing.
+    const rumble = cfg.commands.?.map.get("rumble").?;
+    try std.testing.expectEqual(@as(i64, 0), rumble.interface);
+    try std.testing.expectEqual(@as(?i64, null), rumble.min_interval_ms);
+    try std.testing.expect(rumble.checksum == null);
 }
 
 test "device: output profile overlays default output and preset identity" {
@@ -1633,20 +1635,30 @@ test "device: vader5 IF1 is claimed via libusb (vendor transport)" {
     defer result.deinit();
 
     const cfg = result.value;
-    // IF1 read transport + IF2/IF3 suppress-only claims.
-    try std.testing.expectEqual(@as(usize, 3), cfg.device.interface.len);
-    try std.testing.expectEqual(@as(usize, 1), openedInterfaceCount(&cfg));
+    // IF1 read transport + IF0 write-only rumble + IF2/IF3 suppress-only claims.
+    try std.testing.expectEqual(@as(usize, 4), cfg.device.interface.len);
+    try std.testing.expectEqual(@as(usize, 2), openedInterfaceCount(&cfg));
     const if1 = cfg.device.interface[0];
     try std.testing.expectEqual(@as(i64, 1), if1.id);
     try std.testing.expectEqualStrings("vendor", if1.class);
     try std.testing.expectEqual(@as(i64, 0x82), if1.ep_in orelse return error.MissingEpIn);
     try std.testing.expectEqual(@as(i64, 0x06), if1.ep_out orelse return error.MissingEpOut);
 
-    try std.testing.expectEqualStrings("suppress", cfg.device.interface[1].class);
-    try std.testing.expectEqual(@as(i64, 2), cfg.device.interface[1].id);
-    try std.testing.expect(cfg.device.interface[1].ep_in == null);
+    // IF0 is the XInput rumble endpoint: write-only, and declared after IF1 so
+    // IF1 keeps devices[] index 0.
+    const if0 = cfg.device.interface[1];
+    try std.testing.expectEqual(@as(i64, 0), if0.id);
+    try std.testing.expectEqualStrings("vendor", if0.class);
+    try std.testing.expect(if0.ep_in == null);
+    try std.testing.expectEqual(@as(i64, 0x05), if0.ep_out orelse return error.MissingEpOut);
+    try std.testing.expectEqual(@as(?usize, 0), deviceIndexForInterface(&cfg, 1));
+    try std.testing.expectEqual(@as(?usize, 1), deviceIndexForInterface(&cfg, 0));
+
     try std.testing.expectEqualStrings("suppress", cfg.device.interface[2].class);
-    try std.testing.expectEqual(@as(i64, 3), cfg.device.interface[2].id);
+    try std.testing.expectEqual(@as(i64, 2), cfg.device.interface[2].id);
+    try std.testing.expect(cfg.device.interface[2].ep_in == null);
+    try std.testing.expectEqualStrings("suppress", cfg.device.interface[3].class);
+    try std.testing.expectEqual(@as(i64, 3), cfg.device.interface[3].id);
 
     const init_cfg = cfg.device.init orelse return error.MissingInit;
     try std.testing.expectEqual(@as(i64, 1), init_cfg.interface orelse return error.MissingInterface);

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -405,6 +405,30 @@ fn isSuppressInterface(cfg: *const DeviceConfig, iface_id: i64) bool {
     return false;
 }
 
+/// True for a vendor interface that declares an OUT endpoint and no IN
+/// endpoint. It is claimed and written but never polled, so nothing may expect
+/// input reports from it.
+fn isWriteOnlyInterface(cfg: *const DeviceConfig, iface_id: i64) bool {
+    for (cfg.device.interface) |iface| {
+        if (iface.id != iface_id) continue;
+        return std.mem.eql(u8, iface.class, "vendor") and
+            iface.ep_in == null and iface.ep_out != null;
+    }
+    return false;
+}
+
+/// Interfaces that produce input: everything opened into devices[] except
+/// write-only vendor interfaces. A hid interface always reads from its node.
+fn readableInterfaceCount(cfg: *const DeviceConfig) usize {
+    var n: usize = 0;
+    for (cfg.device.interface) |iface| {
+        if (isSuppressClass(iface.class)) continue;
+        if (isWriteOnlyInterface(cfg, iface.id)) continue;
+        n += 1;
+    }
+    return n;
+}
+
 fn interfaceExists(cfg: *const DeviceConfig, iface_id: i64) bool {
     for (cfg.device.interface) |iface| {
         if (iface.id == iface_id) return true;
@@ -457,9 +481,9 @@ pub fn validate(cfg: *const DeviceConfig) !void {
             return error.InvalidConfig;
     }
 
-    // An all-suppress config opens no read fd, so it can never be observed
-    // for liveness; require at least one readable (hid/vendor) interface.
-    if (openedInterfaceCount(cfg) == 0) return error.InvalidConfig;
+    // A config that opens no readable fd can never be observed for liveness.
+    // A write-only vendor interface does not count: it is never polled.
+    if (readableInterfaceCount(cfg) == 0) return error.InvalidConfig;
 
     // A suppress interface is claimed only to evict the kernel driver; it is
     // never read or written, so no report/command/init may reference it. Every
@@ -467,6 +491,7 @@ pub fn validate(cfg: *const DeviceConfig) !void {
     for (cfg.report) |report| {
         if (!interfaceExists(cfg, report.interface)) return error.InvalidConfig;
         if (isSuppressInterface(cfg, report.interface)) return error.InvalidConfig;
+        if (isWriteOnlyInterface(cfg, report.interface)) return error.InvalidConfig;
     }
     if (cfg.commands) |cmds| {
         var it = cmds.map.iterator();
@@ -482,6 +507,8 @@ pub fn validate(cfg: *const DeviceConfig) !void {
         if (init_cfg.interface) |iface_id| {
             if (!interfaceExists(cfg, iface_id)) return error.InvalidConfig;
             if (isSuppressInterface(cfg, iface_id)) return error.InvalidConfig;
+            // The init sequence reads acknowledgements back.
+            if (isWriteOnlyInterface(cfg, iface_id)) return error.InvalidConfig;
         }
         const has_response_prefix = if (init_cfg.response_prefix) |prefix|
             prefix.len > 0
@@ -1773,6 +1800,133 @@ test "device: suppress interface excluded from devices[] index regardless of ord
         try std.testing.expectEqual(@as(i64, 5), iface0.id);
         try std.testing.expectEqual(@as(?*const InterfaceConfig, null), interfaceForDeviceIndex(&cfg, 1));
     }
+}
+
+// issue #503: a vendor interface may omit ep_in to become write-only. Nothing
+// that reads may then target it, and it cannot be the only opened interface.
+test "device: validate rejects a report reading a write-only vendor interface" {
+    const allocator = std.testing.allocator;
+    const bad =
+        \\[device]
+        \\name = "Bad"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\
+        \\[[device.interface]]
+        \\id = 1
+        \\class = "vendor"
+        \\ep_in = 0x81
+        \\ep_out = 0x01
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "vendor"
+        \\ep_out = 0x05
+        \\
+        \\[[report]]
+        \\name = "main"
+        \\interface = 0
+        \\size = 8
+        \\
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x00]
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad));
+}
+
+test "device: validate rejects init running on a write-only vendor interface" {
+    const allocator = std.testing.allocator;
+    const bad =
+        \\[device]
+        \\name = "Bad"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\
+        \\[[device.interface]]
+        \\id = 1
+        \\class = "vendor"
+        \\ep_in = 0x81
+        \\ep_out = 0x01
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "vendor"
+        \\ep_out = 0x05
+        \\
+        \\[device.init]
+        \\interface = 0
+        \\report_size = 8
+        \\commands = ["0102"]
+        \\
+        \\[[report]]
+        \\name = "main"
+        \\interface = 1
+        \\size = 8
+        \\
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x00]
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad));
+}
+
+test "device: validate rejects a config whose only opened interface is write-only" {
+    const ifaces = [_]InterfaceConfig{
+        .{ .id = 0, .class = "vendor", .ep_out = 0x05 },
+        .{ .id = 2, .class = "suppress" },
+    };
+    const cfg = DeviceConfig{
+        .device = .{
+            .name = "WriteOnlyOnly",
+            .vid = 0x1234,
+            .pid = 0x5678,
+            .interface = &ifaces,
+        },
+        .report = &.{},
+    };
+    // openedInterfaceCount is 1, but nothing is polled, so liveness is
+    // unobservable exactly as in the all-suppress case.
+    try std.testing.expectEqual(@as(usize, 1), openedInterfaceCount(&cfg));
+    try std.testing.expectError(error.InvalidConfig, validate(&cfg));
+}
+
+test "device: validate accepts a write-only vendor interface used only by a command" {
+    const allocator = std.testing.allocator;
+    const good =
+        \\[device]
+        \\name = "Good"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\
+        \\[[device.interface]]
+        \\id = 1
+        \\class = "vendor"
+        \\ep_in = 0x82
+        \\ep_out = 0x06
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "vendor"
+        \\ep_out = 0x05
+        \\
+        \\[commands.rumble]
+        \\interface = 0
+        \\template = "00 08 00 {strong:u8} {weak:u8} 00 00 00"
+        \\
+        \\[[report]]
+        \\name = "main"
+        \\interface = 1
+        \\size = 8
+        \\
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x00]
+    ;
+    const result = try parseString(allocator, good);
+    defer result.deinit();
+    try std.testing.expectEqual(@as(usize, 2), openedInterfaceCount(&result.value));
+    try std.testing.expectEqual(@as(usize, 1), readableInterfaceCount(&result.value));
 }
 
 test "device: validate rejects suppress interface with endpoints" {

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -485,6 +485,15 @@ pub fn validate(cfg: *const DeviceConfig) !void {
     // A write-only vendor interface does not count: it is never polled.
     if (readableInterfaceCount(cfg) == 0) return error.InvalidConfig;
 
+    // The supervisor's liveness probe polls devices[0] for HUP, and a
+    // write-only interface's pipe never HUPs, so the first opened interface
+    // must be readable or a dead instance would look alive forever.
+    for (cfg.device.interface) |iface| {
+        if (isSuppressClass(iface.class)) continue;
+        if (isWriteOnlyInterface(cfg, iface.id)) return error.InvalidConfig;
+        break;
+    }
+
     // A suppress interface is claimed only to evict the kernel driver; it is
     // never read or written, so no report/command/init may reference it. Every
     // referenced interface id must also exist in [[device.interface]].
@@ -1804,6 +1813,37 @@ test "device: suppress interface excluded from devices[] index regardless of ord
 
 // issue #503: a vendor interface may omit ep_in to become write-only. Nothing
 // that reads may then target it, and it cannot be the only opened interface.
+test "device: validate rejects a write-only interface in the first opened slot" {
+    const allocator = std.testing.allocator;
+    const bad =
+        \\[device]
+        \\name = "Bad"
+        \\vid = 0x1234
+        \\pid = 0x5678
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "vendor"
+        \\ep_out = 0x05
+        \\
+        \\[[device.interface]]
+        \\id = 1
+        \\class = "vendor"
+        \\ep_in = 0x82
+        \\ep_out = 0x06
+        \\
+        \\[[report]]
+        \\name = "main"
+        \\interface = 1
+        \\size = 8
+        \\
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x00]
+    ;
+    try std.testing.expectError(error.InvalidConfig, parseString(allocator, bad));
+}
+
 test "device: validate rejects a report reading a write-only vendor interface" {
     const allocator = std.testing.allocator;
     const bad =

--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -87,7 +87,9 @@ fn createDeviceIO(
         };
         return dev.deviceIO();
     } else if (std.mem.eql(u8, iface.class, "vendor")) {
-        const ep_in: u8 = @intCast(iface.ep_in orelse return error.MissingEndpoint);
+        // ep_in may be absent: a write-only interface carries output commands
+        // (e.g. rumble) without contributing input reports.
+        const ep_in: ?u8 = if (iface.ep_in) |e| @intCast(e) else null;
         const ep_out: u8 = @intCast(iface.ep_out orelse return error.MissingEndpoint);
         const dev = try UsbrawDevice.open(allocator, vid, pid, @intCast(iface.id), ep_in, ep_out);
         return dev.deviceIO();
@@ -1107,6 +1109,34 @@ const FailWriteDeviceIO = struct {
 
     fn close(_: *anyopaque) void {}
 };
+
+// issue #503: rumble moved to the Vader 5's write-only XInput interface, which
+// declares ep_out but no ep_in. Requiring ep_in for every vendor interface
+// would reject that config before any USB access is attempted.
+test "openDeviceWithRetry: a vendor interface without ep_in is not rejected as a config error" {
+    const write_only = InterfaceConfig{
+        .id = 0,
+        .class = "vendor",
+        .ep_in = null,
+        .ep_out = 0x05,
+    };
+    // Nothing is plugged in at 0xffff:0xffff, so the open must fail somewhere in
+    // the USB layer. Which error that is depends on the environment; what must
+    // never happen is a rejection on endpoint validation.
+    if (openDeviceWithRetry(testing.allocator, write_only, 0xffff, 0xffff)) |dev| {
+        dev.close();
+        return error.UnexpectedOpenSuccess;
+    } else |err| {
+        try testing.expect(err != error.MissingEndpoint);
+    }
+
+    var missing_out = write_only;
+    missing_out.ep_out = null;
+    try testing.expectError(
+        error.MissingEndpoint,
+        openDeviceWithRetry(testing.allocator, missing_out, 0xffff, 0xffff),
+    );
+}
 
 test "DeviceInstance.init propagates init write errors" {
     const allocator = testing.allocator;

--- a/src/device_instance.zig
+++ b/src/device_instance.zig
@@ -70,6 +70,14 @@ fn closedPollfd(_: *anyopaque) posix.pollfd {
 
 fn closedClose(_: *anyopaque) void {}
 
+/// Which interface the init sequence runs on. Without an explicit id it runs on
+/// every vendor interface, but it reads acknowledgements back, so a write-only
+/// one can never satisfy it.
+fn initTargetsInterface(init_cfg: device_cfg.InitConfig, iface: InterfaceConfig) bool {
+    if (init_cfg.interface) |init_iface| return iface.id == init_iface;
+    return std.mem.eql(u8, iface.class, "vendor") and iface.ep_in != null;
+}
+
 fn createDeviceIO(
     allocator: std.mem.Allocator,
     iface: InterfaceConfig,
@@ -307,11 +315,7 @@ pub const DeviceInstance = struct {
             for (cfg.device.interface) |iface| {
                 if (device_cfg.isSuppressClass(iface.class)) continue;
                 const dev_idx = device_cfg.deviceIndexForInterface(cfg, iface.id) orelse continue;
-                const match = if (init_cfg.interface) |init_iface|
-                    iface.id == init_iface
-                else
-                    std.mem.eql(u8, iface.class, "vendor");
-                if (!match) continue;
+                if (!initTargetsInterface(init_cfg, iface)) continue;
                 init_seq.runInitSequence(allocator, devices[dev_idx], init_cfg) catch |err| {
                     std.log.debug("init on interface {d}: {}", .{ iface.id, err });
                     return err;
@@ -868,11 +872,7 @@ pub const DeviceInstance = struct {
             for (self.device_cfg.device.interface) |iface| {
                 if (device_cfg.isSuppressClass(iface.class)) continue;
                 const dev_idx = device_cfg.deviceIndexForInterface(self.device_cfg, iface.id) orelse continue;
-                const match = if (init_cfg.interface) |init_iface|
-                    iface.id == init_iface
-                else
-                    std.mem.eql(u8, iface.class, "vendor");
-                if (!match) continue;
+                if (!initTargetsInterface(init_cfg, iface)) continue;
                 init_seq.runInitSequence(self.allocator, self.devices[dev_idx], init_cfg) catch |err| {
                     std.log.debug("re-init on interface {d}: {}", .{ iface.id, err });
                     return err;

--- a/src/io/usbraw.zig
+++ b/src/io/usbraw.zig
@@ -122,7 +122,10 @@ fn libusbOpenAndClaim(vid: u16, pid: u16, interface_id: u8) !struct {
 pub const UsbrawDevice = struct {
     handle: *c.libusb_device_handle,
     ctx: *c.libusb_context,
-    ep_in: u8,
+    // null for a write-only interface: no IN endpoint is polled and no reader
+    // thread exists, so the device never produces input and never signals
+    // disconnect from the read side. Disconnect still surfaces from write().
+    ep_in: ?u8,
     ep_out: u8,
     interface_id: i32,
     pipe_r: std.posix.fd_t,
@@ -130,7 +133,7 @@ pub const UsbrawDevice = struct {
     ring: RingBuffer,
     disconnected: std.atomic.Value(bool),
     should_stop: std.atomic.Value(bool),
-    thread: std.Thread,
+    thread: ?std.Thread,
     allocator: std.mem.Allocator,
 
     pub fn open(
@@ -138,7 +141,7 @@ pub const UsbrawDevice = struct {
         vid: u16,
         pid: u16,
         interface_id: u8,
-        ep_in: u8,
+        ep_in: ?u8,
         ep_out: u8,
     ) !*UsbrawDevice {
         const claimed = try libusbOpenAndClaim(vid, pid, interface_id);
@@ -171,10 +174,10 @@ pub const UsbrawDevice = struct {
             .ring = .{},
             .disconnected = std.atomic.Value(bool).init(false),
             .should_stop = std.atomic.Value(bool).init(false),
-            .thread = undefined,
+            .thread = null,
             .allocator = alloc,
         };
-        self.thread = try std.Thread.spawn(.{}, readLoop, .{self});
+        if (ep_in != null) self.thread = try std.Thread.spawn(.{}, readLoop, .{self});
         return self;
     }
 
@@ -191,11 +194,12 @@ pub const UsbrawDevice = struct {
     fn readLoop(self: *UsbrawDevice) void {
         var buf: [RingBuffer.SLOT_SIZE]u8 = undefined;
         var transferred: c_int = 0;
+        const ep_in = self.ep_in.?;
 
         while (!self.should_stop.load(.acquire)) {
             const rc = c.libusb_interrupt_transfer(
                 self.handle,
-                self.ep_in,
+                ep_in,
                 &buf,
                 buf.len,
                 &transferred,
@@ -289,7 +293,7 @@ pub const UsbrawDevice = struct {
     fn close(ptr: *anyopaque) void {
         const self: *UsbrawDevice = @ptrCast(@alignCast(ptr));
         self.should_stop.store(true, .release);
-        self.thread.join();
+        if (self.thread) |t| t.join();
         self.closeWriteEnd();
         std.posix.close(self.pipe_r);
         _ = c.libusb_release_interface(self.handle, self.interface_id);

--- a/src/test/dualsense_edge_rumble_test.zig
+++ b/src/test/dualsense_edge_rumble_test.zig
@@ -58,15 +58,17 @@ const NATIVE_RUMBLE_TOML =
     \\click = true
 ;
 
-test "T9 shipped Vader native profile formats the physical 32-byte rumble frame" {
+test "T9 shipped Vader native profile formats the physical XInput rumble frame" {
     const allocator = testing.allocator;
     var parsed = try device_config.parseFile(allocator, "devices/flydigi/vader5.toml");
     defer parsed.deinit();
     try testing.expect(device_config.selectOutputProfile(&parsed.value, "dualsense-edge-native"));
 
+    // Selecting a native output profile must not change the physical rumble
+    // encoding: it stays the IF0 XInput frame, not a DualSense one.
     const commands = parsed.value.commands orelse return error.MissingCommands;
     const rumble = commands.map.get("rumble") orelse return error.MissingRumbleCommand;
-    try testing.expectEqual(@as(i64, 1), rumble.interface);
+    try testing.expectEqual(@as(i64, 0), rumble.interface);
     const frame = try command.fillTemplate(allocator, rumble.template, &.{
         .{ .name = "strong", .value = 0xA5A5 },
         .{ .name = "weak", .value = 0x3C3C },
@@ -74,9 +76,7 @@ test "T9 shipped Vader native profile formats the physical 32-byte rumble frame"
     defer allocator.free(frame);
     if (rumble.checksum) |*checksum| command.applyChecksum(frame, checksum);
 
-    var expected = [_]u8{0} ** 32;
-    const expected_header = [_]u8{ 0x5A, 0xA5, 0x12, 0x06, 0xA5, 0x3C, 0, 0, 0xF9 };
-    @memcpy(expected[0..expected_header.len], &expected_header);
+    const expected = [_]u8{ 0x00, 0x08, 0x00, 0xA5, 0x3C, 0x00, 0x00, 0x00 };
     try testing.expectEqualSlices(u8, &expected, frame);
 }
 

--- a/src/test/properties/config_props.zig
+++ b/src/test/properties/config_props.zig
@@ -22,37 +22,8 @@ test "property: config self-consistency — field bounds within report size" {
 
         const cfg = &parsed.value;
 
-        // Vendor class interfaces must have ep_out. ep_in is optional: a
-        // write-only interface carries output commands and is never polled,
-        // so nothing may expect input reports from it.
-        for (cfg.device.interface) |iface| {
-            if (!std.mem.eql(u8, iface.class, "vendor")) continue;
-            if (iface.ep_out == null) {
-                std.debug.print("FAIL: {s} vendor interface {d} missing ep_out\n", .{ path, iface.id });
-                return error.TestUnexpectedResult;
-            }
-            if (iface.ep_in != null) continue;
-
-            for (cfg.report) |report| {
-                if (report.interface != iface.id) continue;
-                std.debug.print(
-                    "FAIL: {s} report '{s}' reads interface {d}, which has no ep_in\n",
-                    .{ path, report.name, iface.id },
-                );
-                return error.TestUnexpectedResult;
-            }
-            if (cfg.device.init) |init_cfg| {
-                if (init_cfg.interface) |init_iface| {
-                    if (init_iface == iface.id) {
-                        std.debug.print(
-                            "FAIL: {s} init runs on interface {d}, which has no ep_in to read acks from\n",
-                            .{ path, iface.id },
-                        );
-                        return error.TestUnexpectedResult;
-                    }
-                }
-            }
-        }
+        // Vendor endpoint constraints are enforced by device.validate(), which
+        // parseFile already ran above, so every shipped config is covered.
 
         for (cfg.report) |report| {
             const size: usize = @intCast(report.size);

--- a/src/test/properties/config_props.zig
+++ b/src/test/properties/config_props.zig
@@ -22,16 +22,34 @@ test "property: config self-consistency — field bounds within report size" {
 
         const cfg = &parsed.value;
 
-        // Vendor class interfaces must have ep_in and ep_out
+        // Vendor class interfaces must have ep_out. ep_in is optional: a
+        // write-only interface carries output commands and is never polled,
+        // so nothing may expect input reports from it.
         for (cfg.device.interface) |iface| {
-            if (std.mem.eql(u8, iface.class, "vendor")) {
-                if (iface.ep_in == null) {
-                    std.debug.print("FAIL: {s} vendor interface {d} missing ep_in\n", .{ path, iface.id });
-                    return error.TestUnexpectedResult;
-                }
-                if (iface.ep_out == null) {
-                    std.debug.print("FAIL: {s} vendor interface {d} missing ep_out\n", .{ path, iface.id });
-                    return error.TestUnexpectedResult;
+            if (!std.mem.eql(u8, iface.class, "vendor")) continue;
+            if (iface.ep_out == null) {
+                std.debug.print("FAIL: {s} vendor interface {d} missing ep_out\n", .{ path, iface.id });
+                return error.TestUnexpectedResult;
+            }
+            if (iface.ep_in != null) continue;
+
+            for (cfg.report) |report| {
+                if (report.interface != iface.id) continue;
+                std.debug.print(
+                    "FAIL: {s} report '{s}' reads interface {d}, which has no ep_in\n",
+                    .{ path, report.name, iface.id },
+                );
+                return error.TestUnexpectedResult;
+            }
+            if (cfg.device.init) |init_cfg| {
+                if (init_cfg.interface) |init_iface| {
+                    if (init_iface == iface.id) {
+                        std.debug.print(
+                            "FAIL: {s} init runs on interface {d}, which has no ep_in to read acks from\n",
+                            .{ path, iface.id },
+                        );
+                        return error.TestUnexpectedResult;
+                    }
                 }
             }
         }

--- a/src/test/rumble_trace_corpus_test.zig
+++ b/src/test/rumble_trace_corpus_test.zig
@@ -263,6 +263,11 @@ fn expectShippedVaderEncoder(records: []const Record) !void {
 
     const commands = parsed.value.commands orelse return error.MissingCommands;
     const rumble = commands.map.get("rumble") orelse return error.MissingRumbleCommand;
+    // The corpus was captured while rumble went out the IF1 vendor channel, so
+    // its 32-byte frames no longer match the shipped template byte-for-byte.
+    // What must still hold is that the shipped encoder places the same
+    // magnitudes the trace recorded, now in the 8-byte XInput frame.
+    // validateHidFrame still pins the legacy frame layout the corpus carries.
     for (records) |record| switch (record) {
         .ff => {},
         .hid => |hid| {
@@ -272,7 +277,8 @@ fn expectShippedVaderEncoder(records: []const Record) !void {
             });
             defer allocator.free(encoded);
             if (rumble.checksum) |*checksum| command.applyChecksum(encoded, checksum);
-            try testing.expectEqualSlices(u8, &hid.frame, encoded);
+            const want = [_]u8{ 0x00, 0x08, 0x00, hid.frame[4], hid.frame[5], 0x00, 0x00, 0x00 };
+            try testing.expectEqualSlices(u8, &want, encoded);
         },
     };
 }


### PR DESCRIPTION
## Summary

- add IF0 as a write-only vendor interface (`ep_out = 0x05`, no `ep_in`)
- send rumble as the standard 8-byte XInput frame `00 08 00 <strong> <weak> 00 00 00` there, dropping the sum8 checksum
- drop `min_interval_ms` coalescing, which only rationed the stalling channel
- allow a vendor interface to omit `ep_in`: no IN endpoint is polled and no reader thread is spawned

## Root cause

padctl sent rumble on the Vader 5's IF1 vendor command channel (`5a a5 12 06`), the same channel used for the init handshake and the test-mode toggle. The receiver firmware processes that channel synchronously and pauses **every** input endpoint for ~18ms per command. The pad also exposes an XInput rumble endpoint on IF0 (EP 0x05) that padctl never used, because `block_kernel_drivers = ["xpad"]` keeps xpad off IF0 and padctl only claimed IF1.

This is why #506 only helped a little: reducing the command rate from ~40/s to ~10/s still leaves ~180ms of input stall per second.

## Hardware evidence

Direct libusb A/B on a `37d7:2401` receiver, one run, one instrument, 40 rumble updates/s per channel:

| channel | input report rate | gaps > 15ms | max gap |
|---|---:|---:|---:|
| idle, no rumble | ~547 Hz | 0 | 3.0 ms |
| IF0 EP 0x05 (XInput) | ~520 Hz | 0 | 3.1 ms |
| IF1 EP 0x06 (vendor) | ~205 Hz | 198 in 5s | 18.1 ms |

A separate run confirmed by direct observation that the IF0 frame drives the motors and that a zero-strength frame stops them, while input held ~498 Hz with zero gaps over 5ms. Motors physically running, with no commands in flight, has no measurable effect on the input rate, so this is not power draw, EMI, or RF interference.

End-to-end with this branch, driving 40Hz rumble through padctl's own virtual pad and counting physical IN completions via usbmon:

| phase | input rate | OUT submits |
|---|---:|---:|
| baseline | ~479 Hz | 0/s |
| 40Hz rumble | ~469 Hz | ~37/s |
| recovery | ~465 Hz | 0/s |

All 187 OUT submits in the rumble window went to endpoint 5, carrying 8-byte frames such as `00 08 00 20 df 00 00 00`.

## Tests

- regression is RED on the old channel: reverting only `vader5.toml` fails 6 tests, including the rumble frame format, the interface topology, and the trace-corpus encoder
- the config property test now rejects a write-only interface that any report or the init sequence reads from
- new `openDeviceWithRetry` regression: a vendor interface without `ep_in` must not be rejected as a config error, while one without `ep_out` still must be
- canonical Docker suite: 2047/2058 passed, 11 skipped
- canonical Docker ThreadSanitizer suite: 2043/2054 passed, 11 skipped
- `check-fmt` and `--validate devices/flydigi/vader5.toml` pass

## Notes

Wired (non-dongle) mode is not covered by this evidence; everything above was measured on the 2.4GHz receiver.

Refs #503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved rumble support for the Flydigi Vader 5 using its dedicated rumble channel.
  * Added support for write-only USB interfaces, enabling devices without an input endpoint to operate correctly.

* **Bug Fixes**
  * Fixed USB device initialization and shutdown for write-only interfaces.
  * Updated rumble frame handling for more reliable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->