### PR TITLE
ci(release): make AUR sync a reusable, re-runnable workflow

### DIFF
--- a/.github/workflows/aur-sync.yml
+++ b/.github/workflows/aur-sync.yml
@@ -1,0 +1,93 @@
+name: AUR Sync
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to sync to AUR (e.g. v0.1.26)'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to sync to AUR (e.g. v0.1.26)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  update-aur:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(inputs.tag, '-rc') }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download SHA256SUMS from release
+        env:
+          TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "${TAG}" --pattern SHA256SUMS.txt --repo "${{ github.repository }}"
+
+      - name: Setup SSH
+        env:
+          AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "${AUR_SSH_KEY}" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          echo "Host aur.archlinux.org" >> ~/.ssh/config
+          echo "  IdentityFile ~/.ssh/aur" >> ~/.ssh/config
+          echo "  User aur" >> ~/.ssh/config
+          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Update padctl-bin PKGBUILD
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          X86_HASH=$(grep "x86_64-linux-musl" SHA256SUMS.txt | awk '{print $1}')
+          ARM_HASH=$(grep "aarch64-linux-musl" SHA256SUMS.txt | awk '{print $1}')
+
+          # AUR has occasional maintenance windows that reject SSH connections;
+          # retry the AUR-facing git operations instead of failing the release.
+          retry() {
+            local n=1 max=6 delay=300
+            until "$@"; do
+              if [ "$n" -ge "$max" ]; then
+                echo "::error::command failed after ${max} attempts: $*"
+                return 1
+              fi
+              echo "attempt ${n}/${max} failed, retrying in $((delay / 60))m: $*"
+              n=$((n + 1))
+              sleep "${delay}"
+            done
+          }
+
+          clone_aur_repo() {
+            rm -rf /tmp/padctl-bin
+            git clone ssh://aur@aur.archlinux.org/padctl-bin.git /tmp/padctl-bin
+          }
+
+          retry clone_aur_repo
+          cd /tmp/padctl-bin
+
+          cp "${GITHUB_WORKSPACE}/contrib/aur/padctl-bin/PKGBUILD" PKGBUILD
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+          sed -i "s/^sha256sums_x86_64=.*/sha256sums_x86_64=('${X86_HASH}')/" PKGBUILD
+          sed -i "s/^sha256sums_aarch64=.*/sha256sums_aarch64=('${ARM_HASH}')/" PKGBUILD
+
+          HOST_UID=$(id -u)
+          docker run --rm -v "$PWD:/pkg" archlinux:latest bash -c \
+            "pacman -Sy --noconfirm pacman-contrib fakeroot binutils namcap && useradd -m -u ${HOST_UID} builder && su builder -c 'cd /pkg && makepkg --printsrcinfo > .SRCINFO && namcap PKGBUILD'"
+          sudo chown -R "$(id -u):$(id -g)" /tmp/padctl-bin || true
+
+          # --global writes to ~/.gitconfig (runner home), not .git/config which may be owned by builder uid
+          git config --global user.name "bananasjim"
+          git config --global user.email "bananasjim1@gmail.com"
+          git add PKGBUILD .SRCINFO
+          git commit -m "update to ${VERSION}"
+          retry git push

--- a/.github/workflows/aur-sync.yml
+++ b/.github/workflows/aur-sync.yml
@@ -41,7 +41,9 @@ jobs:
           echo "Host aur.archlinux.org" >> ~/.ssh/config
           echo "  IdentityFile ~/.ssh/aur" >> ~/.ssh/config
           echo "  User aur" >> ~/.ssh/config
-          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
+          echo "  StrictHostKeyChecking yes" >> ~/.ssh/config
+          # pinned AUR host key, no runtime ssh-keyscan (avoids TOFU/MITM)
+          echo 'aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN' >> ~/.ssh/known_hosts
 
       - name: Update padctl-bin PKGBUILD
         env:

--- a/.github/workflows/aur-sync.yml
+++ b/.github/workflows/aur-sync.yml
@@ -89,5 +89,9 @@ jobs:
           git config --global user.name "bananasjim"
           git config --global user.email "bananasjim1@gmail.com"
           git add PKGBUILD .SRCINFO
+          if git diff --cached --quiet; then
+            echo "::notice::AUR padctl-bin already at ${VERSION}, nothing to push"
+            exit 0
+          fi
           git commit -m "update to ${VERSION}"
           retry git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,54 +332,8 @@ jobs:
 
   update-aur:
     needs: checksums
