### PR TITLE
feat(flydigi): map Apex 4 'O' button, confirm layout on hardware

### DIFF
--- a/devices/flydigi/apex4-dinput.toml
+++ b/devices/flydigi/apex4-dinput.toml
@@ -10,10 +10,11 @@
 # upstream against Apex 4 hardware (libsdl-org/SDL#12874), cross-checked with
 # pipe01/flydigictl (dongle enumeration + command channel).
 #
-# NOTE: this layout intentionally differs from vader4-pro-04b4-2412.toml —
-# SDL places the dpad bitmask in the low nibble of byte 9 and the face
-# buttons in the high nibble; verify against a live hidraw capture before
-# trusting either.
+# This layout intentionally differs from vader4-pro-04b4-2412.toml — SDL
+# places the dpad bitmask in the low nibble of byte 9 and the face buttons in
+# the high nibble. Confirmed on Apex 4 hardware via a live hidraw capture of
+# interface 2: every mapped bit below was pressed individually and matched,
+# and all six axes swept the full 0-255 range.
 
 [device]
 name = "Flydigi Apex 4 (DInput/2.4G)"
@@ -28,10 +29,18 @@ class = "hid"
 # --- Extended input (header 0x04 0xFE, 32 bytes) ---
 # offset 0-2:  header 04 FE 66
 # offset 7:    M1-M4 (bits 2-5; bits 0-1 are C/Z on Vader models, absent here)
-# offset 8:    bit3 = Home; bit0 = '+' gyro-mouse toggle (not exposed)
+# offset 8:    bit3 = Home ('house' button); bit0 = the 'circle' button next to
+#              it, labelled '+' on Vader models — mapped as O, matching
+#              vader5.toml
 # offset 9:    low nibble = dpad bitmask (1=up 2=right 4=down 8=left),
 #              bit4=A bit5=B bit6=Select bit7=X
 # offset 10:   bit0=Y bit1=Start bit2=LB bit3=RB bit6=LS bit7=RS
+#              bit4/bit5 are digital LT/RT, deliberately left unmapped: the
+#              capture shows them asserting at an analog value of 1-3 out of
+#              255, i.e. the moment the trigger leaves rest. That is a
+#              hair-trigger, not a click, so it is a worse digital press than
+#              the axis-derived one. Bind LT/RT through the mapping's
+#              trigger_threshold instead (100-120 for a click-like feel).
 # offset 17/19/21/22: LX/LY/RX/RY (u8, center 0x7f)
 # offset 23/24: analog LT/RT (u8)
 # IMU bytes (11-16 accel, 18/20/26-30 gyro) are only populated when the pad's
@@ -61,7 +70,7 @@ rt      = { offset = 24, type = "u8" }
 # (bit 0 = byte 7 bit 0, bit 31 = byte 10 bit 7).
 [report.button_group]
 source = { offset = 7, size = 4 }
-map = { M1 = 2, M2 = 3, M3 = 4, M4 = 5, Home = 11, DPadUp = 16, DPadRight = 17, DPadDown = 18, DPadLeft = 19, A = 20, B = 21, Select = 22, X = 23, Y = 24, Start = 25, LB = 26, RB = 27, LS = 30, RS = 31 }
+map = { M1 = 2, M2 = 3, M3 = 4, M4 = 5, O = 8, Home = 11, DPadUp = 16, DPadRight = 17, DPadDown = 18, DPadLeft = 19, A = 20, B = 21, Select = 22, X = 23, Y = 24, Start = 25, LB = 26, RB = 27, LS = 30, RS = 31 }
 
 # --- Commands ---
 # V1 haptics: report 0x05, command 0x0F, one strength byte per motor.
@@ -104,6 +113,9 @@ M1     = "BTN_TRIGGER_HAPPY5"
 M2     = "BTN_TRIGGER_HAPPY7"
 M3     = "BTN_TRIGGER_HAPPY6"
 M4     = "BTN_TRIGGER_HAPPY8"
+# Same slot vader5.toml gives its 'O' button in the xbox-elite2 profile, so the
+# button emits an identical code on both pads.
+O      = "BTN_TRIGGER_HAPPY13"
 
 [output.dpad]
 type = "hat"


### PR DESCRIPTION
The config shipped with a note asking for a live hidraw capture to settle whether the SDL byte layout (dpad in the low nibble of byte 9, face buttons in the high nibble) or the vader4-pro one is right for this pad. Captured interface 2 on an Apex 4 and pressed every mapped bit individually: all 19 matched, and all six axes swept the full 0-255 range. Note replaced with what was verified and how.

The capture also surfaced two unmapped bits:

- byte 8 bit 0 is the 'circle' button below Home, previously described as an unexposed '+' gyro-mouse toggle. It reports normally, so map it as O and give it BTN_TRIGGER_HAPPY13 — the slot vader5.toml uses for the same button in its xbox-elite2 profile, so both pads emit the same code.

- byte 10 bits 4/5 are digital LT/RT. Left unmapped on purpose: they assert at an analog value of 1-3 out of 255, i.e. the instant the trigger leaves rest. That is a hair-trigger rather than a click, so it makes a worse digital press than the axis-derived one from trigger_threshold. Recorded in the comments so the next reader does not have to rediscover it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Apex 4 controller’s circle button, exposed as the `O` button.

* **Documentation**
  * Clarified controller layout verification and documented the handling of digital trigger inputs to avoid unintended hair-trigger activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->