### PR TITLE
feat(config): allow transform chains on bit-field inputs

### DIFF
--- a/devices/sony/dualsense.toml
+++ b/devices/sony/dualsense.toml
@@ -44,7 +44,7 @@ accel_z = { offset = 26, type = "i16le" }
 # Sensor timestamp: u32le microseconds
 sensor_timestamp = { offset = 28, type = "u32le" }
 # Touchpad contact bytes (offset 33/37): bit7=inactive, bits[6:0]=finger ID
-# Sub-byte extraction (bits DSL) is Phase 2; raw contact bytes declared here
+# Declared as whole bytes: consumers read the ID and the active flag themselves
 touch0_contact = { offset = 33, type = "u8" }
 touch1_contact = { offset = 37, type = "u8" }
 # Battery: bits[3:0]=level(0-10), bits[7:4]=charging state (ignored)

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -168,9 +168,9 @@ Transforms are applied left-to-right as a comma-separated chain:
 
 Example: `transform = "scale(-32768, 32767), negate"` — scales a u8 (0–255) to -32768..32767, then negates the result.
 
-`scale` maps the source field's full scale onto the target range, and `negate` /
-`abs` saturate at the source field's minimum. The full scale comes from the
-declared field:
+`scale` maps the source field's full scale onto the target range. For `negate`
+and `abs`, an input equal to the source minimum saturates to the positive full
+scale. The full scale comes from the declared field:
 
 | Declaration | Full scale |
 |-------------|------------|

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -74,9 +74,32 @@ battery_level = { bits = [53, 0, 4] }
 | `bits` | integer[3] | Sub-byte extraction: `[byte_offset, bit_offset, bit_count]` |
 | `transform` | string | Comma-separated transform chain |
 
-Use `offset` + `type` for whole-byte fields. Use `bits` for sub-byte bit extraction (e.g. a 4-bit battery level packed within a byte).
+Use `offset` + `type` for whole-byte fields. Use `bits` for sub-byte and cross-byte bit extraction.
 
-> **Note:** When using `bits`, the `type` field must be `null`, `"unsigned"`, or `"signed"` — standard type strings like `"u8"` or `"i16le"` are not valid.
+#### Bit Fields
+
+`bits = [byte_offset, bit_offset, bit_count]` reads `bit_count` bits starting at
+`bit_offset` of the byte at `byte_offset`. Bits are numbered from the least
+significant bit of each byte, and the extraction assembles up to 4 consecutive
+bytes little-endian, so a field may cross byte boundaries:
+
+```toml
+[report.fields]
+# 4-bit battery level packed in the low nibble of byte 53
+battery_level = { bits = [53, 0, 4] }
+# 10-bit trigger spanning bytes 4-5: bits 6..15 of the little-endian pair
+rt = { bits = [4, 6, 10], transform = "scale(0, 255)" }
+# 12-bit signed axis, sign-extended from bit 11
+left_x = { bits = [2, 0, 12], type = "signed" }
+```
+
+Rules:
+
+- `bits` and `offset` are mutually exclusive — `bits[0]` already is the byte offset.
+- `bit_offset` is 0–7, `bit_count` is 1–32, and the field must span at most 4 bytes.
+- `type` must be omitted, `"unsigned"` (default), or `"signed"` — standard type
+  strings like `"u8"` or `"i16le"` are not valid here. `"signed"` sign-extends
+  the value from its top bit.
 
 #### Field names
 
@@ -141,6 +164,26 @@ Transforms are applied left-to-right as a comma-separated chain:
 | `deadzone` | Apply deadzone filtering |
 
 Example: `transform = "scale(-32768, 32767), negate"` — scales a u8 (0–255) to -32768..32767, then negates the result.
+
+`scale` maps the source field's full scale onto the target range, and `negate` /
+`abs` saturate at the source field's minimum. The full scale comes from the
+declared field:
+
+| Declaration | Full scale |
+|-------------|------------|
+| `type = "u8"` | 255 |
+| `type = "i16le"` | 32767 |
+| `bits = [b, o, n]` (unsigned) | `2^n - 1` |
+| `bits = [b, o, n]`, `type = "signed"` | `2^(n-1) - 1` |
+
+A `bits` field may carry a `transform`; the bits are extracted first (with sign
+extension when `type = "signed"`), then the chain runs on the extracted integer.
+So `rt = { bits = [4, 6, 10], transform = "scale(0, 255)" }` maps the raw 0–1023
+range onto the full 0–255 trigger range.
+
+> **Note:** `lt` and `rt` are 8-bit. A bit field wider than 8 bits with no
+> `scale` saturates at 255, so a 10-bit trigger reaches full travel after only a
+> quarter of its range — add `scale(0, 255)` to use the whole travel.
 
 ### `[report.button_group]`
 

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -97,6 +97,9 @@ Rules:
 
 - `bits` and `offset` are mutually exclusive — `bits[0]` already is the byte offset.
 - `bit_offset` is 0–7, `bit_count` is 1–32, and the field must span at most 4 bytes.
+  The two bounds interact: `bit_offset + bit_count` must fit in those 4 bytes
+  (that is, be at most 32), so `bits = [b, 7, 32]` is rejected even though each
+  bound alone is satisfied.
 - `type` must be omitted, `"unsigned"` (default), or `"signed"` — standard type
   strings like `"u8"` or `"i16le"` are not valid here. `"signed"` sign-extends
   the value from its top bit.

--- a/formal/lean/test/OracleMain.lean
+++ b/formal/lean/test/OracleMain.lean
@@ -141,6 +141,29 @@ private def emitChainVectors : IO Unit := do
   -- empty chain
   let v5 := runTransformChain 42 [] 255
   println s!"42,255,,{intToString v5}"
