### PR TITLE
chore(release): bump version to 0.1.26

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.25",
+    .version = "0.1.26",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
Bump `build.zig.zon` to 0.1.26 so the `v0.1.26` tag passes the release workflow's version check.

## Changes since v0.1.25

- `edca9d1` fix: send Vader 5 rumble on the native XInput endpoint (#508)

## Test plan

- CI on this PR (Zig 0.15.2 per `.zigversion`)
- Local `zig fmt --check src/ tools/` clean under 0.15.2
- Local pre-push Docker `test-tsan` passed

Refs #503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `.padctl` package to version 0.1.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->