### PR TITLE
fix(dpad): derive dpad output from hat-decoded DPad button bits

### DIFF
--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -118,6 +118,12 @@ the high nibble of byte 9 is `dpad = { bits = [9, 4, 4] }`.
 > is rejected at load time, because two writers for the same four button bits
 > have no defined merge order.
 
+> **Same report as the buttons:** on a multi-report device, put the `dpad` field
+> in the same `[[report]]` as the `[report.button_group]` it ships with. Each
+> report replaces the whole button mask, so a report carrying only the hat's
+> d-pad bits clears the buttons another report set, and vice versa. `padctl`
+> warns at load time when it sees that layout.
+
 #### Data Types
 
 `u8` `i8` `u16le` `i16le` `u16be` `i16be` `u32le` `i32le` `u32be` `i32be`

--- a/docs/src/device-config.md
+++ b/docs/src/device-config.md
@@ -78,6 +78,46 @@ Use `offset` + `type` for whole-byte fields. Use `bits` for sub-byte bit extract
 
 > **Note:** When using `bits`, the `type` field must be `null`, `"unsigned"`, or `"signed"` — standard type strings like `"u8"` or `"i16le"` are not valid.
 
+#### Field names
+
+Field names are fixed: `left_x` `left_y` `right_x` `right_y` (also accepted as
+`ax` `ay` `rx` `ry`), `lt` `rt`, `gyro_x` `gyro_y` `gyro_z`, `accel_x` `accel_y`
+`accel_z`, `touch0_x` `touch0_y` `touch1_x` `touch1_y`, `touch0_active`
+`touch1_active`, `battery_level`, and `dpad`. Unrecognised names are ignored.
+
+#### `dpad` — HID hat switch
+
+`dpad` reads a HID hat switch: a single enum value, not a bitfield. It is
+decoded into the `DPadUp` / `DPadDown` / `DPadLeft` / `DPadRight` buttons, so
+remapping, layers, `[dpad] mode = "arrows"` and both `[output.dpad]` types
+behave exactly as they do for a device whose d-pad arrives as four bits.
+
+| Value | Direction |
+|-------|-----------|
+| `0` | up |
+| `1` | up + right |
+| `2` | right |
+| `3` | down + right |
+| `4` | down |
+| `5` | down + left |
+| `6` | left |
+| `7` | up + left |
+| `8` or above | neutral (all four released) |
+
+```toml
+[report.fields]
+dpad = { offset = 9, type = "u8" }
+```
+
+When the hat occupies part of a byte, declare it with `bits` instead — a hat in
+the high nibble of byte 9 is `dpad = { bits = [9, 4, 4] }`.
+
+> **Exclusive with DPad\* buttons:** a device declares its d-pad *either* as a
+> `dpad` hat field *or* as `DPadUp` / `DPadDown` / `DPadLeft` / `DPadRight`
+> entries in a `[report.button_group]` map — never both. A config that does both
+> is rejected at load time, because two writers for the same four button bits
+> have no defined merge order.
+
 #### Data Types
 
 `u8` `i8` `u16le` `i16le` `u16be` `i16be` `u32le` `i32le` `u32be` `i32be`