+  -- declared-width denominators: 10-bit unsigned field, full scale 1023
+  let v6 := runTransformChain 1023 [.scale 0 255] 1023
+  println s!"1023,1023,scale:0:255,{intToString v6}"
+  if v6 != 255 then
+    throw (IO.userError s!"SELF-CHECK FAILED: chain scale(0,255) of 1023 at tMax=1023 = {intToString v6}, expected 255")
+  let v7 := runTransformChain 255 [.scale 0 255] 1023
+  println s!"255,1023,scale:0:255,{intToString v7}"
+  if v7 != 63 then
+    throw (IO.userError s!"SELF-CHECK FAILED: chain scale(0,255) of 255 at tMax=1023 = {intToString v7}, expected 63")
+  -- declared-width denominators: 10-bit signed field, full scale 511,
+  -- negate/abs guard at the single minimum -512
+  let v8 := runTransformChain (-512) [.negate] 511
+  println s!"-512,511,negate,{intToString v8}"
+  if v8 != 511 then
+    throw (IO.userError s!"SELF-CHECK FAILED: chain negate of -512 at tMax=511 = {intToString v8}, expected 511")
+  let v9 := runTransformChain (-512) [.abs] 511
+  println s!"-512,511,abs,{intToString v9}"
+  if v9 != 511 then
+    throw (IO.userError s!"SELF-CHECK FAILED: chain abs of -512 at tMax=511 = {intToString v9}, expected 511")
+  let v10 := runTransformChain (-100) [.negate] 511
+  println s!"-100,511,negate,{intToString v10}"
+  if v10 != 100 then
+    throw (IO.userError s!"SELF-CHECK FAILED: chain negate of -100 at tMax=511 = {intToString v10}, expected 100")
 
 /-! ## Field read vectors -/
 

--- a/formal/lean/test_vectors.csv
+++ b/formal/lean/test_vectors.csv
@@ -40,6 +40,11 @@ scale,-128,127,0,100,-100
 -80,255,abs,clamp:0:50,50
 7,127,negate,scale:0:100,-5
 42,255,,42
+1023,1023,scale:0:255,255
+255,1023,scale:0:255,63
+-512,511,negate,511
+-512,511,abs,511
+-100,511,negate,100
 # READFIELD
 # field_type,offset,hex_bytes,expected
 FieldType.u8,0,0

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -2674,7 +2674,7 @@ test "device: missing both offset and bits returns error" {
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, toml_str));
 }
 
