### PR TITLE
feat(diagnostics): always-on flight recorder for post-hoc fault evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ See the [getting started guide](https://bananasjim.github.io/padctl/getting-star
 | `padctl config test <mapping>` | Live input preview against the mapping (no apply) |
 | `padctl scan` | Re-scan for connected devices |
 | `padctl dump enable\|disable` | Toggle opt-in diagnostic logging (persists across reboots) |
-| `padctl dump status` | Show logging state, log path, size, and time span |
-| `padctl dump export --period <N>m\|<N>h\|<N>d [-o file]` | Export recent log window for bug reports |
+| `padctl dump status` | Show logging state, flight recorder buffer, log path, size, and time span |
+| `padctl dump export --period <N>m\|<N>h\|<N>d [-o file]` | Export recent log window (including the always-on flight recorder buffer) for bug reports |
 | `padctl dump clear` | Delete all log files |
 
 ## Build

--- a/docs/src/diagnostic-logging.md
+++ b/docs/src/diagnostic-logging.md
@@ -2,7 +2,9 @@
 
 padctl ships with a general-purpose, togglable file logger. It is designed to be the single mechanism you reach for when diagnosing **any** class of bug — stuck rumble, input drops, mapping misses, hotplug oddities, daemon crashes — so that reports come with structured evidence instead of guesswork.
 
-It is **off by default** and has no hot-path formatting cost when disabled. The
+It is **off by default**. With dump off the verbose trace lines never reach the
+journal or disk — they are held only in the in-memory flight recorder described
+below, which persists them when something goes wrong. The
 current build emits a detailed trace of the force-feedback pipeline plus button
 input edges, gesture decisions, and virtual button output edges; other
 subsystems (non-gesture layer/remap decisions, hotplug, config reload, …) will
@@ -26,8 +28,8 @@ Attach `bug.log` to your issue report.
 |---------|-------------|
 | `padctl dump enable` | Turn diagnostic logging on. Persists across restarts by writing `[diagnostics].dump = true` to the user config (and `/etc/padctl/config.toml` via `sudo` when available). Also sends a live IPC to any running daemon so the change takes effect immediately. |
 | `padctl dump disable` | Turn diagnostic logging off (default state). Same persistence semantics as `enable`. |
-| `padctl dump status` | Print current state (`enabled` / `disabled`), the active log path, log file size, oldest/newest entry timestamps, and the rotated backup size if present. |
-| `padctl dump export --period <N>m\|<N>h\|<N>d [-o path]` | Export the window of log lines newer than the given duration. `-o` writes to a file; omit it to print to stdout. Default window: `1d`. |
+| `padctl dump status` | Print current state (`enabled` / `disabled`), the flight recorder's buffered line count and last flush, the active log path, log file size, oldest/newest entry timestamps, and the rotated backup size if present. |
+| `padctl dump export --period <N>m\|<N>h\|<N>d [-o path]` | Export the window of log lines newer than the given duration. Asks a running daemon to flush its flight recorder first, so the export includes the in-memory window. `-o` writes to a file; omit it to print to stdout. Default window: `1d`. |
 | `padctl dump clear` | Delete the live log and any rotated backups. Asks for confirmation. Falls back to `sudo rm` for root-owned logs when the CLI user can't unlink them directly. |
 
 ### Period syntax
@@ -109,9 +111,56 @@ On every daemon startup and on every fresh file-open, padctl stats the existing 
 
 This keeps disk usage bounded to roughly `2 * max_log_size_mb` without needing `logrotate` or any external tooling.
 
+## Flight recorder
+
+Sporadic faults — rumble that will not stop, a dropped rumble write, a
+disconnect — tend to happen when nobody had `padctl dump enable` running. The
+flight recorder closes that gap: the daemon always keeps the most recent **1024
+trace lines** (256 KiB, oldest overwritten first) in memory, even with dump off,
+and appends them to `padctl.log` when something goes wrong. Nothing reaches
+disk until a trigger fires, so the ring costs no I/O and no disk space during
+normal play.
+
+### Triggers
+
+| Reason | Fires when |
+|--------|-----------|
+| `rumble-stuck` | The newest rumble frame written to the device was non-zero and 10 s passed with no newer frame. Reported once per episode; re-arms after a zero frame is written. |
+| `rumble-write-dropped` | A rumble frame exhausted its write retries and was dropped. |
+| `disconnect` | The device went away — POLLHUP, a read error, or a write that reported a disconnect. |
+| `signal` | `kill -USR1 <daemon pid>` |
+| `export` | `padctl dump export` sends this to the running daemon automatically. |
+| `shutdown` | The daemon is stopping. |
+
+The three automatic triggers flush at most once every 30 seconds so a repeating
+fault cannot fill the disk. `signal`, `export` and `shutdown` always flush.
+
+### Reading the output
+
+A flushed window appears in `padctl.log` between markers:
+
+```
+FLIGHT_RECORDER begin reason=rumble-stuck lines=1024
+[2026-09-07T04:53:03.384] [MONO:859498771067408] debug(rumble): [Vader 5 Pro] FF_PLAY: id=0 ...
+...
+FLIGHT_RECORDER end
+```
+
+The buffered lines keep their original timestamps, so they are usually older
+than the surrounding log. `padctl dump status` reports how many lines are
+buffered and when the last flush happened. To capture the current window by
+hand, without waiting for a trigger:
+
+```sh
+kill -USR1 $(pidof padctl)
+```
+
+If the log file cannot be written (for example a root-owned state directory),
+the daemon warns once and keeps the ring in memory rather than dropping it.
+
 ## What gets logged
 
-When `dump = false` (the default), only warnings and errors are written, and only lazily on the first occurrence.
+When `dump = false` (the default), only warnings and errors are written to the log file, and only lazily on the first occurrence. Verbose trace lines still flow into the flight recorder and reach the file when a trigger fires.
 
 When `dump = true`, padctl adds verbose tracing on top. The coverage today is deepest in the force-feedback pipeline — that is the area where the logger was needed first — and is being expanded to other subsystems as issues surface. Current coverage:
 

--- a/src/cli/dump.zig
+++ b/src/cli/dump.zig
@@ -340,8 +340,7 @@ pub fn responseField(line: []const u8, key: []const u8) ?[]const u8 {
     return null;
 }
 
-/// Render the flight-recorder half of a DUMP STATUS response as one human
-/// line. Returns null when the daemon predates the recorder fields.
+/// Render the flight-recorder half of a DUMP STATUS reply; null on an old daemon.
 pub fn formatRecorderStatus(buf: []u8, response: []const u8) ?[]const u8 {
     const lines = responseField(response, "recorder_lines") orelse return null;
     const last = responseField(response, "last_flush") orelse return null;
@@ -352,9 +351,7 @@ pub fn formatRecorderStatus(buf: []u8, response: []const u8) ?[]const u8 {
     return std.fmt.bufPrint(buf, "{s} lines buffered, last flush: {s} {s}ms ago", .{ lines, last, ms_ago }) catch null;
 }
 
-/// Ask a running daemon to append its flight-recorder ring to the log file so
-/// an export includes the in-memory window. Best effort: no daemon, an old
-/// daemon, or a slow reply all fall through to exporting the file as-is.
+/// Best effort: ask a running daemon to flush its ring so the export includes it.
 fn requestFlush(socket_path: []const u8) void {
     const fd = socket_client.connectToSocket(socket_path) catch return;
     defer std.posix.close(fd);

--- a/src/cli/dump.zig
+++ b/src/cli/dump.zig
@@ -3,6 +3,8 @@ const paths = @import("../config/paths.zig");
 const user_config_mod = @import("../config/user_config.zig");
 const socket_client = @import("socket_client.zig");
 
+const DAEMON_FLUSH_TIMEOUT_MS = 500;
+
 pub const WriteError = error{
     MalformedConfig,
     NoSpaceLeft,
@@ -73,17 +75,20 @@ pub fn runStatus(
 ) void {
     // Query daemon for live dump state.
     var daemon_state: []const u8 = "unknown (daemon not running)";
+    var recorder_line: ?[]const u8 = null;
+    var recorder_buf: [128]u8 = undefined;
     if (socket_client.connectToSocket(socket_path)) |sock_fd| {
         defer std.posix.close(sock_fd);
-        var resp_buf: [64]u8 = undefined;
+        var resp_buf: [256]u8 = undefined;
         if (socket_client.sendCommand(sock_fd, "DUMP STATUS\n", &resp_buf)) |resp| {
-            // Parse "OK dump=on\n" or "OK dump=off\n"
+            // Parse "OK dump=on recorder_lines=N last_flush=<reason|never> ..."
             const trimmed = std.mem.trimRight(u8, resp, "\r\n");
             if (std.mem.indexOf(u8, trimmed, "dump=on") != null) {
                 daemon_state = "enabled";
             } else if (std.mem.indexOf(u8, trimmed, "dump=off") != null) {
                 daemon_state = "disabled";
             }
+            recorder_line = formatRecorderStatus(&recorder_buf, trimmed);
         } else |_| {}
     } else |_| {
         // Daemon not running — fall back to config.
@@ -95,6 +100,7 @@ pub fn runStatus(
     }
 
     stdout.print("Dump: {s}\n", .{daemon_state}) catch {};
+    if (recorder_line) |line| stdout.print("Flight recorder: {s}\n", .{line}) catch {};
 
     // Log file stats. Check both user state dir and systemd /var/log/padctl,
     // pick whichever has the newest last_timestamp (the active one).
@@ -323,9 +329,43 @@ fn formatSize(buf: *[32]u8, bytes: u64) []const u8 {
     }
 }
 
+/// Extract the value of `key=` from a whitespace-separated response line.
+pub fn responseField(line: []const u8, key: []const u8) ?[]const u8 {
+    var it = std.mem.tokenizeScalar(u8, line, ' ');
+    while (it.next()) |tok| {
+        if (tok.len > key.len and std.mem.startsWith(u8, tok, key) and tok[key.len] == '=') {
+            return tok[key.len + 1 ..];
+        }
+    }
+    return null;
+}
+
+/// Render the flight-recorder half of a DUMP STATUS response as one human
+/// line. Returns null when the daemon predates the recorder fields.
+pub fn formatRecorderStatus(buf: []u8, response: []const u8) ?[]const u8 {
+    const lines = responseField(response, "recorder_lines") orelse return null;
+    const last = responseField(response, "last_flush") orelse return null;
+    if (std.mem.eql(u8, last, "never")) {
+        return std.fmt.bufPrint(buf, "{s} lines buffered, last flush: never", .{lines}) catch null;
+    }
+    const ms_ago = responseField(response, "last_flush_ms_ago") orelse "?";
+    return std.fmt.bufPrint(buf, "{s} lines buffered, last flush: {s} {s}ms ago", .{ lines, last, ms_ago }) catch null;
+}
+
+/// Ask a running daemon to append its flight-recorder ring to the log file so
+/// an export includes the in-memory window. Best effort: no daemon, an old
+/// daemon, or a slow reply all fall through to exporting the file as-is.
+fn requestFlush(socket_path: []const u8) void {
+    const fd = socket_client.connectToSocket(socket_path) catch return;
+    defer std.posix.close(fd);
+    var resp_buf: [64]u8 = undefined;
+    _ = socket_client.sendCommandTimeout(fd, "DUMP FLUSH\n", &resp_buf, DAEMON_FLUSH_TIMEOUT_MS) catch return;
+}
+
 /// Run `padctl dump export`: filter logs by period, output to stdout or file.
 pub fn runExport(
     allocator: std.mem.Allocator,
+    socket_path: []const u8,
     period_str: []const u8,
     output_path: ?[]const u8,
     stdout: anytype,
@@ -335,6 +375,8 @@ pub fn runExport(
         stderr.print("error: invalid period '{s}' — use Nm, Nh, or Nd (e.g., 10m, 1h, 1d)\n", .{period_str}) catch {};
         std.process.exit(1);
     };
+
+    requestFlush(socket_path);
 
     const now_secs = @as(u64, @intCast(std.time.timestamp()));
     const cutoff_secs = if (now_secs > period_secs) now_secs - period_secs else 0;
@@ -1055,4 +1097,30 @@ test "dump: isSafePadctlLogPath rejects arbitrary paths" {
     try testing.expect(!isSafePadctlLogPath("padctl.log"));
     // Parent directory traversal attempt.
     try testing.expect(!isSafePadctlLogPath("/var/log/padctl/../etc/padctl.log"));
+}
+
+test "dump: responseField extracts values and ignores prefixes" {
+    const line = "OK dump=off recorder_lines=42 last_flush=never";
+    try testing.expectEqualStrings("off", responseField(line, "dump").?);
+    try testing.expectEqualStrings("42", responseField(line, "recorder_lines").?);
+    try testing.expectEqualStrings("never", responseField(line, "last_flush").?);
+    try testing.expectEqual(@as(?[]const u8, null), responseField(line, "last_flush_ms_ago"));
+    try testing.expectEqual(@as(?[]const u8, null), responseField(line, "recorder"));
+}
+
+test "dump: formatRecorderStatus renders never and flushed states" {
+    var buf: [128]u8 = undefined;
+    try testing.expectEqualStrings(
+        "42 lines buffered, last flush: never",
+        formatRecorderStatus(&buf, "OK dump=off recorder_lines=42 last_flush=never").?,
+    );
+    try testing.expectEqualStrings(
+        "7 lines buffered, last flush: rumble-stuck 1234ms ago",
+        formatRecorderStatus(&buf, "OK dump=on recorder_lines=7 last_flush=rumble-stuck last_flush_ms_ago=1234").?,
+    );
+}
+
+test "dump: formatRecorderStatus returns null for a daemon without recorder fields" {
+    var buf: [128]u8 = undefined;
+    try testing.expectEqual(@as(?[]const u8, null), formatRecorderStatus(&buf, "OK dump=on"));
 }

--- a/src/diagnostics/flight_recorder.zig
+++ b/src/diagnostics/flight_recorder.zig
@@ -4,7 +4,7 @@ const padctl_log = @import("../log.zig");
 
 /// Lines held in the ring before the oldest is overwritten.
 pub const RING_LINES: usize = 1024;
-/// Bytes stored per line (`conventions/logging.md` §5).
+/// Bytes stored per line (`conventions/logging.md` section 5).
 pub const LINE_MAX: usize = 256;
 /// Minimum spacing between two automatic flushes.
 pub const MIN_FLUSH_INTERVAL_NS: i128 = 30 * std.time.ns_per_s;
@@ -28,8 +28,7 @@ pub const Reason = enum {
         };
     }
 
-    /// Automatic triggers fire from fault paths that can repeat quickly, so
-    /// they are rate limited. Operator-initiated flushes never are.
+    /// Automatic triggers repeat quickly so they are rate limited; explicit ones are not.
     fn automatic(self: Reason) bool {
         return switch (self) {
             .rumble_stuck, .rumble_write_dropped, .disconnect => true,
@@ -43,9 +42,8 @@ pub const LastFlush = struct {
     ms_ago: u64,
 };
 
-/// Serializes the ring across device threads, the rumble writer worker and
-/// the supervisor thread. Lock order is `mutex` then the log file mutex;
-/// never the reverse, so `flush` may log a warning while holding it.
+/// Serializes the ring. Lock order is `mutex` then the log file mutex, never the
+/// reverse, so `flush` may log a warning while holding it.
 var mutex: std.Thread.Mutex = .{};
 var ring: [RING_LINES][LINE_MAX]u8 = undefined;
 var lens: [RING_LINES]u16 = .{0} ** RING_LINES;
@@ -63,8 +61,7 @@ fn nowNs() i128 {
     return padctl_log.monotonicNs();
 }
 
-/// Store one formatted log line. The trailing newline is dropped and the
-/// content truncated to `LINE_MAX`; `flush` re-adds the separator.
+/// Store one formatted log line, minus its newline, truncated to `LINE_MAX`.
 pub fn record(line: []const u8) void {
     const trimmed = std.mem.trimRight(u8, line, "\r\n");
     if (trimmed.len == 0) return;
@@ -99,10 +96,8 @@ pub fn lastFlush() ?LastFlush {
     };
 }
 
-/// Append the buffered lines to the padctl log file, framed by
-/// `FLIGHT_RECORDER begin`/`end`, then clear the ring. Returns the number of
-/// lines written — zero when the ring is empty, the automatic trigger was
-/// rate limited, or the log file could not be written.
+/// Append the buffered lines to the padctl log file between FLIGHT_RECORDER
+/// markers and clear the ring. Returns lines written; 0 when nothing was.
 pub fn flush(reason: Reason) usize {
     mutex.lock();
     defer mutex.unlock();
@@ -144,8 +139,7 @@ pub fn flush(reason: Reason) usize {
     return written;
 }
 
-/// Buffer `data`, spilling to the log file whenever the staging buffer fills
-/// so a full ring costs tens of writes rather than one per line.
+/// Buffer `data`, spilling to the log file whenever the staging buffer fills.
 fn append(out: *[4096]u8, used: *usize, data: []const u8) bool {
     var rest = data;
     while (rest.len > 0) {
@@ -161,8 +155,7 @@ fn append(out: *[4096]u8, used: *usize, data: []const u8) bool {
     return true;
 }
 
-/// Report an unwritable log file once per process and keep the ring intact so
-/// a later flush (e.g. after `padctl dump enable`) can still persist it.
+/// Warn once per process and keep the ring so a later flush can still persist it.
 fn warnUnwritable() usize {
     if (unwritable_warns == 0) {
         std.log.warn("flight recorder: log file unwritable, flush dropped ({d} lines buffered)", .{count});
@@ -200,8 +193,7 @@ pub fn setClockForTest(ns: ?i128) void {
 
 const testing = std.testing;
 
-/// Redirect the log writer into `tmp` and reset recorder state. The returned
-/// path stays valid for the lifetime of `buf`.
+/// Redirect the log writer into `tmp` and reset recorder state.
 fn attachTestLog(tmp: *std.testing.TmpDir, buf: []u8) ![]const u8 {
     var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
     const dir = try tmp.dir.realpath(".", &dir_buf);
@@ -258,7 +250,6 @@ test "flight_recorder: ring overwrites the oldest line at capacity" {
 
     const content = try readTestLog(&tmp);
     defer testing.allocator.free(content);
-    // The three oldest lines were overwritten; the newest survived.
     try testing.expect(std.mem.indexOf(u8, content, "\nline-0\n") == null);
     try testing.expect(std.mem.indexOf(u8, content, "\nline-2\n") == null);
     try testing.expect(std.mem.indexOf(u8, content, "\nline-3\n") != null);
@@ -335,7 +326,6 @@ test "flight_recorder: automatic flush is rate limited, explicit flush is not" {
     // Explicit triggers ignore the window.
     try testing.expectEqual(@as(usize, 1), flush(.export_request));
 
-    // Past the window an automatic trigger fires again.
     setClockForTest(2 * MIN_FLUSH_INTERVAL_NS);
     record("c");
     try testing.expectEqual(@as(usize, 1), flush(.rumble_write_dropped));

--- a/src/diagnostics/flight_recorder.zig
+++ b/src/diagnostics/flight_recorder.zig
@@ -1,0 +1,422 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const padctl_log = @import("../log.zig");
+
+/// Lines held in the ring before the oldest is overwritten.
+pub const RING_LINES: usize = 1024;
+/// Bytes stored per line (`conventions/logging.md` §5).
+pub const LINE_MAX: usize = 256;
+/// Minimum spacing between two automatic flushes.
+pub const MIN_FLUSH_INTERVAL_NS: i128 = 30 * std.time.ns_per_s;
+
+pub const Reason = enum {
+    rumble_stuck,
+    rumble_write_dropped,
+    disconnect,
+    signal,
+    export_request,
+    shutdown,
+
+    pub fn text(self: Reason) []const u8 {
+        return switch (self) {
+            .rumble_stuck => "rumble-stuck",
+            .rumble_write_dropped => "rumble-write-dropped",
+            .disconnect => "disconnect",
+            .signal => "signal",
+            .export_request => "export",
+            .shutdown => "shutdown",
+        };
+    }
+
+    /// Automatic triggers fire from fault paths that can repeat quickly, so
+    /// they are rate limited. Operator-initiated flushes never are.
+    fn automatic(self: Reason) bool {
+        return switch (self) {
+            .rumble_stuck, .rumble_write_dropped, .disconnect => true,
+            .signal, .export_request, .shutdown => false,
+        };
+    }
+};
+
+pub const LastFlush = struct {
+    reason: Reason,
+    ms_ago: u64,
+};
+
+/// Serializes the ring across device threads, the rumble writer worker and
+/// the supervisor thread. Lock order is `mutex` then the log file mutex;
+/// never the reverse, so `flush` may log a warning while holding it.
+var mutex: std.Thread.Mutex = .{};
+var ring: [RING_LINES][LINE_MAX]u8 = undefined;
+var lens: [RING_LINES]u16 = .{0} ** RING_LINES;
+var head: usize = 0;
+var count: usize = 0;
+var last_flush_ns: ?i128 = null;
+var last_flush_reason: Reason = .shutdown;
+var unwritable_warns: usize = 0;
+var clock_override: ?i128 = null;
+
+fn nowNs() i128 {
+    if (builtin.is_test) {
+        if (clock_override) |v| return v;
+    }
+    return padctl_log.monotonicNs();
+}
+
+/// Store one formatted log line. The trailing newline is dropped and the
+/// content truncated to `LINE_MAX`; `flush` re-adds the separator.
+pub fn record(line: []const u8) void {
+    const trimmed = std.mem.trimRight(u8, line, "\r\n");
+    if (trimmed.len == 0) return;
+    const n = @min(trimmed.len, LINE_MAX);
+
+    mutex.lock();
+    defer mutex.unlock();
+
+    @memcpy(ring[head][0..n], trimmed[0..n]);
+    lens[head] = @intCast(n);
+    head = (head + 1) % RING_LINES;
+    if (count < RING_LINES) count += 1;
+}
+
+/// Number of lines currently buffered.
+pub fn buffered() usize {
+    mutex.lock();
+    defer mutex.unlock();
+    return count;
+}
+
+/// Reason and age of the most recent flush that reached the log file.
+pub fn lastFlush() ?LastFlush {
+    mutex.lock();
+    defer mutex.unlock();
+    const at = last_flush_ns orelse return null;
+    const delta = nowNs() - at;
+    const ms: i128 = if (delta <= 0) 0 else @divFloor(delta, std.time.ns_per_ms);
+    return .{
+        .reason = last_flush_reason,
+        .ms_ago = @intCast(@min(ms, std.math.maxInt(u64))),
+    };
+}
+
+/// Append the buffered lines to the padctl log file, framed by
+/// `FLIGHT_RECORDER begin`/`end`, then clear the ring. Returns the number of
+/// lines written — zero when the ring is empty, the automatic trigger was
+/// rate limited, or the log file could not be written.
+pub fn flush(reason: Reason) usize {
+    mutex.lock();
+    defer mutex.unlock();
+
+    if (count == 0) return 0;
+    const now = nowNs();
+    if (reason.automatic()) {
+        if (last_flush_ns) |prev| {
+            if (now - prev < MIN_FLUSH_INTERVAL_NS) return 0;
+        }
+    }
+
+    var out: [4096]u8 = undefined;
+    var used: usize = 0;
+
+    var header_buf: [96]u8 = undefined;
+    const header = std.fmt.bufPrint(
+        &header_buf,
+        "FLIGHT_RECORDER begin reason={s} lines={d}\n",
+        .{ reason.text(), count },
+    ) catch return warnUnwritable();
+    if (!append(&out, &used, header)) return warnUnwritable();
+
+    const oldest = if (count < RING_LINES) 0 else head;
+    var i: usize = 0;
+    while (i < count) : (i += 1) {
+        const idx = (oldest + i) % RING_LINES;
+        if (!append(&out, &used, ring[idx][0..lens[idx]])) return warnUnwritable();
+        if (!append(&out, &used, "\n")) return warnUnwritable();
+    }
+    if (!append(&out, &used, "FLIGHT_RECORDER end\n")) return warnUnwritable();
+    if (used > 0 and !padctl_log.appendToLogFile(out[0..used])) return warnUnwritable();
+
+    const written = count;
+    head = 0;
+    count = 0;
+    last_flush_ns = now;
+    last_flush_reason = reason;
+    return written;
+}
+
+/// Buffer `data`, spilling to the log file whenever the staging buffer fills
+/// so a full ring costs tens of writes rather than one per line.
+fn append(out: *[4096]u8, used: *usize, data: []const u8) bool {
+    var rest = data;
+    while (rest.len > 0) {
+        if (used.* == out.len) {
+            if (!padctl_log.appendToLogFile(out[0..used.*])) return false;
+            used.* = 0;
+        }
+        const n = @min(out.len - used.*, rest.len);
+        @memcpy(out[used.* .. used.* + n], rest[0..n]);
+        used.* += n;
+        rest = rest[n..];
+    }
+    return true;
+}
+
+/// Report an unwritable log file once per process and keep the ring intact so
+/// a later flush (e.g. after `padctl dump enable`) can still persist it.
+fn warnUnwritable() usize {
+    if (unwritable_warns == 0) {
+        std.log.warn("flight recorder: log file unwritable, flush dropped ({d} lines buffered)", .{count});
+        unwritable_warns += 1;
+    }
+    return 0;
+}
+
+/// Number of unwritable-log-file warnings emitted since process start.
+pub fn unwritableWarnCount() usize {
+    mutex.lock();
+    defer mutex.unlock();
+    return unwritable_warns;
+}
+
+/// Test hook: drop the ring, the rate-limit state and the clock override.
+pub fn resetForTest() void {
+    if (!builtin.is_test) return;
+    mutex.lock();
+    defer mutex.unlock();
+    head = 0;
+    count = 0;
+    last_flush_ns = null;
+    unwritable_warns = 0;
+    clock_override = null;
+}
+
+/// Test hook: freeze the clock used for rate limiting and flush ages.
+pub fn setClockForTest(ns: ?i128) void {
+    if (!builtin.is_test) return;
+    clock_override = ns;
+}
+
+// --- tests ---
+
+const testing = std.testing;
+
+/// Redirect the log writer into `tmp` and reset recorder state. The returned
+/// path stays valid for the lifetime of `buf`.
+fn attachTestLog(tmp: *std.testing.TmpDir, buf: []u8) ![]const u8 {
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = try tmp.dir.realpath(".", &dir_buf);
+    const path = try std.fmt.bufPrint(buf, "{s}/padctl.log", .{dir});
+    padctl_log.setLogPathForTest(path);
+    resetForTest();
+    return path;
+}
+
+fn detachTestLog() void {
+    padctl_log.setLogPathForTest("");
+    resetForTest();
+}
+
+fn readTestLog(tmp: *std.testing.TmpDir) ![]u8 {
+    return tmp.dir.readFileAlloc(testing.allocator, "padctl.log", 4 * 1024 * 1024);
+}
+
+test "flight_recorder: flush frames buffered lines in record order" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try attachTestLog(&tmp, &path_buf);
+    defer detachTestLog();
+
+    record("first\n");
+    record("second\n");
+    record("third\n");
+    try testing.expectEqual(@as(usize, 3), buffered());
+    try testing.expectEqual(@as(usize, 3), flush(.signal));
+
+    const content = try readTestLog(&tmp);
+    defer testing.allocator.free(content);
+    try testing.expectEqualStrings(
+        "FLIGHT_RECORDER begin reason=signal lines=3\nfirst\nsecond\nthird\nFLIGHT_RECORDER end\n",
+        content,
+    );
+}
+
+test "flight_recorder: ring overwrites the oldest line at capacity" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try attachTestLog(&tmp, &path_buf);
+    defer detachTestLog();
+
+    var i: usize = 0;
+    while (i < RING_LINES + 3) : (i += 1) {
+        var line_buf: [32]u8 = undefined;
+        record(try std.fmt.bufPrint(&line_buf, "line-{d}", .{i}));
+    }
+    try testing.expectEqual(RING_LINES, buffered());
+    try testing.expectEqual(RING_LINES, flush(.signal));
+
+    const content = try readTestLog(&tmp);
+    defer testing.allocator.free(content);
+    // The three oldest lines were overwritten; the newest survived.
+    try testing.expect(std.mem.indexOf(u8, content, "\nline-0\n") == null);
+    try testing.expect(std.mem.indexOf(u8, content, "\nline-2\n") == null);
+    try testing.expect(std.mem.indexOf(u8, content, "\nline-3\n") != null);
+    var it = std.mem.splitScalar(u8, content, '\n');
+    _ = it.next(); // header
+    try testing.expectEqualStrings("line-3", it.next().?);
+    const tail = std.mem.indexOf(u8, content, "line-1026\nFLIGHT_RECORDER end\n");
+    try testing.expect(tail != null);
+}
+
+test "flight_recorder: flush clears the ring" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try attachTestLog(&tmp, &path_buf);
+    defer detachTestLog();
+
+    record("only");
+    try testing.expectEqual(@as(usize, 1), flush(.signal));
+    try testing.expectEqual(@as(usize, 0), buffered());
+    try testing.expectEqual(@as(usize, 0), flush(.signal));
+
+    const content = try readTestLog(&tmp);
+    defer testing.allocator.free(content);
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, content, "FLIGHT_RECORDER begin"));
+}
+
+test "flight_recorder: record truncates a line at LINE_MAX" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try attachTestLog(&tmp, &path_buf);
+    defer detachTestLog();
+
+    var long: [LINE_MAX + 100]u8 = undefined;
+    @memset(&long, 'x');
+    record(&long);
+    _ = flush(.signal);
+
+    const content = try readTestLog(&tmp);
+    defer testing.allocator.free(content);
+    var it = std.mem.splitScalar(u8, content, '\n');
+    _ = it.next(); // header
+    try testing.expectEqual(LINE_MAX, it.next().?.len);
+}
+
+test "flight_recorder: empty ring writes nothing" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try attachTestLog(&tmp, &path_buf);
+    defer detachTestLog();
+
+    try testing.expectEqual(@as(usize, 0), flush(.shutdown));
+    try testing.expectError(error.FileNotFound, readTestLog(&tmp));
+}
+
+test "flight_recorder: automatic flush is rate limited, explicit flush is not" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try attachTestLog(&tmp, &path_buf);
+    defer detachTestLog();
+
+    setClockForTest(0);
+    record("a");
+    try testing.expectEqual(@as(usize, 1), flush(.disconnect));
+
+    setClockForTest(MIN_FLUSH_INTERVAL_NS - 1);
+    record("b");
+    try testing.expectEqual(@as(usize, 0), flush(.rumble_stuck));
+    try testing.expectEqual(@as(usize, 1), buffered());
+
+    // Explicit triggers ignore the window.
+    try testing.expectEqual(@as(usize, 1), flush(.export_request));
+
+    // Past the window an automatic trigger fires again.
+    setClockForTest(2 * MIN_FLUSH_INTERVAL_NS);
+    record("c");
+    try testing.expectEqual(@as(usize, 1), flush(.rumble_write_dropped));
+}
+
+test "flight_recorder: lastFlush reports reason and age" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try attachTestLog(&tmp, &path_buf);
+    defer detachTestLog();
+
+    try testing.expectEqual(@as(?LastFlush, null), lastFlush());
+    setClockForTest(0);
+    record("a");
+    _ = flush(.rumble_stuck);
+    setClockForTest(2 * std.time.ns_per_s);
+    const last = lastFlush().?;
+    try testing.expectEqual(Reason.rumble_stuck, last.reason);
+    try testing.expectEqual(@as(u64, 2000), last.ms_ago);
+}
+
+test "flight_recorder: unwritable log file warns once and keeps the ring" {
+    detachTestLog();
+    defer detachTestLog();
+    padctl_log.setLogPathForTest("/proc/padctl-flight-recorder-does-not-exist/padctl.log");
+
+    record("a");
+    record("b");
+    try testing.expectEqual(@as(usize, 0), flush(.signal));
+    try testing.expectEqual(@as(usize, 2), buffered());
+    try testing.expectEqual(@as(usize, 1), unwritableWarnCount());
+
+    try testing.expectEqual(@as(usize, 0), flush(.signal));
+    try testing.expectEqual(@as(usize, 2), buffered());
+    try testing.expectEqual(@as(usize, 1), unwritableWarnCount());
+}
+
+test "flight_recorder: logFn routes debug lines to the ring while dump is off" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try attachTestLog(&tmp, &path_buf);
+    defer detachTestLog();
+    padctl_log.setEnabled(false);
+
+    padctl_log.logFn(.debug, .default, "ring-only-line", .{});
+    try testing.expectEqual(@as(usize, 1), buffered());
+    try testing.expectError(error.FileNotFound, readTestLog(&tmp));
+
+    _ = flush(.signal);
+    const content = try readTestLog(&tmp);
+    defer testing.allocator.free(content);
+    try testing.expect(std.mem.indexOf(u8, content, "ring-only-line") != null);
+}
+
+test "flight_recorder: logFn routes debug lines to the file while dump is on" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try attachTestLog(&tmp, &path_buf);
+    defer detachTestLog();
+    padctl_log.setEnabled(true);
+    defer padctl_log.setEnabled(false);
+
+    padctl_log.logFn(.debug, .default, "file-line", .{});
+    try testing.expectEqual(@as(usize, 0), buffered());
+
+    const content = try readTestLog(&tmp);
+    defer testing.allocator.free(content);
+    try testing.expect(std.mem.indexOf(u8, content, "file-line") != null);
+}
+
+test "flight_recorder: logFn leaves info lines out of the ring" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try attachTestLog(&tmp, &path_buf);
+    defer detachTestLog();
+    padctl_log.setEnabled(false);
+
+    padctl_log.logFn(.info, .default, "info-line", .{});
+    try testing.expectEqual(@as(usize, 0), buffered());
+}

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -31,8 +31,8 @@ const RumbleScheduler = rumble_scheduler_mod.RumbleScheduler;
 const rumble_writer_mod = @import("core/rumble_writer.zig");
 const RumbleWriter = rumble_writer_mod.RumbleWriter;
 const rumble_log = std.log.scoped(.rumble);
-const padctl_log = @import("log.zig");
 const input_trace = @import("diagnostics/input_trace.zig");
+const flight_recorder = @import("diagnostics/flight_recorder.zig");
 const socket_client = @import("cli/socket_client.zig");
 const uhid_mod = @import("io/uhid.zig");
 pub const UhidDevice = uhid_mod.UhidDevice;
@@ -190,6 +190,9 @@ fn slotStr(buf: *const [256]u8) []const u8 {
 const RUMBLE_MIN_INTERVAL_NS: i128 = rumble_writer_mod.DEFAULT_MIN_WRITE_INTERVAL_NS;
 const RUMBLE_RETRY_INTERVAL_NS: i128 = 10_000_000; // 10ms
 const RUMBLE_MAX_RETRY_ATTEMPTS: u8 = 3;
+/// A non-zero frame that is still the newest physical write after this long
+/// is treated as stuck and flushes the flight recorder once.
+const STUCK_RUMBLE_NS: i128 = 10 * std.time.ns_per_s;
 
 fn commandMinIntervalNs(cmd: *const device_cfg.CommandConfig) u64 {
     return if (cmd.min_interval_ms) |interval_ms|
@@ -269,20 +272,17 @@ fn emitRumbleFrame(
     defer alloc.free(bytes);
     if (cmd.checksum) |*cs| applyChecksum(bytes, cs);
 
-    // Log the full post-checksum HID frame — but only when dump is on;
-    // otherwise the hex-dump loop runs unconditionally on every rumble
-    // frame (100+ Hz during gameplay) even with nothing listening.
-    if (padctl_log.shouldWriteToFile(.debug)) {
-        var hex_buf: [512]u8 = undefined;
-        var hex_fbs = std.io.fixedBufferStream(&hex_buf);
-        const hw = hex_fbs.writer();
-        for (bytes) |b| {
-            hw.print("{x:0>2} ", .{b}) catch break;
-        }
-        rumble_log.debug("[{s}] HID_WRITE: cmd={s} strong={d} weak={d} iface={d} len={d} frame=[{s}]", .{
-            tag, ff_type, strong, weak, iface_idx, bytes.len, hex_fbs.getWritten(),
-        });
+    // Log the full post-checksum HID frame. The flight recorder buffers
+    // debug lines even with dump off, so this runs on every rumble frame.
+    var hex_buf: [512]u8 = undefined;
+    var hex_fbs = std.io.fixedBufferStream(&hex_buf);
+    const hw = hex_fbs.writer();
+    for (bytes) |b| {
+        hw.print("{x:0>2} ", .{b}) catch break;
     }
+    rumble_log.debug("[{s}] HID_WRITE: cmd={s} strong={d} weak={d} iface={d} len={d} frame=[{s}]", .{
+        tag, ff_type, strong, weak, iface_idx, bytes.len, hex_fbs.getWritten(),
+    });
 
     if (writer) |w| {
         w.publish(
@@ -350,6 +350,8 @@ fn quiesceTimersAndRumbleImpl(
     disarmTimer(self.rumble_stop_fd);
     self.rumble_scheduler = .{};
     self.last_rumble_ns = 0;
+    self.nonzero_rumble_since_ns = null;
+    self.stuck_rumble_reported = false;
     self.pending_rumble_frame = null;
     self.pending_rumble_deadline_ns = null;
     self.pending_rumble_retry_count = 0;
@@ -508,6 +510,15 @@ pub const EventLoop = struct {
     pending_rumble_retry_count: u8,
     pending_rumble_generation: u64,
     last_heartbeat_ns: i128 = 0,
+    /// Monotonic time of the last non-zero physical rumble frame, or null when
+    /// the newest physical frame was a stop. Drives the stuck-rumble trigger.
+    nonzero_rumble_since_ns: ?i128 = null,
+    /// True once the current non-zero episode has been reported. Cleared when
+    /// a zero frame reaches the device.
+    stuck_rumble_reported: bool = false,
+    /// Idle time after a non-zero frame before the flight recorder is flushed.
+    /// Only tests change it; the daemon always uses STUCK_RUMBLE_NS.
+    stuck_rumble_ns: i128 = STUCK_RUMBLE_NS,
     /// Last successfully emitted virtual button mask. Diagnostic tracing uses
     /// it to log output edges without flooding dumps with axis-only frames.
     diagnostic_output_buttons: u64 = 0,
@@ -692,8 +703,39 @@ pub const EventLoop = struct {
         return self.rumble_generation;
     }
 
-    fn recordRumbleWrite(self: *EventLoop, now_ns: i128) void {
+    fn recordRumbleWrite(self: *EventLoop, now_ns: i128, frame: RumbleScheduler.Frame) void {
         self.last_rumble_ns = now_ns;
+        if (frame.strong == 0 and frame.weak == 0) {
+            self.nonzero_rumble_since_ns = null;
+            self.stuck_rumble_reported = false;
+        } else {
+            self.nonzero_rumble_since_ns = now_ns;
+        }
+    }
+
+    /// Deadline at which an unrelieved non-zero rumble becomes reportable,
+    /// or null when nothing is outstanding or the episode was already logged.
+    fn stuckRumbleDeadline(self: *const EventLoop) ?i128 {
+        if (self.stuck_rumble_reported) return null;
+        const since = self.nonzero_rumble_since_ns orelse return null;
+        return since + self.stuck_rumble_ns;
+    }
+
+    /// Persist the trace window once a non-zero frame has been the newest
+    /// physical write for longer than `stuck_rumble_ns`.
+    fn checkStuckRumble(self: *EventLoop, now_ns: i128) void {
+        const deadline = self.stuckRumbleDeadline() orelse return;
+        if (now_ns < deadline) return;
+        self.stuck_rumble_reported = true;
+        _ = flight_recorder.flush(.rumble_stuck);
+    }
+
+    /// Mark the device gone, stop the loop, and persist the trace window that
+    /// preceded the disconnect.
+    fn markDisconnected(self: *EventLoop) void {
+        self.disconnected = true;
+        self.running = false;
+        _ = flight_recorder.flush(.disconnect);
     }
 
     fn queuePendingRumble(self: *EventLoop, frame: RumbleScheduler.Frame, deadline_ns: i128, retry_count: u8, generation: u64) void {
@@ -742,7 +784,7 @@ pub const EventLoop = struct {
         );
         if (result == .written or result == .queued) {
             if (result == .written) {
-                self.recordRumbleWrite(now_ns);
+                self.recordRumbleWrite(now_ns, frame);
             }
             self.clearPendingRumble();
         } else if (result == .unconfigured or result == .permanent_failure) {
@@ -756,8 +798,7 @@ pub const EventLoop = struct {
             ctx.device_tag, frame.strong, frame.weak,
         });
         self.clearPendingRumble();
-        self.disconnected = true;
-        self.running = false;
+        self.markDisconnected();
     }
 
     fn queueRumbleRetry(self: *EventLoop, ctx: EventLoopContext, frame: RumbleScheduler.Frame, now_ns: i128, generation: u64) void {
@@ -773,6 +814,7 @@ pub const EventLoop = struct {
             rumble_log.warn("[{s}] HID_WRITE: retry limit exceeded strong={d} weak={d}; dropping rumble frame and keeping input loop alive", .{
                 ctx.device_tag, frame.strong, frame.weak,
             });
+            _ = flight_recorder.flush(.rumble_write_dropped);
             self.clearPendingRumble();
             return;
         }
@@ -837,7 +879,12 @@ pub const EventLoop = struct {
             .weak = completion.frame.weak,
         };
         switch (completion.result) {
-            .written => self.recordRumbleWrite(completion.completed_ns),
+            .written => {
+                self.recordRumbleWrite(completion.completed_ns, frame);
+                // Re-arm so the stuck-rumble deadline this write just moved is
+                // reflected in the timerfd; the scheduler deadline is unchanged.
+                self.armRumbleTimer(self.rumble_scheduler.nextDeadline());
+            },
             .disconnected => self.handleRumbleDisconnect(ctx, frame),
             .write_failed => {
                 // A newer logical frame already waiting for its throttle
@@ -848,6 +895,7 @@ pub const EventLoop = struct {
                         rumble_log.warn("[{s}] HID_WRITE: retry limit exceeded strong={d} weak={d}; dropping rumble frame and keeping input loop alive", .{
                             ctx.device_tag, frame.strong, frame.weak,
                         });
+                        _ = flight_recorder.flush(.rumble_write_dropped);
                     } else {
                         self.queuePendingRumble(frame, monotonicNs() + RUMBLE_RETRY_INTERVAL_NS, retry_count, completion.generation);
                     }
@@ -858,7 +906,11 @@ pub const EventLoop = struct {
     }
 
     fn armRumbleTimer(self: *EventLoop, scheduler_deadline_ns: ?i128) void {
-        armRumbleStopFd(self.rumble_stop_fd, minDeadline(scheduler_deadline_ns, self.pending_rumble_deadline_ns));
+        // The stuck deadline joins the scheduler and retry deadlines so the
+        // loop still wakes to report a stuck rumble on an otherwise idle
+        // device, where ppoll would block indefinitely.
+        const pending = minDeadline(scheduler_deadline_ns, self.pending_rumble_deadline_ns);
+        armRumbleStopFd(self.rumble_stop_fd, minDeadline(pending, self.stuckRumbleDeadline()));
     }
 
     pub fn run(self: *EventLoop, ctx: EventLoopContext) !void {
@@ -916,15 +968,15 @@ pub const EventLoop = struct {
             const dt_ms: u32 = @intCast(@min(100, @max(1, @divFloor(dt_ns, 1_000_000))));
             self.last_ts = now;
 
+            self.checkStuckRumble(now);
+
             // Heartbeat: log every 60s to confirm daemon is alive and trigger
             // log file reopen if the file was deleted.
             const heartbeat_interval: i128 = 60 * std.time.ns_per_s;
             if (now - self.last_heartbeat_ns >= heartbeat_interval) {
                 self.last_heartbeat_ns = now;
-                if (padctl_log.shouldWriteToFile(.debug)) {
-                    const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now);
-                    rumble_log.debug("[{s}] HEARTBEAT: alive {s}", .{ ctx.device_tag, slotStr(&slot_buf) });
-                }
+                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now);
+                rumble_log.debug("[{s}] HEARTBEAT: alive {s}", .{ ctx.device_tag, slotStr(&slot_buf) });
             }
 
             // Check signalfd (slot 0)
@@ -955,15 +1007,12 @@ pub const EventLoop = struct {
                 const has_hup = revents & (posix.POLL.HUP | posix.POLL.ERR) != 0;
 
                 if (!has_in and has_hup) {
-                    if (padctl_log.shouldWriteToFile(.debug)) {
-                        const disc_now = monotonicNs();
-                        const disc_slots = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), disc_now);
-                        rumble_log.debug("[{s}] DISCONNECT: HUP/ERR on device slot {d} {s}", .{
-                            ctx.device_tag, slot, slotStr(&disc_slots),
-                        });
-                    }
-                    self.disconnected = true;
-                    self.running = false;
+                    const disc_now = monotonicNs();
+                    const disc_slots = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), disc_now);
+                    rumble_log.debug("[{s}] DISCONNECT: HUP/ERR on device slot {d} {s}", .{
+                        ctx.device_tag, slot, slotStr(&disc_slots),
+                    });
+                    self.markDisconnected();
                     break;
                 }
 
@@ -974,8 +1023,7 @@ pub const EventLoop = struct {
                     const n = dev.read(&buf) catch |err| switch (err) {
                         error.Again => break,
                         error.Disconnected => {
-                            self.disconnected = true;
-                            self.running = false;
+                            self.markDisconnected();
                             break;
                         },
                         error.Io => break,
@@ -1103,12 +1151,10 @@ pub const EventLoop = struct {
                 _ = posix.read(self.rumble_stop_fd, &rs_expiry) catch {};
                 const now_ns = monotonicNs();
                 const result = self.rumble_scheduler.onTimerExpired(now_ns);
-                if (padctl_log.shouldWriteToFile(.debug)) {
-                    const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
-                    rumble_log.debug("[{s}] TIMERFD: expired now={d} frame={?} next_dl={?d} {s}", .{
-                        ctx.device_tag, now_ns, result.frame, result.next_deadline_ns, slotStr(&slot_buf),
-                    });
-                }
+                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                rumble_log.debug("[{s}] TIMERFD: expired now={d} frame={?} next_dl={?d} {s}", .{
+                    ctx.device_tag, now_ns, result.frame, result.next_deadline_ns, slotStr(&slot_buf),
+                });
                 if (result.frame) |frame| {
                     const generation = self.nextRumbleGeneration();
                     self.clearPendingRumble();
@@ -1142,13 +1188,11 @@ pub const EventLoop = struct {
                         if (is_stop) {
                             if (scheduler_on) {
                                 const result = self.rumble_scheduler.onStop(ff_ev.effect_id);
-                                if (padctl_log.shouldWriteToFile(.debug)) {
-                                    const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
-                                    rumble_log.debug("[{s}] FF_STOP: id={d} frame={?} next_dl={?d} {s}", .{
-                                        ctx.device_tag,          ff_ev.effect_id,    result.frame,
-                                        result.next_deadline_ns, slotStr(&slot_buf),
-                                    });
-                                }
+                                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                                rumble_log.debug("[{s}] FF_STOP: id={d} frame={?} next_dl={?d} {s}", .{
+                                    ctx.device_tag,          ff_ev.effect_id,    result.frame,
+                                    result.next_deadline_ns, slotStr(&slot_buf),
+                                });
                                 const frame_to_emit = result.frame orelse if (!result.active_after)
                                     RumbleScheduler.Frame{ .strong = 0, .weak = 0 }
                                 else
@@ -1177,13 +1221,11 @@ pub const EventLoop = struct {
                                     ff_ev.duration_ms,
                                     now_ns,
                                 );
-                                if (padctl_log.shouldWriteToFile(.debug)) {
-                                    const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
-                                    rumble_log.debug("[{s}] FF_PLAY: id={d} dur={d}ms frame={?} next_dl={?d} {s}", .{
-                                        ctx.device_tag,          ff_ev.effect_id,    ff_ev.duration_ms, result.frame,
-                                        result.next_deadline_ns, slotStr(&slot_buf),
-                                    });
-                                }
+                                const slot_buf = fmtSchedulerSlots(self.rumble_scheduler.dumpSlots(), now_ns);
+                                rumble_log.debug("[{s}] FF_PLAY: id={d} dur={d}ms frame={?} next_dl={?d} {s}", .{
+                                    ctx.device_tag,          ff_ev.effect_id,    ff_ev.duration_ms, result.frame,
+                                    result.next_deadline_ns, slotStr(&slot_buf),
+                                });
                                 if (result.frame) |frame| {
                                     const generation = self.nextRumbleGeneration();
                                     const elapsed = now_ns - self.last_rumble_ns;
@@ -2121,4 +2163,66 @@ test "event_loop: applyAdaptiveTrigger: custom command_prefix routes correctly" 
     try testing.expectEqual(@as(u8, 0xaa), mock_dev.write_log.items[0]);
     try testing.expectEqual(@as(u8, 10), mock_dev.write_log.items[1]);
     try testing.expectEqual(@as(u8, 20), mock_dev.write_log.items[2]);
+}
+
+test "event_loop: stuck rumble flushes the flight recorder once per episode" {
+    const padctl_log = @import("log.zig");
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = try tmp.dir.realpath(".", &dir_buf);
+    padctl_log.setLogPathForTest(try std.fmt.bufPrint(&path_buf, "{s}/padctl.log", .{dir}));
+    defer padctl_log.setLogPathForTest("");
+    flight_recorder.resetForTest();
+    defer flight_recorder.resetForTest();
+    flight_recorder.setClockForTest(0);
+
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+    loop.stuck_rumble_ns = 10 * std.time.ns_per_ms;
+
+    loop.recordRumbleWrite(0, .{ .strong = 0x8000, .weak = 0 });
+    flight_recorder.record("trace-1");
+
+    // Before the threshold nothing is persisted.
+    loop.checkStuckRumble(loop.stuck_rumble_ns - 1);
+    try testing.expectEqual(@as(usize, 1), flight_recorder.buffered());
+
+    loop.checkStuckRumble(loop.stuck_rumble_ns);
+    try testing.expectEqual(@as(usize, 0), flight_recorder.buffered());
+
+    // The episode is reported once; staying stuck does not flush again.
+    flight_recorder.setClockForTest(flight_recorder.MIN_FLUSH_INTERVAL_NS);
+    flight_recorder.record("trace-2");
+    loop.checkStuckRumble(loop.stuck_rumble_ns * 100);
+    try testing.expectEqual(@as(usize, 1), flight_recorder.buffered());
+
+    // A zero frame closes the episode; the next non-zero frame re-arms it.
+    loop.recordRumbleWrite(loop.stuck_rumble_ns * 100, .{ .strong = 0, .weak = 0 });
+    loop.checkStuckRumble(loop.stuck_rumble_ns * 200);
+    try testing.expectEqual(@as(usize, 1), flight_recorder.buffered());
+
+    loop.recordRumbleWrite(loop.stuck_rumble_ns * 200, .{ .strong = 1, .weak = 1 });
+    loop.checkStuckRumble(loop.stuck_rumble_ns * 201);
+    try testing.expectEqual(@as(usize, 0), flight_recorder.buffered());
+}
+
+test "event_loop: stuck rumble deadline arms the rumble timerfd on an idle device" {
+    var loop = try EventLoop.initManaged();
+    defer loop.deinit();
+    loop.stuck_rumble_ns = 5 * std.time.ns_per_ms;
+
+    loop.recordRumbleWrite(monotonicNs(), .{ .strong = 0x4000, .weak = 0 });
+    loop.armRumbleTimer(null);
+    var armed = [1]posix.pollfd{.{ .fd = loop.rumble_stop_fd, .events = posix.POLL.IN, .revents = 0 }};
+    try testing.expectEqual(@as(usize, 1), try posix.poll(&armed, 500));
+
+    // A zero frame closes the episode, so nothing keeps the timer armed.
+    var expiry: [8]u8 = undefined;
+    _ = posix.read(loop.rumble_stop_fd, &expiry) catch {};
+    loop.recordRumbleWrite(monotonicNs(), .{ .strong = 0, .weak = 0 });
+    loop.armRumbleTimer(null);
+    var idle = [1]posix.pollfd{.{ .fd = loop.rumble_stop_fd, .events = posix.POLL.IN, .revents = 0 }};
+    try testing.expectEqual(@as(usize, 0), try posix.poll(&idle, 50));
 }

--- a/src/event_loop.zig
+++ b/src/event_loop.zig
@@ -190,8 +190,7 @@ fn slotStr(buf: *const [256]u8) []const u8 {
 const RUMBLE_MIN_INTERVAL_NS: i128 = rumble_writer_mod.DEFAULT_MIN_WRITE_INTERVAL_NS;
 const RUMBLE_RETRY_INTERVAL_NS: i128 = 10_000_000; // 10ms
 const RUMBLE_MAX_RETRY_ATTEMPTS: u8 = 3;
-/// A non-zero frame that is still the newest physical write after this long
-/// is treated as stuck and flushes the flight recorder once.
+/// Idle time after a non-zero frame before the rumble is treated as stuck.
 const STUCK_RUMBLE_NS: i128 = 10 * std.time.ns_per_s;
 
 fn commandMinIntervalNs(cmd: *const device_cfg.CommandConfig) u64 {
@@ -272,8 +271,6 @@ fn emitRumbleFrame(
     defer alloc.free(bytes);
     if (cmd.checksum) |*cs| applyChecksum(bytes, cs);
 
-    // Log the full post-checksum HID frame. The flight recorder buffers
-    // debug lines even with dump off, so this runs on every rumble frame.
     var hex_buf: [512]u8 = undefined;
     var hex_fbs = std.io.fixedBufferStream(&hex_buf);
     const hw = hex_fbs.writer();
@@ -510,14 +507,11 @@ pub const EventLoop = struct {
     pending_rumble_retry_count: u8,
     pending_rumble_generation: u64,
     last_heartbeat_ns: i128 = 0,
-    /// Monotonic time of the last non-zero physical rumble frame, or null when
-    /// the newest physical frame was a stop. Drives the stuck-rumble trigger.
+    /// Monotonic time of the last non-zero physical rumble frame; null after a stop.
     nonzero_rumble_since_ns: ?i128 = null,
-    /// True once the current non-zero episode has been reported. Cleared when
-    /// a zero frame reaches the device.
+    /// True once the current episode was reported; cleared by a zero frame.
     stuck_rumble_reported: bool = false,
-    /// Idle time after a non-zero frame before the flight recorder is flushed.
-    /// Only tests change it; the daemon always uses STUCK_RUMBLE_NS.
+    /// Stuck threshold; only tests change it.
     stuck_rumble_ns: i128 = STUCK_RUMBLE_NS,
     /// Last successfully emitted virtual button mask. Diagnostic tracing uses
     /// it to log output edges without flooding dumps with axis-only frames.
@@ -713,16 +707,14 @@ pub const EventLoop = struct {
         }
     }
 
-    /// Deadline at which an unrelieved non-zero rumble becomes reportable,
-    /// or null when nothing is outstanding or the episode was already logged.
+    /// Deadline at which an unrelieved non-zero rumble becomes reportable.
     fn stuckRumbleDeadline(self: *const EventLoop) ?i128 {
         if (self.stuck_rumble_reported) return null;
         const since = self.nonzero_rumble_since_ns orelse return null;
         return since + self.stuck_rumble_ns;
     }
 
-    /// Persist the trace window once a non-zero frame has been the newest
-    /// physical write for longer than `stuck_rumble_ns`.
+    /// Flush once per episode once a non-zero frame has been newest for `stuck_rumble_ns`.
     fn checkStuckRumble(self: *EventLoop, now_ns: i128) void {
         const deadline = self.stuckRumbleDeadline() orelse return;
         if (now_ns < deadline) return;
@@ -730,8 +722,7 @@ pub const EventLoop = struct {
         _ = flight_recorder.flush(.rumble_stuck);
     }
 
-    /// Mark the device gone, stop the loop, and persist the trace window that
-    /// preceded the disconnect.
+    /// Mark the device gone, stop the loop, and persist the trace window.
     fn markDisconnected(self: *EventLoop) void {
         self.disconnected = true;
         self.running = false;
@@ -881,8 +872,6 @@ pub const EventLoop = struct {
         switch (completion.result) {
             .written => {
                 self.recordRumbleWrite(completion.completed_ns, frame);
-                // Re-arm so the stuck-rumble deadline this write just moved is
-                // reflected in the timerfd; the scheduler deadline is unchanged.
                 self.armRumbleTimer(self.rumble_scheduler.nextDeadline());
             },
             .disconnected => self.handleRumbleDisconnect(ctx, frame),
@@ -906,9 +895,7 @@ pub const EventLoop = struct {
     }
 
     fn armRumbleTimer(self: *EventLoop, scheduler_deadline_ns: ?i128) void {
-        // The stuck deadline joins the scheduler and retry deadlines so the
-        // loop still wakes to report a stuck rumble on an otherwise idle
-        // device, where ppoll would block indefinitely.
+        // Include the stuck deadline so an idle device still wakes to report it.
         const pending = minDeadline(scheduler_deadline_ns, self.pending_rumble_deadline_ns);
         armRumbleStopFd(self.rumble_stop_fd, minDeadline(pending, self.stuckRumbleDeadline()));
     }
@@ -2185,7 +2172,6 @@ test "event_loop: stuck rumble flushes the flight recorder once per episode" {
     loop.recordRumbleWrite(0, .{ .strong = 0x8000, .weak = 0 });
     flight_recorder.record("trace-1");
 
-    // Before the threshold nothing is persisted.
     loop.checkStuckRumble(loop.stuck_rumble_ns - 1);
     try testing.expectEqual(@as(usize, 1), flight_recorder.buffered());
 
@@ -2218,7 +2204,6 @@ test "event_loop: stuck rumble deadline arms the rumble timerfd on an idle devic
     var armed = [1]posix.pollfd{.{ .fd = loop.rumble_stop_fd, .events = posix.POLL.IN, .revents = 0 }};
     try testing.expectEqual(@as(usize, 1), try posix.poll(&armed, 500));
 
-    // A zero frame closes the episode, so nothing keeps the timer armed.
     var expiry: [8]u8 = undefined;
     _ = posix.read(loop.rumble_stop_fd, &expiry) catch {};
     loop.recordRumbleWrite(monotonicNs(), .{ .strong = 0, .weak = 0 });

--- a/src/io/control_socket.zig
+++ b/src/io/control_socket.zig
@@ -178,6 +178,7 @@ pub const CommandTag = enum {
     dump_on,
     dump_off,
     dump_status,
+    dump_flush,
     unknown,
 };
 
@@ -228,6 +229,7 @@ pub fn parseCommand(raw: []const u8) Command {
         if (std.ascii.eqlIgnoreCase(mode, "ON")) return .{ .tag = .dump_on };
         if (std.ascii.eqlIgnoreCase(mode, "OFF")) return .{ .tag = .dump_off };
         if (std.ascii.eqlIgnoreCase(mode, "STATUS")) return .{ .tag = .dump_status };
+        if (std.ascii.eqlIgnoreCase(mode, "FLUSH")) return .{ .tag = .dump_flush };
         return .{ .tag = .unknown };
     }
     return .{ .tag = .unknown };
@@ -295,6 +297,15 @@ test "control_socket: parseCommand: DEVICES" {
 test "control_socket: parseCommand: RELOAD" {
     try testing.expectEqual(CommandTag.reload, parseCommand("RELOAD\n").tag);
     try testing.expectEqual(CommandTag.reload, parseCommand("reload\n").tag);
+}
+
+test "control_socket: parseCommand: DUMP FLUSH" {
+    try testing.expectEqual(CommandTag.dump_flush, parseCommand("DUMP FLUSH\n").tag);
+    try testing.expectEqual(CommandTag.dump_flush, parseCommand("dump flush\n").tag);
+}
+
+test "control_socket: parseCommand: DUMP with unknown mode rejected" {
+    try testing.expectEqual(CommandTag.unknown, parseCommand("DUMP FLUSHX\n").tag);
 }
 
 test "control_socket: parseCommand: CHORD_SWITCH valid index" {

--- a/src/log.zig
+++ b/src/log.zig
@@ -261,11 +261,6 @@ pub fn logFn(
     const msg = fbs.getWritten();
     if (msg.len == 0) return;
 
-    // .debug lines are verbose scheduler / HID traces. With dump off they
-    // reach neither the journal nor the log file; the flight recorder keeps
-    // the most recent ones in memory so a later trigger can persist the
-    // window that preceded a fault. .info / .warn / .err always flow as
-    // normal.
     if (is_debug and !dump_enabled.load(.acquire)) {
         flight_recorder.record(msg);
         return;
@@ -282,8 +277,7 @@ pub fn logFn(
     }
 }
 
-/// Append `bytes` to the log file, opening it on demand when `lazy_open` is
-/// set. Returns true when the bytes reached the file. Takes log_mutex.
+/// Append `bytes` under log_mutex, opening the file on demand when `lazy_open`.
 fn writeToLogFile(bytes: []const u8, lazy_open: bool) bool {
     log_mutex.lock();
     defer log_mutex.unlock();
@@ -301,18 +295,12 @@ fn writeToLogFile(bytes: []const u8, lazy_open: bool) bool {
     return true;
 }
 
-/// Persist `bytes` to the log file, opening it on demand. Used by the flight
-/// recorder, whose output must reach disk regardless of the dump toggle.
+/// Persist `bytes` to the log file, opening it on demand. Used by the flight recorder.
 pub fn appendToLogFile(bytes: []const u8) bool {
     return writeToLogFile(bytes, true);
 }
 
-/// Post-write rotation. openLogFile only rotates at fresh open (startup /
-/// lazy open), so without this check a long dump session grows past
-/// max_log_size_mb until the daemon restarts — at ~100 FF frames/s a
-/// default 100 MiB cap is blown through in under two hours. Stat the live
-/// fd; when it crosses the threshold, close + reopen, which walks through
-/// openLogFile's rotate-rename path. Must be called under log_mutex.
+/// openLogFile only rotates on open; check the live fd after each write. Under log_mutex.
 fn rotateIfOversize(fd: posix.fd_t) void {
     const st = posix.fstat(fd) catch return;
     if (st.size <= max_log_size) return;
@@ -321,9 +309,7 @@ fn rotateIfOversize(fd: posix.fd_t) void {
     openLogFile();
 }
 
-/// Test hook: point the file writer at `path` without touching the
-/// environment, so tests never write to the real state directory. An empty
-/// path detaches the writer entirely.
+/// Test hook: point the file writer at `path`; an empty path detaches it.
 pub fn setLogPathForTest(path: []const u8) void {
     if (!builtin.is_test) return;
     log_mutex.lock();

--- a/src/log.zig
+++ b/src/log.zig
@@ -1,8 +1,10 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const posix = std.posix;
 const linux = std.os.linux;
 const Allocator = std.mem.Allocator;
 const paths = @import("config/paths.zig");
+const flight_recorder = @import("diagnostics/flight_recorder.zig");
 
 /// File descriptor for the log file. -1 when file logging is inactive.
 var log_fd: std.atomic.Value(posix.fd_t) = std.atomic.Value(posix.fd_t).init(-1);
@@ -236,14 +238,7 @@ pub fn logFn(
     comptime format: []const u8,
     args: anytype,
 ) void {
-    // Early exit: .debug lines are verbose scheduler / HID traces that
-    // should be silent unless dump is enabled. Without this short-circuit
-    // every std.log.debug call would format into a 4 KiB stack buffer,
-    // hit stderr, and pollute journalctl with per-frame lines on every
-    // install — contradicting the documented "no hot-path cost when
-    // disabled" contract. .info / .warn / .err always flow as normal.
     const is_debug = comptime (message_level == .debug);
-    if (is_debug and !dump_enabled.load(.acquire)) return;
 
     const level_txt = comptime message_level.asText();
     const scope_prefix = comptime if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
@@ -266,40 +261,83 @@ pub fn logFn(
     const msg = fbs.getWritten();
     if (msg.len == 0) return;
 
+    // .debug lines are verbose scheduler / HID traces. With dump off they
+    // reach neither the journal nor the log file; the flight recorder keeps
+    // the most recent ones in memory so a later trigger can persist the
+    // window that preceded a fault. .info / .warn / .err always flow as
+    // normal.
+    if (is_debug and !dump_enabled.load(.acquire)) {
+        flight_recorder.record(msg);
+        return;
+    }
+
     // Write to stderr (for systemd journal / terminal).
     _ = posix.write(posix.STDERR_FILENO, msg) catch {};
 
     // Write to log file: err/warn always persist; debug/info only when dump enabled.
     const always_write = comptime (message_level == .err or message_level == .warn);
-    const write_to_file = shouldWriteToFile(message_level);
-    if (write_to_file) {
-        log_mutex.lock();
-        defer log_mutex.unlock();
-
-        var fd = log_fd.load(.acquire);
-        if (fd == -1 and always_write) {
-            // Lazy open: first err/warn creates the file even with dump off.
-            fd = ensureFileOpen();
-        }
-        if (fd != -1) {
-            fd = reopenIfDeleted(fd);
-            _ = posix.write(fd, msg) catch {};
-            // Post-write rotation. openLogFile only rotates at fresh
-            // open (startup / lazy open), so without this check a long
-            // dump session grows past max_log_size_mb until the daemon
-            // restarts — at ~100 FF frames/s a default 100 MiB cap is
-            // blown through in under two hours. Stat the live fd; when
-            // it crosses the threshold, close + reopen, which walks
-            // through openLogFile's rotate-rename path.
-            if (posix.fstat(fd)) |st| {
-                if (st.size > max_log_size) {
-                    const old_fd = log_fd.swap(-1, .acq_rel);
-                    if (old_fd != -1) posix.close(old_fd);
-                    openLogFile();
-                }
-            } else |_| {}
-        }
+    if (shouldWriteToFile(message_level)) {
+        // Lazy open: only err/warn create the file when dump is off.
+        _ = writeToLogFile(msg, always_write);
     }
+}
+
+/// Append `bytes` to the log file, opening it on demand when `lazy_open` is
+/// set. Returns true when the bytes reached the file. Takes log_mutex.
+fn writeToLogFile(bytes: []const u8, lazy_open: bool) bool {
+    log_mutex.lock();
+    defer log_mutex.unlock();
+
+    var fd = log_fd.load(.acquire);
+    if (fd == -1) {
+        if (!lazy_open) return false;
+        fd = ensureFileOpen();
+    }
+    if (fd == -1) return false;
+    fd = reopenIfDeleted(fd);
+    if (fd == -1) return false;
+    _ = posix.write(fd, bytes) catch return false;
+    rotateIfOversize(fd);
+    return true;
+}
+
+/// Persist `bytes` to the log file, opening it on demand. Used by the flight
+/// recorder, whose output must reach disk regardless of the dump toggle.
+pub fn appendToLogFile(bytes: []const u8) bool {
+    return writeToLogFile(bytes, true);
+}
+
+/// Post-write rotation. openLogFile only rotates at fresh open (startup /
+/// lazy open), so without this check a long dump session grows past
+/// max_log_size_mb until the daemon restarts — at ~100 FF frames/s a
+/// default 100 MiB cap is blown through in under two hours. Stat the live
+/// fd; when it crosses the threshold, close + reopen, which walks through
+/// openLogFile's rotate-rename path. Must be called under log_mutex.
+fn rotateIfOversize(fd: posix.fd_t) void {
+    const st = posix.fstat(fd) catch return;
+    if (st.size <= max_log_size) return;
+    const old_fd = log_fd.swap(-1, .acq_rel);
+    if (old_fd != -1) posix.close(old_fd);
+    openLogFile();
+}
+
+/// Test hook: point the file writer at `path` without touching the
+/// environment, so tests never write to the real state directory. An empty
+/// path detaches the writer entirely.
+pub fn setLogPathForTest(path: []const u8) void {
+    if (!builtin.is_test) return;
+    log_mutex.lock();
+    defer log_mutex.unlock();
+    const fd = log_fd.swap(-1, .acq_rel);
+    if (fd != -1) posix.close(fd);
+    if (path.len == 0 or path.len > log_path_buf.len) {
+        log_path_len = 0;
+        initialized = false;
+        return;
+    }
+    @memcpy(log_path_buf[0..path.len], path);
+    log_path_len = path.len;
+    initialized = true;
 }
 
 /// Format a wall-clock timestamp as "YYYY-MM-DDTHH:MM:SS.mmm".
@@ -330,7 +368,7 @@ fn wallClockTimestamp(buf: *[32]u8) []const u8 {
 }
 
 /// Returns the current CLOCK_MONOTONIC time in nanoseconds.
-fn monotonicNs() i128 {
+pub fn monotonicNs() i128 {
     var ts: linux.timespec = undefined;
     const rc = linux.clock_gettime(.MONOTONIC, &ts);
     if (rc != 0) return 0;

--- a/src/main.zig
+++ b/src/main.zig
@@ -854,7 +854,7 @@ pub const help_text =
     \\    --socket <path>     Socket path (default: $XDG_RUNTIME_DIR/padctl.sock or /run/padctl/padctl.sock)
     \\  dump enable           Turn on diagnostic logging (persists across reboots)
     \\  dump disable          Turn off diagnostic logging (default)
-    \\  dump status           Show dump state, log path, size, and time span
+    \\  dump status           Show dump state, flight recorder buffer, log path, size, and time span
     \\  dump export           Export filtered logs to stdout or file
     \\    --period <duration> Time window: Nm, Nh, or Nd (default: 1d)
     \\    -o <path>           Write to file instead of stdout
@@ -1214,7 +1214,7 @@ pub fn main() !void {
 
         // dump export: filter and output logs, exit.
         if (dump_action == .@"export") {
-            cli.dump.runExport(allocator, parsed.dump_period, parsed.dump_output_path, stdout_writer, stderr_writer);
+            cli.dump.runExport(allocator, parsed.socket_path, parsed.dump_period, parsed.dump_output_path, stdout_writer, stderr_writer);
             std.process.exit(0);
         }
 

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -25,6 +25,7 @@ const chord_detector_mod = @import("core/chord_detector.zig");
 const ControlSocket = @import("io/control_socket.zig").ControlSocket;
 const control_socket = @import("io/control_socket.zig");
 
+const flight_recorder = @import("diagnostics/flight_recorder.zig");
 const socket_client = @import("cli/socket_client.zig");
 const event_loop = @import("event_loop.zig");
 
@@ -204,8 +205,9 @@ const PendingKind = enum { hidraw, input_grab };
 // not yet settled and a single ADD uevent must not be dropped permanently.
 const HOTPLUG_RETRY_BACKOFF_MS = [_]u32{ 300, 300, 500, 800, 1200, 1500, 1500, 1500 };
 
-// 8 fixed (stop, hup, netlink, inotify, debounce, hotplug_retry, grace, liveness) + 1 listen + 4 clients.
-pub const SUPERVISOR_MAX_FDS: usize = 8 + 1 + 4;
+// 9 fixed (stop, hup, usr1, netlink, inotify, debounce, hotplug_retry, grace,
+// liveness) + 1 listen + 4 clients.
+pub const SUPERVISOR_MAX_FDS: usize = 9 + 1 + 4;
 
 /// Type-erased binding to the active dispatch's reload strategy. `ctx` points at
 /// the dispatch value living on `serveLoop`'s stack for the loop's duration.
@@ -219,6 +221,9 @@ pub const Supervisor = struct {
     managed: std.ArrayList(ManagedInstance),
     stop_fd: posix.fd_t,
     hup_fd: posix.fd_t,
+    /// SIGUSR1 signalfd: flushes the flight recorder to the log file.
+    /// -1 when unavailable (test supervisors).
+    usr1_fd: posix.fd_t = -1,
     netlink_fd: posix.fd_t,
     inotify_fd: posix.fd_t,
     debounce_fd: posix.fd_t,
@@ -341,6 +346,12 @@ pub const Supervisor = struct {
         const hup_fd = try posix.signalfd(-1, &hup_mask, 0);
         errdefer posix.close(hup_fd);
 
+        var usr1_mask = posix.sigemptyset();
+        posix.sigaddset(&usr1_mask, linux.SIG.USR1);
+        posix.sigprocmask(linux.SIG.BLOCK, &usr1_mask, null);
+        const usr1_fd = try posix.signalfd(-1, &usr1_mask, 0);
+        errdefer posix.close(usr1_fd);
+
         const nl_fd = netlink.openNetlinkUevent() catch |err| blk: {
             std.log.warn("netlink unavailable: {}", .{err});
             break :blk -1;
@@ -391,6 +402,7 @@ pub const Supervisor = struct {
             .managed = .{},
             .stop_fd = stop_fd,
             .hup_fd = hup_fd,
+            .usr1_fd = usr1_fd,
             .netlink_fd = nl_fd,
             .inotify_fd = inotify_result.inotify_fd,
             .debounce_fd = inotify_result.debounce_fd,
@@ -466,6 +478,7 @@ pub const Supervisor = struct {
         if (self.test_default_mapping_override) |p| self.allocator.free(p);
         posix.close(self.stop_fd);
         posix.close(self.hup_fd);
+        if (self.usr1_fd >= 0) posix.close(self.usr1_fd);
         if (self.netlink_fd >= 0) posix.close(self.netlink_fd);
         if (self.inotify_fd >= 0) posix.close(self.inotify_fd);
         if (self.debounce_fd >= 0) posix.close(self.debounce_fd);
@@ -1648,10 +1661,11 @@ pub const Supervisor = struct {
     /// Slot indices into the pollfd array. `null` means the corresponding fd
     /// is unavailable (e.g. `initForTest` skips netlink/inotify/grace_timer).
     /// Stop and hup always occupy slots 0/1; the rest are assigned in the
-    /// fixed order netlink → inotify → debounce → hotplug_retry → grace_timer
-    /// → liveness_timer → listen, packed contiguously starting at slot 2.
+    /// fixed order usr1 → netlink → inotify → debounce → hotplug_retry →
+    /// grace_timer → liveness_timer → listen, packed contiguously from slot 2.
     const SupervisorPollSet = struct {
         base_nfds: usize,
+        usr1_slot: ?usize,
         netlink_slot: ?usize,
         inotify_slot: ?usize,
         debounce_slot: ?usize,
@@ -1664,6 +1678,12 @@ pub const Supervisor = struct {
             pollfds[0] = .{ .fd = self.stop_fd, .events = posix.POLL.IN, .revents = 0 };
             pollfds[1] = .{ .fd = self.hup_fd, .events = posix.POLL.IN, .revents = 0 };
             var base_nfds: usize = 2;
+            const usr1_slot: ?usize = if (self.usr1_fd >= 0) blk: {
+                pollfds[base_nfds] = .{ .fd = self.usr1_fd, .events = posix.POLL.IN, .revents = 0 };
+                const s = base_nfds;
+                base_nfds += 1;
+                break :blk s;
+            } else null;
             const netlink_slot: ?usize = if (self.netlink_fd >= 0) blk: {
                 pollfds[base_nfds] = .{ .fd = self.netlink_fd, .events = posix.POLL.IN, .revents = 0 };
                 const s = base_nfds;
@@ -1709,6 +1729,7 @@ pub const Supervisor = struct {
 
             return .{
                 .base_nfds = base_nfds,
+                .usr1_slot = usr1_slot,
                 .netlink_slot = netlink_slot,
                 .inotify_slot = inotify_slot,
                 .debounce_slot = debounce_slot,
@@ -1731,6 +1752,9 @@ pub const Supervisor = struct {
         dispatch: anytype,
         comptime ppoll_propagate_err: bool,
     ) !void {
+        // Registered first so it runs last: the shutdown window then includes
+        // the teardown traces stopAll produces.
+        defer _ = flight_recorder.flush(.shutdown);
         defer self.stopAll();
 
         const Dispatch = @TypeOf(dispatch);
@@ -1772,6 +1796,15 @@ pub const Supervisor = struct {
                 _ = posix.read(self.hup_fd, &buf) catch {};
                 dispatch.reload(self);
                 pollfds[1].revents = 0;
+            }
+
+            if (set.usr1_slot) |slot| {
+                if (pollfds[slot].revents & posix.POLL.IN != 0) {
+                    var buf: [128]u8 = undefined;
+                    _ = posix.read(self.usr1_fd, &buf) catch {};
+                    _ = flight_recorder.flush(.signal);
+                    pollfds[slot].revents = 0;
+                }
             }
 
             if (set.netlink_slot) |slot| {
@@ -1881,6 +1914,7 @@ pub const Supervisor = struct {
             .dump_on => self.handleDump(fd, true),
             .dump_off => self.handleDump(fd, false),
             .dump_status => self.handleDumpStatus(fd),
+            .dump_flush => self.handleDumpFlush(fd),
             .unknown => cs.sendResponse(fd, "ERR unknown-command\n"),
         }
     }
@@ -2304,12 +2338,43 @@ pub const Supervisor = struct {
         cs.sendResponse(fd, resp_buf[0..pos]);
     }
 
+    /// Render the DUMP STATUS reply. Pure so the wire format is testable
+    /// without a control socket.
+    pub fn formatDumpStatus(
+        buf: []u8,
+        dump_on: bool,
+        recorder_lines: usize,
+        last: ?flight_recorder.LastFlush,
+    ) std.fmt.BufPrintError![]const u8 {
+        const state_str: []const u8 = if (dump_on) "on" else "off";
+        if (last) |l| {
+            return std.fmt.bufPrint(buf, "OK dump={s} recorder_lines={d} last_flush={s} last_flush_ms_ago={d}\n", .{
+                state_str, recorder_lines, l.reason.text(), l.ms_ago,
+            });
+        }
+        return std.fmt.bufPrint(buf, "OK dump={s} recorder_lines={d} last_flush=never\n", .{
+            state_str, recorder_lines,
+        });
+    }
+
     fn handleDumpStatus(self: *Supervisor, fd: posix.fd_t) void {
         const padctl_log = @import("log.zig");
         var cs = &self.ctrl_sock.?;
+        var resp_buf: [160]u8 = undefined;
+        const resp = formatDumpStatus(
+            &resp_buf,
+            padctl_log.isEnabled(),
+            flight_recorder.buffered(),
+            flight_recorder.lastFlush(),
+        ) catch return;
+        cs.sendResponse(fd, resp);
+    }
+
+    fn handleDumpFlush(self: *Supervisor, fd: posix.fd_t) void {
+        var cs = &self.ctrl_sock.?;
+        const lines = flight_recorder.flush(.export_request);
         var resp_buf: [64]u8 = undefined;
-        const state_str: []const u8 = if (padctl_log.isEnabled()) "on" else "off";
-        const resp = std.fmt.bufPrint(&resp_buf, "OK dump={s}\n", .{state_str}) catch return;
+        const resp = std.fmt.bufPrint(&resp_buf, "OK flushed={d}\n", .{lines}) catch return;
         cs.sendResponse(fd, resp);
     }
 
@@ -6309,4 +6374,20 @@ test "supervisor: SWITCH rejects absolute path outside mapping dirs" {
     var resp_buf: [64]u8 = undefined;
     const n = try posix.read(resp_fds[1], &resp_buf);
     try testing.expectEqualStrings("ERR mapping-not-allowed\n", resp_buf[0..n]);
+}
+
+test "supervisor: DUMP STATUS reply carries flight recorder fields" {
+    var buf: [160]u8 = undefined;
+    const never = try Supervisor.formatDumpStatus(&buf, false, 42, null);
+    try testing.expectEqualStrings("OK dump=off recorder_lines=42 last_flush=never\n", never);
+
+    var buf2: [160]u8 = undefined;
+    const flushed = try Supervisor.formatDumpStatus(&buf2, true, 7, .{
+        .reason = .rumble_stuck,
+        .ms_ago = 1234,
+    });
+    try testing.expectEqualStrings(
+        "OK dump=on recorder_lines=7 last_flush=rumble-stuck last_flush_ms_ago=1234\n",
+        flushed,
+    );
 }

--- a/src/supervisor.zig
+++ b/src/supervisor.zig
@@ -205,8 +205,7 @@ const PendingKind = enum { hidraw, input_grab };
 // not yet settled and a single ADD uevent must not be dropped permanently.
 const HOTPLUG_RETRY_BACKOFF_MS = [_]u32{ 300, 300, 500, 800, 1200, 1500, 1500, 1500 };
 
-// 9 fixed (stop, hup, usr1, netlink, inotify, debounce, hotplug_retry, grace,
-// liveness) + 1 listen + 4 clients.
+// 9 fixed (stop, hup, usr1, netlink, inotify, debounce, hotplug_retry, grace, liveness) + 1 listen + 4 clients.
 pub const SUPERVISOR_MAX_FDS: usize = 9 + 1 + 4;
 
 /// Type-erased binding to the active dispatch's reload strategy. `ctx` points at
@@ -221,8 +220,7 @@ pub const Supervisor = struct {
     managed: std.ArrayList(ManagedInstance),
     stop_fd: posix.fd_t,
     hup_fd: posix.fd_t,
-    /// SIGUSR1 signalfd: flushes the flight recorder to the log file.
-    /// -1 when unavailable (test supervisors).
+    /// SIGUSR1 signalfd, -1 when unavailable (test supervisors). Flushes the recorder.
     usr1_fd: posix.fd_t = -1,
     netlink_fd: posix.fd_t,
     inotify_fd: posix.fd_t,
@@ -1661,8 +1659,8 @@ pub const Supervisor = struct {
     /// Slot indices into the pollfd array. `null` means the corresponding fd
     /// is unavailable (e.g. `initForTest` skips netlink/inotify/grace_timer).
     /// Stop and hup always occupy slots 0/1; the rest are assigned in the
-    /// fixed order usr1 → netlink → inotify → debounce → hotplug_retry →
-    /// grace_timer → liveness_timer → listen, packed contiguously from slot 2.
+    /// fixed order usr1 -> netlink -> inotify -> debounce -> hotplug_retry ->
+    /// grace_timer -> liveness_timer -> listen, packed contiguously from slot 2.
     const SupervisorPollSet = struct {
         base_nfds: usize,
         usr1_slot: ?usize,
@@ -1752,8 +1750,7 @@ pub const Supervisor = struct {
         dispatch: anytype,
         comptime ppoll_propagate_err: bool,
     ) !void {
-        // Registered first so it runs last: the shutdown window then includes
-        // the teardown traces stopAll produces.
+        // Registered first so it runs last, after stopAll's teardown traces.
         defer _ = flight_recorder.flush(.shutdown);
         defer self.stopAll();
 
@@ -2338,8 +2335,7 @@ pub const Supervisor = struct {
         cs.sendResponse(fd, resp_buf[0..pos]);
     }
 
-    /// Render the DUMP STATUS reply. Pure so the wire format is testable
-    /// without a control socket.
+    /// Render the DUMP STATUS reply. Pure so the wire format is testable.
     pub fn formatDumpStatus(
         buf: []u8,
         dump_on: bool,

--- a/src/test/event_loop_rumble_test.zig
+++ b/src/test/event_loop_rumble_test.zig
@@ -17,14 +17,11 @@ const flight_recorder = @import("../diagnostics/flight_recorder.zig");
 const rumble_scheduler_mod = @import("../core/rumble_scheduler.zig");
 const MockDeviceIO = @import("mock_device_io.zig").MockDeviceIO;
 
-/// A line pushed into the ring before the loop starts. The daemon fills the
-/// ring through `padctl_log.logFn`, which the test runner does not install as
-/// `std.options.logFn`, so these tests seed it directly and assert on what the
-/// trigger persisted.
+/// Seeded directly because the test runner does not install `padctl_log.logFn`
+/// as `std.options.logFn`, so daemon debug lines never reach the ring here.
 const recorder_seed_line = "seeded-trace-line";
 
-/// Point the log writer at `tmp` with dump off, clear the flight recorder and
-/// seed one line.
+/// Point the log writer at `tmp` with dump off, reset the ring and seed a line.
 fn attachRecorderLog(tmp: *std.testing.TmpDir) !void {
     var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;

--- a/src/test/event_loop_rumble_test.zig
+++ b/src/test/event_loop_rumble_test.zig
@@ -13,8 +13,42 @@ const state = @import("../core/state.zig");
 const uinput = @import("../io/uinput.zig");
 const device_mod = @import("../config/device.zig");
 const padctl_log = @import("../log.zig");
+const flight_recorder = @import("../diagnostics/flight_recorder.zig");
 const rumble_scheduler_mod = @import("../core/rumble_scheduler.zig");
 const MockDeviceIO = @import("mock_device_io.zig").MockDeviceIO;
+
+/// A line pushed into the ring before the loop starts. The daemon fills the
+/// ring through `padctl_log.logFn`, which the test runner does not install as
+/// `std.options.logFn`, so these tests seed it directly and assert on what the
+/// trigger persisted.
+const recorder_seed_line = "seeded-trace-line";
+
+/// Point the log writer at `tmp` with dump off, clear the flight recorder and
+/// seed one line.
+fn attachRecorderLog(tmp: *std.testing.TmpDir) !void {
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = try tmp.dir.realpath(".", &dir_buf);
+    padctl_log.setEnabled(false);
+    padctl_log.setLogPathForTest(try std.fmt.bufPrint(&path_buf, "{s}/padctl.log", .{dir}));
+    flight_recorder.resetForTest();
+    flight_recorder.record(recorder_seed_line);
+}
+
+fn detachRecorderLog() void {
+    padctl_log.setLogPathForTest("");
+    flight_recorder.resetForTest();
+}
+
+fn expectFlushReason(tmp: *std.testing.TmpDir, reason: []const u8) !void {
+    const content = try tmp.dir.readFileAlloc(testing.allocator, "padctl.log", 4 * 1024 * 1024);
+    defer testing.allocator.free(content);
+    var marker_buf: [64]u8 = undefined;
+    const marker = try std.fmt.bufPrint(&marker_buf, "FLIGHT_RECORDER begin reason={s} lines=", .{reason});
+    const begin = std.mem.indexOf(u8, content, marker) orelse return error.FlushMarkerMissing;
+    const end = std.mem.indexOfPos(u8, content, begin, "FLIGHT_RECORDER end\n") orelse return error.FlushEndMissing;
+    try testing.expect(std.mem.indexOfPos(u8, content[0..end], begin, recorder_seed_line) != null);
+}
 
 // intentionally minimal; not a vader5 fixture
 const minimal_toml =
@@ -2008,6 +2042,11 @@ test "event_loop: failed stop frame is retried from pending rumble queue" {
 test "event_loop: disconnected rumble write exits without retry queue" {
     const allocator = testing.allocator;
 
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try attachRecorderLog(&tmp);
+    defer detachRecorderLog();
+
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
 
@@ -2074,6 +2113,7 @@ test "event_loop: disconnected rumble write exits without retry queue" {
 
     try testing.expectEqual(@as(usize, 2), fail_dev.write_attempts);
     try testing.expect(loop.disconnected);
+    try expectFlushReason(&tmp, "disconnect");
     try testing.expectEqual(@as(?rumble_scheduler_mod.RumbleScheduler.Frame, null), loop.pending_rumble_frame);
     try testing.expectEqual(@as(?i128, null), loop.pending_rumble_deadline_ns);
     try testing.expectEqual(@as(usize, frame_size), fail_dev.write_log.items.len);
@@ -2082,6 +2122,11 @@ test "event_loop: disconnected rumble write exits without retry queue" {
 
 test "event_loop: repeated rumble write failures stop retrying without disconnecting input loop" {
     const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try attachRecorderLog(&tmp);
+    defer detachRecorderLog();
 
     var loop = try EventLoop.initManaged();
     defer loop.deinit();
@@ -2150,6 +2195,7 @@ test "event_loop: repeated rumble write failures stop retrying without disconnec
 
     try testing.expectEqual(@as(usize, 5), fail_dev.write_attempts);
     try testing.expect(!loop.disconnected);
+    try expectFlushReason(&tmp, "rumble-write-dropped");
     try testing.expectEqual(@as(?rumble_scheduler_mod.RumbleScheduler.Frame, null), loop.pending_rumble_frame);
     try testing.expectEqual(@as(?i128, null), loop.pending_rumble_deadline_ns);
     try testing.expectEqual(@as(usize, frame_size), fail_dev.write_log.items.len);


### PR DESCRIPTION
## What changed

- **New `src/diagnostics/flight_recorder.zig`** — fixed 1024-line x 256-byte in-memory ring (256 KiB, static, no allocation), mutex-protected, oldest line overwritten first.
- **`src/log.zig`** — `logFn` no longer early-returns `.debug` lines when dump is off; it formats them as before and stores them in the ring instead of writing to stderr/file. Dump-on and non-debug behavior is unchanged. The file-write block is extracted into `writeToLogFile`/`appendToLogFile` + `rotateIfOversize` so the recorder reuses the same fd, lazy open, delete-detection and rotation.
- **Flush** — appends the ring to the same `padctl.log` between `FLIGHT_RECORDER begin reason=<r> lines=<n>` and `FLIGHT_RECORDER end`, then clears it. Empty ring writes nothing. An unwritable log file warns once and keeps the ring.
- **Automatic triggers** (rate limited to one flush per 30 s): `rumble-stuck` (a non-zero physical frame still newest after 10 s; once per episode, re-arms after a zero frame), `rumble-write-dropped` (both retry-exhaustion sites), `disconnect` (POLLHUP, read error, write-side disconnect — now routed through one `markDisconnected` helper).
- **Explicit triggers** (never rate limited): SIGUSR1 (new supervisor signalfd), the new `DUMP FLUSH` IPC command, and daemon shutdown.
- **`EventLoop.armRumbleTimer`** folds the stuck deadline into the existing `rumble_stop_fd` deadline so an otherwise idle device still wakes to report; no new thread.
- **CLI** — `padctl dump export` sends `DUMP FLUSH` first (500 ms best-effort) so the export includes the in-memory window; `padctl dump status` prints the buffered line count and last flush, from new `DUMP STATUS` fields.
- **Trace guards** — the rumble sites that built hex frame dumps / scheduler slot tables behind `shouldWriteToFile(.debug)` now run unconditionally, since the ring is always listening. The 1 kHz `input_trace` path stays dump-gated.
- **Docs** — `docs/src/diagnostic-logging.md` gains a "Flight recorder" section (ring size, triggers, output format, SIGUSR1); README and `--help` rows updated.

No new config keys, no new logging system, no device-specific code.

## Test plan

- `./scripts/padctl-docker test` (Zig 0.15.2 in the canonical image): **2070/2082 passed, 11 skipped, 1 failed**. The single failure is `uhid_output_dispatch: multiple events drain in order`, reproduced on `origin/main` 8245ee9 in the same image — pre-existing and unrelated. Baseline on 8245ee9: 2051/2063 passed, 11 skipped, 1 failed.
- `./scripts/padctl-docker build test-tsan`: same 1 pre-existing failure, no ThreadSanitizer reports.
- `./scripts/padctl-docker build check-fmt`: clean.
- 19 new tests: ring order / wrap / clear / 256-byte truncation / empty-ring no-op; `logFn` routing (debug->ring with dump off, debug->file with dump on, info untouched); flush framing, rate limiting (automatic skipped inside the window, explicit not), `lastFlush` age, unwritable path warns once and keeps the ring; EventLoop stuck-rumble once-per-episode + timerfd arming on an idle device; `DUMP FLUSH` parsing; `DUMP STATUS` wire format; CLI response parsing. The two existing retry-exhaustion and disconnect integration tests now also assert the flushed window reached the log file.
- Falsifiability checked twice: dropping `flight_recorder.flush(.rumble_stuck)` from `checkStuckRumble` fails `event_loop: stuck rumble flushes the flight recorder once per episode`; dropping the ring reset in `flush` fails `flight_recorder: flush clears the ring`. Both restored.
- Not exercised: real hardware, and the SIGUSR1 / shutdown paths end-to-end against a live daemon.

## Refs

- Research: always-on diagnostics log (2026-09-07), option A (flight recorder ring).
- `conventions/logging.md` §5 (256-byte line cap), `design/principles.md` P5/P9.