@@ -274,6 +314,12 @@ B = "BTN_EAST"
 [output.dpad]
 type = "hat"   # or "buttons"
 ```
+
+`hat` emits `ABS_HAT0X` / `ABS_HAT0Y`; `buttons` emits key events, which
+requires `DPadUp` / `DPadDown` / `DPadLeft` / `DPadRight` entries in
+`[output.buttons]`. Both forms are driven by the same DPad\* button state, so
+the input side may declare its d-pad in either form (see
+[`dpad` — HID hat switch](#dpad--hid-hat-switch)).
 
 ### `[output.force_feedback]`
 

--- a/formal/lean/Padctl/Interpreter.lean
+++ b/formal/lean/Padctl/Interpreter.lean
@@ -1,5 +1,6 @@
 -- Interpreter core operations matching src/core/interpreter.zig
 import Padctl.Types
+import Padctl.State
 
 -- Byte-level field reading (models readFieldByTag)
 def readU8 (raw : ByteArray) (off : Nat) : Option Nat :=
@@ -122,17 +123,22 @@ def checkMatch (raw : ByteArray) (offset : Nat) (expected : ByteArray) : Bool :=
 
 -- HID hat switch decode (models applyFieldTag .dpad branch)
 -- 0=N, 1=NE, 2=E, 3=SE, 4=S, 5=SW, 6=W, 7=NW, 8+=neutral
-def decodeDpadHat (hatValue : Nat) : Int × Int :=
+def decodeDpadHat (hatValue : Nat) : Nat :=
   match hatValue with
-  | 0 => (0, -1)    -- Up
-  | 1 => (1, -1)    -- Up-Right
-  | 2 => (1, 0)     -- Right
-  | 3 => (1, 1)     -- Down-Right
-  | 4 => (0, 1)     -- Down
-  | 5 => (-1, 1)    -- Down-Left
-  | 6 => (-1, 0)    -- Left
-  | 7 => (-1, -1)   -- Up-Left
-  | _ => (0, 0)     -- Neutral (8 or any other value)
+  | 0 => 1 <<< dpadUpBit                            -- Up
+  | 1 => (1 <<< dpadUpBit) ||| (1 <<< dpadRightBit) -- Up-Right
+  | 2 => 1 <<< dpadRightBit                         -- Right
+  | 3 => (1 <<< dpadDownBit) ||| (1 <<< dpadRightBit) -- Down-Right
+  | 4 => 1 <<< dpadDownBit                          -- Down
+  | 5 => (1 <<< dpadDownBit) ||| (1 <<< dpadLeftBit) -- Down-Left
+  | 6 => 1 <<< dpadLeftBit                          -- Left
+  | 7 => (1 <<< dpadUpBit) ||| (1 <<< dpadLeftBit)  -- Up-Left
+  | _ => 0                                          -- Neutral (8 or any other value)
+
+-- Merge a decoded hat into a button mask: the four DPad* bits are replaced,
+-- every other bit is preserved (models the applyFieldTag .dpad branch).
+def applyDpadHat (buttons : Nat) (hatValue : Nat) : Nat :=
+  (buttons &&& (dpadButtonMask ^^^ (2 ^ 64 - 1))) ||| decodeDpadHat hatValue
 
 -- Button group decoding (models extractAndFillCompiled button logic)
 -- entries: list of (bit_idx_in_source, button_bit_in_output)

--- a/formal/lean/Padctl/Mapper.lean
+++ b/formal/lean/Padctl/Mapper.lean
@@ -258,21 +258,15 @@ def KEY_LEFT : Nat := 105
 def KEY_RIGHT : Nat := 106
 
 structure DpadResult where
-  dpadX : Int := 0
-  dpadY : Int := 0
   auxEvents : List AuxEvent := []
   suppressDpadHat : Bool := false
   suppressButtons : Nat := 0
   deriving Repr
 
--- Dpad button bits for suppression mask
-private def dpadButtonMask : Nat :=
-  (1 <<< dpadUpBit) ||| (1 <<< dpadDownBit) ||| (1 <<< dpadLeftBit) ||| (1 <<< dpadRightBit)
-
 def processDpad (dx dy prevDx prevDy : Int) (mode : DpadMode) (suppressGamepad : Bool)
     : DpadResult :=
   match mode with
-  | .gamepad => { dpadX := dx, dpadY := dy }
+  | .gamepad => {}
   | .arrows =>
     let up := dy < 0
     let down := dy > 0
@@ -288,9 +282,7 @@ def processDpad (dx dy prevDx prevDy : Int) (mode : DpadMode) (suppressGamepad :
       (if left != prevLeft then [AuxEvent.key KEY_LEFT left] else []) ++
       (if right != prevRight then [AuxEvent.key KEY_RIGHT right] else [])
     let suppress := suppressGamepad
-    { dpadX := if suppress then 0 else dx,
-      dpadY := if suppress then 0 else dy,
-      auxEvents := aux,
+    { auxEvents := aux,
       suppressDpadHat := suppress,
       suppressButtons := if suppress then dpadButtonMask else 0 }
 
@@ -467,8 +459,11 @@ def Mapper.apply (s : MapperState) (gs : GamepadState) (delta : GamepadStateDelt
   -- [2b] resolve per-layer config overrides
   let cfg := resolveConfig config curActiveLayer config.layerOverrides
 
-  -- [3] dpad processing
-  let dpadRes := processDpad newGs.dpad_x newGs.dpad_y gs.dpad_x gs.dpad_y
+  -- [3] dpad processing — the arrow-mode edge detector reads the axes derived
+  -- from this frame's and the previous frame's raw DPad* bits
+  let (curDx, curDy) := synthesizeDpadAxes buttons
+  let (prevDx, prevDy) := synthesizeDpadAxes gs.buttons
+  let dpadRes := processDpad curDx curDy prevDx prevDy
       cfg.dpadMode cfg.dpadSuppressGamepad
 
   -- [3b] gyro activation check (boolean only, not float math)
@@ -512,6 +507,8 @@ def Mapper.apply (s : MapperState) (gs : GamepadState) (delta : GamepadStateDelt
 
   -- [8] assemble emit state + prev-frame masking
   let emitButtons := assembleButtons buttons suppress inject'
+  -- The emitted hat axes are derived from the post-remap DPad* bits.
+  let (emitDx, emitDy) := synthesizeDpadAxes emitButtons
   let emitGs : GamepadState := {
     newGs with
     buttons := emitButtons
@@ -523,15 +520,16 @@ def Mapper.apply (s : MapperState) (gs : GamepadState) (delta : GamepadStateDelt
           else if stickSuppressR then 0 else newGs.rx
     ry := if suppressRightStickGyro then newGs.ry
           else if stickSuppressR then 0 else newGs.ry
-    dpad_x := dpadRes.dpadX
-    dpad_y := dpadRes.dpadY
+    dpad_x := if dpadRes.suppressDpadHat then 0 else emitDx
+    dpad_y := if dpadRes.suppressDpadHat then 0 else emitDy
   }
 
   -- prev-frame masking: apply same suppress/inject to prevButtons so that
   -- downstream diff does not produce spurious release events for suppressed buttons
   let maskedPrevButtons := assembleButtons s2.prevButtons suppress inject'
-  let maskedPrevDpadX := if dpadRes.suppressDpadHat then 0 else gs.dpad_x
-  let maskedPrevDpadY := if dpadRes.suppressDpadHat then 0 else gs.dpad_y
+  let (maskedPrevDx, maskedPrevDy) := synthesizeDpadAxes maskedPrevButtons
+  let maskedPrevDpadX := if dpadRes.suppressDpadHat then 0 else maskedPrevDx
+  let maskedPrevDpadY := if dpadRes.suppressDpadHat then 0 else maskedPrevDy
   let maskedPrev : GamepadState := {
     gs with
     buttons := maskedPrevButtons

--- a/formal/lean/Padctl/Properties.lean
+++ b/formal/lean/Padctl/Properties.lean
@@ -256,13 +256,18 @@ theorem dpadHat_preserves_other_bits :
     applyDpadHat ((1 <<< 0) ||| dpadButtonMask) 6 = (1 <<< 0) ||| (1 <<< dpadLeftBit) ∧
     applyDpadHat ((1 <<< 0) ||| dpadButtonMask) 8 = 1 <<< 0 := by decide
 
--- P24: hat decode opposing directions are disjoint (up/down: hat 0 vs hat 4)
+-- P24: hat 0 (up) and hat 4 (down) oppose on the y axis — the bits they decode
+-- to are disjoint, and the axes they synthesize are non-zero and negate
 theorem dpadHat_opposing_y :
-    decodeDpadHat 0 &&& decodeDpadHat 4 = 0 := by decide
+    decodeDpadHat 0 &&& decodeDpadHat 4 = 0 ∧
+    (synthesizeDpadAxes (decodeDpadHat 0)).2 = -(synthesizeDpadAxes (decodeDpadHat 4)).2 ∧
+    (synthesizeDpadAxes (decodeDpadHat 0)).2 ≠ 0 := by decide
 
--- P25: hat decode opposing directions are disjoint (left/right: hat 6 vs hat 2)
+-- P25: hat 6 (left) and hat 2 (right) oppose on the x axis, same sense as P24
 theorem dpadHat_opposing_x :
-    decodeDpadHat 6 &&& decodeDpadHat 2 = 0 := by decide
+    decodeDpadHat 6 &&& decodeDpadHat 2 = 0 ∧
+    (synthesizeDpadAxes (decodeDpadHat 6)).1 = -(synthesizeDpadAxes (decodeDpadHat 2)).1 ∧
+    (synthesizeDpadAxes (decodeDpadHat 6)).1 ≠ 0 := by decide
 
 -- P22: assembleButtons — inject bits always present in output
 theorem assemble_inject_present (raw suppress inject : Nat) :

--- a/formal/lean/Padctl/Properties.lean
+++ b/formal/lean/Padctl/Properties.lean
@@ -88,9 +88,10 @@ theorem chain_singleton (v : Int) (op : TransformOp) (tMax : Nat) :
     runTransformChain v [op] tMax = applyTransform op v tMax := by
   simp [runTransformChain]
 
--- P12: applyDelta(s, diff(t, s)) = t (round-trip)
+-- P12: applyDelta(s, diff(t, s)) = t up to the derived dpad axes, which the
+-- delta does not carry
 theorem apply_diff_roundtrip (s t : GamepadState) :
-    applyDelta s (diff t s) = t := by
+    applyDelta s (diff t s) = { t with dpad_x := s.dpad_x, dpad_y := s.dpad_y } := by
   cases s; cases t
   simp only [applyDelta, diff, Option.getD]
   congr 1 <;> (split <;> simp_all)
@@ -212,33 +213,56 @@ theorem layer_mutual_exclusion (s : MapperState) (th : TapHoldState) (j : Nat)
 theorem toggle_involutive (b : Bool) : !(!b) = b := by
   cases b <;> simp
 
--- P21: Dpad arrows — dx = 0 in output when input dx = 0
-theorem dpad_arrows_zero_dx (dy prevDx prevDy : Int) (suppress : Bool) :
-    (processDpad 0 dy prevDx prevDy .arrows suppress).dpadX = 0 := by
+-- P21: Dpad arrows — an unchanged direction produces no arrow-key events
+theorem dpad_arrows_no_edge (dx dy : Int) (suppress : Bool) :
+    (processDpad dx dy dx dy .arrows suppress).auxEvents = [] := by
   simp [processDpad]
 
--- P21b: Dpad gamepad mode is passthrough
-theorem dpad_gamepad_passthrough (dx dy prevDx prevDy : Int) :
-    (processDpad dx dy prevDx prevDy .gamepad false).dpadX = dx ∧
-    (processDpad dx dy prevDx prevDy .gamepad false).dpadY = dy := by
+-- P21b: Dpad gamepad mode emits nothing and suppresses nothing
+theorem dpad_gamepad_inert (dx dy prevDx prevDy : Int) :
+    (processDpad dx dy prevDx prevDy .gamepad false).auxEvents = [] ∧
+    (processDpad dx dy prevDx prevDy .gamepad false).suppressButtons = 0 ∧
+    (processDpad dx dy prevDx prevDy .gamepad false).suppressDpadHat = false := by
   simp [processDpad]
 
--- P23: decodeDpadHat exhaustive — all 9 cases produce valid (dx, dy) pairs
+-- P23: decodeDpadHat exhaustive — all 9 cases produce the right DPad* bits
 -- Hat values 0-7 each produce a unique direction; 8+ produce neutral
 theorem dpadHat_exhaustive :
-    decodeDpadHat 0 = (0, -1) ∧ decodeDpadHat 1 = (1, -1) ∧
-    decodeDpadHat 2 = (1, 0) ∧ decodeDpadHat 3 = (1, 1) ∧
-    decodeDpadHat 4 = (0, 1) ∧ decodeDpadHat 5 = (-1, 1) ∧
-    decodeDpadHat 6 = (-1, 0) ∧ decodeDpadHat 7 = (-1, -1) ∧
-    decodeDpadHat 8 = (0, 0) := by decide
+    decodeDpadHat 0 = 1 <<< dpadUpBit ∧
+    decodeDpadHat 1 = (1 <<< dpadUpBit) ||| (1 <<< dpadRightBit) ∧
+    decodeDpadHat 2 = 1 <<< dpadRightBit ∧
+    decodeDpadHat 3 = (1 <<< dpadDownBit) ||| (1 <<< dpadRightBit) ∧
+    decodeDpadHat 4 = 1 <<< dpadDownBit ∧
+    decodeDpadHat 5 = (1 <<< dpadDownBit) ||| (1 <<< dpadLeftBit) ∧
+    decodeDpadHat 6 = 1 <<< dpadLeftBit ∧
+    decodeDpadHat 7 = (1 <<< dpadUpBit) ||| (1 <<< dpadLeftBit) ∧
+    decodeDpadHat 8 = 0 := by decide
 
--- P24: decodeDpadHat opposing directions cancel (up/down: hat 0 vs hat 4)
+-- P23b: decoding a hat and then synthesizing the axes reproduces HID hat
+-- semantics end to end
+theorem dpadHat_axes_roundtrip :
+    synthesizeDpadAxes (decodeDpadHat 0) = (0, -1) ∧
+    synthesizeDpadAxes (decodeDpadHat 1) = (1, -1) ∧
+    synthesizeDpadAxes (decodeDpadHat 2) = (1, 0) ∧
+    synthesizeDpadAxes (decodeDpadHat 3) = (1, 1) ∧
+    synthesizeDpadAxes (decodeDpadHat 4) = (0, 1) ∧
+    synthesizeDpadAxes (decodeDpadHat 5) = (-1, 1) ∧
+    synthesizeDpadAxes (decodeDpadHat 6) = (-1, 0) ∧
+    synthesizeDpadAxes (decodeDpadHat 7) = (-1, -1) ∧
+    synthesizeDpadAxes (decodeDpadHat 8) = (0, 0) := by decide
+
+-- P23c: applyDpadHat replaces the DPad* bits and preserves the others
+theorem dpadHat_preserves_other_bits :
+    applyDpadHat ((1 <<< 0) ||| dpadButtonMask) 6 = (1 <<< 0) ||| (1 <<< dpadLeftBit) ∧
+    applyDpadHat ((1 <<< 0) ||| dpadButtonMask) 8 = 1 <<< 0 := by decide
+
+-- P24: hat decode opposing directions are disjoint (up/down: hat 0 vs hat 4)
 theorem dpadHat_opposing_y :
-    (decodeDpadHat 0).2 = -(decodeDpadHat 4).2 := by decide
+    decodeDpadHat 0 &&& decodeDpadHat 4 = 0 := by decide
 
--- P25: decodeDpadHat opposing directions cancel (left/right: hat 6 vs hat 2)
+-- P25: hat decode opposing directions are disjoint (left/right: hat 6 vs hat 2)
 theorem dpadHat_opposing_x :
-    (decodeDpadHat 6).1 = -(decodeDpadHat 2).1 := by decide
+    decodeDpadHat 6 &&& decodeDpadHat 2 = 0 := by decide
 
 -- P22: assembleButtons — inject bits always present in output
 theorem assemble_inject_present (raw suppress inject : Nat) :

--- a/formal/lean/Padctl/State.lean
+++ b/formal/lean/Padctl/State.lean
@@ -9,6 +9,7 @@ structure GamepadState where
   lt : Nat := 0
   rt : Nat := 0
   buttons : Nat := 0
+  -- Output axes derived from the DPad* bits by synthesizeDpadAxes.
   dpad_x : Int := 0
   dpad_y : Int := 0
   gyro_x : Int := 0
@@ -34,8 +35,6 @@ structure GamepadStateDelta where
   lt : Option Nat := none
   rt : Option Nat := none
   buttons : Option Nat := none
-  dpad_x : Option Int := none
-  dpad_y : Option Int := none
   gyro_x : Option Int := none
   gyro_y : Option Int := none
   gyro_z : Option Int := none
@@ -59,8 +58,9 @@ def applyDelta (s : GamepadState) (d : GamepadStateDelta) : GamepadState :=
     lt := d.lt.getD s.lt
     rt := d.rt.getD s.rt
     buttons := d.buttons.getD s.buttons
-    dpad_x := d.dpad_x.getD s.dpad_x
-    dpad_y := d.dpad_y.getD s.dpad_y
+    -- Derived output axes: no delta field writes them.
+    dpad_x := s.dpad_x
+    dpad_y := s.dpad_y
     gyro_x := d.gyro_x.getD s.gyro_x
     gyro_y := d.gyro_y.getD s.gyro_y
     gyro_z := d.gyro_z.getD s.gyro_z
@@ -85,8 +85,6 @@ def diff (a b : GamepadState) : GamepadStateDelta :=
     lt := if a.lt ≠ b.lt then some a.lt else none
     rt := if a.rt ≠ b.rt then some a.rt else none
     buttons := if a.buttons ≠ b.buttons then some a.buttons else none
-    dpad_x := if a.dpad_x ≠ b.dpad_x then some a.dpad_x else none
-    dpad_y := if a.dpad_y ≠ b.dpad_y then some a.dpad_y else none
     gyro_x := if a.gyro_x ≠ b.gyro_x then some a.gyro_x else none
     gyro_y := if a.gyro_y ≠ b.gyro_y then some a.gyro_y else none
     gyro_z := if a.gyro_z ≠ b.gyro_z then some a.gyro_z else none
@@ -131,6 +129,9 @@ def dpadUpBit : Nat := ButtonId.toNat .dpadUp
 def dpadDownBit : Nat := ButtonId.toNat .dpadDown
 def dpadLeftBit : Nat := ButtonId.toNat .dpadLeft
 def dpadRightBit : Nat := ButtonId.toNat .dpadRight
+
+def dpadButtonMask : Nat :=
+  (1 <<< dpadUpBit) ||| (1 <<< dpadDownBit) ||| (1 <<< dpadLeftBit) ||| (1 <<< dpadRightBit)
 
 def testBit (n : Nat) (bit : Nat) : Bool := (n / (2 ^ bit)) % 2 == 1
 

--- a/formal/lean/test/OracleMain.lean
+++ b/formal/lean/test/OracleMain.lean
@@ -386,16 +386,24 @@ private def emitChecksumVectors : IO Unit := do
 
 private def emitHatDecodeVectors : IO Unit := do
   println "# HAT_DECODE"
-  println "# hatValue,expected_dx,expected_dy"
-  let expected : List (Nat × Int × Int) :=
-    [(0, 0, -1), (1, 1, -1), (2, 1, 0), (3, 1, 1),
-     (4, 0, 1), (5, -1, 1), (6, -1, 0), (7, -1, -1),
-     (8, 0, 0), (15, 0, 0)]
-  for (hat, edx, edy) in expected do
-    let (dx, dy) := decodeDpadHat hat
-    println s!"{hat},{intToString dx},{intToString dy}"
+  println "# hatValue,expected_buttons,expected_dx,expected_dy"
+  let up := 1 <<< dpadUpBit
+  let down := 1 <<< dpadDownBit
+  let left := 1 <<< dpadLeftBit
+  let right := 1 <<< dpadRightBit
+  let expected : List (Nat × Nat × Int × Int) :=
+    [(0, up, 0, -1), (1, up ||| right, 1, -1), (2, right, 1, 0),
+     (3, down ||| right, 1, 1), (4, down, 0, 1), (5, down ||| left, -1, 1),
+     (6, left, -1, 0), (7, up ||| left, -1, -1),
+     (8, 0, 0, 0), (15, 0, 0, 0)]
+  for (hat, ebits, edx, edy) in expected do
+    let bits := decodeDpadHat hat
+    let (dx, dy) := synthesizeDpadAxes bits
+    println s!"{hat},{bits},{intToString dx},{intToString dy}"
+    if bits != ebits then
+      throw (IO.userError s!"decodeDpadHat({hat}) = {bits}, expected {ebits}")
     if dx != edx || dy != edy then
-      throw (IO.userError s!"decodeDpadHat({hat}) = ({intToString dx},{intToString dy}), expected ({intToString edx},{intToString edy})")
+      throw (IO.userError s!"synthesizeDpadAxes (decodeDpadHat {hat}) = ({intToString dx},{intToString dy}), expected ({intToString edx},{intToString edy})")
 
 /-! ## Button decode vectors -/
 
@@ -597,9 +605,7 @@ private def handleCommand (parts : List String) (stdout : IO.FS.Stream) : IO Uni
 
   | ["DPAD_HAT", valStr] => do
     match parseNat valStr with
-    | some v =>
-      let (dx, dy) := decodeDpadHat v
-      stdout.putStrLn s!"RESULT {intToString dx} {intToString dy}"
+    | some v => stdout.putStrLn s!"RESULT {decodeDpadHat v}"
     | none => stdout.putStrLn "ERROR bad args"
 
   | ["SIGNEXTEND", valStr, bitCountStr] => do

--- a/formal/lean/test_vectors.csv
+++ b/formal/lean/test_vectors.csv
@@ -132,17 +132,17 @@ xor,0,2,2,0
 crc32,0,9,computed=3421780262,expected=3421780262,1
 crc32_verify,0,9,9,1
 # HAT_DECODE
-# hatValue,expected_dx,expected_dy
-0,0,-1
-1,1,-1
-2,1,0
-3,1,1
-4,0,1
-5,-1,1
-6,-1,0
-7,-1,-1
-8,0,0
-15,0,0
+# hatValue,expected_buttons,expected_dx,expected_dy
+0,16384,0,-1
+1,147456,1,-1
+2,131072,1,0
+3,163840,1,1
+4,32768,0,1
+5,98304,-1,1
+6,65536,-1,0
+7,81920,-1,-1
+8,0,0,0
+15,0,0,0
 # BUTTON_DECODE
 # srcOff,srcSize,entries,hex_bytes,expected
 0,1,0:0|2:4,17

--- a/src/cli/config/test.zig
+++ b/src/cli/config/test.zig
@@ -126,6 +126,9 @@ const Decoder = struct {
         };
         const prev = self.state;
         self.state.applyDelta(delta);
+        // DPadX/DPadY are derived from the DPad* button bits, never carried by
+        // the delta, so they only exist once synthesized.
+        self.state.synthesizeDpadAxes();
         try formatEvents(w, prev, self.state);
     }
 };
@@ -498,6 +501,35 @@ test "decode: axes printed on change with value" {
     raw[15] = 0;
     try dec.feed(w, &raw);
     try testing.expectEqualStrings("LT=0\n", out.items);
+}
+
+test "decode: dpad button bits print the derived DPadX/DPadY axes" {
+    const allocator = testing.allocator;
+    const parsed = try device_mod.parseFile(allocator, "devices/flydigi/vader5.toml");
+    defer parsed.deinit();
+    const interp = interpreter_mod.Interpreter.init(&parsed.value);
+    var dec = Decoder{ .interp = &interp, .interface_id = 1 };
+
+    var out: std.ArrayList(u8) = .{};
+    defer out.deinit(allocator);
+    const w = out.writer(allocator);
+
+    // DPadUp = button_group bit 0 → byte 11, bit 0
+    var raw = vader5Report();
+    raw[11] = 0x01;
+    try dec.feed(w, &raw);
+    try testing.expectEqualStrings("DPadUp down\nDPadY=-1\n", out.items);
+
+    // DPadRight = bit 1: the axes follow the bits on every frame
+    out.clearRetainingCapacity();
+    raw[11] = 0x02;
+    try dec.feed(w, &raw);
+    try testing.expectEqualStrings("DPadUp up\nDPadRight down\nDPadX=1\nDPadY=0\n", out.items);
+
+    out.clearRetainingCapacity();
+    raw[11] = 0;
+    try dec.feed(w, &raw);
+    try testing.expectEqualStrings("DPadRight up\nDPadX=0\n", out.items);
 }
 
 test "decode: buttons and axes in one report" {

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -635,6 +635,8 @@ pub fn validate(cfg: *const DeviceConfig) !void {
         }
     }
 
+    try validateDpadDeclaration(cfg);
+
     // Generic mode validation
     if (cfg.device.mode) |m| {
         if (std.mem.eql(u8, m, "generic")) {
@@ -663,6 +665,46 @@ pub fn validate(cfg: *const DeviceConfig) !void {
             }
         }
     }
+}
+
+fn isDpadButtonName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "DPadUp") or std.mem.eql(u8, name, "DPadDown") or
+        std.mem.eql(u8, name, "DPadLeft") or std.mem.eql(u8, name, "DPadRight");
+}
+
+// A `dpad` hat field and DPad* button_group bits are two writers for the same
+// four button bits with no defined merge order, so a config may declare only
+// one of them — the rule spans the whole config, not a single report.
+fn validateDpadDeclaration(cfg: *const DeviceConfig) !void {
+    var hat_report: ?[]const u8 = null;
+    var bits_report: ?[]const u8 = null;
+
+    for (cfg.report) |report| {
+        if (hat_report == null) {
+            if (report.fields) |fields| {
+                if (fields.map.get("dpad") != null) hat_report = report.name;
+            }
+        }
+        if (bits_report == null) {
+            if (report.button_group) |bg| {
+                var it = bg.map.map.iterator();
+                while (it.next()) |entry| {
+                    if (isDpadButtonName(entry.key_ptr.*)) {
+                        bits_report = report.name;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    const hat = hat_report orelse return;
+    const bits = bits_report orelse return;
+    std.log.warn(
+        "device '{s}': dpad declared twice — hat field in report '{s}' and DPad* button_group bits in report '{s}'; keep only one",
+        .{ cfg.device.name, hat, bits },
+    );
+    return error.InvalidConfig;
 }
 
 fn validateMappingEntries(mapping: toml.HashMap(MappingEntry)) !void {

--- a/src/config/device.zig
+++ b/src/config/device.zig
@@ -636,6 +636,14 @@ pub fn validate(cfg: *const DeviceConfig) !void {
     }
 
     try validateDpadDeclaration(cfg);
+    if (dpadSplitAcrossReports(cfg)) |split| {
+        std.log.warn(
+            "device '{s}': dpad hat in report '{s}' but button bits in report '{s}'; " ++
+                "a report's button mask replaces the previous one, so the two clear each other — " ++
+                "declare the hat in the same report as its button_group",
+            .{ cfg.device.name, split.hat, split.group },
+        );
+    }
 
     // Generic mode validation
     if (cfg.device.mode) |m| {
@@ -705,6 +713,29 @@ fn validateDpadDeclaration(cfg: *const DeviceConfig) !void {
         .{ cfg.device.name, hat, bits },
     );
     return error.InvalidConfig;
+}
+
+const DpadSplit = struct { hat: []const u8, group: []const u8 };
+
+// `applyDelta` replaces the whole button mask, so a report carrying only a
+// hat's DPad* bits clears the buttons another report set, and vice versa. The
+// layout loads but cannot work, so it is warned about rather than rejected.
+fn dpadSplitAcrossReports(cfg: *const DeviceConfig) ?DpadSplit {
+    var hat_report: ?[]const u8 = null;
+    var group_report: ?[]const u8 = null;
+
+    for (cfg.report) |report| {
+        const has_hat = if (report.fields) |fields| fields.map.get("dpad") != null else false;
+        if (has_hat and report.button_group == null) {
+            if (hat_report == null) hat_report = report.name;
+        } else if (report.button_group != null) {
+            if (group_report == null) group_report = report.name;
+        }
+    }
+
+    const hat = hat_report orelse return null;
+    const group = group_report orelse return null;
+    return .{ .hat = hat, .group = group };
 }
 
 fn validateMappingEntries(mapping: toml.HashMap(MappingEntry)) !void {
@@ -3694,4 +3725,80 @@ test "device: all shipped devices/*.toml lint clean" {
         checked += 1;
     }
     try std.testing.expect(checked >= 1);
+}
+
+test "device: dpad hat and button bits in separate reports is flagged as a split" {
+    const allocator = std.testing.allocator;
+    const split_toml =
+        \\[device]
+        \\name = "Split Pad"
+        \\vid = 1
+        \\pid = 2
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\
+        \\[[report]]
+        \\name = "hat"
+        \\interface = 0
+        \\size = 4
+        \\
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x01]
+        \\
+        \\[report.fields]
+        \\dpad = { offset = 1, type = "u8" }
+        \\
+        \\[[report]]
+        \\name = "buttons"
+        \\interface = 0
+        \\size = 4
+        \\
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x02]
+        \\
+        \\[report.button_group]
+        \\source = { offset = 1, size = 1 }
+        \\map = { A = 0 }
+    ;
+    // The shape still loads — only the layout is unsupported.
+    const parsed = try parseString(allocator, split_toml);
+    defer parsed.deinit();
+
+    const split = dpadSplitAcrossReports(&parsed.value) orelse return error.SplitNotDetected;
+    try std.testing.expectEqualStrings("hat", split.hat);
+    try std.testing.expectEqualStrings("buttons", split.group);
+}
+
+test "device: dpad hat beside its button_group in one report is not a split" {
+    const allocator = std.testing.allocator;
+    const joint_toml =
+        \\[device]
+        \\name = "Together Pad"
+        \\vid = 1
+        \\pid = 2
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\
+        \\[[report]]
+        \\name = "input"
+        \\interface = 0
+        \\size = 4
+        \\
+        \\[report.fields]
+        \\dpad = { offset = 1, type = "u8" }
+        \\
+        \\[report.button_group]
+        \\source = { offset = 2, size = 1 }
+        \\map = { A = 0 }
+    ;
+    const parsed = try parseString(allocator, joint_toml);
+    defer parsed.deinit();
+
+    try std.testing.expect(dpadSplitAcrossReports(&parsed.value) == null);
 }

--- a/src/core/interpreter.zig
+++ b/src/core/interpreter.zig
@@ -142,28 +142,34 @@ fn applyFieldTag(delta: *GamepadStateDelta, tag: FieldTag, val: i64) void {
         .touch1_active => delta.touch1_active = val != 0,
         .battery_level => delta.battery_level = saturateCast(u8, val),
         .dpad => {
-            const decoded = decodeDpadHat(val);
-            delta.dpad_x = decoded.x;
-            delta.dpad_y = decoded.y;
+            const bits = delta.buttons orelse 0;
+            delta.buttons = (bits & ~DPAD_BUTTON_MASK) | decodeDpadHat(val);
         },
         .unknown => {},
     }
 }
 
-pub const DpadHat = struct {
-    x: i8,
-    y: i8,
-};
+fn btnBit(id: state.ButtonId) u64 {
+    return @as(u64, 1) << @as(u6, @intCast(@intFromEnum(id)));
+}
 
-pub fn decodeDpadHat(val: i64) DpadHat {
+pub const DPAD_BUTTON_MASK: u64 = btnBit(.DPadUp) | btnBit(.DPadDown) |
+    btnBit(.DPadLeft) | btnBit(.DPadRight);
+
+pub fn decodeDpadHat(val: i64) u64 {
     // HID hat switch: 0=N, 1=NE, 2=E, 3=SE, 4=S, 5=SW, 6=W, 7=NW, 8+=neutral.
-    const HAT_X = [8]i8{ 0, 1, 1, 1, 0, -1, -1, -1 };
-    const HAT_Y = [8]i8{ -1, -1, 0, 1, 1, 1, 0, -1 };
-    if (val >= 0 and val < 8) {
-        const idx: usize = @intCast(val);
-        return .{ .x = HAT_X[idx], .y = HAT_Y[idx] };
-    }
-    return .{ .x = 0, .y = 0 };
+    const HAT_BITS = [8]u64{
+        btnBit(.DPadUp),
+        btnBit(.DPadUp) | btnBit(.DPadRight),
+        btnBit(.DPadRight),
+        btnBit(.DPadDown) | btnBit(.DPadRight),
+        btnBit(.DPadDown),
+        btnBit(.DPadDown) | btnBit(.DPadLeft),
+        btnBit(.DPadLeft),
+        btnBit(.DPadUp) | btnBit(.DPadLeft),
+    };
+    if (val >= 0 and val < 8) return HAT_BITS[@intCast(val)];
+    return 0;
 }
 
 // --- pre-compiled transform chain ---
@@ -1697,16 +1703,29 @@ test "interpreter: touch0_active bits round-trip" {
     try testing.expectEqual(@as(?bool, false), d2.touch0_active);
 }
 
-test "interpreter: FieldTag.dpad: hat switch values 0-7 decode correctly" {
+test "interpreter: FieldTag.dpad: hat switch values 0-7 set DPad button bits" {
     // HID hat: 0=N, 1=NE, 2=E, 3=SE, 4=S, 5=SW, 6=W, 7=NW
-    const HAT_X = [8]i8{ 0, 1, 1, 1, 0, -1, -1, -1 };
-    const HAT_Y = [8]i8{ -1, -1, 0, 1, 1, 1, 0, -1 };
+    const expected = [8]u64{
+        btnBit(.DPadUp),
+        btnBit(.DPadUp) | btnBit(.DPadRight),
+        btnBit(.DPadRight),
+        btnBit(.DPadDown) | btnBit(.DPadRight),
+        btnBit(.DPadDown),
+        btnBit(.DPadDown) | btnBit(.DPadLeft),
+        btnBit(.DPadLeft),
+        btnBit(.DPadUp) | btnBit(.DPadLeft),
+    };
     for (0..8) |i| {
         var delta = GamepadStateDelta{};
         applyFieldTag(&delta, .dpad, @intCast(i));
-        try std.testing.expectEqual(HAT_X[i], delta.dpad_x.?);
-        try std.testing.expectEqual(HAT_Y[i], delta.dpad_y.?);
+        try std.testing.expectEqual(expected[i], delta.buttons.?);
     }
+}
+
+test "interpreter: FieldTag.dpad: hat bits merge with button_group bits" {
+    var delta = GamepadStateDelta{ .buttons = btnBit(.A) | btnBit(.DPadDown) };
+    applyFieldTag(&delta, .dpad, 6);
+    try std.testing.expectEqual(btnBit(.A) | btnBit(.DPadLeft), delta.buttons.?);
 }
 
 // --- mutation audit: each test proves the suite can catch a specific mutation ---
@@ -1887,16 +1906,12 @@ test "mutation audit: processReport match polarity" {
     try testing.expectEqual(@as(?GamepadStateDelta, null), d_zero);
 }
 
-test "interpreter: FieldTag.dpad: value 8 (released) and >8 treated as neutral" {
-    var delta = GamepadStateDelta{};
-    applyFieldTag(&delta, .dpad, 8);
-    try std.testing.expectEqual(@as(i8, 0), delta.dpad_x.?);
-    try std.testing.expectEqual(@as(i8, 0), delta.dpad_y.?);
-
-    var delta2 = GamepadStateDelta{};
-    applyFieldTag(&delta2, .dpad, 15);
-    try std.testing.expectEqual(@as(i8, 0), delta2.dpad_x.?);
-    try std.testing.expectEqual(@as(i8, 0), delta2.dpad_y.?);
+test "interpreter: FieldTag.dpad: value 8 (released), >8 and negative clear DPad bits" {
+    for ([_]i64{ 8, 15, 255, -1 }) |val| {
+        var delta = GamepadStateDelta{ .buttons = btnBit(.A) | DPAD_BUTTON_MASK };
+        applyFieldTag(&delta, .dpad, val);
+        try std.testing.expectEqual(btnBit(.A), delta.buttons.?);
+    }
 }
 
 test "compileReport: rejects button_group source.size > 8" {

--- a/src/core/mapper.zig
+++ b/src/core/mapper.zig
@@ -343,6 +343,8 @@ pub const Mapper = struct {
     pub fn seedInputState(self: *Mapper, current: GamepadState) void {
         var seeded = current;
         self.applyTriggerThreshold(&seeded);
+        // The carried-over axes may be stale; the DPad* bits are the source.
+        seeded.synthesizeDpadAxes();
         self.state = seeded;
         self.prev = seeded;
         self.seeded_buttons = seeded.buttons;
@@ -457,6 +459,9 @@ pub const Mapper = struct {
         }
 
         self.state.applyDelta(delta);
+        // Arrow-mode edge detection reads self.state/self.prev dpad axes, so
+        // they must track the DPad* bits the same way the emitted frame does.
+        self.state.synthesizeDpadAxes();
         self.applyTriggerThreshold(&self.state);
         self.suppressSeededEdges();
 
@@ -1537,6 +1542,27 @@ fn makeMapping(toml_str: []const u8, allocator: std.mem.Allocator) !mapping.Pars
 fn makeMapper(cfg: *const MappingConfig, allocator: std.mem.Allocator) !Mapper {
     // Use -1 as a dummy fd for tests (timer operations are no-ops on invalid fd)
     return Mapper.init(cfg, std.posix.STDIN_FILENO, allocator);
+}
+
+test "mapper: seedInputState derives dpad axes so a held dpad raises no arrow edge" {
+    const allocator = testing.allocator;
+    const parsed = try makeMapping(
+        \\[dpad]
+        \\mode = "arrows"
+    , allocator);
+    defer parsed.deinit();
+
+    var m = try makeMapper(&parsed.value, allocator);
+    defer m.deinit();
+
+    // Takeover: the previous instance hands over raw buttons only.
+    m.seedInputState(.{ .buttons = buttonBit("DPadUp") });
+    const ev = try m.apply(.{ .buttons = buttonBit("DPadUp") }, 16, 0);
+
+    for (ev.aux.slice()) |e| switch (e) {
+        .key => return error.UnexpectedKeyEvent,
+        else => {},
+    };
 }
 
 test "mapper: resetRuntimeState clears transient layer timer and input state" {
@@ -3183,9 +3209,11 @@ test "mapper: dpad arrows layer: key events fire after hold-timer activation" {
 
     const lt_idx: u6 = @intCast(@intFromEnum(ButtonId.LT));
     const lt_mask: u64 = @as(u64, 1) << lt_idx;
+    const up_idx: u6 = @intCast(@intFromEnum(ButtonId.DPadUp));
+    const up_mask: u64 = @as(u64, 1) << up_idx;
 
     // Frame 1: LT + dpad-up pressed simultaneously → layer PENDING, dpad recorded in prev
-    _ = try m.apply(.{ .buttons = lt_mask, .dpad_y = -1 }, 16, 0);
+    _ = try m.apply(.{ .buttons = lt_mask | up_mask }, 16, 0);
 
     // Timer fires: PENDING → ACTIVE
     _ = m.onLayerTimerExpired();
@@ -3194,7 +3222,7 @@ test "mapper: dpad arrows layer: key events fire after hold-timer activation" {
     // prev.dpad_y should be reset to 0 so edge triggers KEY_UP press
     const configs = parsed.value.layer.?;
     _ = configs; // suppress unused warning
-    const ev = try m.apply(.{ .buttons = lt_mask, .dpad_y = -1 }, 16, 0);
+    const ev = try m.apply(.{ .buttons = lt_mask | up_mask }, 16, 0);
 
     var got_key_up = false;
     for (ev.aux.slice()) |e| switch (e) {
@@ -3345,12 +3373,15 @@ test "mapper: dpad prev mask: suppress_dpad_hat applied to masked_prev" {
     var m = try makeMapper(&parsed.value, allocator);
     defer m.deinit();
 
+    const up_idx: u6 = @intCast(@intFromEnum(ButtonId.DPadUp));
+    const up_mask: u64 = @as(u64, 1) << up_idx;
+
     // Frame 1: dpad up
-    const ev1 = try m.apply(.{ .dpad_x = 0, .dpad_y = -1 }, 16, 0);
+    const ev1 = try m.apply(.{ .buttons = up_mask }, 16, 0);
     try testing.expectEqual(@as(i8, 0), ev1.gamepad.dpad_y);
 
     // Frame 2: same dpad — masked_prev should also have dpad_y = 0
-    const ev2 = try m.apply(.{ .dpad_x = 0, .dpad_y = -1 }, 16, 0);
+    const ev2 = try m.apply(.{ .buttons = up_mask }, 16, 0);
     try testing.expectEqual(@as(i8, 0), ev2.prev.dpad_y);
 }
 

--- a/src/core/state.zig
+++ b/src/core/state.zig
@@ -43,6 +43,8 @@ pub const GamepadState = struct {
     ry: i16 = 0,
     lt: u8 = 0,
     rt: u8 = 0,
+    // Output axes derived from the DPad* button bits by synthesizeDpadAxes;
+    // no input path writes them.
     dpad_x: i8 = 0,
     dpad_y: i8 = 0,
     buttons: u64 = 0,
@@ -68,8 +70,6 @@ pub const GamepadState = struct {
         if (self.ry != prev.ry) d.ry = self.ry;
         if (self.lt != prev.lt) d.lt = self.lt;
         if (self.rt != prev.rt) d.rt = self.rt;
-        if (self.dpad_x != prev.dpad_x) d.dpad_x = self.dpad_x;
-        if (self.dpad_y != prev.dpad_y) d.dpad_y = self.dpad_y;
         if (self.buttons != prev.buttons) d.buttons = self.buttons;
         if (self.gyro_x != prev.gyro_x) d.gyro_x = self.gyro_x;
         if (self.gyro_y != prev.gyro_y) d.gyro_y = self.gyro_y;
@@ -106,8 +106,6 @@ pub const GamepadState = struct {
         if (delta.ry) |v| self.ry = v;
         if (delta.lt) |v| self.lt = v;
         if (delta.rt) |v| self.rt = v;
-        if (delta.dpad_x) |v| self.dpad_x = v;
-        if (delta.dpad_y) |v| self.dpad_y = v;
         if (delta.buttons) |v| self.buttons = v;
         if (delta.gyro_x) |v| self.gyro_x = v;
         if (delta.gyro_y) |v| self.gyro_y = v;
@@ -134,8 +132,6 @@ pub const GamepadStateDelta = struct {
     ry: ?i16 = null,
     lt: ?u8 = null,
     rt: ?u8 = null,
-    dpad_x: ?i8 = null,
-    dpad_y: ?i8 = null,
     buttons: ?u64 = null,
     gyro_x: ?i16 = null,
     gyro_y: ?i16 = null,
@@ -189,8 +185,6 @@ test "state: applyDelta: full overwrite" {
         .ry = -200,
         .lt = 128,
         .rt = 64,
-        .dpad_x = 1,
-        .dpad_y = -1,
         .buttons = 0xDEAD,
         .gyro_x = 10,
         .gyro_y = 20,
@@ -205,8 +199,6 @@ test "state: applyDelta: full overwrite" {
     try std.testing.expectEqual(@as(i16, -200), s.ry);
     try std.testing.expectEqual(@as(u8, 128), s.lt);
     try std.testing.expectEqual(@as(u8, 64), s.rt);
-    try std.testing.expectEqual(@as(i8, 1), s.dpad_x);
-    try std.testing.expectEqual(@as(i8, -1), s.dpad_y);
     try std.testing.expectEqual(@as(u64, 0xDEAD), s.buttons);
     try std.testing.expectEqual(@as(i16, 10), s.gyro_x);
     try std.testing.expectEqual(@as(i16, -30), s.accel_z);

--- a/src/io/uinput.zig
+++ b/src/io/uinput.zig
@@ -119,6 +119,26 @@ pub const AuxOutputDevice = struct {
 // Resolved button mapping: ButtonId index → uinput BTN code (0 = unmapped)
 const BUTTON_COUNT = @typeInfo(state.ButtonId).@"enum".fields.len;
 
+/// `[output.dpad] type = "hat"` sends the synthesized hat axes as ABS_HAT0X/Y;
+/// any other value sends BTN_DPAD_* key events resolved from `[output.buttons]`.
+pub fn dpadIsHat(cfg: *const device.OutputConfig) bool {
+    const dp = cfg.dpad orelse return false;
+    return std.mem.eql(u8, dp.type, "hat");
+}
+
+/// Resolve `[output.buttons]` into the ButtonId-indexed BTN code table `emit`
+/// reads (0 = unmapped). Entries naming an unknown button are ignored.
+pub fn resolveButtonCodes(cfg: *const device.OutputConfig) ![BUTTON_COUNT]u16 {
+    var codes: [BUTTON_COUNT]u16 = [_]u16{0} ** BUTTON_COUNT;
+    const buttons = cfg.buttons orelse return codes;
+    var it = buttons.map.iterator();
+    while (it.next()) |entry| {
+        const btn_id = std.meta.stringToEnum(state.ButtonId, entry.key_ptr.*) orelse continue;
+        codes[@intFromEnum(btn_id)] = try input_codes.resolveBtnCode(entry.value_ptr.*);
+    }
+    return codes;
+}
+
 pub const UinputDevice = struct {
     fd: std.posix.fd_t,
     prev: state.GamepadState = .{},
@@ -157,17 +177,12 @@ pub const UinputDevice = struct {
         var axis_codes: [16]u16 = undefined;
         var axis_state_offsets: [16]AxisStateField = undefined;
         var axis_count: usize = 0;
-        var has_dpad_hat = false;
+        const has_dpad_hat = dpadIsHat(cfg);
 
         if (cfg.axes != null) has_abs = true;
         if (cfg.buttons != null) has_key = true;
-        if (cfg.dpad) |dp| {
-            if (std.mem.eql(u8, dp.type, "hat")) {
-                has_abs = true;
-                has_dpad_hat = true;
-            } else {
-                has_key = true;
-            }
+        if (cfg.dpad != null) {
+            if (has_dpad_hat) has_abs = true else has_key = true;
         }
         if (cfg.force_feedback != null) has_ff = true;
 
@@ -194,23 +209,15 @@ pub const UinputDevice = struct {
             try ioctlInt(fd, UI_SET_ABSBIT, c.ABS_HAT0Y);
         }
 
-        var button_codes: [BUTTON_COUNT]u16 = [_]u16{0} ** BUTTON_COUNT;
-        if (cfg.buttons) |buttons| {
-            var it = buttons.map.iterator();
-            while (it.next()) |entry| {
-                const btn_id = std.meta.stringToEnum(state.ButtonId, entry.key_ptr.*) orelse continue;
-                const code = try input_codes.resolveBtnCode(entry.value_ptr.*);
-                try ioctlInt(fd, UI_SET_KEYBIT, @intCast(code));
-                button_codes[@intFromEnum(btn_id)] = code;
-            }
+        const button_codes = try resolveButtonCodes(cfg);
+        for (button_codes) |code| {
+            if (code != 0) try ioctlInt(fd, UI_SET_KEYBIT, @intCast(code));
         }
-        if (cfg.dpad) |dp| {
-            if (!std.mem.eql(u8, dp.type, "hat")) {
-                try ioctlInt(fd, UI_SET_KEYBIT, c.BTN_DPAD_UP);
-                try ioctlInt(fd, UI_SET_KEYBIT, c.BTN_DPAD_DOWN);
-                try ioctlInt(fd, UI_SET_KEYBIT, c.BTN_DPAD_LEFT);
-                try ioctlInt(fd, UI_SET_KEYBIT, c.BTN_DPAD_RIGHT);
-            }
+        if (cfg.dpad != null and !has_dpad_hat) {
+            try ioctlInt(fd, UI_SET_KEYBIT, c.BTN_DPAD_UP);
+            try ioctlInt(fd, UI_SET_KEYBIT, c.BTN_DPAD_DOWN);
+            try ioctlInt(fd, UI_SET_KEYBIT, c.BTN_DPAD_LEFT);
+            try ioctlInt(fd, UI_SET_KEYBIT, c.BTN_DPAD_RIGHT);
         }
         if (has_ff) try ioctlInt(fd, UI_SET_FFBIT, c.FF_RUMBLE);
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -108,6 +108,7 @@ pub const testing_support = struct {
     pub const aux_drt = @import("test/aux_drt.zig");
     pub const interpreter_e2e_test = @import("test/interpreter_e2e_test.zig");
     pub const mapper_e2e_test = @import("test/mapper_e2e_test.zig");
+    pub const dpad_hat_e2e_test = @import("test/dpad_hat_e2e_test.zig");
     pub const gyro_stick_e2e_test = @import("test/gyro_stick_e2e_test.zig");
     pub const macro_e2e_test = @import("test/macro_e2e_test.zig");
     pub const macro_gamepad_button_test = @import("test/macro_gamepad_button_test.zig");

--- a/src/test/dpad_hat_e2e_test.zig
+++ b/src/test/dpad_hat_e2e_test.zig
@@ -2,10 +2,15 @@ const std = @import("std");
 const testing = std.testing;
 
 const device_mod = @import("../config/device.zig");
-const input_codes = @import("../config/input_codes.zig");
 const interpreter_mod = @import("../core/interpreter.zig");
 const state_mod = @import("../core/state.zig");
+const uinput = @import("../io/uinput.zig");
 const helpers = @import("helpers.zig");
+
+const c = @cImport({
+    @cInclude("linux/input.h");
+    @cInclude("linux/input-event-codes.h");
+});
 
 const Interpreter = interpreter_mod.Interpreter;
 const GamepadState = state_mod.GamepadState;
@@ -53,6 +58,10 @@ fn expectedDy(hat: u8) i8 {
 // field, or four button_group bits. Every behavioural test below runs against
 // both so the engine cannot treat them differently.
 const Form = enum { hat, bits };
+
+/// The `[output.dpad] type` a test declares: `hat` emits ABS_HAT0X/Y, `buttons`
+/// emits BTN_DPAD_* key events.
+const OutputForm = enum { hat, buttons };
 
 const hat_device_toml =
     \\[device]
@@ -138,6 +147,13 @@ const output_buttons_toml =
     \\DPadRight = "BTN_DPAD_RIGHT"
     \\
 ;
+
+fn outputToml(out_form: OutputForm) []const u8 {
+    return switch (out_form) {
+        .hat => output_hat_toml,
+        .buttons => output_buttons_toml,
+    };
+}
 
 fn deviceToml(allocator: std.mem.Allocator, form: Form, output: []const u8) ![]u8 {
     const base = switch (form) {
@@ -261,11 +277,63 @@ test "dpad hat: bits-mode hat field decodes identically to offset mode" {
     }
 }
 
+/// Push one emitted state through the real uinput backend over a pipe, with
+/// `[output]` resolved the way `UinputDevice.create` resolves it for a live
+/// node. Every call starts from a fresh device, so the events describe the
+/// whole non-neutral state rather than a diff against an earlier frame.
+fn emitOnce(out_cfg: *const device_mod.OutputConfig, s: GamepadState, out: []c.input_event) !usize {
+    const pfds = try std.posix.pipe2(.{ .NONBLOCK = true });
+    defer std.posix.close(pfds[0]);
+    defer std.posix.close(pfds[1]);
+
+    var dev = uinput.UinputDevice{
+        .fd = pfds[1],
+        .button_codes = try uinput.resolveButtonCodes(out_cfg),
+        .has_dpad_hat = uinput.dpadIsHat(out_cfg),
+    };
+    try dev.emit(s);
+
+    const bytes = std.posix.read(pfds[0], std.mem.sliceAsBytes(out)) catch return 0;
+    return bytes / @sizeOf(c.input_event);
+}
+
+fn eventValue(evs: []const c.input_event, ev_type: u16, code: u16) ?i32 {
+    for (evs) |e| {
+        if (e.type == ev_type and e.code == code) return e.value;
+    }
+    return null;
+}
+
+/// The wire events must carry the d-pad in the form `[output.dpad]` declares:
+/// ABS_HAT0X/Y for `type = "hat"`, BTN_DPAD_* key presses for `type = "buttons"`,
+/// and nothing of the other form. `out_form` is what the test declared, so the
+/// expectation never moves with the code that resolves the declaration.
+fn expectDpadOutput(out_form: OutputForm, hat: u8, evs: []const c.input_event) !void {
+    const hat_form = out_form == .hat;
+    const bits = expectedDpadBits(hat);
+
+    const want_x: ?i32 = if (hat_form and expectedDx(hat) != 0) expectedDx(hat) else null;
+    const want_y: ?i32 = if (hat_form and expectedDy(hat) != 0) expectedDy(hat) else null;
+    try testing.expectEqual(want_x, eventValue(evs, c.EV_ABS, c.ABS_HAT0X));
+    try testing.expectEqual(want_y, eventValue(evs, c.EV_ABS, c.ABS_HAT0Y));
+
+    const dpad_keys = [_]struct { id: ButtonId, code: u16 }{
+        .{ .id = .DPadUp, .code = c.BTN_DPAD_UP },
+        .{ .id = .DPadDown, .code = c.BTN_DPAD_DOWN },
+        .{ .id = .DPadLeft, .code = c.BTN_DPAD_LEFT },
+        .{ .id = .DPadRight, .code = c.BTN_DPAD_RIGHT },
+    };
+    for (dpad_keys) |k| {
+        const want: ?i32 = if (!hat_form and bits & btn(k.id) != 0) 1 else null;
+        try testing.expectEqual(want, eventValue(evs, c.EV_KEY, k.code));
+    }
+}
+
 // --- mapper path and no-mapper path, for both output.dpad types ---
 
-fn runMapperPath(form: Form, output: []const u8, mapping_toml: []const u8) !void {
+fn runMapperPath(form: Form, out_form: OutputForm, mapping_toml: []const u8) !void {
     const allocator = testing.allocator;
-    const toml = try deviceToml(allocator, form, output);
+    const toml = try deviceToml(allocator, form, outputToml(out_form));
     defer allocator.free(toml);
     const parsed = try device_mod.parseString(allocator, toml);
     defer parsed.deinit();
@@ -273,6 +341,8 @@ fn runMapperPath(form: Form, output: []const u8, mapping_toml: []const u8) !void
 
     var ctx = try helpers.makeMapper(mapping_toml, allocator);
     defer ctx.deinit();
+
+    const out_cfg = parsed.value.output orelse return error.NoOutput;
 
     for (0..16) |i| {
         const hat: u8 = @intCast(i);
@@ -282,16 +352,22 @@ fn runMapperPath(form: Form, output: []const u8, mapping_toml: []const u8) !void
         try testing.expectEqual(expectedDx(hat), ev.gamepad.dpad_x);
         try testing.expectEqual(expectedDy(hat), ev.gamepad.dpad_y);
         try testing.expectEqual(expectedDpadBits(hat), ev.gamepad.buttons & dpadMask());
+
+        var evs: [16]c.input_event = undefined;
+        const n = try emitOnce(&out_cfg, ev.gamepad, &evs);
+        try expectDpadOutput(out_form, hat, evs[0..n]);
     }
 }
 
-fn runNoMapperPath(form: Form, output: []const u8) !void {
+fn runNoMapperPath(form: Form, out_form: OutputForm) !void {
     const allocator = testing.allocator;
-    const toml = try deviceToml(allocator, form, output);
+    const toml = try deviceToml(allocator, form, outputToml(out_form));
     defer allocator.free(toml);
     const parsed = try device_mod.parseString(allocator, toml);
     defer parsed.deinit();
     const interp = Interpreter.init(&parsed.value);
+
+    const out_cfg = parsed.value.output orelse return error.NoOutput;
 
     // Mirrors the mapper-less branch of the event loop: accumulate the delta,
     // then derive the hat axes before emitting.
@@ -305,54 +381,34 @@ fn runNoMapperPath(form: Form, output: []const u8) !void {
         try testing.expectEqual(expectedDx(hat), gs.dpad_x);
         try testing.expectEqual(expectedDy(hat), gs.dpad_y);
         try testing.expectEqual(expectedDpadBits(hat), gs.buttons & dpadMask());
+
+        var evs: [16]c.input_event = undefined;
+        const n = try emitOnce(&out_cfg, gs, &evs);
+        try expectDpadOutput(out_form, hat, evs[0..n]);
     }
 }
 
 test "dpad hat: mapper path, output.dpad.type = hat" {
-    try runMapperPath(.hat, output_hat_toml, "");
+    try runMapperPath(.hat, .hat, "");
 }
 
 test "dpad hat: mapper path, output.dpad.type = buttons" {
-    try runMapperPath(.hat, output_buttons_toml, "");
+    try runMapperPath(.hat, .buttons, "");
 }
 
 test "dpad hat: no-mapper path, output.dpad.type = hat" {
-    try runNoMapperPath(.hat, output_hat_toml);
+    try runNoMapperPath(.hat, .hat);
 }
 
 test "dpad hat: no-mapper path, output.dpad.type = buttons" {
-    try runNoMapperPath(.hat, output_buttons_toml);
+    try runNoMapperPath(.hat, .buttons);
 }
 
 test "dpad bits: mapper path and no-mapper path, both output types" {
-    try runMapperPath(.bits, output_hat_toml, "");
-    try runMapperPath(.bits, output_buttons_toml, "");
-    try runNoMapperPath(.bits, output_hat_toml);
-    try runNoMapperPath(.bits, output_buttons_toml);
-}
-
-test "dpad hat: output.dpad.type = buttons declares the four BTN_DPAD codes" {
-    const allocator = testing.allocator;
-    const toml = try deviceToml(allocator, .hat, output_buttons_toml);
-    defer allocator.free(toml);
-    const parsed = try device_mod.parseString(allocator, toml);
-    defer parsed.deinit();
-
-    const out = parsed.value.output orelse return error.NoOutput;
-    const buttons = out.buttons orelse return error.NoOutputButtons;
-    const expected = [_]struct { name: []const u8, code: []const u8 }{
-        .{ .name = "DPadUp", .code = "BTN_DPAD_UP" },
-        .{ .name = "DPadDown", .code = "BTN_DPAD_DOWN" },
-        .{ .name = "DPadLeft", .code = "BTN_DPAD_LEFT" },
-        .{ .name = "DPadRight", .code = "BTN_DPAD_RIGHT" },
-    };
-    for (expected) |e| {
-        const declared = buttons.map.get(e.name) orelse return error.MissingDpadButton;
-        try testing.expectEqual(
-            try input_codes.resolveBtnCode(e.code),
-            try input_codes.resolveBtnCode(declared),
-        );
-    }
+    try runMapperPath(.bits, .hat, "");
+    try runMapperPath(.bits, .buttons, "");
+    try runNoMapperPath(.bits, .hat);
+    try runNoMapperPath(.bits, .buttons);
 }
 
 // --- remap / layer / arrows / suppress_gamepad parity across input forms ---

--- a/src/test/dpad_hat_e2e_test.zig
+++ b/src/test/dpad_hat_e2e_test.zig
@@ -1,0 +1,686 @@
+const std = @import("std");
+const testing = std.testing;
+
+const device_mod = @import("../config/device.zig");
+const input_codes = @import("../config/input_codes.zig");
+const interpreter_mod = @import("../core/interpreter.zig");
+const state_mod = @import("../core/state.zig");
+const helpers = @import("helpers.zig");
+
+const Interpreter = interpreter_mod.Interpreter;
+const GamepadState = state_mod.GamepadState;
+const GamepadStateDelta = state_mod.GamepadStateDelta;
+const ButtonId = state_mod.ButtonId;
+
+fn btn(id: ButtonId) u64 {
+    return @as(u64, 1) << @as(u6, @intCast(@intFromEnum(id)));
+}
+
+fn dpadMask() u64 {
+    return btn(.DPadUp) | btn(.DPadDown) | btn(.DPadLeft) | btn(.DPadRight);
+}
+
+/// HID hat switch: 0=N, 1=NE, 2=E, 3=SE, 4=S, 5=SW, 6=W, 7=NW, >=8 neutral.
+fn expectedDpadBits(hat: u8) u64 {
+    return switch (hat) {
+        0 => btn(.DPadUp),
+        1 => btn(.DPadUp) | btn(.DPadRight),
+        2 => btn(.DPadRight),
+        3 => btn(.DPadDown) | btn(.DPadRight),
+        4 => btn(.DPadDown),
+        5 => btn(.DPadDown) | btn(.DPadLeft),
+        6 => btn(.DPadLeft),
+        7 => btn(.DPadUp) | btn(.DPadLeft),
+        else => 0,
+    };
+}
+
+fn expectedDx(hat: u8) i8 {
+    const bits = expectedDpadBits(hat);
+    const right: i8 = if (bits & btn(.DPadRight) != 0) 1 else 0;
+    const left: i8 = if (bits & btn(.DPadLeft) != 0) 1 else 0;
+    return right - left;
+}
+
+fn expectedDy(hat: u8) i8 {
+    const bits = expectedDpadBits(hat);
+    const down: i8 = if (bits & btn(.DPadDown) != 0) 1 else 0;
+    const up: i8 = if (bits & btn(.DPadUp) != 0) 1 else 0;
+    return down - up;
+}
+
+// The two declaration forms a device can use for its dpad: a HID hat enum
+// field, or four button_group bits. Every behavioural test below runs against
+// both so the engine cannot treat them differently.
+const Form = enum { hat, bits };
+
+const hat_device_toml =
+    \\[device]
+    \\name = "Hat Pad"
+    \\vid = 0x1234
+    \\pid = 0x5678
+    \\
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\
+    \\[[report]]
+    \\name = "input"
+    \\interface = 0
+    \\size = 4
+    \\
+    \\[report.match]
+    \\offset = 0
+    \\expect = [0x01]
+    \\
+    \\[report.fields]
+    \\dpad = { offset = 1, type = "u8" }
+    \\
+    \\[report.button_group]
+    \\source = { offset = 2, size = 1 }
+    \\map = { A = 0, LT = 1 }
+    \\
+;
+
+const bits_device_toml =
+    \\[device]
+    \\name = "Bits Pad"
+    \\vid = 0x1234
+    \\pid = 0x5679
+    \\
+    \\[[device.interface]]
+    \\id = 0
+    \\class = "hid"
+    \\
+    \\[[report]]
+    \\name = "input"
+    \\interface = 0
+    \\size = 4
+    \\
+    \\[report.match]
+    \\offset = 0
+    \\expect = [0x01]
+    \\
+    \\[report.button_group]
+    \\source = { offset = 1, size = 1 }
+    \\map = { DPadUp = 0, DPadDown = 1, DPadLeft = 2, DPadRight = 3, A = 4, LT = 5 }
+    \\
+;
+
+const output_hat_toml =
+    \\[output]
+    \\name = "Virtual Pad"
+    \\vid = 0x045e
+    \\pid = 0x028e
+    \\
+    \\[output.dpad]
+    \\type = "hat"
+    \\
+    \\[output.buttons]
+    \\A = "BTN_SOUTH"
+    \\
+;
+
+const output_buttons_toml =
+    \\[output]
+    \\name = "Virtual Pad"
+    \\vid = 0x045e
+    \\pid = 0x028e
+    \\
+    \\[output.dpad]
+    \\type = "buttons"
+    \\
+    \\[output.buttons]
+    \\A = "BTN_SOUTH"
+    \\DPadUp = "BTN_DPAD_UP"
+    \\DPadDown = "BTN_DPAD_DOWN"
+    \\DPadLeft = "BTN_DPAD_LEFT"
+    \\DPadRight = "BTN_DPAD_RIGHT"
+    \\
+;
+
+fn deviceToml(allocator: std.mem.Allocator, form: Form, output: []const u8) ![]u8 {
+    const base = switch (form) {
+        .hat => hat_device_toml,
+        .bits => bits_device_toml,
+    };
+    return std.fmt.allocPrint(allocator, "{s}{s}", .{ base, output });
+}
+
+/// Encode one input report carrying `hat` plus the optional A / LT buttons, in
+/// whichever form the device declares.
+fn buildReport(form: Form, hat: u8, a: bool, lt: bool) [4]u8 {
+    var raw = [_]u8{ 0x01, 0, 0, 0 };
+    switch (form) {
+        .hat => {
+            raw[1] = hat;
+            if (a) raw[2] |= 1 << 0;
+            if (lt) raw[2] |= 1 << 1;
+        },
+        .bits => {
+            const bits = expectedDpadBits(hat);
+            if (bits & btn(.DPadUp) != 0) raw[1] |= 1 << 0;
+            if (bits & btn(.DPadDown) != 0) raw[1] |= 1 << 1;
+            if (bits & btn(.DPadLeft) != 0) raw[1] |= 1 << 2;
+            if (bits & btn(.DPadRight) != 0) raw[1] |= 1 << 3;
+            if (a) raw[1] |= 1 << 4;
+            if (lt) raw[1] |= 1 << 5;
+        },
+    }
+    return raw;
+}
+
+const KeyEvent = struct { code: u16, pressed: bool };
+
+fn collectKeys(aux: anytype, out: *std.ArrayList(KeyEvent), allocator: std.mem.Allocator) !void {
+    for (aux.slice()) |e| switch (e) {
+        .key => |k| try out.append(allocator, .{ .code = k.code, .pressed = k.pressed }),
+        else => {},
+    };
+}
+
+// --- interpreter: hat enum decodes into DPad* button bits ---
+
+test "dpad hat: interpreter decodes every hat value into DPad button bits" {
+    const allocator = testing.allocator;
+    const toml = try deviceToml(allocator, .hat, output_hat_toml);
+    defer allocator.free(toml);
+    const parsed = try device_mod.parseString(allocator, toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    for (0..16) |i| {
+        const hat: u8 = @intCast(i);
+        const raw = buildReport(.hat, hat, false, false);
+        const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+        const buttons = delta.buttons orelse return error.NoButtons;
+        try testing.expectEqual(expectedDpadBits(hat), buttons & dpadMask());
+    }
+}
+
+test "dpad hat: a report carrying only a hat field still yields button bits" {
+    const allocator = testing.allocator;
+    const toml =
+        \\[device]
+        \\name = "Hat Only"
+        \\vid = 0x1234
+        \\pid = 0x5680
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\
+        \\[[report]]
+        \\name = "input"
+        \\interface = 0
+        \\size = 4
+        \\
+        \\[report.fields]
+        \\dpad = { offset = 1, type = "u8" }
+    ;
+    const parsed = try device_mod.parseString(allocator, toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    var raw = [_]u8{ 0, 6, 0, 0 };
+    const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+    const buttons = delta.buttons orelse return error.NoButtons;
+    try testing.expectEqual(btn(.DPadLeft), buttons & dpadMask());
+}
+
+test "dpad hat: bits-mode hat field decodes identically to offset mode" {
+    const allocator = testing.allocator;
+    const toml =
+        \\[device]
+        \\name = "Hat Nibble"
+        \\vid = 0x1234
+        \\pid = 0x5681
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\
+        \\[[report]]
+        \\name = "input"
+        \\interface = 0
+        \\size = 4
+        \\
+        \\[report.fields]
+        \\dpad = { bits = [1, 4, 4] }
+    ;
+    const parsed = try device_mod.parseString(allocator, toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    for (0..16) |i| {
+        const hat: u8 = @intCast(i);
+        var raw = [_]u8{ 0, hat << 4, 0, 0 };
+        const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+        const buttons = delta.buttons orelse return error.NoButtons;
+        try testing.expectEqual(expectedDpadBits(hat), buttons & dpadMask());
+    }
+}
+
+// --- mapper path and no-mapper path, for both output.dpad types ---
+
+fn runMapperPath(form: Form, output: []const u8, mapping_toml: []const u8) !void {
+    const allocator = testing.allocator;
+    const toml = try deviceToml(allocator, form, output);
+    defer allocator.free(toml);
+    const parsed = try device_mod.parseString(allocator, toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    var ctx = try helpers.makeMapper(mapping_toml, allocator);
+    defer ctx.deinit();
+
+    for (0..16) |i| {
+        const hat: u8 = @intCast(i);
+        const raw = buildReport(form, hat, false, false);
+        const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+        const ev = try ctx.mapper.apply(delta, 16, 0);
+        try testing.expectEqual(expectedDx(hat), ev.gamepad.dpad_x);
+        try testing.expectEqual(expectedDy(hat), ev.gamepad.dpad_y);
+        try testing.expectEqual(expectedDpadBits(hat), ev.gamepad.buttons & dpadMask());
+    }
+}
+
+fn runNoMapperPath(form: Form, output: []const u8) !void {
+    const allocator = testing.allocator;
+    const toml = try deviceToml(allocator, form, output);
+    defer allocator.free(toml);
+    const parsed = try device_mod.parseString(allocator, toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    // Mirrors the mapper-less branch of the event loop: accumulate the delta,
+    // then derive the hat axes before emitting.
+    var gs = GamepadState{};
+    for (0..16) |i| {
+        const hat: u8 = @intCast(i);
+        const raw = buildReport(form, hat, false, false);
+        const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+        gs.applyDelta(delta);
+        gs.synthesizeDpadAxes();
+        try testing.expectEqual(expectedDx(hat), gs.dpad_x);
+        try testing.expectEqual(expectedDy(hat), gs.dpad_y);
+        try testing.expectEqual(expectedDpadBits(hat), gs.buttons & dpadMask());
+    }
+}
+
+test "dpad hat: mapper path, output.dpad.type = hat" {
+    try runMapperPath(.hat, output_hat_toml, "");
+}
+
+test "dpad hat: mapper path, output.dpad.type = buttons" {
+    try runMapperPath(.hat, output_buttons_toml, "");
+}
+
+test "dpad hat: no-mapper path, output.dpad.type = hat" {
+    try runNoMapperPath(.hat, output_hat_toml);
+}
+
+test "dpad hat: no-mapper path, output.dpad.type = buttons" {
+    try runNoMapperPath(.hat, output_buttons_toml);
+}
+
+test "dpad bits: mapper path and no-mapper path, both output types" {
+    try runMapperPath(.bits, output_hat_toml, "");
+    try runMapperPath(.bits, output_buttons_toml, "");
+    try runNoMapperPath(.bits, output_hat_toml);
+    try runNoMapperPath(.bits, output_buttons_toml);
+}
+
+test "dpad hat: output.dpad.type = buttons declares the four BTN_DPAD codes" {
+    const allocator = testing.allocator;
+    const toml = try deviceToml(allocator, .hat, output_buttons_toml);
+    defer allocator.free(toml);
+    const parsed = try device_mod.parseString(allocator, toml);
+    defer parsed.deinit();
+
+    const out = parsed.value.output orelse return error.NoOutput;
+    const buttons = out.buttons orelse return error.NoOutputButtons;
+    const expected = [_]struct { name: []const u8, code: []const u8 }{
+        .{ .name = "DPadUp", .code = "BTN_DPAD_UP" },
+        .{ .name = "DPadDown", .code = "BTN_DPAD_DOWN" },
+        .{ .name = "DPadLeft", .code = "BTN_DPAD_LEFT" },
+        .{ .name = "DPadRight", .code = "BTN_DPAD_RIGHT" },
+    };
+    for (expected) |e| {
+        const declared = buttons.map.get(e.name) orelse return error.MissingDpadButton;
+        try testing.expectEqual(
+            try input_codes.resolveBtnCode(e.code),
+            try input_codes.resolveBtnCode(declared),
+        );
+    }
+}
+
+// --- remap / layer / arrows / suppress_gamepad parity across input forms ---
+
+fn runRemap(form: Form) !void {
+    const allocator = testing.allocator;
+    const toml = try deviceToml(allocator, form, output_hat_toml);
+    defer allocator.free(toml);
+    const parsed = try device_mod.parseString(allocator, toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    var ctx = try helpers.makeMapper(
+        \\[remap]
+        \\DPadUp = "A"
+    , allocator);
+    defer ctx.deinit();
+
+    const raw = buildReport(form, 0, false, false);
+    const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+    const ev = try ctx.mapper.apply(delta, 16, 0);
+
+    try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btn(.DPadUp));
+    try testing.expect(ev.gamepad.buttons & btn(.A) != 0);
+    try testing.expectEqual(@as(i8, 0), ev.gamepad.dpad_y);
+}
+
+test "dpad: remap of DPadUp applies to hat input" {
+    try runRemap(.hat);
+}
+
+test "dpad: remap of DPadUp applies to button-bit input" {
+    try runRemap(.bits);
+}
+
+fn runArrows(form: Form, mapping_toml: []const u8) !void {
+    const allocator = testing.allocator;
+    const toml = try deviceToml(allocator, form, output_hat_toml);
+    defer allocator.free(toml);
+    const parsed = try device_mod.parseString(allocator, toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    var ctx = try helpers.makeMapper(mapping_toml, allocator);
+    defer ctx.deinit();
+
+    var keys: std.ArrayList(KeyEvent) = .{};
+    defer keys.deinit(allocator);
+
+    // hat 0 (up) → KEY_UP press
+    const up_raw = buildReport(form, 0, false, false);
+    const up_delta = (try interp.processReport(0, &up_raw)) orelse return error.NoMatch;
+    const up_ev = try ctx.mapper.apply(up_delta, 16, 0);
+    try collectKeys(up_ev.aux, &keys, allocator);
+    try testing.expectEqual(@as(usize, 1), keys.items.len);
+    try testing.expectEqual(helpers.KEY_UP, keys.items[0].code);
+    try testing.expect(keys.items[0].pressed);
+
+    // hat 8 (neutral) → KEY_UP release
+    keys.clearRetainingCapacity();
+    const rel_raw = buildReport(form, 8, false, false);
+    const rel_delta = (try interp.processReport(0, &rel_raw)) orelse return error.NoMatch;
+    const rel_ev = try ctx.mapper.apply(rel_delta, 16, 0);
+    try collectKeys(rel_ev.aux, &keys, allocator);
+    try testing.expectEqual(@as(usize, 1), keys.items.len);
+    try testing.expectEqual(helpers.KEY_UP, keys.items[0].code);
+    try testing.expect(!keys.items[0].pressed);
+
+    // hat 1 (up-right) → two presses
+    keys.clearRetainingCapacity();
+    const diag_raw = buildReport(form, 1, false, false);
+    const diag_delta = (try interp.processReport(0, &diag_raw)) orelse return error.NoMatch;
+    const diag_ev = try ctx.mapper.apply(diag_delta, 16, 0);
+    try collectKeys(diag_ev.aux, &keys, allocator);
+    try testing.expectEqual(@as(usize, 2), keys.items.len);
+    var got_up = false;
+    var got_right = false;
+    for (keys.items) |k| {
+        if (k.code == helpers.KEY_UP and k.pressed) got_up = true;
+        if (k.code == helpers.KEY_RIGHT and k.pressed) got_right = true;
+    }
+    try testing.expect(got_up);
+    try testing.expect(got_right);
+}
+
+const arrows_mapping =
+    \\[dpad]
+    \\mode = "arrows"
+;
+
+const arrows_suppress_mapping =
+    \\[dpad]
+    \\mode = "arrows"
+    \\suppress_gamepad = true
+;
+
+test "dpad: arrows mode emits KEY events for hat input" {
+    try runArrows(.hat, arrows_mapping);
+}
+
+test "dpad: arrows mode emits KEY events for button-bit input" {
+    try runArrows(.bits, arrows_mapping);
+}
+
+test "dpad: arrows mode with suppress_gamepad emits KEY events for hat input" {
+    try runArrows(.hat, arrows_suppress_mapping);
+}
+
+test "dpad: arrows mode with suppress_gamepad emits KEY events for button-bit input" {
+    try runArrows(.bits, arrows_suppress_mapping);
+}
+
+fn runSuppress(form: Form) !void {
+    const allocator = testing.allocator;
+    const toml = try deviceToml(allocator, form, output_hat_toml);
+    defer allocator.free(toml);
+    const parsed = try device_mod.parseString(allocator, toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    var ctx = try helpers.makeMapper(arrows_suppress_mapping, allocator);
+    defer ctx.deinit();
+
+    const raw = buildReport(form, 0, false, false);
+    const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+    const ev = try ctx.mapper.apply(delta, 16, 0);
+
+    try testing.expectEqual(@as(i8, 0), ev.gamepad.dpad_x);
+    try testing.expectEqual(@as(i8, 0), ev.gamepad.dpad_y);
+    try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & dpadMask());
+}
+
+test "dpad: suppress_gamepad removes both hat axes and DPad bits for hat input" {
+    try runSuppress(.hat);
+}
+
+test "dpad: suppress_gamepad removes both hat axes and DPad bits for button-bit input" {
+    try runSuppress(.bits);
+}
+
+fn runLayerArrows(form: Form) !void {
+    const allocator = testing.allocator;
+    const toml = try deviceToml(allocator, form, output_hat_toml);
+    defer allocator.free(toml);
+    const parsed = try device_mod.parseString(allocator, toml);
+    defer parsed.deinit();
+    const interp = Interpreter.init(&parsed.value);
+
+    var ctx = try helpers.makeMapper(
+        \\[[layer]]
+        \\name = "nav"
+        \\trigger = "LT"
+        \\activation = "hold"
+        \\
+        \\[layer.dpad]
+        \\mode = "arrows"
+        \\suppress_gamepad = true
+    , allocator);
+    defer ctx.deinit();
+
+    // Hold LT past the hold timeout so the layer activates.
+    const hold_raw = buildReport(form, 8, false, true);
+    const hold_delta = (try interp.processReport(0, &hold_raw)) orelse return error.NoMatch;
+    _ = try ctx.mapper.apply(hold_delta, 16, 0);
+    _ = ctx.mapper.onLayerTimerExpired();
+
+    const raw = buildReport(form, 4, false, true);
+    const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
+    const ev = try ctx.mapper.apply(delta, 16, 0);
+
+    var keys: std.ArrayList(KeyEvent) = .{};
+    defer keys.deinit(allocator);
+    try collectKeys(ev.aux, &keys, allocator);
+
+    var got_down = false;
+    for (keys.items) |k| {
+        if (k.code == helpers.KEY_DOWN and k.pressed) got_down = true;
+    }
+    try testing.expect(got_down);
+    try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & dpadMask());
+}
+
+test "dpad: layer dpad override applies to hat input" {
+    try runLayerArrows(.hat);
+}
+
+test "dpad: layer dpad override applies to button-bit input" {
+    try runLayerArrows(.bits);
+}
+
+test "dpad: hat input and button-bit input produce identical mapper output" {
+    const allocator = testing.allocator;
+    const mappings = [_][]const u8{ "", arrows_mapping, arrows_suppress_mapping };
+
+    for (mappings) |mapping_toml| {
+        const hat_toml = try deviceToml(allocator, .hat, output_hat_toml);
+        defer allocator.free(hat_toml);
+        const hat_parsed = try device_mod.parseString(allocator, hat_toml);
+        defer hat_parsed.deinit();
+        const hat_interp = Interpreter.init(&hat_parsed.value);
+
+        const bits_toml = try deviceToml(allocator, .bits, output_hat_toml);
+        defer allocator.free(bits_toml);
+        const bits_parsed = try device_mod.parseString(allocator, bits_toml);
+        defer bits_parsed.deinit();
+        const bits_interp = Interpreter.init(&bits_parsed.value);
+
+        var hat_ctx = try helpers.makeMapper(mapping_toml, allocator);
+        defer hat_ctx.deinit();
+        var bits_ctx = try helpers.makeMapper(mapping_toml, allocator);
+        defer bits_ctx.deinit();
+
+        var hat_keys: std.ArrayList(KeyEvent) = .{};
+        defer hat_keys.deinit(allocator);
+        var bits_keys: std.ArrayList(KeyEvent) = .{};
+        defer bits_keys.deinit(allocator);
+
+        for (0..16) |i| {
+            const hat: u8 = @intCast(i);
+            const hat_raw = buildReport(.hat, hat, false, false);
+            const bits_raw = buildReport(.bits, hat, false, false);
+            const hat_delta = (try hat_interp.processReport(0, &hat_raw)) orelse return error.NoMatch;
+            const bits_delta = (try bits_interp.processReport(0, &bits_raw)) orelse return error.NoMatch;
+
+            const hat_ev = try hat_ctx.mapper.apply(hat_delta, 16, 0);
+            const bits_ev = try bits_ctx.mapper.apply(bits_delta, 16, 0);
+
+            try testing.expectEqual(hat_ev.gamepad.dpad_x, bits_ev.gamepad.dpad_x);
+            try testing.expectEqual(hat_ev.gamepad.dpad_y, bits_ev.gamepad.dpad_y);
+            try testing.expectEqual(
+                hat_ev.gamepad.buttons & dpadMask(),
+                bits_ev.gamepad.buttons & dpadMask(),
+            );
+
+            hat_keys.clearRetainingCapacity();
+            bits_keys.clearRetainingCapacity();
+            try collectKeys(hat_ev.aux, &hat_keys, allocator);
+            try collectKeys(bits_ev.aux, &bits_keys, allocator);
+            try testing.expectEqual(hat_keys.items.len, bits_keys.items.len);
+            for (hat_keys.items, bits_keys.items) |a, b| {
+                try testing.expectEqual(a.code, b.code);
+                try testing.expectEqual(a.pressed, b.pressed);
+            }
+        }
+    }
+}
+
+// --- validate: a dpad hat field and DPad* button bits cannot coexist ---
+
+test "dpad validate: hat field plus DPad button_group in one report is rejected" {
+    const allocator = testing.allocator;
+    const toml =
+        \\[device]
+        \\name = "Double"
+        \\vid = 1
+        \\pid = 2
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\
+        \\[[report]]
+        \\name = "input"
+        \\interface = 0
+        \\size = 4
+        \\
+        \\[report.fields]
+        \\dpad = { offset = 1, type = "u8" }
+        \\
+        \\[report.button_group]
+        \\source = { offset = 2, size = 1 }
+        \\map = { DPadUp = 0, A = 1 }
+    ;
+    try testing.expectError(error.InvalidConfig, device_mod.parseString(allocator, toml));
+}
+
+test "dpad validate: hat field and DPad button_group in different reports is rejected" {
+    const allocator = testing.allocator;
+    const toml =
+        \\[device]
+        \\name = "Double Split"
+        \\vid = 1
+        \\pid = 2
+        \\
+        \\[[device.interface]]
+        \\id = 0
+        \\class = "hid"
+        \\
+        \\[[report]]
+        \\name = "hat"
+        \\interface = 0
+        \\size = 4
+        \\
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x01]
+        \\
+        \\[report.fields]
+        \\dpad = { offset = 1, type = "u8" }
+        \\
+        \\[[report]]
+        \\name = "buttons"
+        \\interface = 0
+        \\size = 4
+        \\
+        \\[report.match]
+        \\offset = 0
+        \\expect = [0x02]
+        \\
+        \\[report.button_group]
+        \\source = { offset = 1, size = 1 }
+        \\map = { DPadRight = 0 }
+    ;
+    try testing.expectError(error.InvalidConfig, device_mod.parseString(allocator, toml));
+}
+
+test "dpad validate: hat field alone is accepted" {
+    const allocator = testing.allocator;
+    const toml = try deviceToml(allocator, .hat, output_hat_toml);
+    defer allocator.free(toml);
+    const parsed = try device_mod.parseString(allocator, toml);
+    defer parsed.deinit();
+}
+
+test "dpad validate: DPad button_group alone is accepted" {
+    const allocator = testing.allocator;
+    const toml = try deviceToml(allocator, .bits, output_buttons_toml);
+    defer allocator.free(toml);
+    const parsed = try device_mod.parseString(allocator, toml);
+    defer parsed.deinit();
+}

--- a/src/test/gen/config_gen.zig
+++ b/src/test/gen/config_gen.zig
@@ -46,6 +46,7 @@ pub fn randomDeviceConfig(rng: std.Random, buf: []u8) []const u8 {
     const n_fields = rng.intRangeAtMost(u8, 3, @min(8, @as(u8, @intCast(field_tags.len))));
     var used: [21]bool = .{false} ** 21;
     var next_offset: u8 = 1; // skip match byte
+    var dpad_field = false;
 
     for (0..n_fields) |fi| {
         const idx = if (fi == 0) blk: {
@@ -55,6 +56,7 @@ pub fn randomDeviceConfig(rng: std.Random, buf: []u8) []const u8 {
             break :blk forced;
         } else pickUnused(rng, &used, field_tags.len);
         const tag = field_tags[idx];
+        if (std.mem.eql(u8, tag, "dpad")) dpad_field = true;
         const type_idx = rng.intRangeAtMost(usize, 0, field_types.len - 1);
         const type_str = field_types[type_idx];
         const size: u8 = typeSize(type_str);
@@ -88,6 +90,13 @@ pub fn randomDeviceConfig(rng: std.Random, buf: []u8) []const u8 {
         w.print("[report.button_group]\nsource = {{ offset = {d}, size = {d} }}\nmap = {{ ", .{ bg_offset, bg_size }) catch return buf[0..fbs.pos];
         const n_btns = rng.intRangeAtMost(u8, 2, @min(4, bg_size * 8));
         var btn_used: [button_names.len]bool = .{false} ** button_names.len;
+        // A dpad hat field already owns the DPad* bits; claiming them in the
+        // button group too is rejected at load time.
+        if (dpad_field) {
+            for (button_names, 0..) |name, i| {
+                if (std.mem.startsWith(u8, name, "DPad")) btn_used[i] = true;
+            }
+        }
         for (0..n_btns) |i| {
             const bi = pickUnused(rng, &btn_used, button_names.len);
             if (i > 0) w.writeAll(", ") catch break;

--- a/src/test/gen/mapper_oracle.zig
+++ b/src/test/gen/mapper_oracle.zig
@@ -90,6 +90,17 @@ pub fn applyWithLayer(
     os.gs.applyDelta(delta);
     const cur_buttons = os.gs.buttons;
 
+    // Production synthesizes the dpad axes from the raw DPad* bits right after
+    // applyDelta so arrow-mode edge detection has them. Reimplemented here.
+    {
+        const up = (cur_buttons & btnMask(.DPadUp)) != 0;
+        const down = (cur_buttons & btnMask(.DPadDown)) != 0;
+        const left = (cur_buttons & btnMask(.DPadLeft)) != 0;
+        const right = (cur_buttons & btnMask(.DPadRight)) != 0;
+        os.gs.dpad_x = @as(i8, @intFromBool(right)) - @as(i8, @intFromBool(left));
+        os.gs.dpad_y = @as(i8, @intFromBool(down)) - @as(i8, @intFromBool(up));
+    }
+
     // [2] layer trigger processing with tap-hold FSM (only when not overridden)
     const layers = cfg.layer orelse &[0]LayerConfig{};
     if (active_layer_override == null) {
@@ -161,10 +172,9 @@ pub fn applyWithLayer(
     emit.buttons = (cur_buttons & ~suppressed_buttons) | injected_buttons;
 
     // Production (`mapper.zig` -> `emit_state.synthesizeDpadAxes()`) derives the
-    // emitted dpad hat axes purely from the post-remap DPad* button bits, NOT
-    // from the raw `delta.dpad_x/y` input. Independently reimplement that
-    // coupling here (no shared code with state.zig — TP5/F5) so the
-    // deterministic differential genuinely covers DPad-button -> hat-axis
+    // emitted dpad hat axes from the post-remap DPad* button bits. Independently
+    // reimplement that coupling here (no shared code with state.zig — TP5/F5) so
+    // the deterministic differential genuinely covers DPad-button -> hat-axis
     // synthesis, suppression, and DPad remap inject/suppress interaction.
     {
         const up = (emit.buttons & btnMask(.DPadUp)) != 0;
@@ -474,7 +484,7 @@ test "mapper_oracle: dpad arrows mode" {
     defer parsed.deinit();
 
     // dpad left
-    const out = apply(&os, .{ .dpad_x = -1 }, &parsed.value, 0);
+    const out = apply(&os, .{ .buttons = btnMask(.DPadLeft) }, &parsed.value, 0);
     try testing.expectEqual(@as(i8, 0), out.gamepad.dpad_x);
     var found_left = false;
     for (out.aux.slice()) |ev| {
@@ -623,10 +633,7 @@ test "mapper_oracle: suppress accumulates base + layer" {
 }
 
 test "mapper_oracle: dpad hat synthesized from DPad button bits" {
-    // Production (`mapper.zig` -> `synthesizeDpadAxes`) derives the emitted hat
-    // axes purely from the post-remap DPad* button bits, not from the raw
-    // `delta.dpad_x/y`. The oracle reimplements that coupling, so a raw
-    // axis-only delta with no DPad buttons emits a neutral hat...
+    // The DPad* button bits are the only source of the emitted hat axes.
     {
         var os = OracleState{};
         const parsed = try parseCfg(
@@ -635,12 +642,11 @@ test "mapper_oracle: dpad hat synthesized from DPad button bits" {
         );
         defer parsed.deinit();
 
-        const out = apply(&os, .{ .dpad_x = 1, .dpad_y = -1 }, &parsed.value, 0);
+        const out = apply(&os, .{ .buttons = 0 }, &parsed.value, 0);
         try testing.expectEqual(@as(i8, 0), out.gamepad.dpad_x);
         try testing.expectEqual(@as(i8, 0), out.gamepad.dpad_y);
         try testing.expectEqual(@as(usize, 0), out.aux.len);
     }
-    // ...while DPad button bits synthesize the corresponding hat axes.
     {
         var os = OracleState{};
         const parsed = try parseCfg(

--- a/src/test/gen/mapper_oracle.zig
+++ b/src/test/gen/mapper_oracle.zig
@@ -633,33 +633,24 @@ test "mapper_oracle: suppress accumulates base + layer" {
 }
 
 test "mapper_oracle: dpad hat synthesized from DPad button bits" {
-    // The DPad* button bits are the only source of the emitted hat axes.
-    {
-        var os = OracleState{};
-        const parsed = try parseCfg(
-            \\[dpad]
-            \\mode = "gamepad"
-        );
-        defer parsed.deinit();
+    // The DPad* button bits are the only source of the emitted hat axes, and
+    // the axes are re-derived every frame rather than latched.
+    var os = OracleState{};
+    const parsed = try parseCfg(
+        \\[dpad]
+        \\mode = "gamepad"
+    );
+    defer parsed.deinit();
 
-        const out = apply(&os, .{ .buttons = 0 }, &parsed.value, 0);
-        try testing.expectEqual(@as(i8, 0), out.gamepad.dpad_x);
-        try testing.expectEqual(@as(i8, 0), out.gamepad.dpad_y);
-        try testing.expectEqual(@as(usize, 0), out.aux.len);
-    }
-    {
-        var os = OracleState{};
-        const parsed = try parseCfg(
-            \\[dpad]
-            \\mode = "gamepad"
-        );
-        defer parsed.deinit();
+    const pressed = apply(&os, .{ .buttons = btnMask(.DPadRight) | btnMask(.DPadUp) }, &parsed.value, 0);
+    try testing.expectEqual(@as(i8, 1), pressed.gamepad.dpad_x);
+    try testing.expectEqual(@as(i8, -1), pressed.gamepad.dpad_y);
+    try testing.expectEqual(@as(usize, 0), pressed.aux.len);
 
-        const out = apply(&os, .{ .buttons = btnMask(.DPadRight) | btnMask(.DPadUp) }, &parsed.value, 0);
-        try testing.expectEqual(@as(i8, 1), out.gamepad.dpad_x);
-        try testing.expectEqual(@as(i8, -1), out.gamepad.dpad_y);
-        try testing.expectEqual(@as(usize, 0), out.aux.len);
-    }
+    const released = apply(&os, .{ .buttons = 0 }, &parsed.value, 0);
+    try testing.expectEqual(@as(i8, 0), released.gamepad.dpad_x);
+    try testing.expectEqual(@as(i8, 0), released.gamepad.dpad_y);
+    try testing.expectEqual(@as(usize, 0), released.aux.len);
 }
 
 test "mapper_oracle: prev_buttons in output" {

--- a/src/test/lean_oracle_client.zig
+++ b/src/test/lean_oracle_client.zig
@@ -108,17 +108,11 @@ pub const LeanOracle = struct {
         return @intCast(try parseUnsigned(result));
     }
 
-    pub fn queryDpadHat(self: *LeanOracle, value: u8) !struct { dx: i8, dy: i8 } {
+    pub fn queryDpadHat(self: *LeanOracle, value: u8) !u64 {
         var cmd_buf: [64]u8 = undefined;
         const cmd = std.fmt.bufPrint(&cmd_buf, "DPAD_HAT {d}", .{value}) catch return error.BufOverflow;
         const result = try self.sendRecv(cmd);
-        var it = std.mem.splitScalar(u8, result, ' ');
-        const dx_str = it.next() orelse return error.BadProtocol;
-        const dy_str = it.next() orelse return error.BadProtocol;
-        return .{
-            .dx = @intCast(try parseInt(dx_str)),
-            .dy = @intCast(try parseInt(dy_str)),
-        };
+        return parseUnsigned(result);
     }
 
     pub fn querySignExtend(self: *LeanOracle, value: u32, bit_count: u6) !i64 {

--- a/src/test/mapper_e2e_test.zig
+++ b/src/test/mapper_e2e_test.zig
@@ -387,7 +387,7 @@ test "e2e: dual uinput routing — same frame: gamepad remap + key remap both ro
 
 // --- 6. DPad arrows ---
 
-test "e2e: dpad arrows — dpad_y=-1 (first press) → KEY_UP press" {
+test "e2e: dpad arrows — DPadUp pressed → KEY_UP press" {
     const allocator = testing.allocator;
     var ctx = try makeMapper(
         \\[dpad]
@@ -396,8 +396,7 @@ test "e2e: dpad arrows — dpad_y=-1 (first press) → KEY_UP press" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    // prev dpad_y = 0 (default), current = -1
-    const ev = try m.apply(.{ .dpad_y = -1 }, 16, 0);
+    const ev = try m.apply(.{ .buttons = btnMask(.DPadUp) }, 16, 0);
     var found_key_up_press = false;
     for (ev.aux.slice()) |e| {
         switch (e) {
@@ -410,7 +409,7 @@ test "e2e: dpad arrows — dpad_y=-1 (first press) → KEY_UP press" {
     try testing.expect(found_key_up_press);
 }
 
-test "e2e: dpad arrows — dpad_y returns to 0 → KEY_UP release" {
+test "e2e: dpad arrows — DPadUp released → KEY_UP release" {
     const allocator = testing.allocator;
     var ctx = try makeMapper(
         \\[dpad]
@@ -419,11 +418,8 @@ test "e2e: dpad arrows — dpad_y returns to 0 → KEY_UP release" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    // Set prev to dpad_y = -1 by applying that state first
-    _ = try m.apply(.{ .dpad_y = -1 }, 16, 0);
-
-    // Now dpad_y returns to 0 → KEY_UP release
-    const ev = try m.apply(.{ .dpad_y = 0 }, 16, 0);
+    _ = try m.apply(.{ .buttons = btnMask(.DPadUp) }, 16, 0);
+    const ev = try m.apply(.{ .buttons = 0 }, 16, 0);
     var found_key_up_release = false;
     for (ev.aux.slice()) |e| {
         switch (e) {
@@ -436,10 +432,8 @@ test "e2e: dpad arrows — dpad_y returns to 0 → KEY_UP release" {
     try testing.expect(found_key_up_release);
 }
 
-test "e2e: dpad gamepad mode — dpad passes through unchanged, no aux KEY events" {
+test "e2e: dpad gamepad mode — DPad bits drive the hat axes, no aux KEY events" {
     const allocator = testing.allocator;
-    // Default mode is "gamepad". emit_state.synthesizeDpadAxes() derives dpad axes
-    // from button state, so drive the test via the DPadUp button bit.
     var ctx = try makeMapper("", allocator);
     defer ctx.deinit();
     var m = &ctx.mapper;
@@ -454,7 +448,7 @@ test "e2e: dpad gamepad mode — dpad passes through unchanged, no aux KEY event
     try testing.expectEqual(@as(i8, -1), ev.gamepad.dpad_y);
 }
 
-test "e2e: dpad arrows suppress_gamepad — dpad_x/y zeroed in emit_state" {
+test "e2e: dpad arrows suppress_gamepad — hat axes and DPad bits zeroed in emit_state" {
     const allocator = testing.allocator;
     var ctx = try makeMapper(
         \\[dpad]
@@ -464,9 +458,10 @@ test "e2e: dpad arrows suppress_gamepad — dpad_x/y zeroed in emit_state" {
     defer ctx.deinit();
     var m = &ctx.mapper;
 
-    const ev = try m.apply(.{ .dpad_y = -1 }, 16, 0);
+    const ev = try m.apply(.{ .buttons = btnMask(.DPadUp) }, 16, 0);
     try testing.expectEqual(@as(i8, 0), ev.gamepad.dpad_y);
     try testing.expectEqual(@as(i8, 0), ev.gamepad.dpad_x);
+    try testing.expectEqual(@as(u64, 0), ev.gamepad.buttons & btnMask(.DPadUp));
 }
 
 // --- 7. prev-frame suppress correctness ---
@@ -648,8 +643,8 @@ test "e2e: layer active — dpad mode switches to arrows" {
     _ = m.layer.onTriggerPress(configs[0].name, 200, 0);
     _ = m.layer.onTimerExpired();
 
-    // dpad_y = -1 → KEY_UP (arrows mode active via layer)
-    const ev_up = try m.apply(.{ .dpad_y = -1 }, 16, 0);
+    // DPadUp → KEY_UP (arrows mode active via layer)
+    const ev_up = try m.apply(.{ .buttons = btnMask(.DPadUp) }, 16, 0);
     var found_key_up = false;
     for (ev_up.aux.slice()) |e| {
         switch (e) {
@@ -661,8 +656,8 @@ test "e2e: layer active — dpad mode switches to arrows" {
     }
     try testing.expect(found_key_up);
 
-    // dpad_y = 1 → KEY_DOWN
-    const ev_down = try m.apply(.{ .dpad_y = 1 }, 16, 0);
+    // DPadDown → KEY_DOWN
+    const ev_down = try m.apply(.{ .buttons = btnMask(.DPadDown) }, 16, 0);
     var found_key_down = false;
     for (ev_down.aux.slice()) |e| {
         switch (e) {

--- a/src/test/properties/drt_props.zig
+++ b/src/test/properties/drt_props.zig
@@ -21,8 +21,31 @@ const CompiledReport = interp_mod.CompiledReport;
 const FieldType = interp_mod.FieldType;
 const MAX_FIELDS = interp_mod.MAX_FIELDS;
 
-const HAT_X = [8]i8{ 0, 1, 1, 1, 0, -1, -1, -1 };
-const HAT_Y = [8]i8{ -1, -1, 0, 1, 1, 1, 0, -1 };
+const ButtonId = @import("../../core/state.zig").ButtonId;
+
+fn btnMask(id: ButtonId) u64 {
+    return @as(u64, 1) << @as(u6, @intCast(@intFromEnum(id)));
+}
+
+const DPAD_MASK = btnMask(.DPadUp) | btnMask(.DPadDown) |
+    btnMask(.DPadLeft) | btnMask(.DPadRight);
+
+// Reference reimplementation of the HID hat -> DPad* bit decode.
+const HAT_BITS = [8]u64{
+    btnMask(.DPadUp),
+    btnMask(.DPadUp) | btnMask(.DPadRight),
+    btnMask(.DPadRight),
+    btnMask(.DPadDown) | btnMask(.DPadRight),
+    btnMask(.DPadDown),
+    btnMask(.DPadDown) | btnMask(.DPadLeft),
+    btnMask(.DPadLeft),
+    btnMask(.DPadUp) | btnMask(.DPadLeft),
+};
+
+fn hatBits(hat: i64) u64 {
+    if (hat >= 0 and hat < 8) return HAT_BITS[@intCast(hat)];
+    return 0;
+}
 
 fn saturate(comptime T: type, v: i64) T {
     if (v > std.math.maxInt(T)) return std.math.maxInt(T);
@@ -55,14 +78,6 @@ fn injectChecksum(cr: *const CompiledReport, pkt: []u8) void {
             std.mem.writeInt(u32, pkt[cs.expect_off..][0..4], computed, .little);
         },
     }
-}
-
-fn hatDecode(hat: i64) struct { x: i8, y: i8 } {
-    if (hat >= 0 and hat < 8) {
-        const idx: usize = @intCast(hat);
-        return .{ .x = HAT_X[idx], .y = HAT_Y[idx] };
-    }
-    return .{ .x = 0, .y = 0 };
 }
 
 // Compare oracle results against production delta.
@@ -145,11 +160,7 @@ fn compareDelta(fr: lean.FieldResult, delta: anytype) !void {
             try testing.expectEqual(@as(u8, @intCast(fr.val & 0xff)), delta.battery_level.?);
         },
         .dpad => {
-            const hat = fr.val;
-            const exp_x: i8 = if (hat >= 0 and hat < 8) HAT_X[@intCast(hat)] else 0;
-            const exp_y: i8 = if (hat >= 0 and hat < 8) HAT_Y[@intCast(hat)] else 0;
-            try testing.expectEqual(exp_x, delta.dpad_x orelse 0);
-            try testing.expectEqual(exp_y, delta.dpad_y orelse 0);
+            try testing.expectEqual(hatBits(fr.val), (delta.buttons orelse 0) & DPAD_MASK);
         },
         .unknown => {},
     }
@@ -348,7 +359,7 @@ fn writeField(buf: []u8, offset: usize, t: FieldType, value: i64) void {
     }
 }
 
-test "DRT: dpad hat-switch exhaustive — all 9 values decode correctly" {
+test "DRT: dpad hat-switch exhaustive — all 9 values set the right DPad bits" {
     const allocator = testing.allocator;
     const toml =
         \\[device]
@@ -372,13 +383,9 @@ test "DRT: dpad hat-switch exhaustive — all 9 values decode correctly" {
     defer parsed.deinit();
     const interp = interp_mod.Interpreter.init(&parsed.value);
 
-    const expected_x = [9]i8{ 0, 1, 1, 1, 0, -1, -1, -1, 0 };
-    const expected_y = [9]i8{ -1, -1, 0, 1, 1, 1, 0, -1, 0 };
-
     for (0..9) |hat| {
         var raw = [_]u8{ 0xAA, @intCast(hat), 0, 0 };
         const delta = (try interp.processReport(0, &raw)) orelse return error.NoMatch;
-        try testing.expectEqual(expected_x[hat], delta.dpad_x orelse 0);
-        try testing.expectEqual(expected_y[hat], delta.dpad_y orelse 0);
+        try testing.expectEqual(hatBits(@intCast(hat)), delta.buttons orelse 0);
     }
 }

--- a/src/test/properties/generative_mapper_props.zig
+++ b/src/test/properties/generative_mapper_props.zig
@@ -73,10 +73,11 @@ const LAYER_TRIGGER_MASK: u64 = blk: {
 ///    each frame (prod `mapper.zig:338-342`; oracle step [6] `.gamepad_button`).
 ///  * `.disabled` — both no-op + source bit added to suppress mask.
 ///  * dpad-arrow synthesis — prod delegates to `dpad.zig:processDpad`; oracle
-///    `processDpad` is line-for-line identical (edge detect on dpad_x/y vs
-///    prev, KEY_UP/DOWN/LEFT/RIGHT, `suppress_gamepad` -> DPad* suppress +
-///    hat zero). `effectiveDpadConfig` with no layer == `cfg.dpad orelse {}`,
-///    matching oracle `dpad_cfg = cfg.dpad`.
+///    `processDpad` is line-for-line identical (edge detect on the axes derived
+///    from the raw DPad* bits vs prev, KEY_UP/DOWN/LEFT/RIGHT,
+///    `suppress_gamepad` -> DPad* suppress + hat zero). `effectiveDpadConfig`
+///    with no layer == `cfg.dpad orelse {}`, matching oracle
+///    `dpad_cfg = cfg.dpad`.
 ///  * dpad hat axis — both derive `emit.dpad_x/y` from post-remap DPad* bits
 ///    (prod `emit_state.synthesizeDpadAxes()`; oracle step [7] reimpl).
 ///  * prev-frame mask — both snapshot prev buttons / prev dpad each frame.
@@ -476,8 +477,9 @@ test "generative: dpad arrows mode emits KEY events" {
     const parsed = try mapping.parseString(allocator, toml_str);
     defer parsed.deinit();
 
-    const prod = ctx.mapper.apply(.{ .dpad_x = -1 }, 0, 0) catch unreachable;
-    const oout = mapper_oracle.apply(&oracle, .{ .dpad_x = -1 }, &parsed.value, 0);
+    const left = helpers.btnMask(.DPadLeft);
+    const prod = ctx.mapper.apply(.{ .buttons = left }, 0, 0) catch unreachable;
+    const oout = mapper_oracle.apply(&oracle, .{ .buttons = left }, &parsed.value, 0);
 
     try testing.expectEqual(oout.gamepad.dpad_x, prod.gamepad.dpad_x);
     try testing.expectEqual(@as(i8, 0), prod.gamepad.dpad_x);

--- a/src/test/properties/lean_drt_props.zig
+++ b/src/test/properties/lean_drt_props.zig
@@ -383,10 +383,14 @@ test "lean_drt: hat decode vectors" {
         if (!isDataLine(line)) break;
         const f = try splitFields(line);
         const decoded = interp.decodeDpadHat(try parseInt(f[0]));
-        const expected_dx: i8 = @intCast(try parseInt(f[1]));
-        const expected_dy: i8 = @intCast(try parseInt(f[2]));
-        try testing.expectEqual(expected_dx, decoded.x);
-        try testing.expectEqual(expected_dy, decoded.y);
+        try testing.expectEqual(try parseUint(f[1]), decoded);
+
+        // Same vector carries the axes the emit path derives from those bits.
+        var gs = state.GamepadState{};
+        gs.buttons = decoded;
+        gs.synthesizeDpadAxes();
+        try testing.expectEqual(@as(i8, @intCast(try parseInt(f[2]))), gs.dpad_x);
+        try testing.expectEqual(@as(i8, @intCast(try parseInt(f[3]))), gs.dpad_y);
         count += 1;
     }
     try testing.expect(count > 0);

--- a/src/test/properties/mapper_props.zig
+++ b/src/test/properties/mapper_props.zig
@@ -329,7 +329,6 @@ test "property: extreme axis values — no overflow after processing" {
         .{ .gyro_x = std.math.minInt(i16), .gyro_y = std.math.maxInt(i16), .gyro_z = std.math.minInt(i16) },
         .{ .accel_x = std.math.maxInt(i16), .accel_y = std.math.minInt(i16), .accel_z = std.math.maxInt(i16) },
         .{ .touch0_x = std.math.minInt(i16), .touch0_y = std.math.maxInt(i16), .touch0_active = true },
-        .{ .dpad_x = std.math.minInt(i8), .dpad_y = std.math.maxInt(i8) },
     };
 
     for (extreme_deltas) |delta| {

--- a/src/test/properties/transition_coverage_props.zig
+++ b/src/test/properties/transition_coverage_props.zig
@@ -205,7 +205,7 @@ test "transition_coverage: all 23 TransitionId classes reached" {
         const parsed = try mapping.parseString(allocator, toml_str);
         defer parsed.deinit();
         var oracle = OracleState{};
-        drive(&tracker, &oracle, .{ .dpad_x = -1 }, &parsed.value, 0); // dpad_arrows_emit
+        drive(&tracker, &oracle, .{ .buttons = helpers.btnMask(.DPadLeft) }, &parsed.value, 0); // dpad_arrows_emit
 
         const toml_str2 =
             \\[dpad]
@@ -214,7 +214,7 @@ test "transition_coverage: all 23 TransitionId classes reached" {
         const parsed2 = try mapping.parseString(allocator, toml_str2);
         defer parsed2.deinit();
         var oracle2 = OracleState{};
-        drive(&tracker, &oracle2, .{ .dpad_x = 1 }, &parsed2.value, 0); // dpad_gamepad_passthrough
+        drive(&tracker, &oracle2, .{ .buttons = helpers.btnMask(.DPadRight) }, &parsed2.value, 0); // dpad_gamepad_passthrough
     }
 
     // --- Scenario 6: gyro activated / deactivated ---


### PR DESCRIPTION
## What changed

- A `dpad` report field (HID hat switch, 0..7 directions, 8+ neutral) is now decoded into the `DPadUp/Down/Left/Right` button bits inside the interpreter instead of into separate delta axes. The output d-pad axes are derived from those bits on every path (mapper emit, masked previous frame, timer frames, mapper-less event loop), so a hat-declared d-pad reaches `ABS_HAT0X/Y` and `BTN_DPAD_*` outputs and takes part in remap, layers, arrows mode and `suppress_gamepad` exactly like button-bit d-pads.
- `GamepadStateDelta.dpad_x/dpad_y` removed; `GamepadState.dpad_x/dpad_y` are derived output axes only.
- Arrows mode derives its edge inputs from the DPad bits; takeover seeding synthesizes the axes so a held d-pad raises no spurious arrow key.
- Validation rejects a config that declares both a `dpad` field and `DPad*` entries in a button group (`error.InvalidConfig`, warning log).
- Lean model updated to the same semantics (hat decode returns a bit mask, apply pipeline derives axes from post-remap bits); `HAT_DECODE` oracle vectors now carry bits and axes; `test_vectors.csv` regenerated.
- `docs/src/device-config.md` documents the `dpad` field.

## Behaviour change

On main a `dpad` field decoded correctly but the output d-pad stayed neutral, and arrows mode was unreachable for button-bit d-pads. Both now work. No shipped config declares a `dpad` field yet.

## Test plan

- [x] new `src/test/dpad_hat_e2e_test.zig`: hat 0..7 and neutral through the mapper and mapper-less paths for `output.dpad.type = "hat"` and `"buttons"`; hat vs button-bit parity under remap, layer, arrows, suppress; validate rejection; all fail on main
- [x] existing oracle/property assertions that enshrined the old overwrite inverted
- [x] `lake build` zero sorry; oracle self-checks; CSV freshness diff
- [x] Docker `zig build test` (also with `PADCTL_TEST_REQUIRE_LEAN=1`), `test-safe`, `test-tsan`, `check-fmt`

Related: #514