-test "device: bits with transform returns error" {
+test "device: bits with transform is accepted" {
     const allocator = std.testing.allocator;
     const toml_str =
         \\[device]
@@ -2690,6 +2690,32 @@ test "device: bits with transform returns error" {
         \\size = 16
         \\[report.fields]
         \\left_x = { bits = [2, 0, 12], transform = "negate" }
+    ;
+    const result = try parseString(allocator, toml_str);
+    defer result.deinit();
+    const fields = result.value.report[0].fields orelse return error.NoFields;
+    const fc = fields.map.get("left_x") orelse return error.NoField;
+    try std.testing.expect(fc.bits != null);
+    try std.testing.expect(fc.transform != null);
+    try std.testing.expect(fc.offset == null);
+}
+
+test "device: bits with malformed transform returns error" {
+    const allocator = std.testing.allocator;
+    const toml_str =
+        \\[device]
+        \\name = "T"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 16
+        \\[report.fields]
+        \\left_x = { bits = [2, 0, 12], transform = "lookup(0)" }
     ;
     try std.testing.expectError(error.InvalidConfig, parseString(allocator, toml_str));
 }

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -572,9 +572,8 @@ pub fn validate(cfg: *const DeviceConfig) !void {
                 }
 
                 if (field.bits) |bits| {
-                    // bits mode: mutual exclusivity
+                    // bits mode: bits[0] is the byte offset, so `offset` is redundant
                     if (field.offset != null) return error.InvalidConfig;
-                    if (field.transform != null) return error.InvalidConfig;
                     if (bits.len != 3) return error.InvalidConfig;
                     if (bits[1] < 0 or bits[1] > 7) return error.InvalidConfig;
                     if (bits[2] < 1 or bits[2] > 32) return error.InvalidConfig;

--- a/src/core/generic.zig
+++ b/src/core/generic.zig
@@ -18,7 +18,7 @@ pub const GenericFieldSlot = struct {
     start_bit: u3 = 0,
     bit_count: u6 = 0,
     is_signed: bool = false,
-    transforms: interpreter.CompiledTransformChain = .{ .type_tag = .u8 },
+    transforms: interpreter.CompiledTransformChain = .{ .t_max = interpreter.typeMaxByTag(.u8) },
     has_transform: bool = false,
 };
 
@@ -100,7 +100,11 @@ pub fn compileGenericState(cfg: *const device.DeviceConfig) !GenericDeviceState 
                         slot.offset = @intCast(fc.offset orelse continue);
                     }
                     if (fc.transform) |tr| {
-                        slot.transforms = interpreter.compileTransformChain(tr, slot.type_tag);
+                        const t_max = switch (slot.mode) {
+                            .standard => interpreter.typeMaxByTag(slot.type_tag),
+                            .bits => interpreter.bitsFullScale(slot.bit_count, slot.is_signed),
+                        };
+                        slot.transforms = interpreter.compileTransformChain(tr, t_max);
                         slot.has_transform = true;
                     }
                     found = true;

--- a/src/core/interpreter.zig
+++ b/src/core/interpreter.zig
@@ -64,6 +64,16 @@ pub fn signExtend(val: u32, bit_count: u6) i32 {
     return @as(i32, @bitCast(val << shift)) >> shift;
 }
 
+// Full scale of a bit field: the largest value it can carry.  Unsigned fields
+// span 0..2^len-1, signed fields -2^(len-1)..2^(len-1)-1, so the positive
+// maximum is 2^len-1 and 2^(len-1)-1 respectively.
+pub fn bitsFullScale(bit_count: u6, is_signed: bool) i64 {
+    const width: u32 = @min(@as(u32, bit_count), 32);
+    const effective = if (is_signed) (if (width == 0) 0 else width - 1) else width;
+    if (effective == 0) return 0;
+    return (@as(i64, 1) << @intCast(effective)) - 1;
+}
+
 // --- compile-time field name catalogue ---
 
 pub const FieldTag = enum {
@@ -187,11 +197,14 @@ pub const MAX_TRANSFORMS = state.MAX_TRANSFORMS;
 pub const CompiledTransformChain = struct {
     items: [MAX_TRANSFORMS]CompiledTransform = undefined,
     len: u8 = 0,
-    type_tag: FieldType,
+    // Full scale of the source field: the `scale` denominator and the point at
+    // which `negate`/`abs` saturate.  Standard fields take it from their type,
+    // bit fields from their declared width (see `bitsFullScale`).
+    t_max: i64,
 };
 
-pub fn compileTransformChain(chain: []const u8, type_tag: FieldType) CompiledTransformChain {
-    var result = CompiledTransformChain{ .type_tag = type_tag };
+pub fn compileTransformChain(chain: []const u8, t_max: i64) CompiledTransformChain {
+    var result = CompiledTransformChain{ .t_max = t_max };
     var pos: usize = 0;
     var depth: usize = 0;
     var seg_start: usize = 0;
@@ -242,7 +255,7 @@ fn compileTransformSeg(seg: []const u8) CompiledTransform {
 
 pub fn runTransformChain(initial: i64, chain: *const CompiledTransformChain) i64 {
     var val = initial;
-    const t_max = typeMaxByTag(chain.type_tag);
+    const t_max = chain.t_max;
     for (chain.items[0..chain.len]) |tr| {
         // Lean oracle (formal/lean/Padctl/Transform.lean): negate/abs saturate
         // at the single type-min point `val == Int.negSucc tMax` (= -(t_max+1))
@@ -259,9 +272,9 @@ pub fn runTransformChain(initial: i64, chain: *const CompiledTransformChain) i64
             },
             .scale => blk: {
                 if (t_max == 0) break :blk val;
-                // Denominator is t_max (positive half of the type range).
-                // For unsigned types this is exact: input range [0, t_max].
-                // For signed types input range is [-t_max-1, t_max]; values
+                // Denominator is t_max (positive half of the source range).
+                // For unsigned sources this is exact: input range [0, t_max].
+                // For signed sources input range is [-t_max-1, t_max]; values
                 // below -t_max produce out-of-range output that saturateCast
                 // clamps.  In practice, signed types are rarely scaled; the
                 // common case is u8 → i16 via scale(-32768, 32767).
@@ -381,7 +394,7 @@ fn compileReport(report: *const ReportConfig) CompiledReport {
                     .has_transform = false,
                 };
                 if (fc.transform) |tr| {
-                    cf.transforms = compileTransformChain(tr, .u8);
+                    cf.transforms = compileTransformChain(tr, bitsFullScale(cf.bit_count, is_signed));
                     cf.has_transform = true;
                 }
                 cr.fields[cr.field_count] = cf;
@@ -404,7 +417,7 @@ fn compileReport(report: *const ReportConfig) CompiledReport {
                     .has_transform = false,
                 };
                 if (fc.transform) |tr| {
-                    cf.transforms = compileTransformChain(tr, type_tag);
+                    cf.transforms = compileTransformChain(tr, typeMaxByTag(type_tag));
                     cf.has_transform = true;
                 }
                 cr.fields[cr.field_count] = cf;
@@ -1897,19 +1910,19 @@ test "mutation audit: readFieldByTag offset boundary" {
 // Mutation 2a: negate(-32768) — without the minInt guard, -(-32768) overflows i64
 // The guard returns maxInt(i64) instead of crashing/wrapping.
 test "mutation audit: negate minInt guard" {
-    // chain type_tag doesn't matter for negate; use i16le (type_max=32767)
-    var chain = compileTransformChain("negate", .i16le);
+    // the full scale only moves the guard point; use i16le's 32767
+    var chain = compileTransformChain("negate", typeMaxByTag(.i16le));
     const result = runTransformChain(std.math.minInt(i64), &chain);
     // A naive -val without guard would overflow or wrap to minInt(i64) again
     try testing.expectEqual(@as(i64, std.math.maxInt(i64)), result);
 }
 
 // Mutation 2b: scale boundary correctness — verify scale math at boundary values.
-// Note: the t_max==0 guard in runTransformChain is defensive code; typeMaxByTag never
-// returns 0 for any valid FieldType, so that branch is unreachable with current types.
+// Note: the t_max==0 guard in runTransformChain only fires for a 1-bit signed
+// field, whose full scale is 0; every FieldType yields a positive denominator.
 test "mutation audit: scale boundary correctness" {
     // scale(0, 100) on u8 type_max=255: scaled(v) = v * 100 / 255
-    var chain = compileTransformChain("scale(0, 100)", .u8);
+    var chain = compileTransformChain("scale(0, 100)", typeMaxByTag(.u8));
     // val = type_max (255): 255 * 100 / 255 = 100 (upper boundary maps to b)
     const result = runTransformChain(255, &chain);
     try testing.expectEqual(@as(i64, 100), result);
@@ -1922,7 +1935,7 @@ test "mutation audit: scale boundary correctness" {
 // out-of-range intermediate that saturateCast clamps to minInt.  Document current behavior.
 test "interpreter: scale signed type minInt edge case" {
     // scale(-32768, 32767) on i16le type_max=32767
-    var chain = compileTransformChain("scale(-32768, 32767)", .i16le);
+    var chain = compileTransformChain("scale(-32768, 32767)", typeMaxByTag(.i16le));
     // val = -32768: (-32768 * 65535) / 32767 + (-32768) = out-of-range, saturated by caller
     // runTransformChain itself returns the raw i64 before saturation; document that value.
     const result = runTransformChain(-32768, &chain);

--- a/src/core/interpreter.zig
+++ b/src/core/interpreter.zig
@@ -1661,6 +1661,156 @@ test "interpreter: bits field unsigned default" {
     try testing.expectEqual(@as(?u8, 255), delta.lt);
 }
 
+// --- bits + transform composition ---
+
+const ten_bit_trigger_toml =
+    \\[device]
+    \\name = "T"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 8
+    \\[report.match]
+    \\offset = 0
+    \\expect = [0x01]
+    \\[report.fields]
+    \\rt = { bits = [4, 6, 10], transform = "scale(0, 255)" }
+;
+
+const ten_bit_trigger_raw_toml =
+    \\[device]
+    \\name = "T"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 8
+    \\[report.match]
+    \\offset = 0
+    \\expect = [0x01]
+    \\[report.fields]
+    \\rt = { bits = [4, 6, 10] }
+;
+
+// Packs `value` into the 10 bits starting at bit 6 of bytes [4..6] and returns rt.
+fn processTenBitTrigger(toml_str: []const u8, value: u16) !?u8 {
+    const allocator = testing.allocator;
+    const parsed = try device.parseString(allocator, toml_str);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+    var raw = [_]u8{0} ** 8;
+    raw[0] = 0x01;
+    std.mem.writeInt(u16, raw[4..6], value << 6, .little);
+    const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+    return delta.rt;
+}
+
+test "interpreter: 10-bit trigger with scale covers the full u8 range" {
+    try testing.expectEqual(@as(?u8, 0), try processTenBitTrigger(ten_bit_trigger_toml, 0));
+    try testing.expectEqual(@as(?u8, 127), try processTenBitTrigger(ten_bit_trigger_toml, 511));
+    try testing.expectEqual(@as(?u8, 127), try processTenBitTrigger(ten_bit_trigger_toml, 512));
+    try testing.expectEqual(@as(?u8, 255), try processTenBitTrigger(ten_bit_trigger_toml, 1023));
+}
+
+// 255/1023 is ~25% of travel. A u8 denominator would map it to full 255 and
+// saturate everything above it; the declared 10-bit full scale gives 63.
+test "interpreter: 10-bit trigger scale uses the declared bit width as full scale" {
+    try testing.expectEqual(@as(?u8, 63), try processTenBitTrigger(ten_bit_trigger_toml, 255));
+    try testing.expectEqual(@as(?u8, 191), try processTenBitTrigger(ten_bit_trigger_toml, 767));
+}
+
+// Without a transform a wide bits field keeps saturating at the u8 field range.
+test "interpreter: 10-bit trigger without transform saturates at 255" {
+    try testing.expectEqual(@as(?u8, 255), try processTenBitTrigger(ten_bit_trigger_raw_toml, 1023));
+    try testing.expectEqual(@as(?u8, 200), try processTenBitTrigger(ten_bit_trigger_raw_toml, 200));
+}
+
+test "interpreter: 4-bit unsigned bits field scales from its own full scale" {
+    const allocator = testing.allocator;
+    const toml_str =
+        \\[device]
+        \\name = "T"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "r"
+        \\interface = 0
+        \\size = 4
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x01]
+        \\[report.fields]
+        \\battery_level = { bits = [2, 0, 4], transform = "scale(0, 100)" }
+    ;
+    const parsed = try device.parseString(allocator, toml_str);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+    var raw = [_]u8{0} ** 4;
+    raw[0] = 0x01;
+    raw[2] = 0x0A; // 10 of 15 → 10 * 100 / 15 = 66
+    const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+    try testing.expectEqual(@as(?u8, 66), delta.battery_level);
+    raw[2] = 0x0F; // full scale → 100
+    const full = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+    try testing.expectEqual(@as(?u8, 100), full.battery_level);
+}
+
+const signed_bits_transform_toml =
+    \\[device]
+    \\name = "T"
+    \\vid = 1
+    \\pid = 2
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\[[report]]
+    \\name = "r"
+    \\interface = 0
+    \\size = 8
+    \\[report.match]
+    \\offset = 0
+    \\expect = [0x01]
+    \\[report.fields]
+    \\left_x = { bits = [1, 0, 10], type = "signed", transform = "negate" }
+    \\right_x = { bits = [3, 0, 10], type = "signed", transform = "abs" }
+;
+
+// negate/abs saturate at the single minimum of the declared width: a 10-bit
+// signed field spans -512..511, so -512 maps to 511 instead of overflowing.
+test "interpreter: signed bits negate and abs guard at the declared width minimum" {
+    const allocator = testing.allocator;
+    const parsed = try device.parseString(allocator, signed_bits_transform_toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    var raw = [_]u8{0} ** 8;
+    raw[0] = 0x01;
+    std.mem.writeInt(u16, raw[1..3], 0x0200, .little); // -512
+    std.mem.writeInt(u16, raw[3..5], 0x0200, .little); // -512
+    const guarded = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+    try testing.expectEqual(@as(?i16, 511), guarded.ax);
+    try testing.expectEqual(@as(?i16, 511), guarded.rx);
+
+    // The guard is a single point, not a range clamp.
+    std.mem.writeInt(u16, raw[1..3], 0x039C, .little); // -100
+    std.mem.writeInt(u16, raw[3..5], 0x039C, .little); // -100
+    const ordinary = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+    try testing.expectEqual(@as(?i16, 100), ordinary.ax);
+    try testing.expectEqual(@as(?i16, 100), ordinary.rx);
+}
+
 test "interpreter: extractBits: start_bit=7 single bit" {
     try testing.expectEqual(@as(u32, 1), extractBits(&[_]u8{0x80}, 0, 7, 1));
     try testing.expectEqual(@as(u32, 0), extractBits(&[_]u8{0x7F}, 0, 7, 1));

--- a/src/test/full_e2e_generative_test.zig
+++ b/src/test/full_e2e_generative_test.zig
@@ -525,11 +525,18 @@ fn buildPacketFromDelta(cr: *const CompiledReport, delta: GamepadStateDelta, buf
             // bits mode — a bit field may carry a transform chain whose
             // denominator is the declared bit width, so invert it here too.
             const raw_val = if (cf.has_transform) applyInverseTransforms(val, cf) else val;
-            const raw: u32 = @intCast(@as(u64, @bitCast(raw_val)) & ((@as(u64, 1) << @intCast(cf.bit_count)) - 1));
+            const field_mask = (@as(u64, 1) << @intCast(cf.bit_count)) - 1;
+            const raw: u32 = @intCast(@as(u64, @bitCast(raw_val)) & field_mask);
             const shifted = @as(u64, raw) << @intCast(cf.start_bit);
+            const shifted_mask = field_mask << @intCast(cf.start_bit);
             const needed: u8 = (@as(u8, cf.start_bit) + @as(u8, cf.bit_count) + 7) / 8;
+            // Clear the declared range first so a repeated write can lower
+            // bits; neighbouring fields sharing these bytes stay untouched.
             for (0..needed) |i| {
-                buf[cf.byte_offset + i] |= @intCast((shifted >> @intCast(i * 8)) & 0xFF);
+                const shift: u6 = @intCast(i * 8);
+                const keep: u8 = ~@as(u8, @intCast((shifted_mask >> shift) & 0xFF));
+                const value: u8 = @intCast((shifted >> shift) & 0xFF);
+                buf[cf.byte_offset + i] = (buf[cf.byte_offset + i] & keep) | value;
             }
         }
     }
@@ -642,8 +649,10 @@ test "l3_e2e: packet builder inverts transform chains on bit fields" {
     const rt_targets = [_]u8{ 0, 37, 128, 200, 255 };
     const rx_targets = [_]i16{ -20000, -8000, 500, 12000, 30000 };
     var saw_negative_rx_raw = false;
+    // One packet reused across targets: each write must replace the previous
+    // value rather than OR into it, or a lower raw could never follow a higher.
+    var packet = [_]u8{0} ** 8;
     for (ax_targets, rt_targets, rx_targets) |ax, rt, rx| {
-        var packet = [_]u8{0} ** 8;
         buildPacketFromDelta(cr, .{ .ax = ax, .rt = rt, .rx = rx }, &packet);
 
         // Read the packed bits back with the same primitives the production

--- a/src/test/full_e2e_generative_test.zig
+++ b/src/test/full_e2e_generative_test.zig
@@ -522,8 +522,10 @@ fn buildPacketFromDelta(cr: *const CompiledReport, delta: GamepadStateDelta, buf
             const raw_val = if (cf.has_transform) applyInverseTransforms(val, cf) else val;
             writeFieldValue(buf, cf.offset, cf.type_tag, raw_val);
         } else {
-            // bits mode
-            const raw: u32 = @intCast(@as(u64, @bitCast(@as(i64, val))) & ((@as(u64, 1) << @intCast(cf.bit_count)) - 1));
+            // bits mode — a bit field may carry a transform chain whose
+            // denominator is the declared bit width, so invert it here too.
+            const raw_val = if (cf.has_transform) applyInverseTransforms(val, cf) else val;
+            const raw: u32 = @intCast(@as(u64, @bitCast(raw_val)) & ((@as(u64, 1) << @intCast(cf.bit_count)) - 1));
             const shifted = @as(u64, raw) << @intCast(cf.start_bit);
             const needed: u8 = (@as(u8, cf.start_bit) + @as(u8, cf.bit_count) + 7) / 8;
             for (0..needed) |i| {
@@ -579,6 +581,59 @@ fn buildPacketFromDelta(cr: *const CompiledReport, delta: GamepadStateDelta, buf
                 crc.update(buf[cs.range_start..cs.range_end]);
                 std.mem.writeInt(u32, buf[cs.expect_off..][0..4], crc.final(), .little);
             },
+        }
+    }
+}
+
+// Harness self-test: a bit field that carries a transform chain must survive
+// buildPacketFromDelta -> production extraction within the same tolerance the
+// generative DRT applies. Touches no kernel device.
+test "l3_e2e: packet builder inverts transform chains on bit fields" {
+    const allocator = testing.allocator;
+    const toml_str =
+        \\[device]
+        \\name = "bits-transform"
+        \\vid = 1
+        \\pid = 2
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\[[report]]
+        \\name = "input"
+        \\interface = 0
+        \\size = 8
+        \\[report.fields]
+        \\left_x = { bits = [0, 0, 12], type = "signed", transform = "scale(-32768, 32767)" }
+        \\rt = { bits = [4, 6, 10], transform = "scale(0, 255)" }
+    ;
+    const parsed = try device_mod.parseString(allocator, toml_str);
+    defer parsed.deinit();
+
+    const interp = Interpreter.init(&parsed.value);
+    try testing.expectEqual(@as(usize, 1), interp.report_count);
+    const cr = &interp.compiled[0];
+
+    // A scale spanning the full i16 range yields a finite tolerance, so the DRT
+    // really asserts on this field.
+    const tol_ax = scaleToleranceForTag(cr, .ax);
+    try testing.expect(tol_ax < std.math.maxInt(i32));
+
+    const ax_targets = [_]i16{ -32768, -12345, 0, 9876, 32767 };
+    const rt_targets = [_]u8{ 0, 37, 128, 200, 255 };
+    for (ax_targets, rt_targets) |ax, rt| {
+        var packet = [_]u8{0} ** 8;
+        buildPacketFromDelta(cr, .{ .ax = ax, .rt = rt }, &packet);
+        const delta = (try interp.processReport(0, &packet)) orelse return error.TestUnexpectedResult;
+        const got_ax = delta.ax orelse return error.TestUnexpectedResult;
+        const got_rt = delta.rt orelse return error.TestUnexpectedResult;
+        const err_ax = @abs(@as(i32, got_ax) - @as(i32, ax));
+        const err_rt = @abs(@as(i32, got_rt) - @as(i32, rt));
+        if (err_ax > tol_ax or err_rt > 1) {
+            std.debug.print(
+                "BITS ROUND-TRIP FAIL: ax want={d} got={d} err={d} tol={d} | rt want={d} got={d} err={d}\n",
+                .{ ax, got_ax, err_ax, tol_ax, rt, got_rt, err_rt },
+            );
+            return error.TestUnexpectedResult;
         }
     }
 }

--- a/src/test/full_e2e_generative_test.zig
+++ b/src/test/full_e2e_generative_test.zig
@@ -585,9 +585,19 @@ fn buildPacketFromDelta(cr: *const CompiledReport, delta: GamepadStateDelta, buf
     }
 }
 
+fn compiledFieldForTag(cr: *const CompiledReport, tag: FieldTag) ?*const CompiledField {
+    for (cr.fields[0..cr.field_count]) |*cf| {
+        if (cf.tag == tag) return cf;
+    }
+    return null;
+}
+
 // Harness self-test: a bit field that carries a transform chain must survive
-// buildPacketFromDelta -> production extraction within the same tolerance the
-// generative DRT applies. Touches no kernel device.
+// buildPacketFromDelta -> production extraction. ax and rx round-trip within
+// the same scale-derived tolerance the generative DRT applies
+// (scaleToleranceForTag); rt is checked against a fixed +/-1 bound instead,
+// because its 255 max output makes that same tolerance non-asserting
+// (scaleToleranceForTag returns maxInt there). Touches no kernel device.
 test "l3_e2e: packet builder inverts transform chains on bit fields" {
     const allocator = testing.allocator;
     const toml_str =
@@ -605,6 +615,7 @@ test "l3_e2e: packet builder inverts transform chains on bit fields" {
         \\[report.fields]
         \\left_x = { bits = [0, 0, 12], type = "signed", transform = "scale(-32768, 32767)" }
         \\rt = { bits = [4, 6, 10], transform = "scale(0, 255)" }
+        \\right_x = { bits = [2, 0, 12], type = "signed", transform = "scale(0, 32767)" }
     ;
     const parsed = try device_mod.parseString(allocator, toml_str);
     defer parsed.deinit();
@@ -618,24 +629,50 @@ test "l3_e2e: packet builder inverts transform chains on bit fields" {
     const tol_ax = scaleToleranceForTag(cr, .ax);
     try testing.expect(tol_ax < std.math.maxInt(i32));
 
+    // right_x anchors its scale at 0 instead of -32768 like left_x, so a
+    // negative target inverts to a negative raw -- the only field here that
+    // exercises sign extension and two's-complement repacking in the bits
+    // branch of buildPacketFromDelta. It spans the same full i16 width as
+    // ax, so it gets the same kind of finite, asserting DRT tolerance.
+    const tol_rx = scaleToleranceForTag(cr, .rx);
+    try testing.expect(tol_rx < std.math.maxInt(i32));
+    const rx_field = compiledFieldForTag(cr, .rx) orelse return error.TestUnexpectedResult;
+
     const ax_targets = [_]i16{ -32768, -12345, 0, 9876, 32767 };
     const rt_targets = [_]u8{ 0, 37, 128, 200, 255 };
-    for (ax_targets, rt_targets) |ax, rt| {
+    const rx_targets = [_]i16{ -20000, -8000, 500, 12000, 30000 };
+    var saw_negative_rx_raw = false;
+    for (ax_targets, rt_targets, rx_targets) |ax, rt, rx| {
         var packet = [_]u8{0} ** 8;
-        buildPacketFromDelta(cr, .{ .ax = ax, .rt = rt }, &packet);
+        buildPacketFromDelta(cr, .{ .ax = ax, .rt = rt, .rx = rx }, &packet);
+
+        // Read the packed bits back with the same primitives the production
+        // decoder uses, independent of the round-trip below, to confirm the
+        // field actually landed as a negative raw rather than being clamped
+        // or truncated to an unsigned pattern.
+        const rx_raw_bits = interp_mod.extractBits(&packet, rx_field.byte_offset, rx_field.start_bit, rx_field.bit_count);
+        const rx_raw = interp_mod.signExtend(rx_raw_bits, rx_field.bit_count);
+        if (rx_raw < 0) saw_negative_rx_raw = true;
+
         const delta = (try interp.processReport(0, &packet)) orelse return error.TestUnexpectedResult;
         const got_ax = delta.ax orelse return error.TestUnexpectedResult;
         const got_rt = delta.rt orelse return error.TestUnexpectedResult;
+        const got_rx = delta.rx orelse return error.TestUnexpectedResult;
         const err_ax = @abs(@as(i32, got_ax) - @as(i32, ax));
         const err_rt = @abs(@as(i32, got_rt) - @as(i32, rt));
-        if (err_ax > tol_ax or err_rt > 1) {
+        const err_rx = @abs(@as(i32, got_rx) - @as(i32, rx));
+        if (err_ax > tol_ax or err_rt > 1 or err_rx > tol_rx) {
             std.debug.print(
-                "BITS ROUND-TRIP FAIL: ax want={d} got={d} err={d} tol={d} | rt want={d} got={d} err={d}\n",
-                .{ ax, got_ax, err_ax, tol_ax, rt, got_rt, err_rt },
+                "BITS ROUND-TRIP FAIL: ax want={d} got={d} err={d} tol={d} | rt want={d} got={d} err={d} | rx want={d} got={d} err={d} tol={d} raw={d}\n",
+                .{ ax, got_ax, err_ax, tol_ax, rt, got_rt, err_rt, rx, got_rx, err_rx, tol_rx, rx_raw },
             );
             return error.TestUnexpectedResult;
         }
     }
+    // At least one right_x target above must invert to a negative raw, or
+    // this case has silently stopped covering sign extension and two's-
+    // complement repacking.
+    try testing.expect(saw_negative_rx_raw);
 }
 
 fn getDeltaFieldForTag(delta: GamepadStateDelta, tag: FieldTag) ?i64 {

--- a/src/test/full_e2e_generative_test.zig
+++ b/src/test/full_e2e_generative_test.zig
@@ -436,27 +436,34 @@ fn writeFieldValue(buf: []u8, offset: usize, t: FieldType, value: i64) void {
 }
 
 const FieldTag = interp_mod.FieldTag;
-const CompiledTransformChain = interp_mod.CompiledTransformChain;
+const CompiledField = interp_mod.CompiledField;
 const TransformOp = interp_mod.TransformOp;
 
 // Compute the max round-trip error for a compiled field's transform chain.
 // Returns maxInt for non-invertible transforms or cases where the inverse
 // cannot faithfully round-trip (abs, deadzone, negate on unsigned, scale
 // with range smaller than GamepadState).
+fn fieldIsSigned(cf: *const CompiledField) bool {
+    return switch (cf.mode) {
+        .bits => cf.is_signed,
+        .standard => switch (cf.type_tag) {
+            .i8, .i16le, .i16be, .i32le, .i32be => true,
+            else => false,
+        },
+    };
+}
+
 fn scaleToleranceForTag(cr: *const CompiledReport, tag: FieldTag) i32 {
     for (cr.fields[0..cr.field_count]) |*cf| {
         if (cf.tag != tag) continue;
         if (!cf.has_transform) return 1;
-        const is_unsigned = switch (cf.transforms.type_tag) {
-            .u8, .u16le, .u16be, .u32le, .u32be => true,
-            else => false,
-        };
+        const is_unsigned = !fieldIsSigned(cf);
         for (cf.transforms.items[0..cf.transforms.len]) |tr| {
             if (tr.op == .abs or tr.op == .deadzone) return std.math.maxInt(i32);
             if (tr.op == .negate and is_unsigned) return std.math.maxInt(i32);
             if (tr.op == .scale) {
-                const t_max = interp_mod.typeMaxByTag(cf.transforms.type_tag);
-                if (t_max == 0) return std.math.maxInt(i32);
+                const t_max = cf.transforms.t_max;
+                if (t_max <= 0) return std.math.maxInt(i32);
                 const span: i64 = tr.b - tr.a;
                 if (span == 0) return std.math.maxInt(i32);
                 // If scale output range is narrower than GamepadState i32,
@@ -474,7 +481,8 @@ fn scaleToleranceForTag(cr: *const CompiledReport, tag: FieldTag) i32 {
 
 // Apply inverse of the transform chain so that production forward-transform yields val.
 // Processes transforms in reverse order; skips abs/clamp/deadzone (not invertible).
-fn applyInverseTransforms(val: i64, chain: *const CompiledTransformChain) i64 {
+fn applyInverseTransforms(val: i64, cf: *const CompiledField) i64 {
+    const chain = &cf.transforms;
     var v = val;
     var i: usize = chain.len;
     while (i > 0) {
@@ -487,19 +495,9 @@ fn applyInverseTransforms(val: i64, chain: *const CompiledTransformChain) i64 {
                 if (span == 0) break :blk v;
                 // Forward transform: raw_val * (b - a) / t_max + a
                 // Inverse: (v - a) * t_max / (b - a)
-                // For signed types, use the full range [-t_max-1, t_max] for negative values.
-                const is_signed = switch (chain.type_tag) {
-                    .i8, .i16le, .i16be, .i32le, .i32be => true,
-                    else => false,
-                };
-                const t_max: i128 = switch (chain.type_tag) {
-                    .u8 => 255,
-                    .i8 => 127,
-                    .u16le, .u16be => 65535,
-                    .i16le, .i16be => 32767,
-                    .u32le, .u32be => 4294967295,
-                    .i32le, .i32be => 2147483647,
-                };
+                // For signed fields, use the full range [-t_max-1, t_max] for negative values.
+                const is_signed = fieldIsSigned(cf);
+                const t_max: i128 = chain.t_max;
                 const shifted: i128 = @as(i128, v) - tr.a;
                 if (is_signed and shifted < 0) {
                     // Negative range uses t_max+1 denominator for symmetric inversion
@@ -521,7 +519,7 @@ fn buildPacketFromDelta(cr: *const CompiledReport, delta: GamepadStateDelta, buf
         const val = getDeltaFieldForTag(delta, cf.tag) orelse continue;
         if (cf.mode == .standard) {
             // Apply inverse transforms so production forward-transform yields val.
-            const raw_val = if (cf.has_transform) applyInverseTransforms(val, &cf.transforms) else val;
+            const raw_val = if (cf.has_transform) applyInverseTransforms(val, cf) else val;
             writeFieldValue(buf, cf.offset, cf.type_tag, raw_val);
         } else {
             // bits mode

--- a/src/test/lean_oracle_client.zig
+++ b/src/test/lean_oracle_client.zig
@@ -160,7 +160,7 @@ pub fn extractFieldsViaLean(oracle: *LeanOracle, cr: *const CompiledReport, raw:
 }
 
 fn runChainViaLean(oracle: *LeanOracle, initial: i64, cf: *const CompiledField) !i64 {
-    const t_max = typeMax(cf.transforms.type_tag);
+    const t_max = cf.transforms.t_max;
     var chain_buf: [512]u8 = undefined;
     var pos: usize = 0;
     for (cf.transforms.items[0..cf.transforms.len], 0..) |tr, i| {
@@ -184,17 +184,6 @@ fn formatTransformOp(tr: interp_mod.CompiledTransform, buf: []u8) !usize {
         .deadzone => try std.fmt.bufPrint(buf, "deadzone({d})", .{tr.a}),
     };
     return s.len;
-}
-
-fn typeMax(t: FieldType) i64 {
-    return switch (t) {
-        .u8 => 255,
-        .i8 => 127,
-        .u16le, .u16be => 65535,
-        .i16le, .i16be => 32767,
-        .u32le, .u32be => 4294967295,
-        .i32le, .i32be => 2147483647,
-    };
 }
 
 fn fieldTypeStr(t: FieldType) []const u8 {

--- a/src/test/properties/lean_drt_props.zig
+++ b/src/test/properties/lean_drt_props.zig
@@ -95,7 +95,7 @@ test "lean_drt: transform negate vectors" {
         const t_max_raw = try parseUint(f[2]);
         const expected = try parseInt(f[3]);
         const op: interp.TransformOp = if (std.mem.eql(u8, f[0], "negate")) .negate else .abs;
-        var chain = interp.CompiledTransformChain{ .type_tag = try tMaxToFieldType(t_max_raw) };
+        var chain = interp.CompiledTransformChain{ .t_max = @intCast(t_max_raw) };
         chain.items[0] = .{ .op = op };
         chain.len = 1;
         const actual = interp.runTransformChain(input, &chain);
@@ -117,7 +117,7 @@ test "lean_drt: transform clamp vectors" {
         const lo = try parseInt(f[2]);
         const hi = try parseInt(f[3]);
         const expected = try parseInt(f[4]);
-        var chain = interp.CompiledTransformChain{ .type_tag = .u8 };
+        var chain = interp.CompiledTransformChain{ .t_max = interp.typeMaxByTag(.u8) };
         chain.items[0] = .{ .op = .clamp, .a = lo, .b = hi };
         chain.len = 1;
         const actual = interp.runTransformChain(input, &chain);
@@ -138,7 +138,7 @@ test "lean_drt: transform deadzone vectors" {
         const input = try parseInt(f[1]);
         const threshold = try parseInt(f[2]);
         const expected = try parseInt(f[3]);
-        var chain = interp.CompiledTransformChain{ .type_tag = .u8 };
+        var chain = interp.CompiledTransformChain{ .t_max = interp.typeMaxByTag(.u8) };
         chain.items[0] = .{ .op = .deadzone, .a = threshold };
         chain.len = 1;
         const actual = interp.runTransformChain(input, &chain);
@@ -162,7 +162,7 @@ test "lean_drt: transform scale vectors" {
         const a = try parseInt(f[3]);
         const b = try parseInt(f[4]);
         const expected = try parseInt(f[5]);
-        var chain = interp.CompiledTransformChain{ .type_tag = try tMaxToFieldType(t_max_raw) };
+        var chain = interp.CompiledTransformChain{ .t_max = @intCast(t_max_raw) };
         chain.items[0] = .{ .op = .scale, .a = a, .b = b };
         chain.len = 1;
         const actual = interp.runTransformChain(input, &chain);
@@ -187,7 +187,7 @@ test "lean_drt: transform chain vectors" {
         while (expected_idx > 2 and f[expected_idx].len == 0) : (expected_idx -= 1) {}
         const expected = try parseInt(f[expected_idx]);
 
-        var chain = interp.CompiledTransformChain{ .type_tag = try tMaxToFieldType(t_max_raw) };
+        var chain = interp.CompiledTransformChain{ .t_max = @intCast(t_max_raw) };
         chain.len = 0;
         for (2..expected_idx) |i| {
             if (f[i].len == 0) continue; // empty chain slot
@@ -496,16 +496,6 @@ fn buttonNameFromIndex(idx: u64) ![]const u8 {
 }
 
 // --- Helpers ---
-
-fn tMaxToFieldType(t_max: u64) !interp.FieldType {
-    return switch (t_max) {
-        255 => .u8,
-        127 => .i8,
-        65535 => .u16le,
-        32767 => .i16le,
-        else => error.UnknownFieldType,
-    };
-}
 
 fn parseLeanFieldType(s: []const u8) !interp.FieldType {
     if (std.mem.eql(u8, s, "FieldType.u8")) return .u8;

--- a/src/test/properties/metamorphic_props.zig
+++ b/src/test/properties/metamorphic_props.zig
@@ -230,7 +230,7 @@ test "metamorphic: scale linearity — doubling input roughly doubles output" {
     const rng = prng.random();
 
     // scale(0, 100) on u8 type_tag (t_max = 255): identity is avoided, exercises real linearity.
-    var chain = compileTransformChain("scale(0, 100)", .u8);
+    var chain = compileTransformChain("scale(0, 100)", interpreter_mod.typeMaxByTag(.u8));
 
     for (0..1000) |_| {
         // Pick v in [1, 127] so 2v fits in u8 range

--- a/src/test/properties/transform_props.zig
+++ b/src/test/properties/transform_props.zig
@@ -7,7 +7,7 @@ const CompiledTransformChain = interpreter.CompiledTransformChain;
 const runTransformChain = interpreter.runTransformChain;
 
 fn makeChain(op: interpreter.TransformOp, a: i64, b: i64) CompiledTransformChain {
-    var chain = CompiledTransformChain{ .type_tag = .i16le };
+    var chain = CompiledTransformChain{ .t_max = interpreter.typeMaxByTag(.i16le) };
     chain.items[0] = .{ .op = op, .a = a, .b = b };
     chain.len = 1;
     return chain;
@@ -40,7 +40,7 @@ test "property: negate self-inverse" {
     var prng = std.Random.DefaultPrng.init(0xB1B1);
     const rng = prng.random();
 
-    var chain = CompiledTransformChain{ .type_tag = .i16le };
+    var chain = CompiledTransformChain{ .t_max = interpreter.typeMaxByTag(.i16le) };
     chain.items[0] = .{ .op = .negate };
     chain.items[1] = .{ .op = .negate };
     chain.len = 2;

--- a/src/test/reference_interp.zig
+++ b/src/test/reference_interp.zig
@@ -78,22 +78,10 @@ fn applyTransform(val: i64, op: TransformOp, a: i64, b: i64, t_max: i64) i64 {
     };
 }
 
-// type_max for a FieldType — mirrors production's typeMaxByTag.
-fn typeMax(t: FieldType) i64 {
-    return switch (t) {
-        .u8 => 255,
-        .i8 => 127,
-        .u16le, .u16be => 65535,
-        .i16le, .i16be => 32767,
-        .u32le, .u32be => 4294967295,
-        .i32le, .i32be => 2147483647,
-    };
-}
-
 pub fn runChain(initial: i64, cf: *const CompiledField) i64 {
     if (!cf.has_transform) return initial;
     var val = initial;
-    const t_max = typeMax(cf.transforms.type_tag);
+    const t_max = cf.transforms.t_max;
     for (cf.transforms.items[0..cf.transforms.len]) |tr| {
         val = applyTransform(val, tr.op, tr.a, tr.b, t_max);
     }

--- a/src/test/transform_boundary_test.zig
+++ b/src/test/transform_boundary_test.zig
@@ -146,9 +146,9 @@ test "boundary: chain deadzone(1000), scale(-32768, 32767)" {
 test "negate/abs single-point saturation matches Lean oracle" {
     // i8: t_max = 127, type-min = -(127+1) = -128.
     {
-        var neg = interpreter.compileTransformChain("negate", .i8);
+        var neg = interpreter.compileTransformChain("negate", interpreter.typeMaxByTag(.i8));
         try testing.expectEqual(@as(i64, 127), interpreter.runTransformChain(-128, &neg));
-        var abs_ = interpreter.compileTransformChain("abs", .i8);
+        var abs_ = interpreter.compileTransformChain("abs", interpreter.typeMaxByTag(.i8));
         try testing.expectEqual(@as(i64, 127), interpreter.runTransformChain(-128, &abs_));
         // Non-minInt out-of-range input must NOT saturate (oracle: raw -val/natAbs).
         try testing.expectEqual(@as(i64, 256), interpreter.runTransformChain(-256, &neg));
@@ -158,9 +158,9 @@ test "negate/abs single-point saturation matches Lean oracle" {
     }
     // Wider type i32le: t_max = 2147483647, type-min = -2147483648.
     {
-        var neg = interpreter.compileTransformChain("negate", .i32le);
+        var neg = interpreter.compileTransformChain("negate", interpreter.typeMaxByTag(.i32le));
         try testing.expectEqual(@as(i64, 2147483647), interpreter.runTransformChain(-2147483648, &neg));
-        var abs_ = interpreter.compileTransformChain("abs", .i32le);
+        var abs_ = interpreter.compileTransformChain("abs", interpreter.typeMaxByTag(.i32le));
         try testing.expectEqual(@as(i64, 2147483647), interpreter.runTransformChain(-2147483648, &abs_));
     }
 }


### PR DESCRIPTION
## What changed

- `bits = [byte, start_bit, len]` fields may now carry a `transform` chain; validation keeps `offset` and `bits` mutually exclusive and all other bit-field rules.
- Order is extract (with sign extension for `signed`) → transform chain → field write. `scale` uses the declared bit width as full scale (`2^len - 1` unsigned, `2^(len-1) - 1` signed); `negate`/`abs` guard at the same width minimum. Compiled chains carry the denominator directly instead of a field type tag.
- `lt`/`rt` still saturate at u8, so a 10-bit trigger needs `transform = "scale(0, 255)"` to cover the full range; documented in `docs/src/device-config.md` with a cross-byte example.
- Lean oracle vectors extended for the new denominators; `test_vectors.csv` regenerated.
- Stale comment in `devices/sony/dualsense.toml` about bit extraction rewritten (comment only).

## Test plan

- [x] validate accepts `bits` + `transform` (fails on main)
- [x] 10-bit trigger with `scale(0, 255)` covers 0..255 instead of saturating at 25% travel (fails on main)
- [x] signed bit-field `negate`/`abs` guard point
- [x] existing single-byte `bits` configs unchanged
- [x] `lake build` zero sorry; oracle self-checks; CSV freshness diff
- [x] Docker `zig build test`, `test-safe`, `check-fmt`, `test-tsan`

Related: #514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Bit-field report fields can now use transform chains, including scaling, negation, and absolute-value operations.
  - Transform scaling now reflects each field’s declared width and signedness, improving results for non-8-bit inputs.
  - Bit-field transforms support round-trip processing while preserving the declared bit width.

- **Documentation**
  - Expanded bit-field guidance with cross-byte extraction examples and validation rules.
  - Added documentation explaining full-scale transform mapping and trigger-value saturation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->