### PR TITLE
chore(release): bump version to 0.1.27

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.26",
+    .version = "0.1.27",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
- build.zig.zon: 0.1.26 -> 0.1.27
- Release notes: #511 (re-runnable AUR sync workflow), #512 (always-on flight recorder)