-    runs-on: ubuntu-latest
     if: ${{ !contains(github.ref_name, '-rc') }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download SHA256SUMS
-        uses: actions/download-artifact@v4
-        with:
-          name: sha256sums
-
-      - name: Setup SSH
-        env:
-          AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
-        run: |
-          mkdir -p ~/.ssh
-          echo "${AUR_SSH_KEY}" > ~/.ssh/aur
-          chmod 600 ~/.ssh/aur
-          echo "Host aur.archlinux.org" >> ~/.ssh/config
-          echo "  IdentityFile ~/.ssh/aur" >> ~/.ssh/config
-          echo "  User aur" >> ~/.ssh/config
-          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
-
-      - name: Update padctl-bin PKGBUILD
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          VERSION="${TAG#v}"
-          X86_HASH=$(grep "x86_64-linux-musl" SHA256SUMS.txt | awk '{print $1}')
-          ARM_HASH=$(grep "aarch64-linux-musl" SHA256SUMS.txt | awk '{print $1}')
-
-          git clone ssh://aur@aur.archlinux.org/padctl-bin.git /tmp/padctl-bin
-          cd /tmp/padctl-bin
-
-          cp "${GITHUB_WORKSPACE}/contrib/aur/padctl-bin/PKGBUILD" PKGBUILD
-          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
-          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
-          sed -i "s/^sha256sums_x86_64=.*/sha256sums_x86_64=('${X86_HASH}')/" PKGBUILD
-          sed -i "s/^sha256sums_aarch64=.*/sha256sums_aarch64=('${ARM_HASH}')/" PKGBUILD
-
-          HOST_UID=$(id -u)
-          docker run --rm -v "$PWD:/pkg" archlinux:latest bash -c \
-            "pacman -Sy --noconfirm pacman-contrib fakeroot binutils namcap && useradd -m -u ${HOST_UID} builder && su builder -c 'cd /pkg && makepkg --printsrcinfo > .SRCINFO && namcap PKGBUILD'"
-          sudo chown -R "$(id -u):$(id -g)" /tmp/padctl-bin || true
-
-          # --global writes to ~/.gitconfig (runner home), not .git/config which may be owned by builder uid
-          git config --global user.name "bananasjim"
-          git config --global user.email "bananasjim1@gmail.com"
-          git add PKGBUILD .SRCINFO
-          git commit -m "update to ${VERSION}"
-          git push
+    uses: ./.github/workflows/aur-sync.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Extract the `update-aur` job body from `release.yml` into a new reusable workflow, `.github/workflows/aur-sync.yml`, triggered by `workflow_call` (from `release.yml`) or `workflow_dispatch` (manual re-run), both taking one required string input, `tag`.
- Fetch `SHA256SUMS.txt` via `gh release download "$TAG" --pattern SHA256SUMS.txt` instead of `actions/download-artifact`, since release assets don't expire the way run artifacts do — this is what makes a manual re-run possible weeks after the original release run.
- Wrap the AUR-facing `git clone` / `git push` steps in a small retry loop (up to 6 attempts, 5 minutes apart) so a transient "AUR is down for maintenance" window no longer fails the release.
- `release.yml`'s `update-aur` job now calls the reusable workflow (`uses: ./.github/workflows/aur-sync.yml`, `secrets: inherit`), keeping `needs: checksums` and the existing `-rc` guard (now evaluated on the `tag` input rather than `github.ref_name`).
- No changes to `src/`, the PKGBUILD template, or any secrets.
- If the target tag's PKGBUILD/.SRCINFO are already up to date on AUR (e.g. a manual re-run after a prior sync already succeeded), the job now prints `::notice::AUR padctl-bin already at ${VERSION}, nothing to push` and exits 0 instead of failing at `git commit` with nothing staged.
- `Setup SSH` no longer trusts `ssh-keyscan` at run time (trust-on-first-use, MITM-able): the AUR host key is now pinned verbatim in `known_hosts` (`SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4`) with `StrictHostKeyChecking yes`, so a key mismatch fails the job loudly instead of silently trusting whatever the network returns.

## How to run manually
After this merges to `main` (required for `workflow_dispatch` to appear in the Actions UI):
```
gh workflow run aur-sync.yml -f tag=v0.1.26
```

## Test plan
- [x] `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))"` on both `release.yml` and `aur-sync.yml` — both parse cleanly.
- [x] `bash -n` on every `run:` block in `aur-sync.yml` (GH `${{ }}` expressions stripped first) — all pass.
- [x] Cross-checked `workflow_call`/`workflow_dispatch` co-existing triggers, `secrets: inherit`, and local `uses: ./.github/workflows/...` syntax against GitHub Actions docs.
- [x] `zig build test-tsan` (Docker canonical image, since this change touches no `.zig` files): 2048/2059 passed, 11 skipped, no regressions.
- [ ] Actual `workflow_dispatch` run against a real tag (requires merge to `main` first; not done here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Automated synchronization of stable releases with the Arch User Repository.
  - Added package validation and retry handling to improve publishing reliability.
  - Streamlined the release process by centralizing package publishing steps.
  - Release-candidate versions continue to be excluded from repository updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

