### PR TITLE
chore(release): bump version to 0.1.28

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .padctl,
     .fingerprint = 0xef30763351dab049,
-    .version = "0.1.27",
+    .version = "0.1.28",
     .dependencies = .{
         .toml = .{
             .url = "https://github.com/sam701/zig-toml/archive/24e0deeceaad1b7f1b12027ebae1c65ff1d86e33.tar.gz",


### PR DESCRIPTION
- build.zig.zon: 0.1.27 -> 0.1.28
- Includes #517 (hat-switch d-pad reaches the output), #516 (transform chains on bit-field inputs) and #515 (X/Y face-button codes for non-Sony output identities)
- Tag v0.1.28 follows the merge; the release workflow verifies the tag against build.zig.zon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Bumped the project version to 0.1.28.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->